### PR TITLE
Fix build for x86/test/fs

### DIFF
--- a/templates/x86/test/fs/mods.config
+++ b/templates/x86/test/fs/mods.config
@@ -7,6 +7,7 @@ configuration conf {
 	@Runlevel(2) include embox.arch.x86.kernel.interrupt
 
 	@Runlevel(2) include embox.arch.x86.stackframe
+	@Runlevel(2) include embox.arch.x86.mmu
 	@Runlevel(2) include embox.lib.debug.whereami
 
 	@Runlevel(2) include embox.driver.interrupt.i8259

--- a/third-party/samba/Mybuild
+++ b/third-party/samba/Mybuild
@@ -17,6 +17,7 @@ module core {
 	depends embox.compat.posix.idx.poll
 	depends embox.compat.posix.proc.exec
 	depends embox.net.lib.getifaddrs
+	depends embox.mem.vmem
 	depends third_party.zlib.libs
 	depends embox.compat.posix.fs.chown_api
 }


### PR DESCRIPTION
mmap() failed to compile in this template, this issue was caused by rewriting mmap() in #952.