### PR TITLE
Revert "fault-car: Add libactuators lib" contains only conflicts signs

### DIFF
--- a/platform/stm32f3_sensors/libactuators/motor.c
+++ b/platform/stm32f3_sensors/libactuators/motor.c
@@ -1,29 +1,18 @@
 /**
  * @file
  *
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> fixup!: Fix libactuators
  * @date 06 july 2015
  * @author Anton Bondarev
  */
 #include <libactuators/motor.h>
 #include <stm32f3xx_hal_gpio.h>
 #include <stm32f3_discovery.h>
-=======
- * @date 06 july 2015 г.
- * @author Anton Bondarev
- */
-#include <libactuators/motor.h>
->>>>>>> fault-car: Add libactuators lib
 
 static void stm32f3_delay(uint32_t delay) {
 	while(delay--)
 		;
 }
 
-<<<<<<< HEAD
 
 static void init_pins(GPIO_TypeDef  *GPIOx, uint16_t pins) {
 	GPIO_InitTypeDef  GPIO_InitStruct;
@@ -41,20 +30,12 @@ static void init_pins(GPIO_TypeDef  *GPIOx, uint16_t pins) {
 
 void motor_init(struct motor *m, GPIO_TypeDef  *GPIOx, uint16_t enable,
 		uint16_t in1, uint16_t in2) {
-=======
-void motor_init(struct motor *m, GPIO_TypeDef  *GPIOx,
-		uint16_t enable, uint16_t in1, uint16_t in2, uint8_t mask) {
->>>>>>> fault-car: Add libactuators lib
 	m->GPIOx = GPIOx;
 	m->enable = enable;
 	m->input[0] = in1;
 	m->input[1] = in2;
-<<<<<<< HEAD
 
 	init_pins(GPIOx, enable | in1 | in2);
-=======
-	m->enabled_inputs = mask;
->>>>>>> fault-car: Add libactuators lib
 }
 
 void motor_enable(struct motor *m) {

--- a/platform/stm32f3_sensors/libactuators/motor.h
+++ b/platform/stm32f3_sensors/libactuators/motor.h
@@ -1,15 +1,7 @@
 /**
  * @file
  *
-<<<<<<< HEAD
-<<<<<<< HEAD
  * @date 06 july 2015
-=======
- * @date 06 july 2015 г.
->>>>>>> fault-car: Add libactuators lib
-=======
- * @date 06 july 2015
->>>>>>> fixup!: Fix libactuators
  * @author Anton Bondarev
  */
 
@@ -32,11 +24,6 @@ struct motor {
 	GPIO_TypeDef  *GPIOx;
 	uint16_t enable;
 	uint16_t input[2];
-<<<<<<< HEAD
-=======
-	/* 10, 01, 11 */
-	uint8_t enabled_inputs:2;
->>>>>>> fault-car: Add libactuators lib
 };
 
 enum motor_run_direction {
@@ -44,13 +31,8 @@ enum motor_run_direction {
 	MOTOR_RUN_RIGHT
 };
 
-<<<<<<< HEAD
 extern void motor_init(struct motor *m, GPIO_TypeDef  *GPIOx, uint16_t enable,
 		uint16_t in1, uint16_t in2);
-=======
-extern void motor_init(struct motor *m, GPIO_TypeDef  *GPIOx,
-		uint16_t enable, uint16_t in1, uint16_t in2, uint8_t mask);
->>>>>>> fault-car: Add libactuators lib
 
 extern void motor_enable(struct motor *m);
 


### PR DESCRIPTION
This reverts commit dc45665a59673c0b818698e0aba15cc8ba89b47f.
It breaks compiling and has only conflicts signs.