### PR TITLE
Travis & Coverity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ addons:
 notifications:
   slack:
     secure: ATPx+JnB3aMwuyXlJElYv47Z17o5h7rVN2xGOdwKyvuB0HKiGxkUfxAOK37CkLVTZ1i1Jozb1aoDGojTO+zmo4kCfKP3VXRLW9RTVhxt96MlUM0FCRed1bxi1A9rswpaEfWQXpuk9GjUPZOYgSK8D+IV63rhT5F9m4b3Z8WLkr0=
+    on_success: :change

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ before_script:
   - make buildgen  # Make as much as possible before the actual build step.
 
 script:
-  - make
-  - ./scripts/continuous/run.sh "$TEMPLATE"
+  - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make && ./scripts/continuous/run.sh "$TEMPLATE"; fi
 
 addons:
   coverity_scan:
@@ -40,9 +39,8 @@ addons:
       name: "embox/embox"
       description: "Build submitted via Travis CI"
     notification_email: eldar.abusalimov@gmail.com
-    build_command_prepend: make confload-"$TEMPLATE" buildgen
     build_command: make
-    branch_pattern: coverity_scan
+    branch_pattern: coverity
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ env:
     - AUTOQEMU_NICS=''
   matrix:
     - TEMPLATE=arm/qemu
+    - TEMPLATE=arm/stm32_f4
     - TEMPLATE=x86/qemu
+    - TEMPLATE=x86/test/lang
 
 before_install:
   - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
@@ -27,7 +29,7 @@ install:
 
 before_script:
   - make confload-"$TEMPLATE"
-  - sed -ie '/eth0/d' conf/start_script.inc  # FIXME
+  - sed -ie '/eth0\|http/d' conf/start_script.inc  # FIXME
   - make buildgen  # Make as much as possible before the actual build step.
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 env:
   global:
     # Encrypted COVERITY_SCAN_TOKEN
-    - secure: fFf+lgHUkycCUGXTpVCnSL8G+sI/Wr+lbm/9jdy6Lw19MF33E4eC8oln/0OZFrfWY4Xy1QC9jfVgdsYd1jeI+e+mtrVdUzBJPO2z6BN978KiNmQzgff8epkpQB0k9qbDAqsNmjSwShN3PaeOZTUHiusWg0PMCQRb3SokLhKplhk=    - AUTOQEMU_NICS=''
+    - secure: KKhG29VpIOr5mq9xHptpDSfFEcSRKB8BX4e5zL0VQNJGkrNAHJ7ba+boHKEmSJJ1fZvHC18XOb886BIsn0i+lFrVymYDR8L8ca3e/k26LktnqMn76ORK1WYkD1fiRg3lX25v/j0TkoLB7pmDnMhZyGzg20675V1sHbl/KCO1LJI=
     - AUTOQEMU_NICS=''
   matrix:
     - TEMPLATE=arm/qemu

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Embox [![Build Status](https://travis-ci.org/embox/embox.svg?branch=master)](https://travis-ci.org/embox/embox)
+Embox [![Build Status](https://travis-ci.org/embox/embox.svg?branch=master)](https://travis-ci.org/embox/embox) [![Coverity Scan Build Status](https://scan.coverity.com/projects/700/badge.svg)](https://scan.coverity.com/projects/700)
 =====
 
 Embox is a configurable operating system kernel designed for resource


### PR DESCRIPTION
This change makes Slack notifications less verbose, directs pushes to 'coverity' branch to the [proper](https://scan.coverity.com/projects/700) Coverity Scan project, and adds 2 more templates to test.