### PR TITLE
Optimized build

### DIFF
--- a/src/arch/arm/lib/Mybuild
+++ b/src/arch/arm/lib/Mybuild
@@ -15,6 +15,8 @@ module cxxabi {
 
 static module vfork extends embox.arch.vfork_entry {
 	source "vfork.S"
+
+	depends embox.compat.posix.proc.vfork_entry
 }
 
 static module fork extends embox.arch.fork_entry {

--- a/src/cmds/net/ntpdate.c
+++ b/src/cmds/net/ntpdate.c
@@ -58,7 +58,7 @@ static int make_socket(const struct timeval *timeout, int *out_sock,
 
 static int ntpdate_exec(struct ntphdr *req, in_addr_t server_addr,
 		const struct timeval *timeout, struct ntphdr *out_rep) {
-	int ret, sock;
+	int ret, sock = 0;
 	struct sockaddr_in addr;
 
 	assert(req != NULL);

--- a/src/cmds/net/tftp.c
+++ b/src/cmds/net/tftp.c
@@ -327,7 +327,7 @@ static int tftp_send_file(char *filename, char *hostname, char binary_on) {
 	socklen_t remote_addr_len;
 	FILE *fp = NULL;
 	struct tftp_msg snd, rcv;
-	size_t snd_len, rcv_len;
+	size_t snd_len, rcv_len = 0;
 	uint16_t pkg_number;
 
 	ret = make_remote_addr(hostname,
@@ -409,7 +409,7 @@ static int tftp_recv_file(char *filename, char *hostname, char binary_on) {
 	socklen_t remote_addr_len;
 	FILE *fp = NULL;
 	struct tftp_msg snd, rcv;
-	size_t snd_len, rcv_len, data_len;
+	size_t snd_len, rcv_len = 0, data_len;
 	uint16_t pkg_number;
 
 	ret = make_remote_addr(hostname,

--- a/src/cmds/play.c
+++ b/src/cmds/play.c
@@ -83,7 +83,7 @@ static int fd_callback(const void *inputBuffer, void *outputBuffer,
 int main(int argc, char **argv) {
 	int opt;
 	int err;
-	FILE *fd;
+	FILE *fd = NULL;
 	static uint8_t fmt_buf[128];
 	int chan_n = 2;
 	int sample_rate = 44100;
@@ -208,6 +208,7 @@ err_terminate_pa:
 		printf("Portaudio error: could not terminate!\n");
 
 err_close_fd:
-	fclose(fd);
+	if (fd)
+		fclose(fd);
 	return 0;
 }

--- a/src/drivers/audio/aaci_pl041/aaci_pl041.c
+++ b/src/drivers/audio/aaci_pl041/aaci_pl041.c
@@ -154,7 +154,7 @@ static void aaci_pl041_dev_resume(struct audio_dev *dev) {
 static int aaci_pl041_ioctl(struct audio_dev *dev, int cmd, void *args) {
 	log_debug("dev = 0x%X", dev);
 	switch(cmd) {
-	case ADIOCTL_SUPPORT:
+	case ADIOCTL_OUT_SUPPORT:
 		return AD_STEREO_SUPPORT |
 		       AD_16BIT_SUPPORT;
 	case ADIOCTL_BUFLEN:
@@ -394,7 +394,7 @@ static void aaci_fifo_irq(uint32_t base, int channel, uint32_t mask) {
 
 	if (mask & AACI_ISR_TXINTR) {
 	/*
-	AACITXINTR 1-4 
+	AACITXINTR 1-4
 	If the FIFO is enabled, the FIFO transmit interrupt is asserted
 	when the PrimeCell AACI transmit FIFO is less than, or equal to,
 	half-empty and the mask bit TxIE is set. The FIFO transmit

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -498,7 +498,7 @@ static int nfs_create_dir_entry(node_t *parent_node) {
 	char *point;
 	nfs_file_info_t *parent_fi;
 	nfs_filehandle_t *fh;
-	readdir_desc_t *predesc;
+	readdir_desc_t *predesc = NULL;
 
 	char *rcv_buf;
 

--- a/templates/arm/overo/mods.config
+++ b/templates/arm/overo/mods.config
@@ -10,6 +10,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.stackframe
 	//@Runlevel(0) include embox.arch.arm.mmu_small_page
 	//@Runlevel(0) include embox.mem.vmem_alloc(pgd_align=0x4000,pmd_align=0x1000,pte_align=0x1000)
+	@Runlevel(0) include embox.arch.arm.vfork
 
 	@Runlevel(0) include embox.kernel.stack(stack_size=4096)
 	@Runlevel(1) include embox.driver.serial.ns16550


### PR DESCRIPTION
We had some problems with -O2 optimization as some variables could be used uninitialized in some cases. For some reason with -O0 these errors are not detected (even as warnings).

Now this problem is fixed for x86/qemu, arm/qemu, arm/overo.

Also fix minor dependency issues for arm/vfork.