### PR TITLE
Implement umount for new VFS

### DIFF
--- a/src/cmds/fs/Mkdir.my
+++ b/src/cmds/fs/Mkdir.my
@@ -10,6 +10,9 @@ package embox.cmd.fs
 			mkdir [ -m MODE ] directory_name
 		DESCRIPTION
 			mkdir is used to create a directory
+		OPTIONS
+			-v
+				Create virtual directory. Could be useful for readonly FS.
 		AUTHORS
 			Nikolay Korotky
 	''')

--- a/src/cmds/fs/mkdir.c
+++ b/src/cmds/fs/mkdir.c
@@ -13,8 +13,10 @@
 #include <string.h>
 #include <stdlib.h>
 
+#define DVFS_DIR_VIRTUAL   0x01000000
+
 static void print_usage(void) {
-	printf("Usage: mkdir [ -m MODE ] DIR ...\n");
+	printf("Usage: mkdir [-v] [-m MODE] DIR ...\n");
 }
 
 int main(int argc, char **argv) {
@@ -23,7 +25,7 @@ int main(int argc, char **argv) {
 	int mode_set = 0;
 	int mode = 0777;
 
-	while (-1 != (opt = getopt(argc - 1, argv, "hm:"))) {
+	while (-1 != (opt = getopt(argc - 1, argv, "hm:v"))) {
 		switch(opt) {
 		case 'h':
 			print_usage();
@@ -31,6 +33,9 @@ int main(int argc, char **argv) {
 		case 'm':
 			mode = strtol(optarg, NULL, 8);
 			mode_set = 1;
+			break;
+		case 'v':
+			mode |= DVFS_DIR_VIRTUAL;
 			break;
 		default:
 			return 0;

--- a/src/cmds/fs/mount.c
+++ b/src/cmds/fs/mount.c
@@ -64,7 +64,7 @@ extern struct dlist_head dentry_dlist;
 
 static void show_mount_list(void) {
 	struct dentry *d;
-	char mount_path[DENTRY_NAME_LEN];
+	char mount_path[DVFS_MAX_PATH_LEN];
 
 	dlist_foreach_entry(d, &dentry_dlist, d_lnk) {
 		if (d->flags & DVFS_MOUNT_POINT) {

--- a/src/cmds/fs/umount.c
+++ b/src/cmds/fs/umount.c
@@ -45,10 +45,10 @@ int main(int argc, char **argv) {
 		printf("Can't unmount %s, device is in use.\n", dir);
 		break;
 	case -ENOENT:
-		printf("%s not found.\n");
+		printf("%s not found.\n", dir);
 		break;
 	case -EINVAL:
-		printf("%s is not a mount point.\n");
+		printf("%s is not a mount point.\n", dir);
 	}
 
 	return 0;

--- a/src/cmds/fs/umount.c
+++ b/src/cmds/fs/umount.c
@@ -40,5 +40,14 @@ int main(int argc, char **argv) {
 	}
 	dir = argv[argc - 1];
 
-	return umount(dir);
+	switch(umount(dir)) {
+	case -EBUSY:
+		printf("Can't unmount %s, device is in use!\n", dir);
+		break;
+	case -ENOENT:
+		printf("%s not found!\n");
+		break;
+	}
+
+	return 0;
 }

--- a/src/cmds/fs/umount.c
+++ b/src/cmds/fs/umount.c
@@ -42,11 +42,13 @@ int main(int argc, char **argv) {
 
 	switch(umount(dir)) {
 	case -EBUSY:
-		printf("Can't unmount %s, device is in use!\n", dir);
+		printf("Can't unmount %s, device is in use.\n", dir);
 		break;
 	case -ENOENT:
-		printf("%s not found!\n");
+		printf("%s not found.\n");
 		break;
+	case -EINVAL:
+		printf("%s is not a mount point.\n");
 	}
 
 	return 0;

--- a/src/compat/posix/fs/dvfs/fsop.c
+++ b/src/compat/posix/fs/dvfs/fsop.c
@@ -29,16 +29,23 @@ int mkdir(const char *pathname, mode_t mode) {
 		parent[strlen(parent) - 1] = '\0';
 
 	t = strrchr(parent, '/');
-	memset(t, '\0', parent + DENTRY_NAME_LEN - t);
+	if (t) {
+		memset(t, '\0', parent + DENTRY_NAME_LEN - t);
 
-	dvfs_lookup(parent, &lu);
-	if (!lu.item)
-		return SET_ERRNO(ENOENT);
+		dvfs_lookup(parent, &lu);
+		if (!lu.item)
+			return SET_ERRNO(ENOENT);
 
-	lu.parent = lu.item;
-	lu.item = NULL;
+		lu.parent = lu.item;
+		lu.item = NULL;
+	} else {
+		parent[0] = '\0';
+		dvfs_lookup(pathname, &lu);
+	}
 
-	return dvfs_create_new(pathname + strlen(parent), &lu, S_IFDIR);
+	return dvfs_create_new(pathname + strlen(parent),
+	                       &lu,
+			       S_IFDIR | (mode & DVFS_DIR_VIRTUAL));
 }
 
 int remove(const char *pathname) {

--- a/src/compat/posix/fs/dvfs/fsop.c
+++ b/src/compat/posix/fs/dvfs/fsop.c
@@ -24,7 +24,8 @@ int mkdir(const char *pathname, mode_t mode) {
 	if (lu.item)
 		return SET_ERRNO(EEXIST);
 
-	strncpy(parent, pathname, sizeof(parent));
+	parent[0] = '\0';
+	strncat(parent, pathname, sizeof(parent) - 1);
 	if (parent[strlen(parent) - 1] == '/')
 		parent[strlen(parent) - 1] = '\0';
 

--- a/src/compat/posix/fs/dvfs/fsop.c
+++ b/src/compat/posix/fs/dvfs/fsop.c
@@ -17,7 +17,7 @@ int mkdir(const char *pathname, mode_t mode) {
 	struct lookup lu;
 	char *t;
 
-	char parent[DENTRY_NAME_LEN];
+	char parent[DVFS_MAX_PATH_LEN];
 
 	dvfs_lookup(pathname, &lu);
 
@@ -30,7 +30,7 @@ int mkdir(const char *pathname, mode_t mode) {
 
 	t = strrchr(parent, '/');
 	if (t) {
-		memset(t + 1, '\0', parent + DENTRY_NAME_LEN - t);
+		memset(t + 1, '\0', parent + DVFS_MAX_PATH_LEN - t);
 
 		dvfs_lookup(parent, &lu);
 		if (!lu.item)

--- a/src/compat/posix/fs/dvfs/fsop.c
+++ b/src/compat/posix/fs/dvfs/fsop.c
@@ -30,7 +30,7 @@ int mkdir(const char *pathname, mode_t mode) {
 
 	t = strrchr(parent, '/');
 	if (t) {
-		memset(t, '\0', parent + DENTRY_NAME_LEN - t);
+		memset(t + 1, '\0', parent + DENTRY_NAME_LEN - t);
 
 		dvfs_lookup(parent, &lu);
 		if (!lu.item)

--- a/src/fs/driver/dfs/dfs.c
+++ b/src/fs/driver/dfs/dfs.c
@@ -497,13 +497,14 @@ struct inode_operations dfs_iops = {
 	.pathname = dfs_pathname,
 };
 
-static int dfs_open(struct inode *node, struct file *desc) {
+static struct idesc *dfs_open(struct inode *node, struct idesc *desc) {
 	if (!desc || !node) {
-		return ENOENT;
+		SET_ERRNO(ENOENT);
+		return NULL;
 	}
 
-	desc->f_ops = &dfs_fops;
-	return 0;
+	((struct file*)desc)->f_ops = &dfs_fops;
+	return desc;
 }
 
 static int dfs_close(struct file *desc) {

--- a/src/fs/driver/dfs/dfs.c
+++ b/src/fs/driver/dfs/dfs.c
@@ -209,7 +209,7 @@ int dfs_format(void) {
 	root.flags     = S_IFDIR;
 	sbi->free_space += MIN_FILE_SZ;
 	dfs_write_dirent(0, &root);
-	memset(buf, 0xff, sizeof(buf));
+	memset(buf, DFS_DIRENT_EMPTY, sizeof(buf));
 	for (i = 0; i < MIN_FILE_SZ / sizeof(buf); i++)
 		dfs_write_raw(root.pos_start + i * sizeof(buf),
 		              buf,
@@ -340,7 +340,7 @@ static int dfs_icreate(struct inode *i_new,
 	};
 
 	if (FILE_TYPE(S_IFDIR, mode)) {
-		memset(buf, 0xff, sizeof(buf));
+		memset(buf, DFS_DIRENT_EMPTY, sizeof(buf));
 		for (i = 0; i < dirent.len / sizeof(buf); i++)
 			dfs_write_raw(dirent.pos_start + i * sizeof(buf),
 			              buf,
@@ -356,7 +356,7 @@ static int dfs_icreate(struct inode *i_new,
 	/* Write entry to parent directory */
 	for (i = 0; i < i_dir->length; i++) {
 		_read(i_dir->start_pos + i, &t, 1);
-		if (t != 0xFF)
+		if (t != DFS_DIRENT_EMPTY)
 			/* Entry taken */
 			continue;
 		_write(i_dir->start_pos + i, &i_new->i_no, 1);
@@ -449,8 +449,7 @@ static int dfs_iterate(struct inode *next, struct inode *parent, struct dir_ctx 
 
 	for (i = dir_pos; i < parent->length; i++) {
 		_read(parent->start_pos + i, &candidate, 1);
-		if (candidate == 0xFF)
-			/* Empty entry */
+		if (candidate == DFS_DIRENT_EMPTY)
 			continue;
 
 		dfs_read_dirent(candidate, &dirent);

--- a/src/fs/driver/dfs/dfs.h
+++ b/src/fs/driver/dfs/dfs.h
@@ -16,8 +16,9 @@
 #define DFS_NAME_LEN \
 	OPTION_MODULE_GET(embox__fs__driver__dfs, NUMBER, max_name_len)
 
-#define DFS_POS_MASK 0x00FF
-#define DFS_DIR_MASK 0xFF00
+#define DFS_POS_MASK     0x00FF
+#define DFS_DIR_MASK     0xFF00
+#define DFS_DIRENT_EMPTY 0xFF
 
 /* Non-VFS declarations */
 struct dfs_sb_info {

--- a/src/fs/driver/fat/fat.h
+++ b/src/fs/driver/fat/fat.h
@@ -13,9 +13,11 @@
 
 #include <fs/mbr.h>
 
-#define MSDOS_NAME      11
-#define ROOT_DIR        "/"
 #define DIR_SEPARATOR   '/'	/* character separating directory components*/
+#define ROOT_DIR        "/"
+#define MSDOS_NAME      11
+#define MSDOS_DOT     ".          "
+#define MSDOS_DOTDOT  "..         "
 
 /* 32-bit error codes */
 #define DFS_OK        0          /* no error */
@@ -26,7 +28,7 @@
 #define DFS_ALLOCNEW  5	         /* must allocate new directory cluster */
 #define DFS_ERRMISC   0xffffffff /* generic error */
 #define DFS_WRONGRES  6          /* file expected but dir found or vice versa */
-
+#define DFS_BAD_CLUS  0x0ffffff7
 /* Internal subformat identifiers */
 #define FAT12 0
 #define FAT16 1

--- a/src/fs/driver/fat/fat.h
+++ b/src/fs/driver/fat/fat.h
@@ -241,13 +241,12 @@ struct fat_file_info {
  *	Directory search structure (Internal to DOSFS)
  */
 struct dirinfo {
+	struct fat_file_info fi;	/* Must be first field in structure */
 	uint32_t currentcluster;	/* current cluster in dir */
 	uint8_t currentsector;		/* current sector in cluster */
 	uint8_t currententry;		/* current dir entry in sector */
 	uint8_t *p_scratch;			/* ptr to user-supplied scratch buffer (one sector) */
 	uint8_t flags;				/* internal DOSFS flags */
-
-	struct fat_file_info fi;
 };
 
 #include <framework/mod/options.h>

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -1631,9 +1631,23 @@ int fat_create_file(struct fat_file_info *fi, struct dirinfo *di, char *name, in
 	return DFS_OK;
 }
 
-POOL_DEF(fat_fs_pool, struct fat_fs_info, 4);
-POOL_DEF(fat_file_pool, struct fat_file_info, 16);
-POOL_DEF(fat_dirinfo_pool, struct dirinfo, 16);
+#include <framework/mod/options.h>
+
+POOL_DEF(fat_fs_pool,
+         struct fat_fs_info,
+	 OPTION_GET(NUMBER, fat_descriptor_quantity));
+
+POOL_DEF(fat_file_pool,
+         struct fat_file_info,
+         OPTION_GET(NUMBER, inode_quantity));
+
+POOL_DEF(fat_dirinfo_pool,
+         struct dirinfo,
+         OPTION_GET(NUMBER, inode_quantity));
+
+POOL_DEF(fat_dirent_pool,
+         struct dirent,
+         OPTION_GET(NUMBER, inode_quantity));
 
 struct fat_fs_info *fat_fs_alloc(void) {
 	return pool_alloc(&fat_fs_pool);
@@ -1658,4 +1672,3 @@ struct dirinfo *fat_dirinfo_alloc(void) {
 void fat_dirinfo_free(struct dirinfo *di) {
 	pool_free(&fat_dirinfo_pool, di);
 }
-

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -634,14 +634,12 @@ uint32_t fat_open_dir(struct fat_fs_info *fsi,
 
 	if (dir_is_root(dirname)) {
 		dirinfo->currentcluster = volinfo->rootdir / volinfo->secperclus;
-		if (volinfo->filesystem == FAT32) {
-			return fat_read_sector(fsi, dirinfo->p_scratch,
-					volinfo->dataarea +	((volinfo->rootdir - 2)
-							* volinfo->secperclus));
-		} else {
-			return fat_read_sector(fsi, dirinfo->p_scratch,
-					volinfo->rootdir);
-		}
+		if (volinfo->filesystem == FAT32)
+			dirinfo->currentsector = volinfo->dataarea +
+				((volinfo->rootdir - 2) * volinfo->secperclus);
+		else
+			dirinfo->currentsector = volinfo->rootdir;
+		return fat_read_sector(fsi, dirinfo->p_scratch, dirinfo->currentsector);
 	} else {
 		uint8_t tmpfn[12];
 		uint8_t *ptr = dirname;
@@ -1596,7 +1594,7 @@ int fat_create_file(struct fat_file_info *fi, struct dirinfo *di, char *name, in
 
 	//fi->dirsector = volinfo->dataarea + (di->fi.cluster - 2) * volinfo->secperclus;
 	/* 'di' have to be filled already */
-	fi->dirsector = di->currentcluster;
+	fi->dirsector = di->currentsector;
 	fi->diroffset = di->currententry - 1;
 	fi->cluster = cluster;
 	fi->firstcluster = cluster;

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -346,12 +346,8 @@ uint32_t fat_get_fat_(struct fat_fs_info *fsi,
 		default:
 			return DFS_BAD_CLUS;
 	}
-	/*
-	 * at this point, offset is the BYTE offset of the desired sector from
-	 * the start of the FAT. Calculate the physical sector containing this
-	 *  FAT entry.
-	 */
-	sector = ldiv(offset, volinfo->bytepersec).quot + volinfo->fat1;
+
+	sector = offset / volinfo->bytepersec + volinfo->fat1;
 
 	if (sector != *p_scratchcache) {
 		if (fat_read_sector(fsi, p_scratch, sector)) {
@@ -372,7 +368,7 @@ uint32_t fat_get_fat_(struct fat_fs_info *fsi,
 	 * always to read two FAT sectors, but that luxury is (by design intent)
 	 * unavailable to DOSFS.
 	 */
-	offset = ldiv(offset, volinfo->bytepersec).rem;
+	offset %= volinfo->bytepersec;
 	if (volinfo->filesystem == FAT12) {
 		/* Special case for sector boundary - Store last byte of current sector
 		 * Then read in the next sector and put the first byte of that sector
@@ -938,7 +934,7 @@ int fat_root_dir_record(void *bdev) {
 		return -1;
 	}
 
-	cluster = fat_get_free_fat_(&fsi, fat_sector_buff);
+	cluster = 0; //fat_get_free_fat_(&fsi, fat_sector_buff);
 
 	de = (struct dirent) {
 		.name = "ROOT DIR   ",

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -856,9 +856,9 @@ uint32_t fat_get_free_dir_ent(struct fat_fs_info *fsi, uint8_t *path,
 
 	volinfo = &fsi->vi;
 
-	if (fat_open_dir(fsi, path, di)) {
-		return DFS_NOTFOUND;
-	}
+	//if (fat_open_dir(fsi, path, di)) {
+	//	return DFS_NOTFOUND;
+	//}
 
 	di->flags |= DFS_DI_BLANKENT;
 

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -959,12 +959,6 @@ int fat_root_dir_record(void *bdev) {
 	 * entry, tragically, so we have to re-read it
 	 */
 
-	if (0 > block_dev_read(	bdev,
-				(char *) fat_sector_buff,
-				sizeof(struct dirent),
-				fsi.vi.rootdir * fsi.vi.bytepersec / dev_blk_size)) {
-		return DFS_ERRMISC;
-	}
 	/* we clear other FAT TABLE */
 	memset(fat_sector_buff, 0, sizeof(fat_sector_buff));
 

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -455,7 +455,7 @@ uint32_t fat_set_fat_(struct fat_fs_info *fsi, uint8_t *p_scratch,
 	 * the start of the FAT.
 	 * Calculate the physical sector containing this FAT entry.
 	 */
-	sector = ldiv(offset, volinfo->bytepersec).quot + volinfo->fat1;
+	sector = offset / volinfo->bytepersec + volinfo->fat1;
 
 	/* If this is not the same sector we last read, then read it into RAM */
 	if (sector != *p_scratchcache) {
@@ -477,7 +477,7 @@ uint32_t fat_set_fat_(struct fat_fs_info *fsi, uint8_t *p_scratch,
 	 * is always to read two FAT sectors, but that luxury is (by design intent)
 	 * unavailable to DOSFS.
 	 */
-	offset = ldiv(offset, volinfo->bytepersec).rem;
+	offset %= volinfo->bytepersec;
 
 	switch (volinfo->filesystem) {
 	case FAT12:
@@ -1590,7 +1590,7 @@ int fat_create_file(struct fat_file_info *fi, struct dirinfo *di, char *name, in
 
 	//fi->dirsector = volinfo->dataarea + (di->fi.cluster - 2) * volinfo->secperclus;
 	/* 'di' have to be filled already */
-	fi->dirsector = di->currentsector;
+	fi->dirsector = di->currentsector + di->currentcluster * volinfo->secperclus;
 	fi->diroffset = di->currententry - 1;
 	fi->cluster = cluster;
 	fi->firstcluster = cluster;

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -956,7 +956,7 @@ int fat_root_dir_record(void *bdev) {
 		return -1;
 	}
 
-	cluster = 0; //fat_get_free_fat_(&fsi, fat_sector_buff);
+	cluster = fsi.vi.rootdir / fsi.vi.secperclus;
 
 	de = (struct dirent) {
 		.name = "ROOT DIR   ",

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -943,7 +943,7 @@ int fat_root_dir_record(void *bdev) {
 	cluster = fat_get_free_fat_(&fsi, fat_sector_buff);
 
 	de = (struct dirent) {
-		.name = "/ROOT      ",
+		.name = ".          ",
 		.attr = ATTR_DIRECTORY,
 		.startclus_l_l = cluster & 0xff,
 		.startclus_l_h = (cluster & 0xff00) >> 8,

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -167,6 +167,8 @@ int fat_create_partition(void *dev, int fat_n) {
 		memcpy(lbr.ebpb.ebpb32.system, SYSTEM32, sizeof(lbr.ebpb.ebpb32.system));
 		memcpy(lbr.ebpb.ebpb32.code, bootcode, sizeof(bootcode));
 		break;
+	default:
+		return -1;
 	}
 
 	return 0 < block_dev_write(bdev, (void *) &lbr, sizeof(lbr), 0);

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -944,7 +944,7 @@ int fat_root_dir_record(void *bdev) {
 	cluster = fat_get_free_fat_(&fsi, fat_sector_buff);
 
 	de = (struct dirent) {
-		.name = ".          ",
+		.name = "ROOT DIR   ",
 		.attr = ATTR_DIRECTORY,
 		.startclus_l_l = cluster & 0xff,
 		.startclus_l_h = (cluster & 0xff00) >> 8,

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -245,7 +245,7 @@ static int fat_iterate(struct inode *next, struct inode *parent, struct dir_ctx 
 
 	fsi = parent->i_sb->sb_data;
 	dirinfo = parent->i_data;
-	dirinfo->currententry = 0;
+	dirinfo->currententry = (int) ctx->fs_ctx;
 	read_dir_buf(fsi, dirinfo);
 
 	while (((res = fat_get_next(fsi, dirinfo, &de)) ==  DFS_OK) || res == DFS_ALLOCNEW)
@@ -257,6 +257,7 @@ static int fat_iterate(struct inode *next, struct inode *parent, struct dir_ctx 
 	switch (res) {
 	case DFS_OK:
 		fat_fill_inode(next, &de, dirinfo);
+		ctx->fs_ctx = (void*) ((int)dirinfo->currententry);
 		return 0;
 	case DFS_EOF:
 		/* Fall through */
@@ -301,7 +302,7 @@ static int fat_pathname(struct inode *inode, char *buf, int flags) {
 
 		if (fat_read_sector(fsi, fat_sector_buff, fi->dirsector))
 			return -1;
-		strcpy(buf, (char*) ((struct dirent*) fat_sector_buff)[fi->diroffset].name);
+		strncpy(buf, (char*) ((struct dirent*) fat_sector_buff)[fi->diroffset].name, 11);
 		return 0;
 	default:
 		/* NIY */

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -382,12 +382,13 @@ static int fat_fill_sb(struct super_block *sb, struct block_dev *dev) {
 */
 static int fat_mount_end(struct super_block *sb) {
 	struct dirinfo *di;
-	uint8_t tmp[] = { 'R', 'O', 'O', 'T', ' ', 'D',
-	                  'I', 'R', ' ', ' ', ' '};
+	uint8_t tmp[] = { '\0' };
 	assert(sb->bdev->block_size <= FAT_MAX_SECTOR_SIZE);
 
 	if (NULL == (di = fat_dirinfo_alloc()))
 		return -ENOMEM;
+
+	di->p_scratch = fat_sector_buff;
 
 	if (fat_open_dir(sb->sb_data, tmp, di))
 		return -1;

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -145,7 +145,9 @@ err_out:
 * @retval 0 Success
 */
 static inline int read_dir_buf(struct fat_fs_info *fsi, struct dirinfo *di) {
-	return fat_read_sector(fsi, fat_sector_buff, di->currentsector);
+	return fat_read_sector(fsi,
+	                       di->p_scratch,
+	                       fsi->vi.secperclus * di->currentcluster + di->currentsector);
 }
 
 /* @brief Figure out if node at specific path exists or not

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -251,6 +251,7 @@ static int fat_create(struct inode *i_new, struct inode *i_dir, int mode) {
 
 	fat_flags |= FILE_TYPE(mode, S_IFDIR);
 
+	fat_reset_dir(i_dir->i_data);
 	read_dir_buf(fsi, i_dir->i_data);
 	res = fat_create_file(fi, i_dir->i_data, i_new->i_dentry->name, fat_flags);
 

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -477,6 +477,9 @@ static int fat_mount_end(struct super_block *sb) {
  */
 static int fat_format(void *dev, void *priv) {
 	int fat_n = priv ? atoi((char*) priv) : 12;
+	if (!fat_n)
+		fat_n = 12;
+
 	fat_create_partition(dev, fat_n);
 	fat_root_dir_record(dev);
 

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -310,6 +310,11 @@ static int fat_pathname(struct inode *inode, char *buf, int flags) {
 	}
 }
 
+static int fat_truncate(struct inode *inode, size_t len) {
+	/* This is a stub, but files should be extended automatically
+	 * with the common part of the driver on write */
+	return 0;
+}
 
 /* Declaration of operations */
 struct inode_operations fat_iops = {
@@ -318,6 +323,7 @@ struct inode_operations fat_iops = {
 	.remove   = fat_remove,
 	.iterate  = fat_iterate,
 	.pathname = fat_pathname,
+	.truncate = fat_truncate,
 };
 
 struct file_operations fat_fops = {

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -70,14 +70,7 @@ static int fat_fill_inode(struct inode *inode, struct dirent *de, struct dirinfo
 		.volinfo = vi,
 	};
 
-	if (di->currentcluster < 2)
-		/* This file is in root directory */
-		fi->dirsector = vi->rootdir + di->currentsector;
-	else
-		fi->dirsector = vi->dataarea +
-				((di->currentcluster - 2) *
-				vi->secperclus) + di->currentsector;
-
+	fi->dirsector = di->currentsector;
 	fi->diroffset = di->currententry - 1;
 	if (vi->filesystem == FAT32)
 		fi->cluster = (uint32_t) de->startclus_l_l |

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -103,12 +103,7 @@ err_out:
 * @retval 0 Success
 */
 static inline int read_dir_buf(struct fat_fs_info *fsi, struct dirinfo *di) {
-	struct volinfo *vi = &fsi->vi;
-	if (vi->filesystem == FAT32)
-		return fat_read_sector(fsi, fat_sector_buff,
-		                       vi->dataarea + (di->currentcluster - 2) * vi->secperclus);
-	else
-		return fat_read_sector(fsi, fat_sector_buff, vi->rootdir);
+	return fat_read_sector(fsi, fat_sector_buff, di->currentsector);
 }
 
 /* @brief Figure out if node at specific path exists or not

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -361,6 +361,7 @@ static int fat_pathname(struct inode *inode, char *buf, int flags) {
 		if (fat_read_sector(fsi, fat_sector_buff, fi->dirsector))
 			return -1;
 		strncpy(buf, (char*) ((struct dirent*) fat_sector_buff)[fi->diroffset].name, 11);
+		buf[11] = '\0';
 		return 0;
 	default:
 		/* NIY */

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -195,10 +195,10 @@ static struct inode *fat_ilookup(char const *name, struct dentry const *dir) {
 	  ((uint32_t) de.startclus_h_h) << 24;
 
 	fsi = sb->sb_data;
-	if (cluster == 0) {
+	if (cluster == 0)
 		sector = fsi->vi.rootdir;
-	} else
-		sector = di->fi.dirsector + cluster * fsi->vi.secperclus;
+	else
+		sector = cluster * fsi->vi.secperclus;
 
 	if (fat_read_sector(sb->sb_data, di->p_scratch, sector))
 		goto err_out;

--- a/src/fs/dvfs/Mybuild
+++ b/src/fs/dvfs/Mybuild
@@ -9,7 +9,11 @@ module dvfs extends fs_api {
 	option number dentry_pool_size=64
 	option number file_pool_size=64
 	option number mnt_pool_size=4
+
 	option boolean use_dcache=false
+
+	option number dentry_name_len=36
+	option number max_path_len=128
 
 	source "dvfs.c"
 	source "dvfs_dentry.c"

--- a/src/fs/dvfs/compat.c
+++ b/src/fs/dvfs/compat.c
@@ -6,6 +6,7 @@
  * @date 2015-06-10
  */
 
+#include <errno.h>
 #include <string.h>
 
 #include <fs/dvfs.h>
@@ -34,6 +35,17 @@ int mount(char *dev, char *dir, char *fs_type) {
 	return dvfs_mount(bdev, dir, fs_type, 0);
 }
 
+
+/**
+ * @brief Unmount given mount point
+ *
+ * @param dir Path to mount point
+ *
+ * @return Negative error number of zero if succeed
+ * @retval 0 Success
+ * @retval -ENOENT Mount point not found
+ * @retval -EBUSY File system is in use
+ */
 int umount(char *dir) {
 	extern struct dlist_head dentry_dlist;
 	struct dentry *d, *dmount;
@@ -52,6 +64,9 @@ int umount(char *dir) {
 			}
 		}
 	}
+	if (!dmount)
+		return -ENOENT;
+
 	dvfs_umount(dmount);
 	return 0;
 }

--- a/src/fs/dvfs/compat.c
+++ b/src/fs/dvfs/compat.c
@@ -46,7 +46,7 @@ int umount(char *dir) {
 			if (dentry_full_path(d, mount_path)) {
 				continue;
 			}
-			if (strncmp(mount_path, dir, sizeof(mount_path))) {
+			if (!strncmp(mount_path, dir, sizeof(mount_path))) {
 				dmount = d;
 				break;
 			}

--- a/src/fs/dvfs/compat.c
+++ b/src/fs/dvfs/compat.c
@@ -35,7 +35,6 @@ int mount(char *dev, char *dir, char *fs_type) {
 	return dvfs_mount(bdev, dir, fs_type, 0);
 }
 
-
 /**
  * @brief Unmount given mount point
  *
@@ -45,28 +44,19 @@ int mount(char *dev, char *dir, char *fs_type) {
  * @retval 0 Success
  * @retval -ENOENT Mount point not found
  * @retval -EBUSY File system is in use
+ * @retval -EINVAL File is not a mount point
  */
 int umount(char *dir) {
-	extern struct dlist_head dentry_dlist;
-	struct dentry *d, *dmount;
-	char mount_path[DENTRY_NAME_LEN];
+	struct lookup lu;
 
-	dmount = NULL;
-
-	dlist_foreach_entry(d, &dentry_dlist, d_lnk) {
-		if (d->flags & DVFS_MOUNT_POINT) {
-			if (dentry_full_path(d, mount_path)) {
-				continue;
-			}
-			if (!strncmp(mount_path, dir, sizeof(mount_path))) {
-				dmount = d;
-				break;
-			}
-		}
-	}
-	if (!dmount)
+	dvfs_lookup(dir, &lu);
+	if (!lu.item)
 		return -ENOENT;
 
-	dvfs_umount(dmount);
+	if (!(lu.item->flags & DVFS_MOUNT_POINT))
+		/* Not a mount point */
+		return -EINVAL;
+
+	dvfs_umount(lu.item);
 	return 0;
 }

--- a/src/fs/dvfs/dcache_no.c
+++ b/src/fs/dvfs/dcache_no.c
@@ -21,10 +21,8 @@ struct dentry *dvfs_cache_get(char *path, struct lookup *lookup) {
 			continue;
 		d = mcast_out(l, struct dentry, children_lnk);
 
-		if (d != lookup->item && !strcmp(d->name, lookup->item->name)) {
-			dvfs_destroy_dentry(lookup->item);
+		if (d != lookup->item && !strcmp(d->name, lookup->item->name))
 			return d;
-		}
 	}
 
 	return NULL;

--- a/src/fs/dvfs/dcache_polynomial.c
+++ b/src/fs/dvfs/dcache_polynomial.c
@@ -17,13 +17,13 @@
 #define DENTRY_POOL_SIZE 64
 
 static const unsigned long long prime = 19, module = 1023;
-static unsigned long long pows[DENTRY_NAME_LEN];
+static unsigned long long pows[DVFS_MAX_PATH_LEN];
 
 static void hash_init(void) {
 	/* TODO precount in runtime or even in compiletime */
 	int i;
 	pows[0] = 1;
-	for (i = 1; i < DENTRY_NAME_LEN; i++)
+	for (i = 1; i < DVFS_MAX_PATH_LEN; i++)
 		pows[i] = (pows[i - 1] * prime) % module;
 }
 
@@ -65,7 +65,7 @@ extern int dentry_full_path(struct dentry *dentry, char *buf);
  * @return Negative error code
  */
 int dvfs_cache_add(struct dentry *dentry) {
-	char pathname[DENTRY_NAME_LEN]; /* XXX constant for max pathname ? */
+	char pathname[DVFS_MAX_PATH_LEN];
 	unsigned long long hash;
 	struct hashtable_item *ht_item = pool_alloc(&dentry_ht_pool);
 	assert(ht_item);
@@ -85,7 +85,7 @@ int dvfs_cache_add(struct dentry *dentry) {
  * @return Negative error code
  */
 int dvfs_cache_del(struct dentry *dentry) {
-	char pathname[DENTRY_NAME_LEN]; /* XXX constant for max pathname ? */
+	char pathname[DVFS_MAX_PATH_LEN];
 	unsigned long long hash;
 	struct hashtable_item *ht_item;
 	if (dentry->name[0] == '\0')
@@ -116,9 +116,9 @@ struct dentry *dvfs_cache_get(char *path, struct lookup *lookup) {
 
 struct dentry *dvfs_cache_lookup(const char *path,
 	struct dentry *base) {
-	char full_path[DENTRY_NAME_LEN];
+	char full_path[DVFS_MAX_PATH_LEN];
 	dentry_full_path(base, full_path);
-	strcat(full_path, path);
+	strncat(full_path, path, DVFS_MAX_PATH_LEN - strlen(path));
 
 	/* TODO check path from root */
 

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -340,7 +340,19 @@ int dvfs_mount(struct block_dev *dev, char *dest, const char *fstype, int flags)
 	return 0;
 }
 
+
+/**
+ * @brief Perform unmount operation
+ *
+ * @param d Dentry of FS root
+ *
+ * @return Negative error code or zero if succeed
+ * @retval -ENOBUSY Some files in FS tree are being used, can't unmount
+ */
 int dvfs_umount(struct dentry *d) {
+	if (d->usage_count > 1)
+		return -EBUSY;
+
 	return ENOERR;
 }
 

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -342,18 +342,46 @@ int dvfs_mount(struct block_dev *dev, char *dest, const char *fstype, int flags)
 
 
 /**
+ * @brief Recoursive dentry freeing
+ *
+ * @param d Dentry to be freed
+ *
+ * @return Negative error code or zero if succed
+ */
+static int _dentry_destroy(struct dentry *parent) {
+	struct dentry *child;
+	int err;
+	dlist_foreach_entry(child, &parent->children, children_lnk) {
+		if ((err = _dentry_destroy(child)))
+			/* Something went wrong */
+			return err;
+	}
+
+	return dvfs_destroy_dentry(parent);
+}
+
+/**
  * @brief Perform unmount operation
  *
- * @param d Dentry of FS root
+ * @param mpoint Dentry of FS root
  *
  * @return Negative error code or zero if succeed
+ * @retval 0 Success
  * @retval -ENOBUSY Some files in FS tree are being used, can't unmount
  */
-int dvfs_umount(struct dentry *d) {
-	if (d->usage_count > 1)
-		return -EBUSY;
+int dvfs_umount(struct dentry *mpoint) {
+	int err;
+	struct super_block *sb;
 
-	return ENOERR;
+	sb = mpoint->d_sb;
+
+	mpoint->usage_count--;
+	if ((err = _dentry_destroy(mpoint)))
+		return err;
+
+	dvfs_destroy_sb(sb);
+
+	return 0;
 }
 
 static struct dentry *iterate_virtual(struct lookup *lookup, struct dir_ctx *ctx) {

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -409,7 +409,7 @@ static struct dentry *iterate_virtual(struct lookup *lookup, struct dir_ctx *ctx
 
 static int iterate_cached(struct super_block *sb,
 		struct lookup *lookup, struct inode *next_inode) {
-	char full_path[DENTRY_NAME_LEN * 2];
+	char full_path[DVFS_MAX_PATH_LEN];
 	struct dentry *cached;
 	struct dentry *next_dentry;
 	int path_end;

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -89,7 +89,7 @@ int dvfs_create_new(const char *name, struct lookup *lookup, int flags) {
 	new_inode->flags |= flags;
 	if (flags & DVFS_DIR_VIRTUAL) {
 		res = 0;
-
+		lookup->item->d_sb = NULL;
 		dentry_ref_inc(lookup->item);
 		lookup->parent->flags |= DVFS_CHILD_VIRTUAL;
 	} else {
@@ -453,6 +453,14 @@ int dvfs_iterate(struct lookup *lookup, struct dir_ctx *ctx) {
 	assert(ctx);
 	assert(lookup);
 	assert(lookup->parent);
+
+	if (lookup->parent->flags & DVFS_DIR_VIRTUAL &&
+			!lookup->parent->d_sb) {
+		/* Clean virtual dir, no files */
+		lookup->item = NULL;
+		return 0;
+	}
+
 	assert(lookup->parent->d_sb);
 	assert(lookup->parent->d_inode);
 

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -8,6 +8,7 @@
 #define _DVFS_H_
 
 #include <drivers/block_dev.h>
+#include <framework/mod/options.h>
 #include <fs/idesc.h>
 #include <fs/file_system.h>
 #include <util/dlist.h>
@@ -16,8 +17,10 @@
  New VFS prototype
  *****************/
 
-#define DENTRY_NAME_LEN 36
-#define FS_NAME_LEN     16
+#include <config/embox/fs/dvfs.h>
+#define DENTRY_NAME_LEN   OPTION_MODULE_GET(embox__fs__dvfs, NUMBER, dentry_name_len)
+#define DVFS_MAX_PATH_LEN OPTION_MODULE_GET(embox__fs__dvfs, NUMBER, max_path_len)
+#define FS_NAME_LEN       16
 
 #define DVFS_PATH_FULL     0x001
 #define DVFS_PATH_FS       0x002
@@ -132,7 +135,7 @@ struct dumb_fs_driver {
 };
 
 struct auto_mount {
-	char mount_path[DENTRY_NAME_LEN];
+	char mount_path[DVFS_MAX_PATH_LEN];
 	struct dumb_fs_driver *fs_driver;
 };
 

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -119,6 +119,14 @@ struct file {
 	struct file_operations *f_ops;
 };
 
+/* NOTE ON FILE OPEN
+ *
+ * Basically,  in  regular  file  systems  file  open  driver  function  should
+ * just  return  the same  idesc  that  was  passed as second  parameter.  This
+ * feature  is  required for device-dependent operations, otherwise just return
+ * the second argument.
+ */
+
 struct file_operations {
 	struct idesc *(*open)(struct inode *node, struct idesc *desc);
 	int    (*close)(struct file *desc);

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -189,7 +189,7 @@ extern int dvfs_cache_del(struct dentry *dentry);
 extern int dvfs_cache_add(struct dentry *dentry);
 
 extern struct super_block *dvfs_alloc_sb(struct dumb_fs_driver *drv, struct block_dev *dev);
-
+extern int dvfs_destroy_sb(struct super_block *sb);
 extern struct dumb_fs_driver *dumb_fs_driver_find(const char *name);
 
 extern int dvfs_mount(struct block_dev *dev, char *dest, const char *fstype, int flags);

--- a/src/fs/dvfs/dvfs_util.c
+++ b/src/fs/dvfs/dvfs_util.c
@@ -338,6 +338,9 @@ struct dentry *local_lookup(struct dentry *parent, char *name) {
  */
 int dvfs_destroy_sb(struct super_block *sb) {
 	/* TODO fs-specific resource free? */
+	if (sb->root)
+		sb->root->d_sb = NULL;
+
 	pool_free(&superblock_pool, sb);
 	return 0;
 }

--- a/src/fs/dvfs/dvfs_util.c
+++ b/src/fs/dvfs/dvfs_util.c
@@ -315,7 +315,6 @@ struct dentry *dvfs_root(void) {
 	return global_root;
 }
 
-
 /**
 * @brief Check if element with given name presents as a subelement
 *        of the folder in RAM.
@@ -339,4 +338,17 @@ struct dentry *local_lookup(struct dentry *parent, char *name) {
 	}
 
 	return NULL;
+}
+
+/**
+ * @brief Free superblock resources
+ *
+ * @param sb Superblock to be destroyed
+ *
+ * @return Negative error code or zero if succeed
+ */
+int dvfs_destroy_sb(struct super_block *sb) {
+	/* TODO fs-specific resource free? */
+	pool_free(&superblock_pool, sb);
+	return 0;
 }

--- a/src/fs/dvfs/dvfs_util.c
+++ b/src/fs/dvfs/dvfs_util.c
@@ -160,7 +160,7 @@ int dvfs_destroy_dentry(struct dentry *dentry) {
 	if (dentry->usage_count == 0) {
 		if (dentry->d_inode)
 			dvfs_destroy_inode(dentry->d_inode);
-		dentry->parent->usage_count--;
+		dentry_ref_dec(dentry->parent);
 		dlist_del(&dentry->children_lnk);
 		dlist_del(&dentry->d_lnk);
 		dvfs_cache_del(dentry);
@@ -236,29 +236,17 @@ int dentry_fill(struct super_block *sb, struct inode *inode,
 
 	if (parent) {
 		dlist_add_prev(&dentry->children_lnk, &parent->children);
-		parent->usage_count++;
+		dentry_ref_inc(parent);
 	}
 	return 0;
 }
+
 int dentry_ref_inc(struct dentry *dentry) {
-	dentry->usage_count ++;
-
-	if (dentry->d_sb->root != dentry) {
-		dentry->d_sb->root->usage_count ++;
-	}
-
-	return dentry->usage_count;
+	return ++dentry->usage_count;
 }
 
 int dentry_ref_dec(struct dentry *dentry) {
-	dentry->usage_count --;
-
-	if (dentry->d_sb->root != dentry) {
-		dentry->d_sb->root->usage_count --;
-	}
-
-	return dentry->usage_count;
-
+	return --dentry->usage_count;
 }
 
 /* Root-related stuff */

--- a/src/fs/dvfs/dvfs_util.c
+++ b/src/fs/dvfs/dvfs_util.c
@@ -4,6 +4,7 @@
  * @date   8 Apr 2014
  */
 
+#include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -166,7 +167,7 @@ int dvfs_destroy_dentry(struct dentry *dentry) {
 		pool_free(&dentry_pool, dentry);
 		return 0;
 	} else
-		return -1;
+		return -EBUSY;
 }
 
 /**


### PR DESCRIPTION
Umount was not very helpful, as it was a stub. Now it works fine with all bdev types, therefore ramdisk-related issue was closed.

Some VFS issues were fixed, e.g. double destroy of dentries, which led to inconsistency of dentries.

A number of fatfs issues were fixed. There were a bunch of typos and misusing sectors/clusters numbers. Now fatfs fully supports subdirectories, clears garbage on system volume data on disk format (previously FAT and root directory were not being erased).