### PR TITLE
Autoqemu comments handling fix

### DIFF
--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -57,7 +57,7 @@ guess_mem() {
 get_user_empty_guess AUTOQEMU_MEM guess_mem
 
 guess_nics() {
-	sed 's#\(.*\)//.*#\1#p' $MODS_CONF | sed -n 's#.*include\ embox.driver.net.\([a-z0-9_]\+\)\((.*)\|\)$#\1#p' | grep -v loopback | head -n 1;
+	cat $MODS_CONF | gcc -P -E - | sed -n 's#.*include\ embox.driver.net.\([a-z0-9_]\+\)\((.*)\|\)$#\1#p' | grep -v loopback | head -n 1;
 }
 get_user_undef_guess AUTOQEMU_NICS guess_nics
 

--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -43,11 +43,13 @@ get_user_empty_guess() {
 	error_empty "$1"
 }
 
-guess_arch() { sed -n 's/ARCH *= *//p' $BUILD_CONF; }
+guess_arch() {
+	cat $BUILD_CONF | gcc -P -E - | sed -n 's/ARCH *= *//p';
+}
 get_user_empty_guess AUTOQEMU_ARCH guess_arch
 
 guess_mem() {
-	ram=$(sed -n 's/^RAM *([0-9x]*, *\([0-9]*\)M)/\1/p' $LDS_CONF)
+	ram=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/^RAM *([0-9x]*, *\([0-9]*\)M)/\1/p')
 	if [ $ram ]; then
 		echo $ram
 	else
@@ -91,7 +93,7 @@ guess_kvm() {
 get_user_undef_guess AUTOQEMU_KVM_ARG guess_kvm
 
 guess_load_arg() {
-	NAND_SIZE=$(sed -n 's/.*\<AUTOQEMU_UIMAGE_SIZE_MB=\([0-9]\+\).*$/\1/p' $LDS_CONF)
+	NAND_SIZE=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/.*\<AUTOQEMU_UIMAGE_SIZE_MB=\([0-9]\+\).*$/\1/p')
 	if [ ! $NAND_SIZE ]; then
 		echo "-kernel ${KERNEL:-./build/base/bin/embox}"
 	else
@@ -116,7 +118,7 @@ get_user_undef_guess AUTOQEMU_NOGRAPHIC_ARG guess_nographic
 guess_machine() {
 	case $AUTOQEMU_ARCH in
 		arm)
-			if grep "overo" $BUILD_CONF >/dev/null; then
+			if cat $BUILD_CONF | gcc -P -E - | grep "overo" >/dev/null; then
 				echo "-M overo"
 			fi
 			;;

--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -56,7 +56,9 @@ guess_mem() {
 }
 get_user_empty_guess AUTOQEMU_MEM guess_mem
 
-guess_nics() { sed -n 's/\t*\(@Runlevel([0-9])\|\) \+include\ embox.driver.net.\([a-z0-9_]\+\)\((.*)\|\)$/\2/p' $MODS_CONF | grep -v loopback | head -n 1; }
+guess_nics() {
+	sed -n 's#.*include\ embox.driver.net.\([a-z0-9_]\+\)\((.*)\|\)$#\1#p' $MODS_CONF | grep -v loopback | head -n 1;
+}
 get_user_undef_guess AUTOQEMU_NICS guess_nics
 
 guessed_info AUTOQEMU_NICS_CONFIG "(got)"

--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -57,7 +57,7 @@ guess_mem() {
 get_user_empty_guess AUTOQEMU_MEM guess_mem
 
 guess_nics() {
-	sed -n 's#.*include\ embox.driver.net.\([a-z0-9_]\+\)\((.*)\|\)$#\1#p' $MODS_CONF | grep -v loopback | head -n 1;
+	sed 's#\(.*\)//.*#\1#p' $MODS_CONF | sed -n 's#.*include\ embox.driver.net.\([a-z0-9_]\+\)\((.*)\|\)$#\1#p' | grep -v loopback | head -n 1;
 }
 get_user_undef_guess AUTOQEMU_NICS guess_nics
 

--- a/templates/arm/footprint_eval_qemu/lds.conf
+++ b/templates/arm/footprint_eval_qemu/lds.conf
@@ -2,7 +2,7 @@
  * Linkage configuration.
  */
 
-/* AUTOQEMU_UIMAGE_SIZE_MB=1 */
+AUTOQEMU_UIMAGE_SIZE_MB=1
 
 RAM (0x81008040, 0x00a0000)
 ROM (0x0, 0M)

--- a/templates/arm/qemu/lds.conf
+++ b/templates/arm/qemu/lds.conf
@@ -2,7 +2,7 @@
  * Linkage configuration.
  */
 
-/* AUTOQEMU_UIMAGE_SIZE_MB=1 */
+AUTOQEMU_UIMAGE_SIZE_MB=1
 /* region (origin, length) */
 /* RAM starts from 0x81000000, uboot end at 0x81000000, board have 128M == 0x8000000,
  pad for bootargs places by uboot is 0x8000 and 0x40 is uboot header,


### PR DESCRIPTION
There were some problems with commented options. For example, it you will replace

@Runlevel(2) include embox.driver.net.virtio

with

//@Runlevel(2) include embox.driver.net.virtio

(i.e. comment this string), autoqemu will try to use nic type "//virtio"

1) Original regex was not correct
2) There is no need to analyze commented strings

This branch fixes this issue