### PR TITLE
Rootfs automount

### DIFF
--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -194,7 +194,7 @@ static int devfs_create(struct inode *i_new, struct inode *i_dir, int mode) {
 	return 0;
 }
 
-static int devfs_ioctl(struct file *desc, int request, ...) {
+static int devfs_ioctl(struct file *desc, int request, void *data) {
 	return 0;
 }
 

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -231,3 +231,11 @@ static struct dumb_fs_driver devfs_dumb_driver = {
 
 ARRAY_SPREAD_DECLARE(struct dumb_fs_driver *, dumb_drv_tab);
 ARRAY_SPREAD_ADD(dumb_drv_tab, &devfs_dumb_driver);
+
+static struct auto_mount devfs_auto_mount = {
+	.mount_path = "/dev",
+	.fs_driver  = &devfs_dumb_driver,
+};
+
+ARRAY_SPREAD_DECLARE(struct auto_mount *, auto_mount_tab);
+ARRAY_SPREAD_ADD(auto_mount_tab, &devfs_auto_mount);

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -81,8 +81,13 @@ int dvfs_create_new(const char *name, struct lookup *lookup, int flags) {
 	dentry_fill(sb, new_inode, lookup->item, lookup->parent);
 	strncpy(lookup->item->name, name, DENTRY_NAME_LEN);
 	inode_fill(sb, new_inode, lookup->item);
-	res = sb->sb_iops->create(new_inode, lookup->parent->d_inode, flags);
 
+	if (flags & DVFS_DIR_VIRTUAL) {
+		lookup->item->flags |= flags;
+		lookup->item->usage_count++;
+	} else {
+		res = sb->sb_iops->create(new_inode, lookup->parent->d_inode, flags);
+	}
 	if (res) {
 		dvfs_destroy_dentry(lookup->item);
 	}
@@ -268,7 +273,7 @@ extern int set_rootfs_sb(struct super_block *sb);
  * @retval       0 Ok
  * @retval -ENOENT Mount point or device not found
  */
-int dvfs_mount(struct block_dev *dev, char *dest, char *fstype, int flags) {
+int dvfs_mount(struct block_dev *dev, char *dest, const char *fstype, int flags) {
 	struct lookup lookup;
 	struct dumb_fs_driver *drv;
 	struct super_block *sb;

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -85,6 +85,8 @@ int dvfs_create_new(const char *name, struct lookup *lookup, int flags) {
 	if (flags & DVFS_DIR_VIRTUAL) {
 		lookup->item->flags |= flags;
 		lookup->item->usage_count++;
+
+		lookup->parent->flags |= DVFS_CHILD_VIRTUAL;
 	} else {
 		res = sb->sb_iops->create(new_inode, lookup->parent->d_inode, flags);
 	}
@@ -293,16 +295,24 @@ int dvfs_mount(struct block_dev *dev, char *dest, const char *fstype, int flags)
 
 		assert(lookup.item->flags & S_IFDIR);
 
-		/* Hide dentry of the directory */
-		dlist_del(&lookup.item->children_lnk);
-		dvfs_cache_del(lookup.item);
+		if (!(lookup.item->flags & DVFS_DIR_VIRTUAL)) {
+			/* Hide dentry of the directory */
+			dlist_del(&lookup.item->children_lnk);
+			dvfs_cache_del(lookup.item);
 
-		d = dvfs_alloc_dentry();
-		dentry_fill(sb, NULL, d, lookup.parent);
+			d = dvfs_alloc_dentry();
+
+			dentry_fill(sb, NULL, d, lookup.parent);
+			strcpy(d->name, lookup.item->name);
+			d->flags |= S_IFDIR;
+		} else {
+			d = lookup.item;
+			/* TODO free related inode */
+		}
+		d->d_sb  = sb,
+		d->d_ops = sb ? sb->sb_dops : NULL,
 		d->usage_count++;
 		sb->root = d;
-		d->flags = S_IFDIR;
-		strcpy(d->name, lookup.item->name);
 
 		d->d_inode = dvfs_alloc_inode(sb);
 		*d->d_inode = (struct inode) {
@@ -335,9 +345,14 @@ int dvfs_iterate(struct lookup *lookup, struct dir_ctx *ctx) {
 	struct inode *parent_inode;
 	struct inode *next_inode;
 	struct dentry *next_dentry = NULL;
+	struct dlist_head *l;
+	int i;
 	int res;
 	assert(lookup);
 	assert(ctx);
+
+	if (ctx->flags & DVFS_CHILD_VIRTUAL)
+		goto lookup_virt;
 
 	sb = lookup->parent->d_sb;
 	parent_inode = lookup->parent->d_inode;
@@ -361,8 +376,25 @@ int dvfs_iterate(struct lookup *lookup, struct dir_ctx *ctx) {
 	dentry_upd_flags(next_dentry);
 
 	if (res) {
-		ctx->pos = 0;
 		dvfs_destroy_dentry(next_dentry);
+		if (lookup->parent->flags & DVFS_CHILD_VIRTUAL) {
+			ctx->flags = DVFS_CHILD_VIRTUAL;
+lookup_virt:
+			i = 0;
+			dlist_foreach(l, &lookup->parent->children) {
+				next_dentry = mcast_out(l, struct dentry, children_lnk);
+
+				if (next_dentry->flags & DVFS_DIR_VIRTUAL) {
+					if (i++ == (ctx->flags & ~DVFS_CHILD_VIRTUAL)) {
+						ctx->flags++;
+						lookup->item = next_dentry;
+						return 0;
+					}
+				}
+			}
+		}
+
+		ctx->pos = 0;
 		next_dentry = NULL;
 	} else {
 		char full_path[DENTRY_NAME_LEN];

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -123,6 +123,11 @@ struct dumb_fs_driver {
 	int (*mount_end)(struct super_block *sb);
 };
 
+struct auto_mount {
+	char mount_path[DENTRY_NAME_LEN];
+	struct dumb_fs_driver *fs_driver;
+};
+
 struct dvfsmnt {
 	struct dvfsmnt *mnt_parent;
 	struct dentry  *mnt_mountpoint;

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -19,9 +19,10 @@
 #define DENTRY_NAME_LEN 36
 #define FS_NAME_LEN     16
 
-#define DVFS_PATH_FULL  0x01
-#define DVFS_PATH_FS    0x02
-#define DVFS_NAME       0x04
+#define DVFS_PATH_FULL   0x01
+#define DVFS_PATH_FS     0x02
+#define DVFS_NAME        0x04
+#define DVFS_DIR_VIRTUAL 0x10000
 
 struct dentry;
 struct dir_ctx;
@@ -184,5 +185,5 @@ extern struct super_block *dvfs_alloc_sb(struct dumb_fs_driver *drv, struct bloc
 
 extern struct dumb_fs_driver *dumb_fs_driver_find(const char *name);
 
-extern int dvfs_mount(struct block_dev *dev, char *dest, char *fstype, int flags);
+extern int dvfs_mount(struct block_dev *dev, char *dest, const char *fstype, int flags);
 #endif

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -19,10 +19,11 @@
 #define DENTRY_NAME_LEN 36
 #define FS_NAME_LEN     16
 
-#define DVFS_PATH_FULL   0x01
-#define DVFS_PATH_FS     0x02
-#define DVFS_NAME        0x04
-#define DVFS_DIR_VIRTUAL 0x10000
+#define DVFS_PATH_FULL     0x01
+#define DVFS_PATH_FS       0x02
+#define DVFS_NAME          0x04
+#define DVFS_DIR_VIRTUAL   0x01
+#define DVFS_CHILD_VIRTUAL 0x10
 
 struct dentry;
 struct dir_ctx;
@@ -143,6 +144,7 @@ struct dvfsmnt {
 
 struct dir_ctx {
 	int   pos;
+	int   flags;
 	void *fs_ctx;
 };
 

--- a/src/fs/rootfs_dvfs.c
+++ b/src/fs/rootfs_dvfs.c
@@ -45,6 +45,8 @@ static int rootfs_mount(void) {
 	struct dumb_fs_driver *fsdrv;
 	struct block_dev *bdev = NULL;
 	struct auto_mount *auto_mnt;
+	struct lookup lu;
+	char *tmp;
 
 	dev = OPTION_STRING_GET(bdev);
 	fs_type = OPTION_STRING_GET(fstype);
@@ -67,9 +69,15 @@ static int rootfs_mount(void) {
 	array_spread_foreach(auto_mnt, auto_mount_tab) {
 		if (fsdrv == auto_mnt->fs_driver)
 			continue;
-		/* TODO Create virtual directory */
-		/* TODO Mount */
-		//dvfs_mount(NULL, auto_mnt->mount_path, auto_mnt->fs_driver->name, 0);
+
+		dvfs_lookup(auto_mnt->mount_path, &lu);
+		if (lu.item == NULL) {
+			tmp = strrchr(auto_mnt->mount_path, '/');
+			dvfs_create_new(tmp ? tmp + 1: auto_mnt->mount_path,
+					&lu, DVFS_DIR_VIRTUAL | S_IFDIR);
+		}
+		dvfs_mount(NULL, auto_mnt->mount_path, auto_mnt->fs_driver->name, 0);
 	}
+
 	return 0;
 }


### PR DESCRIPTION
Implement automatic mount of required FS on system initialization.
Corresponding folders are now being created even if root file system is read-only.