### PR TITLE
BananaPi port: working SGI

### DIFF
--- a/src/drivers/interrupt/Mybuild
+++ b/src/drivers/interrupt/Mybuild
@@ -68,6 +68,10 @@ module omap3_intc extends irqctrl_api {
 	source "omap3_intc.c", "omap3_intc.h"
 }
 
+module bpi_intc extends irqctrl_api {
+	source "bpi_intc.c", "bpi_intc.h"
+}
+
 module ppc_intc extends irqctrl_api {
 	source "ppc_intc.c", "ppc_intc.h"
 }

--- a/src/drivers/interrupt/bpi_intc.c
+++ b/src/drivers/interrupt/bpi_intc.c
@@ -1,0 +1,153 @@
+/**
+ * @file
+ * @brief Banana Pi interrupt controller driver
+ *
+ * @date 15.04.15
+ * @author Dmitrii Petukhov
+ */
+
+#include <assert.h>
+
+#include <kernel/critical.h>
+#include <hal/reg.h>
+#include <hal/ipl.h>
+#include <drivers/irqctrl.h>
+
+#include <kernel/irq.h>
+#include <embox/unit.h>
+#include <kernel/printk.h>
+
+EMBOX_UNIT_INIT(bpi_intc_init);
+
+/** On BananaPi SGI source numbers lie between 0 and 15 */
+#define SGI_MAX_SRC         15
+
+#define GIC_BASE            0x01C80000
+
+/** 0x1000-0x1FFF Distributor */
+#define GICD_BASE          (GIC_BASE + 0x1000)
+
+/** 0x2000-0x3FFF CPU interfaces */
+#define GICC_BASE          (GIC_BASE + 0x2000)
+
+#define GICD_CTRL          (GICD_BASE + 0x000)
+#define GICD_ISENABLER(n)  (GICD_BASE + 0x100 + (n) * 0x4)
+#define GICD_ICENABLER(n)  (GICD_BASE + 0x180 + (n) * 0x4)
+#define GICD_ISACTIVER(n)  (GICD_BASE + 0x300 + (n) * 0x4)
+#define GICD_ICACTIVER(n)  (GICD_BASE + 0x380 + (n) * 0x4)
+#define GICD_IPRIORITYR(n) (GICD_BASE + 0x400 + (n) * 0x4)
+#define GICD_SGIR          (GICD_BASE + 0xF00)
+#define GICD_CPENDSGIR(n)  (GICD_BASE + 0xF10 + (n) * 0x4)
+
+#define GICC_CTRL          (GICC_BASE + 0x00)
+#define GICC_PMR           (GICC_BASE + 0x04)
+#define GICC_INTACK        (GICC_BASE + 0x0c)
+#define GICC_EOI           (GICC_BASE + 0x10)
+
+/** CPUTargetList[0] corresponds to CPU interface 0 */
+#define CPU_TARGET_LIST_0 (1 << 16) 
+
+void software_init_hook(void) {
+	int i;
+
+	REG_STORE(GICD_CTRL, 0);
+	REG_STORE(GICD_CTRL, 1);
+
+	REG_STORE(GICD_ICENABLER(0), 0xffff0000);
+	REG_STORE(GICD_ISENABLER(0), 0x0000ffff);
+
+	/**
+	 * Set priority on PPI and SGI interrupts
+	 */
+	for (i = 0; i < 32; i += 4) {
+		REG_STORE(GICD_IPRIORITYR(i >> 2), 0xa0a0a0a0);
+	}
+
+	/**
+	 * The GICC_PMR for a CPU interface defines a priority threshold for the target processor.
+	 * The GIC only signals pending interrupts with a higher priority than this threshold value 
+	 * to the target processor.
+	 */
+	REG_STORE(GICC_PMR, 0xf0);
+
+	REG_STORE(GICC_CTRL, 0x1);
+}
+
+static int bpi_intc_init(void) {
+	return 0;
+}
+
+void irqctrl_enable(unsigned int interrupt_nr) {
+	assert(interrupt_nr <= SGI_MAX_SRC);
+	/**
+	 * Writes to bits corresponding to the SGIs are ignored.
+	 * SGIs are always enabled.
+	 */
+}
+
+void irqctrl_disable(unsigned int interrupt_nr) {
+	assert(interrupt_nr <= SGI_MAX_SRC);
+	/** 
+	 * Writing 1 to a Clear-enable bit disables forwarding of 
+	 * the corresponding interrupt from the Distributor to the CPU interfaces
+	 * Writes to bits corresponding to the SGIs are ignored.
+	 * SGIs are always enabled.
+	 *
+	 * REG_STORE(GICD_ICENABLER(), ABC)
+	 */
+
+	/**
+	 * Writing to a Clear-active bit Deactivates the corresponding interrupt
+	 *
+	 * REG_STORE(GICD_ICACTIVER(interrupt_nr >> 5), 1 << (interrupt_nr & 0x1f));
+	 */
+}
+
+void irqctrl_clear(unsigned int interrupt_nr) {
+	assert(interrupt_nr <= SGI_MAX_SRC);
+}
+
+void irqctrl_force(unsigned int interrupt_nr) {
+	assert(interrupt_nr <= SGI_MAX_SRC);
+
+	/** SGI is made pending by writing to the SGIR */
+	REG_STORE(GICD_SGIR, CPU_TARGET_LIST_0 | (interrupt_nr & 0xf));
+
+	/** 
+	 * Writing to a Set-active bit Activates the corresponding interrupt
+	 * REG_STORE(GICD_ISACTIVER(interrupt_nr >> 5), 1 << (interrupt_nr & 0x1f));
+	 */
+}
+
+void interrupt_handle(void) {
+	/** Read acts as an acknowledge for the interrupt */
+	unsigned int irqstat = REG_LOAD(GICC_INTACK);
+
+	unsigned int irq = irqstat & 0x3ff;
+
+	critical_enter(CRITICAL_IRQ_HANDLER);
+	{
+		ipl_enable();
+
+		/**
+		 * A processor writes to this register to inform the CPU interface either:
+		 *	1. that it has completed the processing of the specified interrupt
+		 *	2. in a GICv2 implementation, when the appropriate GICC_CTLR.EOImode bit 
+		 *	   is set to 1, to indicate that the interface should perform priority drop 
+		 *	   for the specified interrupt.
+		 */
+		REG_STORE(GICC_EOI, irqstat);
+
+		irq_dispatch(irq);
+
+		ipl_disable();
+
+	}
+
+	critical_leave(CRITICAL_IRQ_HANDLER);
+	critical_dispatch_pending();
+}
+
+void swi_handle(void) {
+	printk("swi!\n");
+}

