### PR TITLE
dvfs: Fix dvfs_create_new

### DIFF
--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -107,7 +107,6 @@ int dvfs_create_new(const char *name, struct lookup *lookup, int flags) {
 
 	if (res) {
 		dvfs_destroy_dentry(lookup->item);
-		dvfs_destroy_inode(new_inode);
 	}
 
 	return res;


### PR DESCRIPTION
There was double freeing of the new_inode