### PR TITLE
Fix some redundant checks for non-NULL values raised up by clang

### DIFF
--- a/src/drivers/char/terminal/vt.h
+++ b/src/drivers/char/terminal/vt.h
@@ -41,7 +41,7 @@ struct vt_token {
 	vt_action_t action;
 	char        ch;
 	char        attrs[VT_TOKEN_ATTRS_MAX];
-	char        attrs_len;
+	int         attrs_len;
 	short      *params;
 	int         params_len;
 };

--- a/src/net/util/show_packet.h
+++ b/src/net/util/show_packet.h
@@ -20,8 +20,7 @@ static inline void show_packet(uint8_t *raw, int size, char *title) {
 	if (!&mod_logger)
 		return;
 
-	if (&mod_logger.logging &&
-		mod_logger.logging.level >= LOG_DEBUG - 1) {
+	if (mod_logger.logging.level >= LOG_DEBUG - 1) {
 
 		log_raw(LOG_DEBUG, "PACKET(%d) %s:\n", size, title);
 		int rows = (size + STR_BYTES - 1) / STR_BYTES;

--- a/src/net/util/show_packet.h
+++ b/src/net/util/show_packet.h
@@ -9,12 +9,12 @@
 #ifndef SHOW_PACKET_H
 #define SHOW_PACKET_H
 
-#include <kernel/printk.h>
 #include <util/log.h>
+#include <stdint.h>
+
 
 #define STR_BYTES 16
 
-extern struct logger mod_logger __attribute__ ((weak));
 
 static inline void show_packet(uint8_t *raw, int size, char *title) {
 	if (!&mod_logger)
@@ -23,17 +23,19 @@ static inline void show_packet(uint8_t *raw, int size, char *title) {
 	if (&mod_logger.logging &&
 		mod_logger.logging.level >= LOG_DEBUG - 1) {
 
-		printk("\nPACKET(%d) %s:\n", size, title);
+		log_raw(LOG_DEBUG, "PACKET(%d) %s:\n", size, title);
 		int rows = (size + STR_BYTES - 1) / STR_BYTES;
 		for (int i = 0; i < rows; i++) {
 			for (int j = 0; j < STR_BYTES; j++) {
 				int pos = i * STR_BYTES + j;
-				if (pos < size)
-					printk(" %02hhX", *(raw + pos));
-				else
-					printk("   ");
+				if (pos < size) {
+					log_raw(LOG_DEBUG, " %02hhX", *(raw + pos));
+				}
+				else {
+					log_raw(LOG_DEBUG, "   ");
+				}
 			}
-			printk("   ");
+			log_raw(LOG_DEBUG, "   ");
 			for (int j = 0; j < STR_BYTES; j++) {
 				int pos = i * STR_BYTES + j;
 				if (pos < size) {
@@ -41,10 +43,10 @@ static inline void show_packet(uint8_t *raw, int size, char *title) {
 					if (c < 33 || c > 126)
 						c = '.';
 
-					printk("%c", c);
+					log_raw(LOG_DEBUG, "%c", c);
 				}
 			}
-			printk("\n");
+			log_raw(LOG_DEBUG, "\n");
 		}
 	}
 }

--- a/src/util/logging.c
+++ b/src/util/logging.c
@@ -6,9 +6,11 @@
  * @author Vita Loginova
  */
 
+#include <assert.h>
+#include <stdarg.h>
+
 #include <kernel/printk.h>
 #include <util/logging.h>
-#include <stdarg.h>
 
 char *log_levels[LOG_DEBUG] = {
 	"error",
@@ -18,7 +20,9 @@ char *log_levels[LOG_DEBUG] = {
 };
 
 void logging_raw(struct logging *logging, int level, const char* fmt, ...) {
-	if (logging && level <= logging->level) {
+	assert(logging);
+
+	if (level <= logging->level) {
 		va_list args;
 
 		va_start(args, fmt);


### PR DESCRIPTION
This is re-based #1024 

@AntonKozlov commented log_level is not break any templates