### PR TITLE
Fix google drive downloads

### DIFF
--- a/third-party/bsp/st_f3/Makefile
+++ b/third-party/bsp/st_f3/Makefile
@@ -1,7 +1,8 @@
 
 PKG_NAME := stm32f3
 
-PKG_SOURCES := https://googledrive.com/host/0B5aAX-lbLDf-fldVXzVHVVdtVXZseTJDR0Uwc2ZtcHJEQmlXd2lGMHZKOEtiLWl2cklCdkE/stm32f3discovery.zip
+PKG_SOURCES := https://drive.google.com/uc?export=download&id=0B5aAX-lbLDf-VTFmc3h5SXA4djA
+PKG_ARCHIVE_NAME :=stm32f3discovery.zip
 PKG_MD5     := e7eddb371433c2dd8ab101a0fb337827
 
 PKG_PATCHES := buildfix.patch

--- a/third-party/bsp/st_f4/Makefile
+++ b/third-party/bsp/st_f4/Makefile
@@ -1,7 +1,8 @@
 
 PKG_NAME := stsw-stm32070
 
-PKG_SOURCES := https://googledrive.com/host/0B7g4WwjaJX23ZExQU2hHTzYyRm8/STM32F4xx_Ethernet_Example.zip
+PKG_SOURCES := https://drive.google.com/uc?export=download&id=0B6HXc8wjtHNwNjd1ZVdFSTRSdDQ
+PKG_ARCHIVE_NAME :=STM32F4xx_Ethernet_Example.zip
 PKG_MD5     := 7f1a0e638e1b944be66cd335f69507cd
 
 PKG_PATCHES := stmf4_audio_codec.patch stmf4_eth_buildfix.patch

--- a/third-party/phoneme/Makefile
+++ b/third-party/phoneme/Makefile
@@ -2,7 +2,8 @@
 PKG_NAME := phoneme
 PKG_VER  := trunk
 
-PKG_SOURCES := https://googledrive.com/host/0B7g4WwjaJX23ZExQU2hHTzYyRm8/$(PKG_NAME)-$(PKG_VER).tar.gz
+PKG_SOURCES := https://drive.google.com/uc?export=download&id=0B6HXc8wjtHNwc3ZlUkxLSVZtRjQ
+PKG_ARCHIVE_NAME :=phoneme-trunk.tar.gz
 PKG_MD5     := b552aa86b2832d00563636330ec64299
 
 PKG_PATCHES := pkg_patch.txt


### PR DESCRIPTION
There is an issue with deprecating web hosting support in Google Drive (https://gsuiteupdates.googleblog.com/2015/08/deprecating-web-hosting-support-in.html), which rejects download of files using direct links in usual google drive's style http://googledrive.com/host/<...>.
This PR fixes corrupted direct links to the correct ones.