### PR TITLE
Fix ide_drive after refactoring

### DIFF
--- a/src/drivers/block_dev/ide/ide_drive.c
+++ b/src/drivers/block_dev/ide/ide_drive.c
@@ -233,7 +233,7 @@ static int hd_identify(hd_t *hd) {
 
 	/* Read parameter data */
 	insw(hd->hdc->iobase + HDC_DATA,
-			(char *) &(hd->param), sizeof(hd->param));
+			(char *) &(hd->param), sizeof(hd->param) / 2);
 
 	/* XXX this was added when ide drive with reported block size equals 64
  	 * However, block dev tries to use this and fails */


### PR DESCRIPTION
'/dev/hda' hasn't been found before this fix