### PR TITLE
mk-addcflag-annotation: New Cflags annotation

### DIFF
--- a/mk/mybuild/lang/AddCflags.my
+++ b/mk/mybuild/lang/AddCflags.my
@@ -1,0 +1,7 @@
+
+package mybuild.lang
+
+annotation AddCflags {
+	string value
+}
+

--- a/mk/mybuild/lang/Cflags.my
+++ b/mk/mybuild/lang/Cflags.my
@@ -1,7 +1,7 @@
 
 package mybuild.lang
 
-annotation AddCflags {
+annotation Cflags {
 	string value
 }
 

--- a/mk/script/build/build-gen.mk
+++ b/mk/script/build/build-gen.mk
@@ -618,7 +618,7 @@ $(@source_rmk) : flags = $(call trim, \
 						$(mod_path)) \
 			-D__EMBUILD_MOD__=$(call module_id,$(module)) \
 			$(call check_profiling,$(instrument)) \
-			$(call get,$(additional_cflags),value))
+			$(call do_flags,,$(additional_cflags)))
 
 source_rmk_mk_pat   = $(MKGEN_DIR)/%.rule.mk
 

--- a/mk/script/build/build-gen.mk
+++ b/mk/script/build/build-gen.mk
@@ -594,14 +594,14 @@ my_incpath_before_val := \
 		$(call mybuild_resolve_or_die,mybuild.lang.IncludePathBefore.value)
 my_incpath_val  := $(call mybuild_resolve_or_die,mybuild.lang.IncludePath.value)
 my_defmacro_val := $(call mybuild_resolve_or_die,mybuild.lang.DefineMacro.value)
-my_addcflags_val := $(call mybuild_resolve_or_die,mybuild.lang.AddCflags.value)
+my_cflags_val := $(call mybuild_resolve_or_die,mybuild.lang.Cflags.value)
 my_instrument_val := \
 		$(call mybuild_resolve_or_die,mybuild.lang.InstrumentProfiling.value)
 
 $(@source_rmk) : includes_before = $(call values_of,$(my_incpath_before_val))
 $(@source_rmk) : includes = $(call values_of,$(my_incpath_val))
 $(@source_rmk) : defines  = $(call values_of,$(my_defmacro_val))
-$(@source_rmk) : additional_cflags  = $(call values_of,$(my_addcflags_val))
+$(@source_rmk) : additional_cflags  = $(call values_of,$(my_cflags_val))
 $(@source_rmk) : instrument = $(call values_of,$(my_instrument_val))
 
 

--- a/mk/script/build/build-gen.mk
+++ b/mk/script/build/build-gen.mk
@@ -594,12 +594,14 @@ my_incpath_before_val := \
 		$(call mybuild_resolve_or_die,mybuild.lang.IncludePathBefore.value)
 my_incpath_val  := $(call mybuild_resolve_or_die,mybuild.lang.IncludePath.value)
 my_defmacro_val := $(call mybuild_resolve_or_die,mybuild.lang.DefineMacro.value)
+my_addcflags_val := $(call mybuild_resolve_or_die,mybuild.lang.AddCflags.value)
 my_instrument_val := \
 		$(call mybuild_resolve_or_die,mybuild.lang.InstrumentProfiling.value)
 
 $(@source_rmk) : includes_before = $(call values_of,$(my_incpath_before_val))
 $(@source_rmk) : includes = $(call values_of,$(my_incpath_val))
 $(@source_rmk) : defines  = $(call values_of,$(my_defmacro_val))
+$(@source_rmk) : additional_cflags  = $(call values_of,$(my_addcflags_val))
 $(@source_rmk) : instrument = $(call values_of,$(my_instrument_val))
 
 
@@ -615,7 +617,8 @@ $(@source_rmk) : flags = $(call trim, \
 			-include $(patsubst %,$(value module_config_h_pat), \
 						$(mod_path)) \
 			-D__EMBUILD_MOD__=$(call module_id,$(module)) \
-			$(call check_profiling,$(instrument)))
+			$(call check_profiling,$(instrument)) \
+			$(call get,$(additional_cflags),value))
 
 source_rmk_mk_pat   = $(MKGEN_DIR)/%.rule.mk
 


### PR DESCRIPTION
The reason:
* It's needed when we want to add some extra clags to the end of the current Embox's CFLAGS when compiling an external library. Currently it is needed in branches stm32f3discovery-port and usbnet

What's done:
* New @Cflags annotation is added

! Please, be careful when reviewing this change, because of I am newbie in gnu make