### PR TITLE
Block dev open in devfs

### DIFF
--- a/src/compat/posix/fs/dvfs/fsop.c
+++ b/src/compat/posix/fs/dvfs/fsop.c
@@ -16,6 +16,7 @@
 int mkdir(const char *pathname, mode_t mode) {
 	struct lookup lu;
 	char *t;
+	int res;
 
 	char parent[DVFS_MAX_PATH_LEN];
 
@@ -44,9 +45,13 @@ int mkdir(const char *pathname, mode_t mode) {
 		dvfs_lookup(pathname, &lu);
 	}
 
-	return dvfs_create_new(pathname + strlen(parent),
-	                       &lu,
+	res = dvfs_create_new(pathname + strlen(parent), &lu,
 			       S_IFDIR | (mode & DVFS_DIR_VIRTUAL));
+	if (res) {
+		return SET_ERRNO(-res);
+	}
+
+	return 0;
 }
 
 int remove(const char *pathname) {

--- a/src/drivers/block_dev/Mybuild
+++ b/src/drivers/block_dev/Mybuild
@@ -31,6 +31,7 @@ module block {
 
 module block_dvfs {
 	source "block_dev_dvfs.c"
+	source "block_dev_idesc_dvfs.c"
 
 	depends block_common
 }

--- a/src/drivers/block_dev/block_dev.c
+++ b/src/drivers/block_dev/block_dev.c
@@ -36,7 +36,7 @@ static int bdev_close(struct file_desc *desc) {
 }
 
 static size_t bdev_read(struct file_desc *desc, void *buf, size_t size) {
-	int n_read = block_dev_read_buffered((block_dev_t *) desc->node->nas->fi->privdata,
+	int n_read = block_dev_read_buffered((struct block_dev *) desc->node->nas->fi->privdata,
 			buf, size, desc->cursor);
 	if (n_read > 0) {
 		desc->cursor += n_read;
@@ -45,7 +45,7 @@ static size_t bdev_read(struct file_desc *desc, void *buf, size_t size) {
 }
 
 static size_t bdev_write(struct file_desc *desc, void *buf, size_t size) {
-	int n_write = block_dev_write_buffered((block_dev_t *) desc->node->nas->fi->privdata,
+	int n_write = block_dev_write_buffered((struct block_dev *) desc->node->nas->fi->privdata,
 			buf, size, desc->cursor);
 	if (n_write > 0) {
 		desc->cursor += n_write;
@@ -71,7 +71,7 @@ static int blockdev_init(void) {
 }
 
 struct block_dev *block_dev_create(char *path, void *driver, void *privdata) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	struct path node, root;
 	struct nas *nas;
 	struct node_fi *node_fi;

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -39,9 +39,9 @@ typedef struct block_dev {
 typedef struct block_dev_driver {
 	char *name;
 
-	int (*ioctl)(block_dev_t *bdev, int cmd, void *args, size_t size);
-	int (*read)(block_dev_t *bdev, char *buffer, size_t count, blkno_t blkno);
-	int (*write)(block_dev_t *bdev, char *buffer, size_t count, blkno_t blkno);
+	int (*ioctl)(struct block_dev *bdev, int cmd, void *args, size_t size);
+	int (*read)(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
+	int (*write)(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
 } block_dev_driver_t;
 
 typedef int (* block_dev_module_init_ft)(void *args);
@@ -73,8 +73,8 @@ extern struct block_dev *block_dev(void *bdev);
 extern block_dev_cache_t *block_dev_cache_init(void *bdev, int blocks);
 extern block_dev_cache_t *block_dev_cached_read(void *bdev, blkno_t blkno);
 extern int block_dev_read(void *bdev, char *buffer, size_t count, blkno_t blkno);
-extern int block_dev_read_buffered(block_dev_t *bdev, char *buffer, size_t count, size_t offset);
-extern int block_dev_write_buffered(block_dev_t *bdev, const char *buffer, size_t count, size_t offset);
+extern int block_dev_read_buffered(struct block_dev *bdev, char *buffer, size_t count, size_t offset);
+extern int block_dev_write_buffered(struct block_dev *bdev, const char *buffer, size_t count, size_t offset);
 extern int block_dev_write(void *bdev, const char *buffer, size_t count, blkno_t blkno);
 extern int block_dev_ioctl(void *bdev, int cmd, void *args, size_t size);
 extern int block_dev_close(void *bdev);

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -23,7 +23,9 @@
 #define DEV_TYPE_BLOCK          2
 #define DEV_TYPE_PACKET         3
 
+struct file_operations;
 typedef struct block_dev {
+	struct file_operations *dev_ops;
 	dev_t id;
 	char name[NAME_MAX];
 	void *dev_vfs_info;

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -87,7 +87,7 @@ extern struct block_dev *block_dev_find(const char *bd_name);
 
 #include <util/array.h>
 
-#define EMBOX_BLOCK_DEV(name, block_dev_driver, init_func) \
+#define BLOCK_DEV_DEF(name, block_dev_driver, init_func) \
 	ARRAY_SPREAD_DECLARE(const struct block_dev_module, __block_dev_registry); \
 	ARRAY_SPREAD_ADD(__block_dev_registry, {name, block_dev_driver, init_func})
 

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -80,7 +80,7 @@ extern int block_dev_ioctl(void *bdev, int cmd, void *args, size_t size);
 extern int block_dev_close(void *bdev);
 extern int block_dev_destroy(void *bdev);
 extern int block_dev_named(char *name, struct indexator *indexator);
-extern block_dev_module_t *block_dev_lookup(const char *name);
+extern struct block_dev_module *block_dev_lookup(const char *name);
 extern void block_dev_free(struct block_dev *dev);
 extern struct block_dev *block_dev_create_common(char *path, void *driver, void *privdata);
 extern struct block_dev *block_dev_find(const char *bd_name);
@@ -88,7 +88,7 @@ extern struct block_dev *block_dev_find(const char *bd_name);
 #include <util/array.h>
 
 #define EMBOX_BLOCK_DEV(name, block_dev_driver, init_func) \
-	ARRAY_SPREAD_DECLARE(const block_dev_module_t, __block_dev_registry); \
+	ARRAY_SPREAD_DECLARE(const struct block_dev_module, __block_dev_registry); \
 	ARRAY_SPREAD_ADD(__block_dev_registry, {name, block_dev_driver, init_func})
 
 

--- a/src/drivers/block_dev/block_dev_common.c
+++ b/src/drivers/block_dev/block_dev_common.c
@@ -34,7 +34,7 @@ struct block_dev **get_bdev_tab() {
 }
 
 static int block_dev_cache_free(void *dev) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	block_dev_cache_t *cache;
 
 	if (NULL == dev) {
@@ -57,12 +57,12 @@ struct block_dev *block_dev_create_common(char *path, void *driver, void *privda
 	struct block_dev *bdev;
 	size_t bdev_id;
 
-	bdev = (block_dev_t *) pool_alloc(&blockdev_pool);
+	bdev = (struct block_dev *) pool_alloc(&blockdev_pool);
 	if (NULL == bdev) {
 		return NULL;
 	}
 
-	memset(bdev, 0, sizeof(block_dev_t));
+	memset(bdev, 0, sizeof(struct block_dev));
 
 	bdev_id = index_alloc(&block_dev_idx, INDEX_MIN);
 	if (bdev_id == INDEX_NONE) {
@@ -136,7 +136,7 @@ struct block_dev *block_dev(void *dev) {
 	return (struct block_dev *)dev;
 }
 
-int block_dev_read_buffered(block_dev_t *bdev, char *buffer, size_t count, size_t offset) {
+int block_dev_read_buffered(struct block_dev *bdev, char *buffer, size_t count, size_t offset) {
 	int blksize, blkno, cplen, cursor;
 	int res, i;
 	struct buffer_head *bh;
@@ -176,7 +176,7 @@ int block_dev_read_buffered(block_dev_t *bdev, char *buffer, size_t count, size_
 	return cursor;
 }
 
-int block_dev_write_buffered(block_dev_t *bdev, const char *buffer, size_t count, size_t offset) {
+int block_dev_write_buffered(struct block_dev *bdev, const char *buffer, size_t count, size_t offset) {
 	int blksize, blkno, cplen, cursor;
 	int res, i;
 	struct buffer_head *bh;
@@ -233,7 +233,7 @@ int block_dev_write_buffered(block_dev_t *bdev, const char *buffer, size_t count
 }
 
 int block_dev_read(void *dev, char *buffer, size_t count, blkno_t blkno) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	int blksize;
 
 	if (NULL == dev) {
@@ -249,7 +249,7 @@ int block_dev_read(void *dev, char *buffer, size_t count, blkno_t blkno) {
 }
 
 int block_dev_write(void *dev, const char *buffer, size_t count, blkno_t blkno) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	int blksize;
 
 	if (NULL == dev) {
@@ -266,7 +266,7 @@ int block_dev_write(void *dev, const char *buffer, size_t count, blkno_t blkno) 
 }
 
 int block_dev_ioctl(void *dev, int cmd, void *args, size_t size) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 
 	if (NULL == dev) {
 		return -ENODEV;
@@ -283,7 +283,7 @@ int block_dev_ioctl(void *dev, int cmd, void *args, size_t size) {
 block_dev_cache_t *block_dev_cache_init(void *dev, int blocks) {
 	int pagecnt;
 	block_dev_cache_t *cache;
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 
 	if (NULL == dev) {
 		return NULL;
@@ -324,7 +324,7 @@ block_dev_cache_t *block_dev_cache_init(void *dev, int blocks) {
 
 block_dev_cache_t *block_dev_cached_read(void *dev, blkno_t blkno) {
 	block_dev_cache_t *cache;
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 
 	if (NULL == dev) {
 		return NULL;

--- a/src/drivers/block_dev/block_dev_common.c
+++ b/src/drivers/block_dev/block_dev_common.c
@@ -22,7 +22,7 @@
 #define DEFAULT_BDEV_BLOCK_SIZE OPTION_GET(NUMBER, default_block_size)
 #define MAX_DEV_QUANTITY OPTION_GET(NUMBER, dev_quantity)
 
-ARRAY_SPREAD_DEF(const block_dev_module_t, __block_dev_registry);
+ARRAY_SPREAD_DEF(const struct block_dev_module, __block_dev_registry);
 POOL_DEF(cache_pool, struct block_dev_cache, MAX_DEV_QUANTITY);
 POOL_DEF(blockdev_pool, struct block_dev, MAX_DEV_QUANTITY);
 INDEX_DEF(block_dev_idx, 0, MAX_DEV_QUANTITY);
@@ -93,7 +93,7 @@ void block_dev_free(struct block_dev *dev) {
 
 int block_devs_init(void) {
 	int ret;
-	const block_dev_module_t *bdev_module;
+	const struct block_dev_module *bdev_module;
 
 	array_spread_foreach_ptr(bdev_module, __block_dev_registry) {
 		if (bdev_module->init != NULL) {
@@ -108,8 +108,8 @@ int block_devs_init(void) {
 	return 0;
 }
 
-block_dev_module_t *block_dev_lookup(const char *bd_name) {
-	block_dev_module_t *bdev_module;
+struct block_dev_module *block_dev_lookup(const char *bd_name) {
+	struct block_dev_module *bdev_module;
 
 	array_spread_foreach_ptr(bdev_module, __block_dev_registry) {
 		if (0 == strcmp(bdev_module->name, bd_name)) {

--- a/src/drivers/block_dev/block_dev_dvfs.c
+++ b/src/drivers/block_dev/block_dev_dvfs.c
@@ -21,7 +21,7 @@
  * @return Pointer to created device or NULL if failed
  */
 struct block_dev *block_dev_create(char *path, void *driver, void *privdata) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	char full_path[256];
 	struct lookup lu;
 

--- a/src/drivers/block_dev/block_dev_dvfs.c
+++ b/src/drivers/block_dev/block_dev_dvfs.c
@@ -11,6 +11,7 @@
 #include <drivers/block_dev.h>
 #include <fs/dvfs.h>
 
+extern struct file_operations bdev_dev_ops;
 /**
  * @brief Create node in devfs
  *
@@ -27,6 +28,8 @@ struct block_dev *block_dev_create(char *path, void *driver, void *privdata) {
 
 	if (NULL == (bdev = block_dev_create_common(path, driver, privdata)))
 		return NULL;
+
+	bdev->dev_ops = &bdev_dev_ops;
 
 	/* Get root of devfs in smarter way? */
 

--- a/src/drivers/block_dev/block_dev_idesc_dvfs.c
+++ b/src/drivers/block_dev/block_dev_idesc_dvfs.c
@@ -1,0 +1,59 @@
+/**
+ * @file
+ * @brief DVFS-specific bdev handling
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version 0.1
+ * @date 2015-10-01
+ */
+#include <errno.h>
+#include <string.h>
+#include <util/err.h>
+
+
+#include <drivers/block_dev.h>
+#include <fs/dvfs.h>
+
+static void bdev_idesc_close(struct idesc *desc) {
+	dvfs_destroy_file((struct file *)desc);
+}
+
+static ssize_t bdev_idesc_read(struct idesc *desc, void *buf, size_t size) {
+	struct block_dev *bdev;
+
+	bdev = desc->f_inode->i_data;
+	return bdev->driver->read(bdev, buf, size, desc->pos / bdev->block_size);
+}
+
+static ssize_t bdev_idesc_write(struct idesc *desc, const void *buf, size_t size) {
+	struct block_dev *bdev;
+
+	bdev = desc->f_inode->i_data;
+	assert(bdev->driver);
+	assert(bdev->driver->write);
+	return bdev->driver->write(bdev, buf, size, desc->pos / bdev->block_size);
+}
+
+static struct idesc_ops idesc_bdev_ops = {
+	.close = bdev_idesc_close,
+	.read  = bdev_idesc_read,
+	.write = bdev_idesc_write,
+};
+
+static struct idesc *bdev_idesc_open(struct inode *node, struct idesc *idesc) {
+	struct file *file;
+	file = dvfs_alloc_file();
+	if (!file) {
+		return err_ptr(ENOMEM);
+	}
+	*file = (struct file) {
+		.f_idesc  = {
+				.idesc_amode = FS_MAY_READ | FS_MAY_WRITE,
+				.idesc_ops   = &idesc_bdev_ops,
+		},
+	};
+	return &file->f_idesc;
+}
+
+struct file_operations bdev_dev_ops = {
+		.open = bdev_idesc_open,
+};

--- a/src/drivers/block_dev/flash/flash.c
+++ b/src/drivers/block_dev/flash/flash.c
@@ -312,7 +312,7 @@ static int flashbdev_ioctl(struct block_dev *bdev, int cmd,
 	}
 }
 
-EMBOX_BLOCK_DEV("flash", &flashbdev_pio_driver, NULL);
+BLOCK_DEV_DEF("flash", &flashbdev_pio_driver, NULL);
 
 ARRAY_SPREAD_DEF(const flash_dev_module_t, __flash_dev_registry);
 

--- a/src/drivers/block_dev/flash/flash.c
+++ b/src/drivers/block_dev/flash/flash.c
@@ -36,7 +36,6 @@
 POOL_DEF(flash_pool,struct flash_dev,MAX_DEV_QUANTITY);
 INDEX_DEF(flash_idx,0,MAX_DEV_QUANTITY);
 
-static int flashbdev_init(void *arg);
 static int flashbdev_ioctl(struct block_dev *bdev, int kmd, void *buf, size_t size);
 static int flashbdev_read(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
 static int flashbdev_write(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
@@ -131,12 +130,6 @@ int flash_delete(const char *name) {
 		block_dev_destroy (node_fi->privdata);
 		vfs_del_leaf(flash_node.node);
 	}
-	return 0;
-}
-
-
-static int flashbdev_init(void *arg) {
-
 	return 0;
 }
 
@@ -319,7 +312,7 @@ static int flashbdev_ioctl(struct block_dev *bdev, int cmd,
 	}
 }
 
-EMBOX_BLOCK_DEV("flash", &flashbdev_pio_driver, flashbdev_init);
+EMBOX_BLOCK_DEV("flash", &flashbdev_pio_driver, NULL);
 
 ARRAY_SPREAD_DEF(const flash_dev_module_t, __flash_dev_registry);
 

--- a/src/drivers/block_dev/flash/flash.c
+++ b/src/drivers/block_dev/flash/flash.c
@@ -140,7 +140,7 @@ static int flashbdev_init(void *arg) {
 	return 0;
 }
 
-static int flashbdev_read(block_dev_t *bdev,
+static int flashbdev_read(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	struct flash_dev *flash;
 	uint32_t startpos, endpos;
@@ -164,7 +164,7 @@ static int flashbdev_read(block_dev_t *bdev,
 }
 
 
-static int flashbdev_write(block_dev_t *bdev,
+static int flashbdev_write(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	struct flash_dev *flash;
 	uint32_t startpos, endpos;

--- a/src/drivers/block_dev/ide/cdrom.c
+++ b/src/drivers/block_dev/ide/cdrom.c
@@ -147,7 +147,7 @@ static int atapi_request_sense(hd_t *hd) {
 	return 0;
 }
 
-static int cd_read(block_dev_t *bdev, char *buffer,
+static int cd_read(struct block_dev *bdev, char *buffer,
 					size_t count, blkno_t blkno) {
 	unsigned char pkt[12];
 	unsigned int blks;
@@ -170,12 +170,12 @@ static int cd_read(block_dev_t *bdev, char *buffer,
 	return atapi_packet_read(hd, pkt, 12, buffer, count);
 }
 
-static int cd_write(block_dev_t *bdev, char *buffer,
+static int cd_write(struct block_dev *bdev, char *buffer,
 					size_t count, blkno_t blkno) {
 	return -ENODEV;
 }
 
-static int cd_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size) {
+static int cd_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	hd_t *hd = (hd_t *) bdev->privdata;
 	int rc;
 

--- a/src/drivers/block_dev/ide/cdrom.c
+++ b/src/drivers/block_dev/ide/cdrom.c
@@ -239,4 +239,4 @@ static int idecd_init (void *args) {
 	return 0;
 }
 
-EMBOX_BLOCK_DEV("idecd", &idecd_pio_driver, idecd_init);
+BLOCK_DEV_DEF("idecd", &idecd_pio_driver, idecd_init);

--- a/src/drivers/block_dev/ide/harddisk_dma.c
+++ b/src/drivers/block_dev/ide/harddisk_dma.c
@@ -19,7 +19,7 @@
 #include <mem/phymem.h>
 
 
-extern int hd_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size);
+extern int hd_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size);
 
 static void setup_dma(hdc_t *hdc, char *buffer, int count, int cmd) {
 	int i;
@@ -81,7 +81,7 @@ static int stop_dma(hdc_t *hdc) {
 	return 0;
 }
 
-static int hd_read_udma(block_dev_t *bdev, char *buffer, size_t count, blkno_t blkno) {
+static int hd_read_udma(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno) {
 	hd_t *hd;
 	hdc_t *hdc;
 	int sectsleft;
@@ -159,7 +159,7 @@ static int hd_read_udma(block_dev_t *bdev, char *buffer, size_t count, blkno_t b
 	return result == 0 ? count : result;
 }
 
-static int hd_write_udma(block_dev_t *bdev, char *buffer, size_t count, blkno_t blkno) {
+static int hd_write_udma(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno) {
 	hd_t *hd;
 	hdc_t *hdc;
 	int sectsleft;

--- a/src/drivers/block_dev/ide/harddisk_dma.c
+++ b/src/drivers/block_dev/ide/harddisk_dma.c
@@ -271,4 +271,4 @@ static int idedisk_udma_init (void *args) {
 	return 0;
 }
 
-EMBOX_BLOCK_DEV("idedisk_udma", &idedisk_udma_driver, idedisk_udma_init);
+BLOCK_DEV_DEF("idedisk_udma", &idedisk_udma_driver, idedisk_udma_init);

--- a/src/drivers/block_dev/ide/harddisk_pio.c
+++ b/src/drivers/block_dev/ide/harddisk_pio.c
@@ -25,9 +25,9 @@
 
 #define HD_WAIT_MS 10
 
-extern int hd_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size);
+extern int hd_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size);
 
-static int hd_read_pio(block_dev_t *bdev, char *buffer, size_t count, blkno_t blkno) {
+static int hd_read_pio(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno) {
 	hd_t *hd;
 	hdc_t *hdc;
 	int sectsleft;
@@ -93,7 +93,7 @@ static int hd_read_pio(block_dev_t *bdev, char *buffer, size_t count, blkno_t bl
 	return result == 0 ? count : result;
 }
 
-static int hd_write_pio(block_dev_t *bdev, char *buffer, size_t count, blkno_t blkno) {
+static int hd_write_pio(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno) {
 	hd_t *hd;
 	hdc_t *hdc;
 	int sectsleft;

--- a/src/drivers/block_dev/ide/harddisk_pio.c
+++ b/src/drivers/block_dev/ide/harddisk_pio.c
@@ -217,4 +217,4 @@ static int idedisk_init (void *args) {
 	return 0;
 }
 
-EMBOX_BLOCK_DEV("idedisk", &idedisk_pio_driver, idedisk_init);
+BLOCK_DEV_DEF("idedisk", &idedisk_pio_driver, idedisk_init);

--- a/src/drivers/block_dev/ide/ide_drive.c
+++ b/src/drivers/block_dev/ide/ide_drive.c
@@ -306,7 +306,7 @@ static int hd_cmd(hd_t *hd, unsigned int cmd,
 	return 0;
 }
 
-int hd_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size) {
+int hd_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	struct dev_geometry *geom;
 	hd_t *hd = (hd_t *) bdev->privdata;
 

--- a/src/drivers/block_dev/ide/ide_drive.c
+++ b/src/drivers/block_dev/ide/ide_drive.c
@@ -579,7 +579,7 @@ static int setup_controller(hdc_t *hdc, int iobase, int irq,
 }
 
 static int ide_create_block_dev(hd_t *hd) {
-	const block_dev_module_t *bdev;
+	const struct block_dev_module *bdev;
 
 	switch (hd->media) {
 		case IDE_CDROM:

--- a/src/drivers/block_dev/ramdisk/ramdisk.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk.c
@@ -192,4 +192,4 @@ static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	return -ENOSYS;
 }
 
-EMBOX_BLOCK_DEV("ramdisk", &ramdisk_pio_driver, NULL);
+BLOCK_DEV_DEF("ramdisk", &ramdisk_pio_driver, NULL);

--- a/src/drivers/block_dev/ramdisk/ramdisk.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk.c
@@ -32,7 +32,6 @@
 POOL_DEF(ramdisk_pool,struct ramdisk,MAX_DEV_QUANTITY);
 INDEX_DEF(ramdisk_idx,0,MAX_DEV_QUANTITY);
 
-static int ram_init(void *arg);
 static int read_sectors(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
 static int write_sectors(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
 static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size);
@@ -155,11 +154,6 @@ int ramdisk_delete(const char *name) {
 	return 0;
 }
 
-
-static int ram_init(void *arg) {
-	return 0;
-}
-
 static int read_sectors(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	ramdisk_t *ramdisk;
@@ -198,4 +192,4 @@ static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	return -ENOSYS;
 }
 
-EMBOX_BLOCK_DEV("ramdisk", &ramdisk_pio_driver, ram_init);
+EMBOX_BLOCK_DEV("ramdisk", &ramdisk_pio_driver, NULL);

--- a/src/drivers/block_dev/ramdisk/ramdisk.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk.c
@@ -160,7 +160,7 @@ static int ram_init(void *arg) {
 	return 0;
 }
 
-static int read_sectors(block_dev_t *bdev,
+static int read_sectors(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	ramdisk_t *ramdisk;
 	char *read_addr;
@@ -173,7 +173,7 @@ static int read_sectors(block_dev_t *bdev,
 }
 
 
-static int write_sectors(block_dev_t *bdev,
+static int write_sectors(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	ramdisk_t *ramdisk;
 	char *write_addr;
@@ -185,7 +185,7 @@ static int write_sectors(block_dev_t *bdev,
 	return count;
 }
 
-static int ram_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size) {
+static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	ramdisk_t *ramd = (ramdisk_t *) bdev->privdata;
 
 	switch (cmd) {

--- a/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
@@ -126,4 +126,4 @@ static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	return -ENOSYS;
 }
 
-EMBOX_BLOCK_DEV("ramdisk", &ramdisk_pio_driver, NULL);
+BLOCK_DEV_DEF("ramdisk", &ramdisk_pio_driver, NULL);

--- a/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
@@ -33,7 +33,6 @@
 POOL_DEF(ramdisk_pool,struct ramdisk,MAX_DEV_QUANTITY);
 INDEX_DEF(ramdisk_idx, 0, MAX_DEV_QUANTITY);
 
-static int ram_init(void *arg);
 static int read_sectors(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
 static int write_sectors(struct block_dev *bdev, char *buffer, size_t count, blkno_t blkno);
 static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size);
@@ -89,11 +88,6 @@ int ramdisk_delete(const char *name) {
 	return 0;
 }
 
-
-static int ram_init(void *arg) {
-	return 0;
-}
-
 static int read_sectors(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	ramdisk_t *ramdisk;
@@ -132,4 +126,4 @@ static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	return -ENOSYS;
 }
 
-EMBOX_BLOCK_DEV("ramdisk", &ramdisk_pio_driver, ram_init);
+EMBOX_BLOCK_DEV("ramdisk", &ramdisk_pio_driver, NULL);

--- a/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
+++ b/src/drivers/block_dev/ramdisk/ramdisk_dvfs.c
@@ -94,7 +94,7 @@ static int ram_init(void *arg) {
 	return 0;
 }
 
-static int read_sectors(block_dev_t *bdev,
+static int read_sectors(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	ramdisk_t *ramdisk;
 	char *read_addr;
@@ -107,7 +107,7 @@ static int read_sectors(block_dev_t *bdev,
 }
 
 
-static int write_sectors(block_dev_t *bdev,
+static int write_sectors(struct block_dev *bdev,
 		char *buffer, size_t count, blkno_t blkno) {
 	ramdisk_t *ramdisk;
 	char *write_addr;
@@ -119,7 +119,7 @@ static int write_sectors(block_dev_t *bdev,
 	return count;
 }
 
-static int ram_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size) {
+static int ram_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	ramdisk_t *ramd = (ramdisk_t *) bdev->privdata;
 
 	switch (cmd) {

--- a/src/drivers/block_dev/scsi/scsi_disc.c
+++ b/src/drivers/block_dev/scsi/scsi_disc.c
@@ -90,7 +90,7 @@ static void scsi_disk_unlock(struct block_dev *bdev) {
 	scsi_dev_use_dec(sdev);
 }
 
-static int scsi_read(block_dev_t *bdev, char *buffer, size_t count,
+static int scsi_read(struct block_dev *bdev, char *buffer, size_t count,
 		blkno_t blkno) {
 	struct scsi_dev *sdev = bdev->privdata;
 	int blksize = sdev->blk_size;
@@ -130,7 +130,7 @@ static int scsi_read(block_dev_t *bdev, char *buffer, size_t count,
 	return bp - buffer;
 }
 
-static int scsi_write(block_dev_t *bdev, char *buffer, size_t count,
+static int scsi_write(struct block_dev *bdev, char *buffer, size_t count,
 		blkno_t blkno) {
 	struct scsi_dev *sdev;
 	int blksize;
@@ -176,7 +176,7 @@ static int scsi_write(block_dev_t *bdev, char *buffer, size_t count,
 	return bp - buffer;
 }
 
-static int scsi_ioctl(block_dev_t *bdev, int cmd, void *args, size_t size) {
+static int scsi_ioctl(struct block_dev *bdev, int cmd, void *args, size_t size) {
 	struct scsi_dev *sdev = bdev->privdata;
 	int ret;
 

--- a/src/drivers/block_dev/stm32_sd/stm32f4_sd.c
+++ b/src/drivers/block_dev/stm32_sd/stm32f4_sd.c
@@ -32,7 +32,7 @@ block_dev_driver_t stm32f4_sd_driver = {
 EMBOX_BLOCK_DEV(STM32F4_SD_DEVNAME, &stm32f4_sd_driver, stm32f4_sd_init);
 
 static int stm32f4_sd_init(void *arg) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	if (block_dev_lookup(STM32F4_SD_DEVNAME) && (SD_Init() == SD_OK)) {
 		bdev = block_dev_create_common(STM32F4_SD_DEVNAME, &stm32f4_sd_driver, NULL);
 		bdev->size = stm32f4_sd_ioctl(bdev, IOCTL_GETDEVSIZE, NULL, 0);

--- a/src/drivers/block_dev/stm32_sd/stm32f4_sd.c
+++ b/src/drivers/block_dev/stm32_sd/stm32f4_sd.c
@@ -29,7 +29,7 @@ block_dev_driver_t stm32f4_sd_driver = {
 	.write = stm32f4_sd_write,
 };
 
-EMBOX_BLOCK_DEV(STM32F4_SD_DEVNAME, &stm32f4_sd_driver, stm32f4_sd_init);
+BLOCK_DEV_DEF(STM32F4_SD_DEVNAME, &stm32f4_sd_driver, stm32f4_sd_init);
 
 static int stm32f4_sd_init(void *arg) {
 	struct block_dev *bdev;

--- a/src/drivers/char/char_dev_dvfs/char_dev.h
+++ b/src/drivers/char/char_dev_dvfs/char_dev.h
@@ -15,16 +15,16 @@
 struct file_operations;
 
 struct device_module {
-	const char *name;
 	struct file_operations *fops;
 	struct idesc_ops *idesc_ops;
+	const char *name;
 	struct dlist_head cdev_list;
 	void *dev_data;
 };
 
 #define CHAR_DEV_DEF(name, file_op, idesc_op) \
 	ARRAY_SPREAD_DECLARE(const struct device_module, __char_device_registry); \
-	ARRAY_SPREAD_ADD(__char_device_registry, {name, file_op, idesc_op} )
+	ARRAY_SPREAD_ADD(__char_device_registry, {file_op, idesc_op, name} )
 
 extern int char_dev_register(struct device_module *cdev);
 

--- a/src/drivers/char/char_dev_dvfs/char_dev_dvfs.c
+++ b/src/drivers/char/char_dev_dvfs/char_dev_dvfs.c
@@ -19,10 +19,6 @@ DLIST_DEFINE(cdev_repo_list);
 
 ARRAY_SPREAD_DEF(const struct device_module, __char_device_registry);
 
-int char_dev_init_all(void) {
-	return 0;
-}
-
 int char_dev_register(struct device_module *cdev) {
 	assert(cdev);
 

--- a/src/drivers/flash/flash_emu.c
+++ b/src/drivers/flash/flash_emu.c
@@ -36,7 +36,7 @@ static size_t flash_emu_query (struct flash_dev *dev,
 }
 
 static int flash_emu_erase_block (struct flash_dev *dev, uint32_t block_base) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 	int len;
 	char * data;
 	int rc;
@@ -65,7 +65,7 @@ static int flash_emu_erase_block (struct flash_dev *dev, uint32_t block_base) {
 
 static int flash_emu_program (struct flash_dev *dev, uint32_t base,
 		const void* data, size_t len) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 
 	bdev = dev->privdata;
 	if(NULL == bdev) {
@@ -77,7 +77,7 @@ static int flash_emu_program (struct flash_dev *dev, uint32_t base,
 
 static int flash_emu_read (struct flash_dev *dev,
 		uint32_t base, void* data, size_t len) {
-	block_dev_t *bdev;
+	struct block_dev *bdev;
 
 	bdev = dev->privdata;
 	if(NULL == bdev) {

--- a/src/fs/bcache.c
+++ b/src/fs/bcache.c
@@ -34,10 +34,10 @@ POOL_DEF(bcach_ht_item_pool, struct hashtable_item, BCACHE_SIZE);
 
 static struct hashtable *bcache = &bcache_ht;
 static struct mutex bcache_mutex;
-static int graw_buffers(block_dev_t *bdev, int block, size_t size);
+static int graw_buffers(struct block_dev *bdev, int block, size_t size);
 static void free_more_memory(size_t size);
 
-struct buffer_head *bcache_getblk_locked(block_dev_t *bdev, int block, size_t size) {
+struct buffer_head *bcache_getblk_locked(struct block_dev *bdev, int block, size_t size) {
 	struct buffer_head key = { .bdev = bdev, .block = block };
 	struct buffer_head *bh;
 
@@ -99,7 +99,7 @@ static void free_more_memory(size_t size) {
 	}
 }
 
-static int graw_buffers(block_dev_t *bdev, int block, size_t size) {
+static int graw_buffers(struct block_dev *bdev, int block, size_t size) {
 	struct buffer_head *bh;
 	struct hashtable_item *ht_item;
 

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -167,45 +167,6 @@ static struct idesc *devfs_open(struct inode *node, struct idesc *desc) {
 	return dev->fops->open(node, desc);
 }
 
-static size_t devfs_read(struct file *desc, void *buf, size_t size) {
-	struct block_dev *bdev;
-	struct device_module *cdev;
-
-	switch (desc->f_inode->flags & (S_IFBLK | S_IFCHR)) {
-	case S_IFBLK:
-		bdev = desc->f_inode->i_data;
-		return bdev->driver->read(bdev, buf, size, desc->pos / bdev->block_size);
-	case S_IFCHR:
-		cdev = desc->f_inode->i_data;
-		return cdev->fops->read(desc, buf, size);
-	default:
-		printk("Unknown device type!\n");
-	}
-
-	return 0;
-}
-
-static size_t devfs_write(struct file *desc, void *buf, size_t size) {
-	struct block_dev *bdev;
-	struct device_module *cdev;
-
-	switch (desc->f_inode->flags & (S_IFBLK | S_IFCHR)) {
-	case S_IFBLK:
-		bdev = desc->f_inode->i_data;
-		assert(bdev->driver);
-		assert(bdev->driver->write);
-		return bdev->driver->write(bdev, buf, size, desc->pos / bdev->block_size);
-	case S_IFCHR:
-		cdev = desc->f_inode->i_data;
-		assert(cdev->fops);
-		assert(cdev->fops->write);
-		return cdev->fops->write(desc, buf, size);
-	default:
-		printk("Unknown device type!\n");
-	}
-
-	return 0;
-}
 
 static int devfs_pathname(struct inode *node, char *buf, int flags) {
 	struct device_module *dev_module;
@@ -250,8 +211,6 @@ struct inode_operations devfs_iops = {
 
 struct file_operations devfs_fops = {
 	.open  = devfs_open,
-	.read  = devfs_read,
-	.write = devfs_write,
 	.ioctl = devfs_ioctl,
 };
 

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -152,17 +152,19 @@ static struct inode *devfs_lookup(char const *name, struct dentry const *dir) {
 static int devfs_mount_end(struct super_block *sb) {
 	return 0;
 }
-
+struct dev_wraper {
+	struct file_operations *fops;
+};
 static struct idesc *devfs_open(struct inode *node, struct idesc *desc) {
-	struct device_module *cdev;
+	struct dev_wraper *dev;
 
 	assert(node->i_data);
 
-	cdev = node->i_data;
-	assert(cdev->fops);
-	assert(cdev->fops->open);
+	dev = node->i_data;
+	assert(dev->fops);
+	assert(dev->fops->open);
 
-	return cdev->fops->open(node, desc);
+	return dev->fops->open(node, desc);
 }
 
 static size_t devfs_read(struct file *desc, void *buf, size_t size) {

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -195,7 +195,7 @@ static int ext3fs_format(void *dev) {
 	return main_mke2fs(argc, argv);
 }
 
-static int ext3_journal_load(journal_t *jp, block_dev_t *jdev, block_t start) {
+static int ext3_journal_load(journal_t *jp, struct block_dev *jdev, block_t start) {
     ext3_journal_superblock_t *sb;
     ext3_journal_specific_t *spec = (ext3_journal_specific_t *)jp->j_fs_specific.data;
     char buf[4096];
@@ -298,7 +298,7 @@ static int ext3fs_mount(void *dev, void *dir) {
 	/* XXX Hack to use ext2 functions */
 	dir_nas->fs->drv = &ext3fs_driver;
 	ext3_spec->ext3_journal_inode = dip;
-	if (0 > ext3_journal_load(jp, (block_dev_t *) dev_node->nas->fi->privdata,
+	if (0 > ext3_journal_load(jp, (struct block_dev *) dev_node->nas->fi->privdata,
 			fsbtodb(fsi, dip->i_block[0]))) {
 		return -EIO;
 	}

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -561,7 +561,7 @@ static size_t ntfs_write(struct file_desc *file_desc, void *buf, size_t size) {
 
 
 struct ntfs_bdev_desc {
-	block_dev_t *dev;
+	struct block_dev *dev;
 	size_t pos;
 };
 
@@ -729,7 +729,7 @@ static s64 ntfs_device_bdev_io_write(struct ntfs_device *dev, const void *buf,
 static s64 ntfs_device_bdev_io_pread(struct ntfs_device *dev, void *buf,
 		s64 count, s64 offset)
 {
-	block_dev_t *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
+	struct block_dev *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
 	//int blksize = block_dev_ioctl(bdev, IOCTL_GETBLKSIZE, NULL, 0);
 	if (count == block_dev_read_buffered(bdev, buf, count, offset)) {
 		return count;
@@ -752,7 +752,7 @@ static s64 ntfs_device_bdev_io_pread(struct ntfs_device *dev, void *buf,
 static s64 ntfs_device_bdev_io_pwrite(struct ntfs_device *dev, const void *buf,
 		s64 count, s64 offset)
 {
-	block_dev_t *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
+	struct block_dev *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
 	//int blksize = block_dev_ioctl(bdev, IOCTL_GETBLKSIZE, NULL, 0);
 	if (NDevReadOnly(dev)) {
 		errno = EROFS;
@@ -817,7 +817,7 @@ static int ntfs_device_bdev_io_stat(struct ntfs_device *dev, struct stat *buf)
 static int ntfs_device_bdev_io_ioctl(struct ntfs_device *dev, int request,
 		void *argp)
 {
-	block_dev_t *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
+	struct block_dev *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
 	return block_dev_ioctl(bdev, request, argp, 0);
 }
 

--- a/src/fs/driver/power_save/qnx6.h
+++ b/src/fs/driver/power_save/qnx6.h
@@ -63,7 +63,7 @@ struct qnx6_superblock {
 	unsigned char s_blocksize_bits;
 	unsigned long s_blocksize;
 	void *s_fs_info;
-	block_dev_t *s_bdev;
+	struct block_dev *s_bdev;
 	struct node *s_root;
 };
 
@@ -103,7 +103,7 @@ typedef int (*filldir_t)(void *, const char *, int, loff_t, __u64, unsigned);
 static inline struct buffer_head *sb_bread(struct qnx6_superblock *sb, unsigned int block) {
 	struct buffer_head *bh = bcache_getblk_locked(sb->s_bdev, block, sb->s_blocksize);
 	unsigned fs_blksize = sb->s_blocksize;
-	block_dev_t *bdev = bh->bdev;
+	struct block_dev *bdev = bh->bdev;
 	unsigned bdev_blksize;
 
 	/* FIXME */

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -77,10 +77,15 @@ int dvfs_create_new(const char *name, struct lookup *lookup, int flags) {
 
 	sb = lookup->parent->d_sb;
 	lookup->item = dvfs_alloc_dentry();
-	if (!lookup->item)
+	if (!lookup->item) {
 		return -ENOMEM;
+	}
 
 	new_inode = dvfs_alloc_inode(sb);
+	if (!new_inode) {
+		dvfs_destroy_dentry(lookup->item);
+		return -ENOMEM;
+	}
 	dentry_fill(sb, new_inode, lookup->item, lookup->parent);
 	strncpy(lookup->item->name, name, DENTRY_NAME_LEN);
 	inode_fill(sb, new_inode, lookup->item);
@@ -101,7 +106,7 @@ int dvfs_create_new(const char *name, struct lookup *lookup, int flags) {
 
 	if (res) {
 		dvfs_destroy_dentry(lookup->item);
-		dvfs_destroy_inode(lookup->item->d_inode);
+		dvfs_destroy_inode(new_inode);
 	}
 
 	return res;

--- a/src/include/fs/bcache.h
+++ b/src/include/fs/bcache.h
@@ -26,6 +26,6 @@ static inline void bcache_buffer_unlock(struct buffer_head *bh) {
  *   Block with number @a block and with size @a size from device @a bdev.
  *   Block is returned in locked state.
  */
-extern struct buffer_head *bcache_getblk_locked(block_dev_t *bdev, int block, size_t size);
+extern struct buffer_head *bcache_getblk_locked(struct block_dev *bdev, int block, size_t size);
 
 #endif /* FS_BCACHE_H_ */

--- a/src/include/fs/buffer_head.h
+++ b/src/include/fs/buffer_head.h
@@ -30,7 +30,7 @@
  * A buffer_head is used to map a single block within a disk
  */
 struct buffer_head {
-	block_dev_t *bdev;              /* device buffer_header is from */
+	struct block_dev *bdev;              /* device buffer_header is from */
 	int block;                      /* start block number */
 	size_t blocksize;               /* size of mapping */
 	int flags;                      /* buffer state bitmap */

--- a/src/include/fs/journal.h
+++ b/src/include/fs/journal.h
@@ -261,7 +261,7 @@ struct journal_s {
      * Device, blocksize and starting block offset for the location where we
      * store the journal.
      */
-    block_dev_t *j_dev;
+    struct block_dev *j_dev;
     size_t j_blocksize;
     size_t j_disk_sectorsize;
     block_t j_blk_offset;


### PR DESCRIPTION
Enable 'dd' command in dvfs by adding idesc operations to block devices.
Clean block devices