### PR TITLE
Fix regression introduced in #856, fix Dash 'bad substitution' error

### DIFF
--- a/mk/image2.mk
+++ b/mk/image2.mk
@@ -35,6 +35,18 @@ initfs_cp_prerequisites = $(src_file) $(common_prereqs)
 cp_T_if_supported := \
 	$(shell $(CP) --version 2>&1 | grep -l GNU >/dev/null && echo -T)
 
+# This rule is necessary because otherwise, when considering a rule for
+# creating the $(ROOTFS_DIR) directory (required through $(common_prereqs)
+# using the secondarily-expanded order-only '| $(@D)/.' prerequisite),
+# the '$(ROOTFS_DIR)/%' rule takes precedence over the proper '%/.' one, since
+# the former needs a shorter stem ('.') than the latter ('build/.../rootfs').
+# This is reproduced only on GNU Make >= 3.82, because of the change in how
+# implicit rule search works in Make.
+$(ROOTFS_DIR)/. :
+	@mkdir -p $@
+$(ROOTFS_DIR)/%/. :
+	@mkdir -p $@
+
 $(ROOTFS_DIR)/% :
 	$(CP) -r $(cp_T_if_supported) $(src_file) $@$(if \
 		$(and $(chmod),$(findstring $(chmod),'')),,;chmod $(chmod) $@)

--- a/mk/image_lib.mk
+++ b/mk/image_lib.mk
@@ -47,7 +47,28 @@ $(OBJ_DIR)/%.lds : $(ROOT_DIR)/%.lds.S
 	-imacros $(SRCGEN_DIR)/config.lds.h \
 		-MMD -MT $@ -MF $@.d -o $@ $<
 
-# XXX GCC built for Windows doesn't recognize /cygdrive/... absolute paths -- Eldar
-.SHELLFLAGS = -c$(if $(filter %.o %.lds,$(value @)), '$(SHELL) -c "$${0//$$PWD/.}"')
+ifeq ($(value OSTYPE),cygwin)
+# GCC built for Windows doesn't recognize /cygdrive/... absolute paths. As a
+# workaround, for every rule calling GCC (determined through the target
+# extension: .o and .lds) we invoke a sub-shell, passing a patched command to
+# it. That is,
+#
+#     sh -c 'gcc ... /cygdrive/path/to/embox/src/file.c'
+#
+# Becomes:
+#
+#     sh -c "${0//$PWD/.}" "sh -c 'gcc ... /cygdrive/path/to/embox/src/file.c'"
+#
+# Which, in turn, expands by the outer shell to (roughly) the following:
+#
+#     sh -c "sh -c 'gcc ... ./src/file.c'"
+#
+# This is a _really_ dirty hack. It also breaks the build in case of using dash
+# as a shell, since the latter doesn't understand ${PARAMETER//PATTERN/STRING}
+# expansions, resulting in a 'Bad substitution' error.
+.SHELLFLAGS = \
+	-c$(if $(filter %.o %.lds,$(value @)), \
+		'$(SHELL) -c "$${0//$$PWD/.}"')
+endif
 
 endif


### PR DESCRIPTION
Fix a bug occurring on GNU Make >= 3.82 (reported by @Deryugin for gmake-4.0, reproduced on remake-4.1) due to the changed order of implicit rule search.

Also make a `/cygdrive/...` SHELL workaround conditional for Cygwin only. This one was breaking builds using Dash with the 'Bad substitution' error.