--- a/src/drivers/interrupt/bpi_intc.h
+++ b/src/drivers/interrupt/bpi_intc.h
@@ -1,0 +1,14 @@
+/**
+ * @file
+ * @brief Banana Pi interrupt controller HAL definitions.
+ *
+ * @date 15.04.15
+ * @author Dmitrii Petukhov
+ */
+
+#ifndef IRQCTRL_BPI_INTC_IMPL_H_
+#define IRQCTRL_BPI_INTC_IMPL_H_
+
+#define __IRQCTRL_IRQS_TOTAL 123
+
+#endif /* IRQCTRL_BPI_INTC_IMPL_H_ */

--- a/templates/arm/bpi/mods.config
+++ b/templates/arm/bpi/mods.config
@@ -7,12 +7,8 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.stack(stack_size=4096)
 	@Runlevel(1) include embox.driver.serial.bpi
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__bpi")
-	@Runlevel(1) include embox.driver.interrupt.omap3_intc
+	@Runlevel(1) include embox.driver.interrupt.bpi_intc
 	@Runlevel(1) include embox.driver.clock.omap3_clk
-	@Runlevel(1) include embox.driver.gpmc.omap3_gpmc
-	@Runlevel(1) include embox.driver.gpio.omap3_gpio
-	@Runlevel(1) include embox.driver.net.lan9118
-	@Runlevel(2) include embox.driver.net.loopback
 	@Runlevel(1) include embox.kernel.timer.sys_timer
 
 	@Runlevel(1) include embox.kernel.timer.strategy.head_timer
@@ -63,22 +59,8 @@ configuration conf {
 	include embox.compat.libc.all
 	include third_party.lib.libgcc_toolchain
 
-	@Runlevel(1) include embox.test.critical
-	@Runlevel(1) include embox.test.framework.mod.member.ops_test
-	@Runlevel(1) include embox.test.kernel.timer_test
 	@Runlevel(1) include embox.test.kernel.irq_test(forced_irq_clear=true)
-	@Runlevel(1) include embox.test.recursion
-	@Runlevel(1) include embox.test.posix.sleep_test
-	@Runlevel(1) include embox.test.stdlib.bsearch_test
-	@Runlevel(1) include embox.test.stdlib.qsort_test
-	@Runlevel(1) include embox.test.util.array_test
-	@Runlevel(1) include embox.test.util.bit_test
-	@Runlevel(1) include embox.test.util.slist_test
-	@Runlevel(1) include embox.test.mem.pool_test
 	include embox.kernel.timer.sys_timer(timer_quantity=512) // each sleep thread requires a timer
-	@Runlevel(1) include embox.test.kernel.thread.thread_priority_test
-	@Runlevel(1) include embox.test.stdlib.setjmp_test
-
 
 	include embox.net.dev
 	include embox.net.skbuff(amount_skb=100,


### PR DESCRIPTION
As discussed, this change provides basic support for SGI on BananaPi, successfully passing all IRQ tests.