### PR TITLE
fatfs file create error fix

### DIFF
--- a/src/drivers/block_dev/ramdisk/ramdisk.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk.c
@@ -77,7 +77,6 @@ struct ramdisk *ramdisk_create(char *path, size_t size) {
 	}
 
 	ramdisk->blocks = ramdisk_size / RAMDISK_BLOCK_SIZE;
-	ramdisk->block_size = RAMDISK_BLOCK_SIZE;
 
 	ramdisk->p_start_addr = phymem_alloc(page_n);
 	if (NULL == (ramdisk->p_start_addr)) {
@@ -97,7 +96,7 @@ struct ramdisk *ramdisk_create(char *path, size_t size) {
 	}
 
 	ramdisk->bdev->size = ramdisk_size;
-
+	ramdisk->bdev->block_size = RAMDISK_BLOCK_SIZE;
 	return ramdisk;
 
 err_free_bdev_idx:
@@ -167,7 +166,7 @@ static int read_sectors(block_dev_t *bdev,
 	char *read_addr;
 
 	ramdisk = (ramdisk_t *) bdev->privdata;
-	read_addr = ramdisk->p_start_addr + (blkno * ramdisk->block_size);
+	read_addr = ramdisk->p_start_addr + (blkno * bdev->block_size);
 
 	memcpy(buffer, read_addr, count);
 	return count;
@@ -180,7 +179,7 @@ static int write_sectors(block_dev_t *bdev,
 	char *write_addr;
 
 	ramdisk = (ramdisk_t *) bdev->privdata;
-	write_addr = ramdisk->p_start_addr + (blkno * ramdisk->block_size);
+	write_addr = ramdisk->p_start_addr + (blkno * bdev->block_size);
 
 	memcpy(write_addr, buffer, count);
 	return count;
@@ -194,7 +193,7 @@ static int ram_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size) {
 		return ramd->blocks;
 
 	case IOCTL_GETBLKSIZE:
-		return ramd->block_size;
+		return bdev->block_size;
 	}
 	return -ENOSYS;
 }

--- a/src/drivers/block_dev/ramdisk/ramdisk.h
+++ b/src/drivers/block_dev/ramdisk/ramdisk.h
@@ -18,7 +18,6 @@ typedef struct ramdisk {
 	struct block_dev *bdev;
 	char             *p_start_addr;
 	size_t            blocks;
-	size_t            block_size;
 } ramdisk_t;
 
 extern struct ramdisk *ramdisk_create(char *path, size_t size);

--- a/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
@@ -71,6 +71,7 @@ struct ramdisk *ramdisk_create(char *path, size_t size) {
 		goto err_free_mem;
 
 	bdev->privdata = ram;
+	bdev->block_size = ram->block_size; /* TODO use single block size */
 	bdev->size = ramdisk_size;
 err_free_mem:
 	phymem_free(ram->p_start_addr, page_n);

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -87,6 +87,7 @@ int fat_create_partition(void *dev, int fat_n) {
 	struct block_dev *bdev = dev;
 	uint16_t bytepersec = bdev->block_size;
 	size_t num_sect = block_dev(bdev)->size / bytepersec;
+	assert(bdev->block_size <= FAT_MAX_SECTOR_SIZE);
 	uint32_t secperfat = 1;
 	uint16_t rootentries = 0x0200;             /* 512 for FAT16 */
 	struct lbr lbr = (struct lbr) {

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -87,7 +87,7 @@ int fat_create_partition(void *dev, int fat_n) {
 	struct block_dev *bdev = dev;
 	uint16_t bytepersec = bdev->block_size;
 	size_t num_sect = block_dev(bdev)->size / bytepersec;
-	uint32_t secperfat; /* We have two FA Tables */
+	uint32_t secperfat = 1;
 	uint16_t rootentries = 0x0200;             /* 512 for FAT16 */
 	struct lbr lbr = (struct lbr) {
 		.jump = {0xeb, 0x3c, 0x90},        /* JMP 0x3c; NOP; */
@@ -125,7 +125,6 @@ int fat_create_partition(void *dev, int fat_n) {
 	switch (fat_n) {
 	case 12:
 	case 16:
-		secperfat = min(0xFFFF, num_sect / 2);
 		lbr.bpb.secperfat_l   = (uint8_t)(0x00FF & secperfat),
 		lbr.bpb.secperfat_h   = (uint8_t)(0x00FF & (secperfat >> 8)),
 		lbr.ebpb.ebpb = (struct ebpb) {
@@ -145,7 +144,6 @@ int fat_create_partition(void *dev, int fat_n) {
 		memcpy(lbr.ebpb.ebpb.code, bootcode, sizeof(bootcode));
 		break;
 	case 32:
-		secperfat = num_sect / 2;
 		lbr.ebpb.ebpb32 = (struct ebpb32) {
 			.fatsize_0 = (uint8_t) (0xFF & secperfat),
 			.fatsize_1 = (uint8_t) (0xFF & (secperfat >> 8)),
@@ -278,7 +276,6 @@ uint32_t fat_get_volinfo(void *bdev, struct volinfo * volinfo, uint32_t startsec
 	else {
 		memcpy(volinfo->label, lbr->ebpb.ebpb.label, MSDOS_NAME);
 		volinfo->label[11] = 0;
-
 	}
 
 	/* note: if rootentries is 0, we must be in a FAT32 volume. */
@@ -295,8 +292,7 @@ uint32_t fat_get_volinfo(void *bdev, struct volinfo * volinfo, uint32_t startsec
 
 	if (volinfo->rootentries) {
 		volinfo->rootdir = volinfo->fat1 + (volinfo->secperfat * 2);
-		volinfo->dataarea = volinfo->rootdir + (((volinfo->rootentries * 32) +
-				(volinfo->bytepersec - 1)) / volinfo->bytepersec);
+		volinfo->dataarea = volinfo->rootdir + (((volinfo->rootentries * 32) + (volinfo->bytepersec - 1)) / volinfo->bytepersec);
 	} else {
 		volinfo->dataarea = volinfo->fat1 + (volinfo->secperfat * 2);
 		volinfo->rootdir = (uint32_t) lbr->ebpb.ebpb32.root_0 |

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -337,6 +337,9 @@ static int fat_fill_sb(struct super_block *sb, struct block_dev *dev) {
 static int fat_mount_end(struct super_block *sb) {
 	struct dirinfo *di;
 	struct volinfo *vi;
+
+	assert(sb->bdev->block_size <= FAT_MAX_SECTOR_SIZE);
+
 	if (NULL == (di = fat_dirinfo_alloc()))
 		return -ENOMEM;
 


### PR DESCRIPTION
Fix error on file create. Error was related to ramdisk block size (default 4096, and fat was expecting 512).