### PR TITLE
Clang stm32f4cube support

### DIFF
--- a/mk/core/compiler.mk
+++ b/mk/core/compiler.mk
@@ -1,0 +1,4 @@
+ifndef COMPILER
+COMPILER := gcc
+endif
+export COMPILER

--- a/mk/extbld.mk
+++ b/mk/extbld.mk
@@ -6,6 +6,7 @@ __extbld-1 __extbld-2 :
 
 FORCE :
 
+include $(ROOT_DIR)/mk/core/compiler.mk
 include mk/image_lib.mk
 include $(MKGEN_DIR)/build.mk
 

--- a/mk/extbld/arch-embox-clang
+++ b/mk/extbld/arch-embox-clang
@@ -1,0 +1,1 @@
+arch-embox-gcc

--- a/mk/extbld/arch-embox-gcc
+++ b/mk/extbld/arch-embox-gcc
@@ -9,9 +9,9 @@ fi
 
 cmd=$(basename $0)
 case $cmd in
-	*-gcc) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CFLAGS";;
-	*-g++) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CXXFLAGS";;
-	*)     echo "Unknown flags for $cmd"; exit 1;;
+	*-gcc|*-clang) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CFLAGS";;
+	*-g++)         C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CXXFLAGS";;
+	*)             echo "Unknown flags for $cmd"; exit 1;;
 esac
 
 case $EMBOX_GCC_LINK in
@@ -34,5 +34,11 @@ esac
 ARG_LINE="$ARG_LINE $EMBOX_IMPORTED_CPPFLAGS"
 PWD_ARG_LINE="$(for i in $ARG_LINE; do echo ${i/$PWD/.}; done)"
 # echo "$EMBOX_CROSS_COMPILE${cmd#arch-embox-} $@ $PWD_ARG_LINE" >&2
