### PR TITLE
Fix extbld toolchain

### DIFF
--- a/mk/extbld/arch-embox-gcc
+++ b/mk/extbld/arch-embox-gcc
@@ -32,6 +32,7 @@ case " $@ " in
 esac
 
 ARG_LINE="$ARG_LINE $EMBOX_IMPORTED_CPPFLAGS"
-# echo "$EMBOX_CROSS_COMPILE${cmd#arch-embox-} $@ ${ARG_LINE//$PWD/.}" >&2
-$EMBOX_CROSS_COMPILE${cmd#arch-embox-} "$@" ${ARG_LINE//$PWD/.}
+PWD_ARG_LINE="$(for i in $ARG_LINE; do echo ${i/$PWD/.}; done)"
+# echo "$EMBOX_CROSS_COMPILE${cmd#arch-embox-} $@ $PWD_ARG_LINE" >&2
+$EMBOX_CROSS_COMPILE${cmd#arch-embox-} "$@" $PWD_ARG_LINE
 exit $?


### PR DESCRIPTION
Now PWD occuriencies in middle of words aren't substituted.
Problem arise when repo cloned to /embox