### PR TITLE
mk: Disable -Wmisleading-indentation gcc option

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -181,6 +181,9 @@ override COMMON_CCFLAGS += -Wundef -Wno-trigraphs -Wno-char-subscripts
 
 override COMMON_CCFLAGS += -Wno-gnu-designator
 
+# This option conflicts with some third-party stuff, so we disable it.
+override COMMON_CCFLAGS += -Wno-misleading-indentation
+
 
 # GCC 6 seems to have many library functions declared as __nonnull__, like
 # fread, fwrite, fprintf, ...  Since accessing NULL in embox without MMU 


### PR DESCRIPTION
Disable -Wmisleading-indentation - "Warn when the indentation of the code does not reflect the block structure. Specifically, a warning is issued for if, else, while, and for clauses with a guarded statement that does not use braces, followed by an unguarded statement with the same indentation".
This option breaks some of third-party stuff (cJSON for instance), so we decided just to disable it for the whole project for a while.