-$EMBOX_CROSS_COMPILE${cmd#arch-embox-} "$@" $PWD_ARG_LINE
-exit $?
+
+if [[ "$cmd" == *clang ]]; then
+	clang "$@" -target arm-none-eabi $PWD_ARG_LINE
+	exit $?
+else
+	$EMBOX_CROSS_COMPILE${cmd#arch-embox-} "$@" $PWD_ARG_LINE
+	exit $?
+fi

--- a/mk/extbld/lib.mk
+++ b/mk/extbld/lib.mk
@@ -126,5 +126,9 @@ endif
 AUTOCONF_TARGET_TRIPLET=$(AUTOCONF_ARCH)-unknown-none
 endif
 
+ifeq ($(COMPILER),clang)
+EMBOX_GCC := $(ROOT_DIR)/mk/extbld/arch-embox-clang
+else
 EMBOX_GCC := $(ROOT_DIR)/mk/extbld/arch-embox-gcc
 EMBOX_GXX := $(ROOT_DIR)/mk/extbld/arch-embox-g++
+endif

--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -9,9 +9,6 @@ ARFLAGS ?=
 LDFLAGS ?=
 
 CROSS_COMPILE ?=
-
-CC      ?= $(CROSS_COMPILE)gcc
-CPP     ?= $(CC) -E
 CXX     ?= $(CROSS_COMPILE)g++
 AR      ?= $(CROSS_COMPILE)ar
 AS      ?= $(CROSS_COMPILE)as
@@ -20,6 +17,15 @@ NM      ?= $(CROSS_COMPILE)nm
 OBJDUMP ?= $(CROSS_COMPILE)objdump
 OBJCOPY ?= $(CROSS_COMPILE)objcopy
 SIZE    ?= $(CROSS_COMPILE)size
+
+ifeq ($(COMPILER),clang)
+CC      ?= clang
+# for clang LIBGCC_FINDER will be set externally to arm-none-eabi-gcc or something like that
+else
+CC      ?= $(CROSS_COMPILE)gcc
+LIBGCC_FINDER=$(CC) $(CFLAGS)
+endif
+CPP     ?= $(CC) -E
 
 comma_sep_list = $(subst $(\s),$(,),$(strip $1))
 
@@ -90,6 +96,7 @@ EXTERNAL_MAKE_FLAGS = \
 			CACHE_DIR, \
 		$(path_var)=$(abspath $($(path_var)))) \
 	BUILD_DIR=$(abspath $(mod_build_dir)) \
+	COMPILER=$(COMPILER) \
 	EMBOX_ARCH='$(ARCH)' \
 	EMBOX_CROSS_COMPILE='$(CROSS_COMPILE)' \
 	EMBOX_MAKEFLAGS='$(MAKEFLAGS)' \
@@ -177,19 +184,21 @@ override ASFLAGS += $(asflags)
 override COMMON_CCFLAGS := $(COMMON_FLAGS)
 override COMMON_CCFLAGS += -fno-strict-aliasing -fno-common
 override COMMON_CCFLAGS += -Wall -Werror
-override COMMON_CCFLAGS += -Wundef -Wno-trigraphs -Wno-char-subscripts 
+override COMMON_CCFLAGS += -Wundef -Wno-trigraphs -Wno-char-subscripts
 
 override COMMON_CCFLAGS += -Wno-gnu-designator
 
+ifneq ($(COMPILER),clang)
+# Not clang means gcc
 # This option conflicts with some third-party stuff, so we disable it.
 override COMMON_CCFLAGS += -Wno-misleading-indentation
 
-
 # GCC 6 seems to have many library functions declared as __nonnull__, like
-# fread, fwrite, fprintf, ...  Since accessing NULL in embox without MMU 
-# support could cause real damage to whole system in contrast with segfault of 
+# fread, fwrite, fprintf, ...  Since accessing NULL in embox without MMU
+# support could cause real damage to whole system in contrast with segfault of
 # application, we decided to keep explicit null checks and disable the warning.
 override COMMON_CCFLAGS += -Wno-nonnull-compare
+endif
 
 override COMMON_CCFLAGS += -Wformat
 
@@ -222,4 +231,3 @@ CCFLAGS ?=
 
 INCLUDES_FROM_FLAGS := \
 	$(patsubst -I%,%,$(filter -I%,$(CPPFLAGS) $(CXXFLAGS)))
-

--- a/mk/main-stripping.sh
+++ b/mk/main-stripping.sh
@@ -25,7 +25,11 @@ fi
 
 OBJCOPY=${EMBOX_CROSS_COMPILE}objcopy
 OBJDUMP=${EMBOX_CROSS_COMPILE}objdump
-CC=${EMBOX_CROSS_COMPILE}gcc
+if [ "$COMPILER" = "clang" ]; then
+	CC=clang
+else
+	CC=${EMBOX_CROSS_COMPILE}gcc
+fi
 LD=${EMBOX_CROSS_COMPILE}ld
 
 CMD_WRAPPER_SRC=$ROOT_DIR/mk/script/application_template.c

--- a/src/include/sys/cdefs.h
+++ b/src/include/sys/cdefs.h
@@ -35,4 +35,10 @@
 # define EMPTY_STRUCT_BODY
 #endif
 
+#ifdef __clang__
+#define __strong_alias(alias, sym) \
+    __asm__(".global " #alias "\n" \
+            #alias " = " #sym);
+#endif
+
 #endif /* SYS_CDEFS_H_ */

--- a/templates/arm/stm32f4cube_clang/build.conf
+++ b/templates/arm/stm32f4cube_clang/build.conf
@@ -1,0 +1,39 @@
+COMPILER=clang
+
+# to see which target clang supports:
+# sudo update-alternatives --install /usr/bin/llc llc /usr/lib/llvm-3.9/bin/llc 20
+# llc -march=arm -mattr=help
+
+TARGET = embox
+
+PLATFORM = stm32f4
+
+ARCH = arm
+
+CROSS_COMPILE = arm-none-eabi-
+
+CFLAGS += -O0 -g
+ifeq ($(COMPILER),clang)
+CFLAGS += -target armv7e-m---  -mlittle-endian -mcpu=cortex-m4 -msoft-float \
+	-ffreestanding
+OLIBM_ARCH = armv7e-m
+LIBGCC_FINDER=arm-none-eabi-gcc -mthumb -march=armv7e-m
+else
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float \
+	-ffreestanding
+endif
+
+LDFLAGS += -N -g
+
+# happens in stm32_flash_cube.c
+override CFLAGS += -Wno-unused-const-variable
+# in ping.c
+override CFLAGS += -Wno-gnu-variable-sized-type-not-at-end
+# icmpv4.c
+override CFLAGS += -Wno-varargs
+# src/drivers/tty/serial/ttys_processing.c and maybe many others
+override CFLAGS += -Wno-unused-function
+# src/lib/crypt/b64.c
+override CFLAGS += -Wno-tautological-constant-out-of-range-compare
+# build/extbld/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash_ex.c
+override CFLAGS += -Wno-parentheses-equality

--- a/templates/arm/stm32f4cube_clang/lds.conf
+++ b/templates/arm/stm32f4cube_clang/lds.conf
@@ -1,0 +1,14 @@
+/*
+ * Linkage configuration.
+ */
+
+/* region (origin, length) */
+ROM (0x08000000, 1M)
+RAM (0x20000000, 128K)
+region(SRAM_CCM, 0x10000000, 64K)
+
+/* section (region[, lma_region]) */
+text   (ROM)
+rodata (ROM)
+data   (RAM, ROM)
+bss    (RAM)

--- a/templates/arm/stm32f4cube_clang/mods.config
+++ b/templates/arm/stm32f4cube_clang/mods.config
@@ -1,0 +1,100 @@
+
+package genconfig
+
+configuration conf {
+	@Runlevel(0) include embox.arch.system(core_freq=144000000)
+	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
+	@Runlevel(0) include third_party.bsp.stmf4cube.arch
+	include embox.arch.arm.vfork
+
+	@Runlevel(0) include embox.kernel.stack(stack_size=4096,alignment=4)
+
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
+	/*@Runlevel(1) include embox.driver.interrupt.cmsis_nvic*/
+	@Runlevel(1) include embox.driver.clock.cortexm_systick
+	@Runlevel(1) include embox.driver.serial.stm_usart_f4(baud_rate=115200, usartx=6)
+	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f4")
+	@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=57600, usartx=2)
+	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=6)
+
+	//@Runlevel(2) include embox.driver.net.stm32f4_eth
+	@Runlevel(2) include embox.driver.net.stm32cube_eth
+	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(2) include embox.driver.flash.stm32f4cube
+
+	include embox.kernel.task.multi
+	include embox.kernel.task.resource.idesc_table(idesc_table_size=6)
+
+	include embox.kernel.thread.thread_local_none
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.thread.signal_stub
+	include embox.kernel.timer.sleep_nosched
+	include embox.net.skbuff(amount_skb=10)
+	include embox.net.skbuff_data(amount_skb_data=10)
+	include embox.net.sock_noxattr
+	include embox.net.tcp
+	include embox.net.tcp_sock
+	include embox.kernel.sched.sched
+	include embox.kernel.sched.idle_light
+	include embox.kernel.thread.signal_stub
+
+	include embox.kernel.lthread.lthread
+	include embox.kernel.thread.core(thread_pool_size=1)
+
+	/* tty requires */
+	include embox.kernel.thread.mutex
+	include embox.driver.tty.tty(rx_buff_sz=16, io_buff_sz=16)
+	include embox.driver.tty.task_breaking_disable
+
+	@Runlevel(2) include embox.cmd.shell
+	include embox.init.setup_tty_diag
+	@Runlevel(3) include embox.init.start_script(shell_name="diag_shell")
+
+	include embox.cmd.fs.ls
+	/* commented out to reduce image size */
+	/*
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.route
+	include embox.cmd.net.ping
+	include embox.cmd.net.httpd(use_real_cmd=true)
+	include embox.cmd.net.httpd_cgi
+	include embox.service.http_admin */
+	include embox.compat.posix.proc.vfork_exchanged
+	include embox.compat.posix.proc.exec_exchanged
+
+	include embox.util.hashtable
+	include embox.cmd.help
+	include embox.cmd.sys.version
+	include embox.util.log
+	include embox.kernel.critical
+	include embox.kernel.irq
+	include embox.mem.pool_adapter
+
+	include embox.util.LibUtil
+	/*include embox.framework.embuild_light*/
+	include embox.framework.LibFramework
+	include embox.arch.arm.libarch
+	include embox.compat.libc.stdio.print(support_floating=0)
+
+	include embox.mem.heap_bm
+	include embox.mem.static_heap(heap_size=0x4000)
+	include embox.mem.bitmask(page_size=64)
+
+	include third_party.bsp.stmf4cube.core
+	include third_party.bsp.stmf4cube.cmsis
+
+	include embox.fs.driver.initfs_dvfs
+	include embox.fs.driver.devfs_dvfs
+	include embox.fs.rootfs_dvfs(fstype="initfs")
+/*
+	include embox.driver.char_dev_dvfs
+	include embox.driver.virtual.null_dvfs
+	include embox.driver.virtual.zero_dvfs*/
+	include embox.driver.serial.uart_dev_dvfs
+
+	include embox.fs.dvfs.core
+	include embox.compat.posix.fs.all_dvfs
+	include embox.fs.syslib.perm_stub
+	include embox.driver.block_common
+	include embox.driver.block_dvfs
+}

