### PR TITLE
webui: Reduce too long led's name (maxlen is 9)

### DIFF
--- a/platform/stm32f4_iocontrol/http_admin/app.js
+++ b/platform/stm32f4_iocontrol/http_admin/app.js
@@ -104,6 +104,7 @@ angular.module("HttpAdmin", ['ngRoute', 'ui.bootstrap'])
         });
         modalInstance.result.then(function (new_name) {
             led_pair.name = new_name;
+            led_pair.short_name = new_name.length <= 9 ? new_name : new_name.substr(0, 6) + "...";
             $http.post('cgi-bin/cgi_cmd_wrapper?c=led_names&a=store&a=' + led_pair.index.toString(), new_name);
         });
     }

--- a/platform/stm32f4_iocontrol/http_admin/css/app.css
+++ b/platform/stm32f4_iocontrol/http_admin/css/app.css
@@ -35,6 +35,7 @@
 }
 
 .block-caption {
+  font-family: monospace;
   margin: 3px 0px;
   text-align: center;
   -webkit-touch-callout: none;

--- a/platform/stm32f4_iocontrol/http_admin/partials/leds.html
+++ b/platform/stm32f4_iocontrol/http_admin/partials/leds.html
@@ -35,7 +35,7 @@
 	<div class="block-pair" ng-repeat="block_pair in leds_state">
 		<div class="block" ng-class="{'block-error' : led_pair.error}" ng-repeat="led_pair in block_pair">
 			<led-template led="led_pair.red" led-on="led-red" led-switch="led_switch(led)" led-name="Red"></led-template>
-			<div class="block-caption" ng-dblclick="name_change_request(led_pair)">{{led_pair.name || led_pair.index + 1}}</div>
+			<div class="block-caption" ng-dblclick="name_change_request(led_pair)">{{led_pair.short_name || led_pair.index + 1}}</div>
 			<led-template led="led_pair.blue" led-on="led-blue" led-switch="led_switch(led)" led-name="Blue"></led-template>
 		</div>
 	    <hr>


### PR DESCRIPTION
 - Use monospace font-family as default for .block-caption
 - Add led.short_name field