### PR TITLE
Fix some redundant checks for non-NULL values raised up by clang

### DIFF
--- a/src/drivers/char/terminal/vt.h
+++ b/src/drivers/char/terminal/vt.h
@@ -41,7 +41,7 @@ struct vt_token {
 	vt_action_t action;
 	char        ch;
 	char        attrs[VT_TOKEN_ATTRS_MAX];
-	char        attrs_len;
+	int         attrs_len;
 	short      *params;
 	int         params_len;
 };

--- a/src/net/util/show_packet.h
+++ b/src/net/util/show_packet.h
@@ -20,7 +20,7 @@ static inline void show_packet(uint8_t *raw, int size, char *title) {
 	if (!&mod_logger)
 		return;
 
-	if (&mod_logger.logging &&
+	if (//&mod_logger.logging &&
 		mod_logger.logging.level >= LOG_DEBUG - 1) {
 
 		printk("\nPACKET(%d) %s:\n", size, title);


### PR DESCRIPTION
Some warnings raised during compiling with clang for stm32f4cube. In `vtparse.c ` we compare unsigned value with -1. In another file we test that the pointer to global value is not null.

@anton-bondarev 

P.S. It is a part of #1023 for now.

````
src/drivers/char/terminal/vtparse.c:49:24: error: comparison of constant -1 with expression of type 'char' is always false
      [-Werror,-Wtautological-constant-out-of-range-compare]
                if (token->attrs_len == -1) {
                    ~~~~~~~~~~~~~~~~ ^  ~~

````