### PR TITLE
Fix arm/stm32_modbus template

### DIFF
--- a/templates/arm/stm32_modbus/mods.config
+++ b/templates/arm/stm32_modbus/mods.config
@@ -56,7 +56,6 @@ configuration conf {
 	include embox.driver.serial.fsnode_none
 	include embox.driver.tty.task_breaking_disable
 
-	@Runlevel(2) include embox.cmd.shell
 	@Runlevel(2) include embox.cmd.sh.shell_registry(input_buff_sz=80)
 	@Runlevel(2) include embox.cmd.sleep
 	@Runlevel(2) include embox.cmd.sh.tish(builtin_commands = "cd export exit logout httpd")


### PR DESCRIPTION
diag_shell was in conflict by tish, diag_shell picked as shell
implementation. So background feature ('&') was not implemented.