--- a/templates/arm/stm32f4cube_clang/start_script.inc
+++ b/templates/arm/stm32f4cube_clang/start_script.inc
@@ -1,0 +1,5 @@
+"ifconfig lo 127.0.0.1 netmask 255.0.0.0 up",
+"route add 127.0.0.0 netmask 255.0.0.0 lo",
+
+"ifconfig eth0 192.168.1.128 netmask 255.255.255.0 hw ether AA:BB:CC:DD:EE:02 up",
+"route add 192.168.1.0 netmask 255.255.255.0 eth0",

--- a/third-party/lib/libgcc/Mybuild
+++ b/third-party/lib/libgcc/Mybuild
@@ -1,7 +1,7 @@
 package third_party.lib
 
 static module libgcc_toolchain extends embox.lib.LibGcc {
-	@Rule(script="$(CP) \"$$($(CC) $(CFLAGS) -print-file-name=libgcc.a | sed $$'s/\r$$//')\" $(OBJ_DIR)/third-party/lib/libgcc")
+	@Rule(script="$(CP) \"$$($(LIBGCC_FINDER) -print-file-name=libgcc.a | sed $$'s/\r$$//')\" $(OBJ_DIR)/third-party/lib/libgcc")
 	source "libgcc.a"
 	source "empty.c"
 }

