### PR TITLE
Ignore built img files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,10 @@
 *~
 /tags
 
-## Stuff
-# Build
-/beagle_nand.img
+## Build
+/*.img
 
-# Other
+## Other
 /.dep.inc
 /.dropbox
 /.tmp


### PR DESCRIPTION
It would probably be better to place these files in something like `build` or `run` directory, but it needs more investigating first.