### PR TITLE
mem: Add debug version of pool

### DIFF
--- a/src/include/mem/misc/pool.h
+++ b/src/include/mem/misc/pool.h
@@ -14,6 +14,9 @@
 #include <stddef.h>
 #include <util/macro.h>
 #include <util/slist.h>
+#include <util/bitmap.h>
+
+#include <module/embox/mem/pool.h>
 
 /** Representation of the pool*/
 struct pool {
@@ -29,7 +32,16 @@ struct pool {
 	size_t pool_size;
 	/* Boundary, after which begin non-allocated memory */
 	void *bound_free;
+#ifdef POOL_DEBUG
+	BITMAP_DECL(blocks, POOL_MAX_OBJECTS);
+#endif
 };
+
+#ifdef POOL_DEBUG
+#define POOL_BLOCKS_INIT .blocks = {0},
+#else
+#define POOL_BLOCKS_INIT
+#endif
 
 /**
  * Create pool descriptor. The memory for pool is allocated in special section
@@ -51,6 +63,7 @@ struct pool {
 			.free_blocks = SLIST_INIT(&name.free_blocks),\
 			.obj_size = sizeof(__pool_storage ## name[0]), \
 			.pool_size = sizeof(__pool_storage ## name), \
+			POOL_BLOCKS_INIT \
 	};
 
 /**

--- a/src/mem/misc/Mybuild
+++ b/src/mem/misc/Mybuild
@@ -2,13 +2,26 @@ package embox.mem
 
 module slab {
 	option number heap_size = 524288
+
 	source "slab.c", "slab_impl.h"
 	depends embox.mem.page_api
 	depends embox.mem.phymem
 	depends embox.mem.static_heap
 }
 
-module pool {
+@DefaultImpl(pool_ndebug)
+abstract module pool {}
+
+module pool_ndebug extends pool {
 	source "pool.c"
+
 	depends embox.util.SList
+}
+
+module pool_debug extends pool {
+	source "pool_debug.c"
+	source "pool_debug.h"
+
+	depends embox.util.SList
+	depends embox.util.Bitmap
 }

--- a/src/mem/misc/pool_debug.c
+++ b/src/mem/misc/pool_debug.c
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * @brief It is debug version of fixed-size pool with fixed size objects
+ *  We add a bitmap of free blocks in struct pool to catch double freeing.
+ *	
+ * @see For more information see pool.c
+ *
+ * @date	04.03.2016
+ * @author	Alex Kalmuk
+ *			-- It is derived from pool.c with added double freeing catching
+ */
+
+#include <mem/misc/pool.h>
+
+#include <assert.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <util/member.h>
+
+void * pool_alloc(struct pool *pl) {
+	void *obj;
+	size_t index;
+
+	assert(pl != NULL);
+
+	if (!slist_empty(&pl->free_blocks)) {
+		obj = (void *)slist_remove_first_link(&pl->free_blocks);
+
+		index = (obj - pl->memory) / pl->obj_size;
+		bitmap_set_bit(pl->blocks, index);
+
+		return obj;
+	}
+
+	if (pl->bound_free != pl->memory + pl->pool_size) {
+		obj = pl->bound_free;
+		pl->bound_free += pl->obj_size;
+		assert(pl->bound_free <= pl->memory + pl->pool_size);
+
+		index = (obj - pl->memory) / pl->obj_size;
+		bitmap_set_bit(pl->blocks, index);
+
+		return obj;
+	}
+
+	return NULL;
+}
+
+void pool_free(struct pool *pl, void *obj) {
+	size_t index;
+
+	assert(pl != NULL);
+	assert(obj != NULL);
+	assert(pool_belong(pl, obj));
+
+	index = (obj - pl->memory) / pl->obj_size;
+	assert(bitmap_test_bit(pl->blocks, index) == 1);
+	bitmap_clear_bit(pl->blocks, index);
+
+	obj = slist_link_init((struct slist_link *)obj);
+	slist_add_first_link(obj, &pl->free_blocks);
+}
+
+int pool_belong(const struct pool *pl, const void *obj) {
+	return (pl->memory <= obj)
+			&& (obj + pl->obj_size <= pl->memory + pl->pool_size)
+			&& ((obj - pl->memory) % pl->obj_size == 0);
+}

--- a/src/mem/misc/pool_debug.h
+++ b/src/mem/misc/pool_debug.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * @brief It is a debug version of pool.c
+ *  
+ * @see For more information see pool_debug.c
+ *
+ * @date 04.03.2016
+ * @author Alex Kalmuk
+ */
+
+#ifndef POOL_DEBUG_H_
+#define POOL_DEBUG_H_
+
+#define POOL_DEBUG
+#define POOL_MAX_OBJECTS 0x8000
+
+#endif /* POOL_DEBUG_H_ */


### PR DESCRIPTION
This version of pool is safe from double freeing (catches double freeing with asserts)

There is a bitmap of free blocks, so every time when somebody calls pool_free() it's checked whether the specified object was previously allocated.