### PR TITLE
Ipl restore fix

### DIFF
--- a/src/arch/mips/kernel/ipl_impl.h
+++ b/src/arch/mips/kernel/ipl_impl.h
@@ -46,9 +46,11 @@ static inline void ipl_restore(__ipl_t ipl) {
 
 	/* read status registers for cleaning interrupts mask */
 	c0_reg = mips_read_c0_status();
-	if((ipl & ST0_IE) && !(c0_reg & ST0_IE)) {
-		c0_reg |= ST0_IE;              /* restore interrupts mask */
-		mips_write_c0_status(c0_reg);  /* enable interrupts */
+
+	if (ipl & ST0_IE) {
+		mips_write_c0_status(c0_reg | ST0_IE);
+	} else {
+		mips_write_c0_status(c0_reg & ~ST0_IE);
 	}
 }
 

--- a/src/arch/ppc/kernel/ipl_impl.h
+++ b/src/arch/ppc/kernel/ipl_impl.h
@@ -28,7 +28,11 @@ static inline __ipl_t ipl_save(void) {
 }
 
 static inline void ipl_restore(__ipl_t ipl) {
-	__set_msr(__get_msr() | (ipl ? MSR_EE : 0));
+	if (ipl) {
+		__set_msr(__get_msr() | MSR_EE);
+	} else {
+		__set_msr(__get_msr() & ~MSR_EE);
+	}
 }
 
 #endif /* !__ASSEMBLER__ */

--- a/src/arch/usermode86/host/host_irq.c
+++ b/src/arch/usermode86/host/host_irq.c
@@ -81,10 +81,13 @@ int host_ipl_save(void) {
 void host_ipl_restore(int ipl) {
 	sigset_t iset;
 
-	if (!ipl) {
+	if (ipl) {
+		host_sigfillset(&iset);
+	} else {
 		host_sigemptyset(&iset);
-		host_sigprocmask(SIG_SETMASK, &iset, NULL);
 	}
+
+	host_sigprocmask(SIG_SETMASK, &iset, NULL);
 }
 
 void host_signal_send_self(int sig_nr) {

--- a/src/arch/x86/kernel/ipl_impl.h
+++ b/src/arch/x86/kernel/ipl_impl.h
@@ -49,6 +49,8 @@ static inline unsigned int ipl_save(void) {
 static inline void ipl_restore(unsigned int ipl) {
 	if (ipl & X86_EFLAGS_IF) {
 		__asm__ __volatile__ ("sti;\n\t" : : : "memory");
+	} else {
+		__asm__ __volatile__ ("cli;\n\t" : : : "memory");
 	}
 }
 

--- a/src/kernel/sched/sched.c
+++ b/src/kernel/sched/sched.c
@@ -406,9 +406,6 @@ static void __schedule(int preempt) {
 
 	sched_timing_start(next);
 
-	/* FIXME: ipl_disable() should be removed after fixing ipl_restore
-	 * issues. */
-	ipl_disable();
 	/* Restoring ipl is vital as __schedule() can be called both with IRQs
 	 * enabled and disabled. */
 	ipl_restore(ipl);


### PR DESCRIPTION
Previously the function restored ipl only in case disabled IRQs in several architectures, that might cause problems from time to time. This request fixes the issue for such architectures, namely mips, x86, ppc and usermode.