### PR TITLE
ARM callstack

### DIFF
--- a/src/arch/arm/lib/debug/Mybuild
+++ b/src/arch/arm/lib/debug/Mybuild
@@ -1,0 +1,5 @@
+package embox.arch.arm
+
+module stackframe extends embox.arch.stackframe {
+	source "stack_iter.h", "stack_iter.c"
+}

--- a/src/arch/arm/lib/debug/stack_iter.c
+++ b/src/arch/arm/lib/debug/stack_iter.c
@@ -1,0 +1,33 @@
+/**
+ * @file stack_iter.c
+ * @brief 
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version 0.1
+ * @date 2016-02-29
+ */
+
+#include <stddef.h>
+
+#include <hal/context.h>
+#include <util/lang.h>
+#include <util/math.h>
+
+#include "stack_iter.h"
+
+void stack_iter_context(stack_iter_t *f, struct context *ctx) {
+}
+
+void stack_iter_current(stack_iter_t *f) {
+}
+
+int stack_iter_next(stack_iter_t *f) {
+	return 0;
+}
+
+void *stack_iter_get_fp(stack_iter_t *f) {
+	return NULL;
+}
+
+void *stack_iter_get_retpc(stack_iter_t *f) {
+	return NULL;
+}

--- a/src/arch/arm/lib/debug/stack_iter.c
+++ b/src/arch/arm/lib/debug/stack_iter.c
@@ -4,6 +4,9 @@
  * @author Denis Deryugin <deryugin.denis@gmail.com>
  * @version 0.1
  * @date 2016-02-29
+ *
+ * @note Remember to add -mapcs-frame option to CFLAGS as 
+ * different frame formats require different offets
  */
 
 #include <stddef.h>

--- a/src/arch/arm/lib/debug/stack_iter.c
+++ b/src/arch/arm/lib/debug/stack_iter.c
@@ -17,6 +17,14 @@
 void stack_iter_context(stack_iter_t *f, struct context *ctx) {
 }
 
+int stack_iter_next(stack_iter_t *f) {
+	f->fp = (void*) *((int*)f->fp - 3);
+	f->pc = (void*) *((int*)f->fp);
+	f->lr = (void*) *((int*)f->fp - 1);
+
+	return *((int*)f->fp - 3) != 0;
+}
+
 void stack_iter_current(stack_iter_t *f) {
 	__asm__ __volatile__ (
 		"mov %[fp], FP\n\t"
@@ -33,20 +41,14 @@ void stack_iter_current(stack_iter_t *f) {
 	 * so we have to make one unwind operation
 	 * by hand */
 
+	stack_iter_next(f);
 	f->fp = (void*) *((int*)f->fp - 3);
-	f->pc = (void*) *((int*)f->fp);
-	f->lr = (void*) *((int*)f->fp - 1);
-	f->fp = (void*) *((int*)f->fp - 3);
-}
-
-int stack_iter_next(stack_iter_t *f) {
-	return 0;
 }
 
 void *stack_iter_get_fp(stack_iter_t *f) {
-	return NULL;
+	return f->fp - 3;
 }
 
 void *stack_iter_get_retpc(stack_iter_t *f) {
-	return NULL;
+	return f->pc;
 }

--- a/src/arch/arm/lib/debug/stack_iter.c
+++ b/src/arch/arm/lib/debug/stack_iter.c
@@ -14,15 +14,18 @@
 
 #include "stack_iter.h"
 
-void stack_iter_context(stack_iter_t *f, struct context *ctx) {
-}
-
 int stack_iter_next(stack_iter_t *f) {
 	f->fp = (void*) *((int*)f->fp - 3);
 	f->pc = (void*) *((int*)f->fp);
 	f->lr = (void*) *((int*)f->fp - 1);
 
 	return *((int*)f->fp - 3) != 0;
+}
+
+void stack_iter_context(stack_iter_t *f, struct context *ctx) {
+	f->fp = (void*) ctx->system_r[11];	/* R11 is frame pointer */
+	f->pc = (void*) ctx->lr;
+	f->lr = (void*) ctx->lr;		/* R14 is link register */
 }
 
 void stack_iter_current(stack_iter_t *f) {

--- a/src/arch/arm/lib/debug/stack_iter.h
+++ b/src/arch/arm/lib/debug/stack_iter.h
@@ -1,0 +1,18 @@
+/**
+ * @file stack_iter.h
+ * @brief 
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version 0.1
+ * @date 2016-02-29
+ */
+
+#ifndef ARM_STACK_ITER_H_
+#define ARM_STACK_ITER_H_
+
+typedef struct stack_iter {
+	void *fp;	/* Frame pointer */
+	void *lr;	/* Link register */
+	void *pc;	/* Program counter */
+} stack_iter_t;
+
+#endif /* ARM_STACK_ITER_H_ */

--- a/templates/arm/qemu/build.conf
+++ b/templates/arm/qemu/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv7-a -mtune=cortex-a8
+CFLAGS += -march=armv7-a -mtune=cortex-a8 -fno-omit-frame-pointer -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/qemu/mods.config
+++ b/templates/arm/qemu/mods.config
@@ -4,7 +4,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.omap3.cpu
 	@Runlevel(0) include embox.arch.arm.cortexa8.bundle
 	@Runlevel(0) include embox.arch.system(core_freq=48054841)
-
+	@Runlevel(0) include embox.arch.arm.stackframe
 	@Runlevel(0) include embox.arch.arm.cortexa8.mmu
 	@Runlevel(0) include embox.mem.vmem_alloc(virtual_pages_count=20,virtual_tables_count=2)
 
@@ -128,4 +128,6 @@ configuration conf {
 
 	@Runlevel(2) include embox.mem.static_heap(heap_size=64000000)
 	@Runlevel(2) include embox.mem.heap_bm(heap_size=32000000)
+
+	include embox.lib.debug.whereami
 }


### PR DESCRIPTION
Implement stack unwind for ARM Procedure Call Standart frame format (-mapcs-frame option for gcc).
Now backtrace could be obtained correctly.