### PR TITLE
Arm telnetd

### DIFF
--- a/src/arch/arm/mmu/mmu_small_page.c
+++ b/src/arch/arm/mmu/mmu_small_page.c
@@ -34,13 +34,8 @@ void mmu_pmd_set(mmu_pgd_t *pmd, mmu_pmd_t *pte) {
 }
 
 void mmu_pte_set(mmu_pte_t *pte, mmu_paddr_t addr) {
-#if 0
 	*pte = (mmu_pte_t) ((((uint32_t)addr) & ~MMU_PAGE_MASK)
-			| ARM_MMU_PAGE_READ_ACC
-			| ARM_MMU_SMALL_PAGE);
-#endif
-	*pte = (mmu_pte_t) ((((uint32_t)addr) & ~MMU_PAGE_MASK)
-			| 0x036);
+			| 0x030 | L1D_TYPE_SD | L1D_B);
 }
 
 void mmu_pgd_unset(mmu_pgd_t *pgd) {
@@ -68,20 +63,16 @@ int mmu_pte_present(mmu_pte_t *pte) {
 }
 
 void mmu_pte_set_writable(mmu_pte_t *pte, int value) {
-#if 0
-	if (value & VMEM_PAGE_WRITABLE) {
-		*pte |= ARM_MMU_PAGE_WRITE_ACC;
-	} else {
-		*pte &= ~ARM_MMU_PAGE_WRITE_ACC;
-	}
-#endif
+
 }
 
 void mmu_pte_set_cacheable(mmu_pte_t *pte, int value) {
 	if (value & VMEM_PAGE_CACHEABLE) {
-		*pte |= L1D_C;
+		*pte &= ~L1D_B;
+		*pte |= L1D_C;// | (7 << 6);
 	} else {
 		*pte &= ~L1D_C;
+		*pte |= L1D_B;
 	}
 }
 

--- a/src/compat/posix/proc/exec.c
+++ b/src/compat/posix/proc/exec.c
@@ -70,23 +70,32 @@ int exec_call(void) {
 int execv(const char *path, char *const argv[]) {
 	struct task *task;
 	int i;
-	char cmd_name[MAX_TASK_NAME_LEN] = {0};
+	size_t len;
+	char cmd_name[MAX_TASK_NAME_LEN];
+
 	/* save starting arguments for the task */
 	task = task_self();
 	task_resource_exec(task, path, argv);
 
+	cmd_name[0] = '\0';
 
 	for (i = 0; argv[i] != NULL; i ++) {
-		strncat(cmd_name, argv[i], MAX_TASK_NAME_LEN);
+		len = strlen(cmd_name);
+		strncat(cmd_name, argv[i], MAX_TASK_NAME_LEN - len - 1);
 		cmd_name[MAX_TASK_NAME_LEN - 1] = '\0';
-		strncat(cmd_name, " ", MAX_TASK_NAME_LEN);
-		cmd_name[MAX_TASK_NAME_LEN - 1] = '\0';
+		if (argv[i + 1] == NULL) {
+			break;
+		}
 
 		/* this code is required the only if argv is not NULL terminated */
 		if (i >= 3){
 			// TODO for protection from a lot of arguments
 			break;
 		}
+
+		strncat(cmd_name, " ", MAX_TASK_NAME_LEN - len - 1);
+		cmd_name[MAX_TASK_NAME_LEN - 1] = '\0';
+
 	}
 
 	task_set_name(task, cmd_name);

--- a/src/compat/posix/proc/exec.c
+++ b/src/compat/posix/proc/exec.c
@@ -81,8 +81,10 @@ int execv(const char *path, char *const argv[]) {
 
 	for (i = 0; argv[i] != NULL; i ++) {
 		len = strlen(cmd_name);
+		if (MAX_TASK_NAME_LEN - len - 1 <= 0) {
+			break;
+		}
 		strncat(cmd_name, argv[i], MAX_TASK_NAME_LEN - len - 1);
-		cmd_name[MAX_TASK_NAME_LEN - 1] = '\0';
 		if (argv[i + 1] == NULL) {
 			break;
 		}
@@ -93,9 +95,11 @@ int execv(const char *path, char *const argv[]) {
 			break;
 		}
 
+		len = strlen(cmd_name);
+		if (MAX_TASK_NAME_LEN - len - 1 <= 0) {
+			break;
+		}
 		strncat(cmd_name, " ", MAX_TASK_NAME_LEN - len - 1);
-		cmd_name[MAX_TASK_NAME_LEN - 1] = '\0';
-
 	}
 
 	task_set_name(task, cmd_name);

--- a/templates/arm/imx6/mods.config
+++ b/templates/arm/imx6/mods.config
@@ -8,6 +8,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.cpu.cpudata
 	@Runlevel(0) include embox.kernel.irq
 	@Runlevel(0) include embox.arch.arm.stackframe
+	include embox.arch.arm.vfork
 
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
@@ -57,6 +58,8 @@ configuration conf {
 	@Runlevel(2) include embox.net.skbuff_data(amount_skb_data=4000,data_size=1514,data_align=1,data_padto=1,ip_align=true)
 	@Runlevel(2) include embox.net.skbuff_extra(amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
 
+	include embox.cmd.help
+	include embox.cmd.service
 	include embox.cmd.sys.env
 	include embox.cmd.sys.export
 

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -8,6 +8,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.cpu.cpudata
 	@Runlevel(0) include embox.kernel.irq
 	@Runlevel(0) include embox.arch.arm.stackframe
+	include embox.arch.arm.vfork
 
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
@@ -57,6 +58,8 @@ configuration conf {
 	@Runlevel(2) include embox.net.skbuff_data(amount_skb_data=4000,data_size=1514,data_align=1,data_padto=1,ip_align=true)
 	@Runlevel(2) include embox.net.skbuff_extra(amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
 
+	include embox.cmd.help
+	include embox.cmd.service
 	include embox.cmd.sys.env
 	include embox.cmd.sys.export
 

--- a/templates/arm/vexpress-a9/mods.config
+++ b/templates/arm/vexpress-a9/mods.config
@@ -53,6 +53,7 @@ configuration conf {
 	@Runlevel(2) include embox.cmd.sh.tish(prompt="embox#")
 	@Runlevel(3) include embox.init.start_script(shell_name="tish", shell_start=1, stop_on_error=true)
 
+	include embox.cmd.service
 	include embox.cmd.net.arp
 	include embox.cmd.net.arping
 	include embox.cmd.net.ping


### PR DESCRIPTION
- Fix telnetd for cortex-a9 boards. execv was broken where setup task_name.
- Correct arm mmu-small pages cache flags
- Implement arasan net driver  (gemac)
  