### PR TITLE
mk: initfs: Remove explicit commands for creating parent directory

### DIFF
--- a/mk/image2.mk
+++ b/mk/image2.mk
@@ -31,19 +31,15 @@ include $(__include_initfs)
 include $(__include)
 
 initfs_cp_prerequisites = $(src_file) $(common_prereqs)
-$(ROOTFS_DIR)/%/. : | $(ROOTFS_DIR)/.
-	@mkdir -p $(@D)
-	@touch $@
 
-cp_T_if_supported := $(shell $(CP) --version 2>&1 | grep -l GNU >/dev/null && echo -T)
-$(ROOTFS_DIR)/% : | $(ROOTFS_DIR)/.
+cp_T_if_supported := \
+	$(shell $(CP) --version 2>&1 | grep -l GNU >/dev/null && echo -T)
+
+$(ROOTFS_DIR)/% :
 	$(CP) -r $(cp_T_if_supported) $(src_file) $@$(if \
 		$(and $(chmod),$(findstring $(chmod),'')),,;chmod $(chmod) $@)
 	@touch $@ # workaround when copying directories
 	@find $@ -name .gitkeep -type f -print0 | xargs -0 /bin/rm -rf
-
-$(ROOTFS_DIR)/. :
-	@$(MKDIR) $(@D)
 
 fmt_line = $(addprefix \$(\n)$(\t)$(\t),$1)
 
@@ -51,8 +47,8 @@ initfs_prerequisites = $(cpio_files) \
 	$(wildcard $(USER_ROOTFS_DIR) $(USER_ROOTFS_DIR)/*) $(common_prereqs)
 $(ROOTFS_IMAGE) : rel_cpio_files = \
 		$(patsubst $(abspath $(ROOTFS_DIR))/%,%,$(abspath $(cpio_files)))
-$(ROOTFS_IMAGE) : | $(ROOTFS_DIR)/.
 $(ROOTFS_IMAGE) :
+	@mkdir -p $(ROOTFS_DIR)
 	cd $(ROOTFS_DIR) \
 		&& find $(rel_cpio_files) -depth -print | $(CPIO) -L --quiet -H newc -o -O $(abspath $@)
 	if [ -d $(USER_ROOTFS_DIR) ]; \

--- a/mk/script/build/build-gen.mk
+++ b/mk/script/build/build-gen.mk
@@ -652,11 +652,11 @@ $(@source_mk_rmk):
 		$(gen_banner); \
 		$(call gen_make_include,$(file)))
 
-source_initfs_cp_target_dir=$(call get,$(call source_annotation_values,$s,$(my_initfs_target_dir)),value)
+source_initfs_cp_target_dir = $(call get,$(call source_annotation_values,$s,$(my_initfs_target_dir)),value)/
 source_initfs_cp_target_name=$(or $(strip \
 	$(call get,$(call source_annotation_values,$s,$(my_initfs_target_name)),value)),$(call get,$s,fileName))
 source_initfs_cp_out = $(addprefix $$(ROOTFS_DIR)/, \
-	       $(foreach s,$1,$(source_initfs_cp_target_dir)/$(source_initfs_cp_target_name)))
+		$(foreach s,$1,$(source_initfs_cp_target_dir:/%=%)$(source_initfs_cp_target_name)))
 
 $(@source_initfs_cp_rmk) : out = $(call source_initfs_cp_out,$@)
 $(@source_initfs_cp_rmk) : src_file = $(file)


### PR DESCRIPTION
The necessary behavior is handled through `$(common_prereqs)` that contains a secondarily-expanded order-only `| $(@D)/.` prerequisite.

This should fix weird and floating bug reproduced during parallel builds, when (presumably) an initfs target rule was itself applied for creating its parent directory, inheriting the target-specific `$(src_file)`:

    cp -r -T $(src_file) $@    # $@ is $(ROOTFS_DIR)/dst_file

Which depends on (order-only) `| $(ROOTFS_DIR)/`.

    cp -r -T $(src_file) $@    # $@ is now $(ROOTFS_DIR)/.

Resulting in the following error:

    cp: cannot overwrite directory .../rootfs//. with non-directory

An indirect reason of this behavior is a bogus double-slash ('//') as a separator that made Make choose the `$(ROOTFS_DIR)/%` rule instead of the proper `$(ROOTFS_DIR)/.` one. This is fixed in build-gen.