### PR TITLE
extbld: Change .zip to .tar.gz for archives from GitHub

### DIFF
--- a/third-party/lib/openlibm/Makefile
+++ b/third-party/lib/openlibm/Makefile
@@ -4,10 +4,10 @@ PKG_VER := ef29d06db1b57c415cbee51b90b492ae89812b5d
 
 PKG_DOWNLOADS_SEPARATE := true
 
-PKG_SOURCES := https://github.com/JuliaLang/$(PKG_NAME)/archive/$(PKG_VER).zip
-PKG_PATCHES := openlibm_embox.patch
+PKG_SOURCES := https://github.com/JuliaLang/openlibm/archive/$(PKG_VER).tar.gz
+PKG_MD5 := 4bc22ffc211f959080173587e81742ec
 
-PKG_MD5 := a8d4531e2d35384d244977fce009dbe2
+PKG_PATCHES := openlibm_embox.patch
 
 include $(EXTBLD_LIB)
 

--- a/third-party/lua/lib/luasocket/Makefile
+++ b/third-party/lua/lib/luasocket/Makefile
@@ -2,8 +2,8 @@
 PKG_NAME := luasocket
 PKG_VER  := 321c0c9b1f7b6b83cd83b58e7e259f53eca69373
 
-PKG_SOURCES := https://github.com/diegonehab/$(PKG_NAME)/archive/$(PKG_VER).zip
-PKG_MD5     := dc3028d6deebd935ae80068d5c286534
+PKG_SOURCES := https://github.com/diegonehab/luasocket/archive/$(PKG_VER).tar.gz
+PKG_MD5     := e2d6845e1f75d2e24df5563f643598af
 
 PKG_PATCHES := pkg_patch.txt
 

--- a/third-party/mruby/Makefile
+++ b/third-party/mruby/Makefile
@@ -2,8 +2,8 @@
 PKG_NAME := mruby
 PKG_VER  := 1.1.0
 
-PKG_SOURCES := https://github.com/mruby/mruby/archive/$(PKG_VER).zip
-PKG_MD5     := 3897db6c8efc3b946b015489d3ddd1f9
+PKG_SOURCES := https://github.com/mruby/mruby/archive/$(PKG_VER).tar.gz
+PKG_MD5     := 60d75ea704c9285f3c80b3ad1d2b68de
 
 PKG_PATCHES := pkg_patch.txt
 


### PR DESCRIPTION
It seems, that contents of zip archives has been changed somehow, causing builds to fail due to md5 sum mismatch.

Anyway, tgz is a better choice.