### PR TITLE
dvfs: Fix dvfs open build

### DIFF
--- a/src/compat/posix/fs/dvfs/open.c
+++ b/src/compat/posix/fs/dvfs/open.c
@@ -9,7 +9,7 @@
 #include <fcntl.h>
 #include <fs/dvfs.h>
 #include <kernel/task.h>
-#include <kernel/task/resource/idesc_table.h>
+#include <kernel/task/idesc_table.h>
 
 int open(const char *path, int __oflag, ...) {
 	struct file *file;


### PR DESCRIPTION
dvfs open fails to build, at least at arm/stm32_modbus