### PR TITLE
Starting clang support

### DIFF
--- a/mk/core/compiler.mk
+++ b/mk/core/compiler.mk
@@ -1,0 +1,4 @@
+ifndef COMPILER
+COMPILER := gcc
+endif
+export COMPILER

--- a/mk/extbld.mk
+++ b/mk/extbld.mk
@@ -6,6 +6,7 @@ __extbld-1 __extbld-2 :
 
 FORCE :
 
+include $(ROOT_DIR)/mk/core/compiler.mk
 include mk/image_lib.mk
 include $(MKGEN_DIR)/build.mk
 

--- a/mk/extbld/arch-embox-clang
+++ b/mk/extbld/arch-embox-clang
@@ -1,0 +1,1 @@
+arch-embox-gcc

--- a/mk/extbld/arch-embox-gcc
+++ b/mk/extbld/arch-embox-gcc
@@ -9,9 +9,9 @@ fi
 
 cmd=$(basename $0)
 case $cmd in
-	*-gcc) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CFLAGS";;
-	*-g++) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CXXFLAGS";;
-	*)     echo "Unknown flags for $cmd"; exit 1;;
+	*-gcc|*-clang) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CFLAGS";;
+	*-g++)         C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CXXFLAGS";;
+	*)             echo "Unknown flags for $cmd"; exit 1;;
 esac
 
 case $EMBOX_GCC_LINK in
@@ -34,5 +34,11 @@ esac
 ARG_LINE="$ARG_LINE $EMBOX_IMPORTED_CPPFLAGS"
 PWD_ARG_LINE="$(for i in $ARG_LINE; do echo ${i/$PWD/.}; done)"
 # echo "$EMBOX_CROSS_COMPILE${cmd#arch-embox-} $@ $PWD_ARG_LINE" >&2
-$EMBOX_CROSS_COMPILE${cmd#arch-embox-} "$@" $PWD_ARG_LINE
-exit $?
+
+if [[ "$cmd" == *clang ]]; then
+	clang "$@" -target arm-none-eabi $PWD_ARG_LINE
+	exit $?
+else
+	$EMBOX_CROSS_COMPILE${cmd#arch-embox-} "$@" $PWD_ARG_LINE
+	exit $?
+fi

--- a/mk/extbld/lib.mk
+++ b/mk/extbld/lib.mk
@@ -126,5 +126,9 @@ endif
 AUTOCONF_TARGET_TRIPLET=$(AUTOCONF_ARCH)-unknown-none
 endif
 
+ifeq ($(COMPILER),clang)
+EMBOX_GCC := $(ROOT_DIR)/mk/extbld/arch-embox-clang
+else
 EMBOX_GCC := $(ROOT_DIR)/mk/extbld/arch-embox-gcc
 EMBOX_GXX := $(ROOT_DIR)/mk/extbld/arch-embox-g++
+endif

--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -9,9 +9,6 @@ ARFLAGS ?=
 LDFLAGS ?=
 
 CROSS_COMPILE ?=
-
-CC      ?= $(CROSS_COMPILE)gcc
-CPP     ?= $(CC) -E
 CXX     ?= $(CROSS_COMPILE)g++
 AR      ?= $(CROSS_COMPILE)ar
 AS      ?= $(CROSS_COMPILE)as
@@ -20,6 +17,15 @@ NM      ?= $(CROSS_COMPILE)nm
 OBJDUMP ?= $(CROSS_COMPILE)objdump
 OBJCOPY ?= $(CROSS_COMPILE)objcopy
 SIZE    ?= $(CROSS_COMPILE)size
+
+ifeq ($(COMPILER),clang)
+CC      ?= clang
+# for clang LIBGCC_FINDER will be set externally to arm-none-eabi-gcc or something like that
+else
+CC      ?= $(CROSS_COMPILE)gcc
+LIBGCC_FINDER=$(CC) $(CFLAGS)
+endif
+CPP     ?= $(CC) -E
 
 comma_sep_list = $(subst $(\s),$(,),$(strip $1))
 
@@ -90,6 +96,7 @@ EXTERNAL_MAKE_FLAGS = \
 			CACHE_DIR, \
 		$(path_var)=$(abspath $($(path_var)))) \
 	BUILD_DIR=$(abspath $(mod_build_dir)) \
+	COMPILER=$(COMPILER) \
 	EMBOX_ARCH='$(ARCH)' \
 	EMBOX_CROSS_COMPILE='$(CROSS_COMPILE)' \
 	EMBOX_MAKEFLAGS='$(MAKEFLAGS)' \
@@ -177,19 +184,21 @@ override ASFLAGS += $(asflags)
 override COMMON_CCFLAGS := $(COMMON_FLAGS)
 override COMMON_CCFLAGS += -fno-strict-aliasing -fno-common
 override COMMON_CCFLAGS += -Wall -Werror
-override COMMON_CCFLAGS += -Wundef -Wno-trigraphs -Wno-char-subscripts 
+override COMMON_CCFLAGS += -Wundef -Wno-trigraphs -Wno-char-subscripts
 
 override COMMON_CCFLAGS += -Wno-gnu-designator
 
+ifneq ($(COMPILER),clang)
+# Not clang means gcc
 # This option conflicts with some third-party stuff, so we disable it.
 override COMMON_CCFLAGS += -Wno-misleading-indentation
 
-
 # GCC 6 seems to have many library functions declared as __nonnull__, like
-# fread, fwrite, fprintf, ...  Since accessing NULL in embox without MMU 
-# support could cause real damage to whole system in contrast with segfault of 
+# fread, fwrite, fprintf, ...  Since accessing NULL in embox without MMU
+# support could cause real damage to whole system in contrast with segfault of
 # application, we decided to keep explicit null checks and disable the warning.
 override COMMON_CCFLAGS += -Wno-nonnull-compare
+endif
 
 override COMMON_CCFLAGS += -Wformat
 
@@ -222,4 +231,3 @@ CCFLAGS ?=
 
 INCLUDES_FROM_FLAGS := \
 	$(patsubst -I%,%,$(filter -I%,$(CPPFLAGS) $(CXXFLAGS)))
-

--- a/mk/main-stripping.sh
+++ b/mk/main-stripping.sh
@@ -25,7 +25,11 @@ fi
 
 OBJCOPY=${EMBOX_CROSS_COMPILE}objcopy
 OBJDUMP=${EMBOX_CROSS_COMPILE}objdump
-CC=${EMBOX_CROSS_COMPILE}gcc
+if [ "$COMPILER" = "clang" ]; then
+	CC=clang
+else
+	CC=${EMBOX_CROSS_COMPILE}gcc
+fi
 LD=${EMBOX_CROSS_COMPILE}ld
 
 CMD_WRAPPER_SRC=$ROOT_DIR/mk/script/application_template.c


### PR DESCRIPTION
First of all it compiles and it doesn't break compilation with gcc.
Run COMPILER=clang make confload-arm/stm32f4cube all to get the image.

There are some difficulties about supporting two different compilers.
Maybe I did it not in optiomal way but it works. The main issue that
command line switcher are different for gcc and clang (the latter uses
-target switch to specify a triplet). Also we can't compiler with clang
and without gcc because clang is only a compiler and relies on cross
toolchain.

Also there some issues with clang codegeneration: generated object files
are bigger than with GCC. That's why some modules were commented out for
stm32f4cube.