### PR TITLE
mk: oldconf: Fix an undefined 'config_h' variable warning

### DIFF
--- a/mk/script/build/oldconf-gen.mk
+++ b/mk/script/build/oldconf-gen.mk
@@ -64,7 +64,7 @@ $(config_lds_h) :
 $(AUTOCONF_DIR)/start_script.inc: $(CONF_DIR)/start_script.inc
 	@$(call cmd_notouch_stdout,$@,cat $<)
 
--include $(addsuffix .d,$(build_mk) $(config_h) $(config_lds_h))
+-include $(addsuffix .d,$(build_mk) $(config_lds_h))
 
 %/. :
 	@$(MKDIR) $*


### PR DESCRIPTION
The warning was introduced in e51a50a ("mk: oldconf: Remove processing of option.conf from scripts / macros") merged through #750.