### PR TITLE
Cleanup mybuild files

### DIFF
--- a/platform/lego_nxt/cmds/menu/Mybuild
+++ b/platform/lego_nxt/cmds/menu/Mybuild
@@ -1,9 +1,8 @@
 package lego_nxt.cmd
 
-import lego_nxt.driver.*
-
 module menu {
 	source "menu.c"
 
-	depends nxt_lcd, nxt_avr_init
+	depends lego_nxt.driver.nxt_lcd
+	depends lego_nxt.driver.nxt_avr_init
 }

--- a/platform/lego_nxt/cmds/snake/Mybuild
+++ b/platform/lego_nxt/cmds/snake/Mybuild
@@ -1,9 +1,8 @@
 package lego_nxt.cmd
 
-import lego_nxt.driver.*
-
 module nxt_snake {
 	source "snake.c"
 
-	depends nxt_lcd, nxt_avr_init
+	depends lego_nxt.driver.nxt_lcd
+	depends lego_nxt.driver.nxt_avr_init
 }

--- a/platform/lego_nxt/drivers/sensors/Mybuild
+++ b/platform/lego_nxt/drivers/sensors/Mybuild
@@ -1,7 +1,5 @@
 package lego_nxt.driver
 
-import lego_nxt.driver.*
-
 module touch_sensor {
 	source "touch.c"
 

--- a/platform/lego_nxt/example/box_around/Mybuild
+++ b/platform/lego_nxt/example/box_around/Mybuild
@@ -1,10 +1,10 @@
 package lego_nxt.example
 
-import lego_nxt.driver.*
-
 module box_around {
 	source "box_around.c"
 
-	depends sonar_sensor, nxt_motor, nxt_avr_init
+	depends lego_nxt.driver.sonar_sensor
+	depends lego_nxt.driver.nxt_motor
+	depends lego_nxt.driver.nxt_avr_init
 }
 

--- a/platform/lego_nxt/example/pendulum/Mybuild
+++ b/platform/lego_nxt/example/pendulum/Mybuild
@@ -1,20 +1,21 @@
-
 package lego_nxt.example.pendulum
-
-import lego_nxt.driver.*
 
 module without_sensors {
 	source "without_sensors.c"
-	depends nxt_motor
+	depends lego_nxt.driver.nxt_motor
 }
 
 module with_light_sensor {
 	source "pen_light.c"
-	depends nxt_motor, nxt_avr_init
+	depends lego_nxt.driver.nxt_motor
+	depends lego_nxt.driver.nxt_avr_init
 	depends embox.driver.gpio.at91_pins
 }
 
 module with_angle_sensor {
 	source "pen_angle.c"
-	depends soft_i2c, angle_sensor, nxt_motor, angle_sensor
+	depends lego_nxt.driver.soft_i2c
+	depends lego_nxt.driver.angle_sensor
+	depends lego_nxt.driver.nxt_motor
+	depends lego_nxt.driver.angle_sensor
 }

--- a/platform/lego_nxt/example/sensors/Mybuild
+++ b/platform/lego_nxt/example/sensors/Mybuild
@@ -1,29 +1,31 @@
-
 package lego_nxt.example.sensor
-
-import lego_nxt.driver.*
 
 module touch {
 	source "touch.c"
-	depends touch_sensor, nxt_motor
+	depends lego_nxt.driver.touch_sensor
+	depends lego_nxt.driver.nxt_motor
 }
 
 module sensor {
 	source "sensor.c"
-	depends nxt_avr_init, embox.driver.gpio.at91_pins
+	depends lego_nxt.driver.nxt_avr_init
+	depends embox.driver.gpio.at91_pins
 }
 
 module light {
 	source "light.c"
-	depends nxt_avr_init, embox.driver.gpio.at91_pins
+	depends lego_nxt.driver.nxt_avr_init
+	depends embox.driver.gpio.at91_pins
 }
 
 module sonar {
 	source "sonar.c"
-	depends soft_i2c, sonar_sensor
+	depends lego_nxt.driver.soft_i2c
+	depends lego_nxt.driver.sonar_sensor
 }
 
 module angle {
 	source "angle.c"
-	depends soft_i2c, angle_sensor
+	depends lego_nxt.driver.soft_i2c
+	depends lego_nxt.driver.angle_sensor
 }

--- a/platform/lego_nxt/example/wake_up/Mybuild
+++ b/platform/lego_nxt/example/wake_up/Mybuild
@@ -1,11 +1,10 @@
-
 package lego_nxt.example
-
-import lego_nxt.driver.*
 
 module wake_up {
 	source "wake_up.c"
 
-	depends nxt_motor, nxt_avr_init, soft_i2c
+	depends lego_nxt.driver.nxt_motor
+	depends lego_nxt.driver.nxt_avr_init
+	depends lego_nxt.driver.soft_i2c
 	depends embox.driver.gpio.at91_pins
 }

--- a/src/cmds/fs/Mount.my
+++ b/src/cmds/fs/Mount.my
@@ -1,7 +1,5 @@
 package embox.cmd.fs
 
-import embox.compat.posix.LibPosix
-
 @AutoCmd
 @Cmd(name = "mount",
 	help = "Mount a filesystem",

--- a/src/cmds/fs/Umount.my
+++ b/src/cmds/fs/Umount.my
@@ -1,7 +1,5 @@
 package embox.cmd.fs
 
-import embox.compat.posix.LibPosix
-
 @AutoCmd
 @Cmd(name = "umount",
 	help = "Unmount a filesystem",

--- a/src/cmds/shell/Mybuild
+++ b/src/cmds/shell/Mybuild
@@ -8,16 +8,15 @@ module shell {
 	source "shell.h"
 }
 
-abstract module shell_api { }
-
-module tish {
-	option number rich_prompt_support = 0
-
+abstract module shell_api {
 	option string prompt = "embox> "
 	option string welcome_msg = "Welcome to Embox and have a lot of fun!"
-	option string builtin_commands = "cd export exit logout"
+}
 
-	provides embox.cmd.Shell.commandLine
+module tish extends shell_api {
+	option number rich_prompt_support = 0
+
+	option string builtin_commands = "cd export exit logout"
 
 	source "tish.c"
 

--- a/src/cmds/shell/Mybuild
+++ b/src/cmds/shell/Mybuild
@@ -1,6 +1,6 @@
 package embox.cmd.sh
 
-module shell {
+module shell_registry {
 	option number input_buff_sz = 80
 	source "shell.c"
 
@@ -26,7 +26,7 @@ module tish extends shell_api {
 	depends embox.mem.heap_api
 
 	depends embox.framework.LibFramework
-	depends embox.cmd.sh.shell
+	depends embox.cmd.sh.shell_registry
 	depends embox.kernel.task.api
 	depends embox.compat.posix.proc.pid
 	depends embox.compat.posix.proc.uid

--- a/src/cmds/shell/diag_shell/Mybuild
+++ b/src/cmds/shell/diag_shell/Mybuild
@@ -1,16 +1,8 @@
 package embox.cmd
 
-interface Shell {
-	feature commandLine
-}
-
-module shell {
+module shell extends embox.cmd.sh.shell_api {
 	option number prompt_len = 80
 	option number history_size = 8
-	option string prompt = "embox> "
-	option string welcome_msg = "Welcome to Embox and have a lot of fun!"
-
-	provides Shell.commandLine
 
 	@IncludePath("$(CONF_DIR)")
 	source "shell.c", "console/console.c",

--- a/src/cmds/shell/diag_shell/Mybuild
+++ b/src/cmds/shell/diag_shell/Mybuild
@@ -11,6 +11,6 @@ module shell extends embox.cmd.sh.shell_api {
 
 	depends embox.lib.Tokenizer
 	depends embox.driver.terminal
-	depends embox.cmd.sh.shell
+	depends embox.cmd.sh.shell_registry
 	@NoRuntime depends embox.framework.cmd
 }

--- a/src/cmds/shell/shell.h
+++ b/src/cmds/shell/shell.h
@@ -15,9 +15,9 @@
 #include <framework/mod/self.h>
 
 #include <framework/mod/options.h>
-#include <module/embox/cmd/sh/shell.h>
+#include <module/embox/cmd/sh/shell_registry.h>
 #define SHELL_INPUT_BUFF_SZ \
-	OPTION_MODULE_GET(embox__cmd__sh__shell, NUMBER, input_buff_sz)
+	OPTION_MODULE_GET(embox__cmd__sh__shell_registry, NUMBER, input_buff_sz)
 
 typedef void (*shell_run_ft)(void);
 typedef int  (*shell_exec_ft)(const char *line);

--- a/src/cmds/user/Login.my
+++ b/src/cmds/user/Login.my
@@ -29,7 +29,7 @@ module login {
 
 	depends embox.lib.readline_api
 
-	requires embox.cmd.Shell.commandLine
+	depends embox.cmd.sh.shell_api
 
 	depends embox.security.smac_user_db
 }

--- a/src/cmds/user/Su.my
+++ b/src/cmds/user/Su.my
@@ -23,6 +23,6 @@ module su {
 	depends embox.kernel.task.resource.u_area
 
 	depends embox.cmd.user.login
-	requires embox.cmd.Shell.commandLine
+	depends embox.cmd.sh.shell_api
 
 }

--- a/src/compat/libc/stdlib/Mybuild
+++ b/src/compat/libc/stdlib/Mybuild
@@ -31,7 +31,7 @@ static module core {
 
 static module system {
 	source "system.c"
-	depends embox.cmd.sh.shell
+	depends embox.cmd.sh.shell_registry
 }
 
 static module all {

--- a/src/compat/posix/proc/Proc.my
+++ b/src/compat/posix/proc/Proc.my
@@ -51,7 +51,7 @@ static module waitpid {
 static module signal {
 	source "signal.c"
 
-	depends embox.kernel.thread.signal
+	depends embox.kernel.thread.signal_impl
 	depends embox.kernel.task.resource.sig_table
 	depends sigset
 }

--- a/src/compat/posix/proc/Proc.my
+++ b/src/compat/posix/proc/Proc.my
@@ -25,7 +25,7 @@ static module exec {
 	depends embox.kernel.task.resource.module_ptr
 	depends embox.kernel.task.resource.argv
 
-	depends embox.cmd.shell
+	depends embox.cmd.sh.shell_registry
 }
 
 @DefaultImpl(fork_copy_everything)

--- a/src/drivers/clock/Mybuild
+++ b/src/drivers/clock/Mybuild
@@ -5,7 +5,7 @@ module at91_pitc extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module gptimer extends embox.arch.clock {
@@ -13,7 +13,7 @@ module gptimer extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 
 	depends embox.driver.ambapp_api /*if ampa pnp enable option not required */
 	option number gptimer_base=0x80000300 /* if amba pnp disable */
@@ -27,7 +27,7 @@ module mb_timer extends embox.arch.clock {
 	option number irq_num
 
 	depends embox.kernel.irq
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module pit extends embox.arch.clock {
@@ -37,7 +37,7 @@ module pit extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	@NoRuntime depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module cortexm_systick extends embox.arch.clock {
@@ -45,7 +45,7 @@ module cortexm_systick extends embox.arch.clock {
 
 	//depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 @BuildDepends(embox.arch.arm.cmsis)
@@ -54,7 +54,7 @@ module cmsis_systick extends embox.arch.clock {
 
 	//depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 
@@ -63,7 +63,7 @@ module omap3_clk extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module ti8168_clk extends embox.arch.clock {
@@ -71,7 +71,7 @@ module ti8168_clk extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module ppc_clk extends embox.arch.clock {
@@ -79,7 +79,7 @@ module ppc_clk extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 // TODO Can be used with pit. That means tsc not implements embox.arch.clock
@@ -94,14 +94,14 @@ module mips_clk extends embox.arch.clock {
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
 	depends embox.arch.interrupt
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module lapic_timer extends embox.arch.clock {
 	source "lapic_timer.c"
 
 	depends embox.driver.interrupt.lapic
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module usermode extends embox.arch.clock {
@@ -109,7 +109,7 @@ module usermode extends embox.arch.clock {
 
 	depends embox.kernel.irq
 	depends embox.kernel.time.clock_source
-	@NoRuntime depends embox.kernel.time.timer
+	@NoRuntime depends embox.kernel.time.timer_handler
 }
 
 module hpet {

--- a/src/drivers/diag/Mybuild
+++ b/src/drivers/diag/Mybuild
@@ -1,7 +1,6 @@
 package embox.driver.diag
 
-abstract module diag_api {
-}
+module diag_api {}
 
 module mem_diag extends diag_api {
 	option number buffer_len = 128

--- a/src/init/Mybuild
+++ b/src/init/Mybuild
@@ -65,6 +65,6 @@ module start_script {
 
 	depends setup_tty_api
 	depends embox.cmd.sh.shell
-	requires embox.cmd.Shell.commandLine
+	depends embox.cmd.sh.shell_api
 	@NoRuntime depends embox.compat.libc.stdio.file_ops
 }

--- a/src/init/Mybuild
+++ b/src/init/Mybuild
@@ -64,7 +64,7 @@ module start_script {
 	source "start_script.c"
 
 	depends setup_tty_api
-	depends embox.cmd.sh.shell
+	depends embox.cmd.sh.shell_registry
 	depends embox.cmd.sh.shell_api
 	@NoRuntime depends embox.compat.libc.stdio.file_ops
 }

--- a/src/kernel/thread/Mybuild
+++ b/src/kernel/thread/Mybuild
@@ -32,7 +32,7 @@ module sched_wait {
 	source "thread_sched_wait.c"
 }
 
-@DefaultImpl(signal)
+@DefaultImpl(signal_impl)
 abstract module signal_api { }
 
 module signal_stub extends signal_api {
@@ -42,7 +42,7 @@ module signal_stub extends signal_api {
 	@NoRuntime depends embox.kernel.thread.signal.lock_stub
 }
 
-module signal extends signal_api {
+module signal_impl extends signal_api {
 	source "signal.c"
 	@NoRuntime depends embox.kernel.thread.signal.sigstate
 	@NoRuntime depends embox.kernel.thread.signal.siginfoq

--- a/src/kernel/time/Time.my
+++ b/src/kernel/time/Time.my
@@ -29,7 +29,7 @@ module jiffies {
 	depends slowdown
 }
 
-module timer {
+module timer_handler {
 	option number hnd_priority = 200
 	source "timer.c"
 	depends jiffies

--- a/src/kernel/time/timer/Mybuild
+++ b/src/kernel/time/timer/Mybuild
@@ -9,7 +9,7 @@ module sys_timer {
 
 	depends embox.kernel.timer.strategy.api
 	depends embox.kernel.time.clock_source
-	depends embox.kernel.time.timer
+	depends embox.kernel.time.timer_handler
 	/*uses ms2jiffies */
 	depends embox.kernel.time.jiffies
 	depends embox.arch.clock

--- a/src/mem/misc/Mybuild
+++ b/src/mem/misc/Mybuild
@@ -1,14 +1,8 @@
 package embox.mem
 
-interface iobjalloc {
-	feature alloc
-	feature rt_alloc extends alloc
-}
-
 module slab {
 	option number heap_size = 524288
 	source "slab.c", "slab_impl.h"
-	provides iobjalloc.alloc
 	depends embox.mem.page_api
 	depends embox.mem.phymem
 	depends embox.mem.static_heap
@@ -16,6 +10,5 @@ module slab {
 
 module pool {
 	source "pool.c"
-	provides iobjalloc.rt_alloc
 	depends embox.util.SList
 }

--- a/src/tests/kernel/Mybuild
+++ b/src/tests/kernel/Mybuild
@@ -19,7 +19,7 @@ module timer_test {
 
 	depends embox.kernel.timer.strategy.api
 	depends embox.framework.test
-	depends embox.kernel.time.timer
+	depends embox.kernel.time.timer_handler
 }
 
 @TestFor(embox.kernel.timer.strategy.api)
@@ -27,7 +27,7 @@ module periodic_timer_test {
 	source "periodic_timer_test.c"
 
 	depends embox.kernel.timer.strategy.api
-	depends embox.kernel.time.timer
+	depends embox.kernel.time.timer_handler
 }
 
 @TestFor(embox.kernel.timer.strategy.api)
@@ -35,7 +35,7 @@ module oneshot_timer_test {
 	source "oneshot_timer_test.c"
 
 	depends embox.kernel.timer.strategy.api
-	depends embox.kernel.time.timer
+	depends embox.kernel.time.timer_handler
 }
 
 //@TestFor(embox.kernel.syscall)

--- a/templates/arm/stm32_modbus/mods.config
+++ b/templates/arm/stm32_modbus/mods.config
@@ -57,7 +57,7 @@ configuration conf {
 	include embox.driver.tty.task_breaking_disable
 
 	@Runlevel(2) include embox.cmd.shell
-	@Runlevel(2) include embox.cmd.sh.shell(input_buff_sz=80)
+	@Runlevel(2) include embox.cmd.sh.shell_registry(input_buff_sz=80)
 	@Runlevel(2) include embox.cmd.sleep
 	@Runlevel(2) include embox.cmd.sh.tish(builtin_commands = "cd export exit logout httpd")
 	include embox.init.setup_tty_diag


### PR DESCRIPTION
Remove some rarely used features of Mybuild like imports or features. Also avoid clashes between module and package names that could only lead to ambiguity.

The only changes that affect the logic are in the last two commits. Though it'd be nice if you also check that I didn't miss anything when renaming modules (i.e. references to options in C code).