### PR TITLE
Python 2.6 doesn't support dict comprehension syntax

### DIFF
--- a/mk/gensums.py
+++ b/mk/gensums.py
@@ -31,7 +31,7 @@ def parse(file, sectname):
         target[k] = int(m.group(1), 16)
 
     assert len(vmas) == len(lens)
-    return { k: (vmas[k], lens[k]) for k in vmas }
+    return dict( (k, (vmas[k], lens[k])) for k in vmas )
 
 def main(nmfile, sectname, sectfile, vma_offset):
     stat = parse(sys.stdin, sectname)


### PR DESCRIPTION
Centos/RHEL 7/6: default python 2.6.