--- a/third-party/lib/openlibm/Makefile
+++ b/third-party/lib/openlibm/Makefile
@@ -10,7 +10,11 @@ PKG_MD5 := 4bc22ffc211f959080173587e81742ec
 PKG_PATCHES := openlibm_embox.patch
 
 include $(EXTBLD_LIB)
+include $(ROOT_DIR)/mk/core/compiler.mk
 
+ifeq ($(COMPILER),clang)
+
+else
 OLIBM_ARCH ?=
 ifneq ($(filter x86 usermode86,$(ARCH)),)
 OLIBM_ARCH := i386
@@ -26,6 +30,7 @@ OLIBM_ARCH := $(subst -march=,,$(filter -march=%,$(CFLAGS)))
 endif
 ifeq ($(strip $(OLIBM_ARCH)),)
 $(error OLIBM_ARCH -march is undefined)
+endif
 endif
 endif
 


### PR DESCRIPTION
First of all it compiles and it doesn't break compilation with gcc.
Run `make confload-arm/stm32f4cube_clang all` to get the image.

There are some difficulties about supporting two different compilers.
Maybe I did it not in optiomal way but it works. The main issue that
command line switcher are different for gcc and clang (the latter uses
`-target` switch to specify a triplet). Also we can't compiler with clang
and _without_ gcc because clang is only a compiler and relies on cross
toolchain.

Also there some issues with clang codegeneration: generated object files
are bigger than with GCC. That's why some modules were commented out for
stm32f4cube.