### PR TITLE
third-party: Add PKG_ARCHIVE_NAME for some extern packages

### DIFF
--- a/third-party/chibi-scheme/Makefile
+++ b/third-party/chibi-scheme/Makefile
@@ -2,6 +2,8 @@
 PKG_NAME := chibi-scheme
 PKG_VER  := 0.6.1
 
+PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
+
 PKG_SOURCES := https://github.com/ashinn/$(PKG_NAME)/archive/$(PKG_VER).tar.gz
 PKG_MD5     := 16b69c3497b46dfb65af8d98549b037b
 

--- a/third-party/libcoap/lib/Makefile
+++ b/third-party/libcoap/lib/Makefile
@@ -1,6 +1,8 @@
 PKG_NAME := libcoap
 PKG_VER  := 4.1.1
 
+PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
+
 PKG_SOURCES := https://github.com/obgm/$(PKG_NAME)/archive/v$(PKG_VER).tar.gz
 PKG_MD5     := ff1af4bd9893c1728e765aa08a816e41
 

--- a/third-party/lua/lib/luasocket/Makefile
+++ b/third-party/lua/lib/luasocket/Makefile
@@ -2,6 +2,7 @@
 PKG_NAME := luasocket
 PKG_VER  := 321c0c9b1f7b6b83cd83b58e7e259f53eca69373
 
+PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
 PKG_SOURCES := https://github.com/diegonehab/luasocket/archive/$(PKG_VER).tar.gz
 PKG_MD5     := e2d6845e1f75d2e24df5563f643598af
 

--- a/third-party/mruby/Makefile
+++ b/third-party/mruby/Makefile
@@ -2,6 +2,8 @@
 PKG_NAME := mruby
 PKG_VER  := 1.1.0
 
+PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
+
 PKG_SOURCES := https://github.com/mruby/mruby/archive/$(PKG_VER).tar.gz
 PKG_MD5     := 60d75ea704c9285f3c80b3ad1d2b68de
 


### PR DESCRIPTION
Add PKG_ARCHIVE_NAME for packages:
 * chibi-scheme
 * libcoap
 * luasocket
 * mruby