### PR TITLE
Fix stm32f4cube

### DIFF
--- a/src/drivers/interrupt/cortexm_nvic.c
+++ b/src/drivers/interrupt/cortexm_nvic.c
@@ -118,3 +118,17 @@ void irqctrl_force(unsigned int interrupt_nr) {
 	}
 }
 
+static void hnd_stub(void) {
+	/* It's just a stub. DO NOTHING */
+}
+
+void nvic_table_fill_stubs(void) {
+	int i;
+
+	for (i = 0; i < EXCEPTION_TABLE_SZ; i++) {
+		exception_table[i] = ((int) hnd_stub) | 1;
+	}
+
+	REG_STORE(SCB_VTOR, 1 << 29 /* indicate, table in SRAM */ |
+			(int) exception_table);
+}

--- a/third-party/bsp/stmf4cube/arch.c
+++ b/third-party/bsp/stmf4cube/arch.c
@@ -61,11 +61,15 @@ static void SystemClock_Config(void)
   }
 }
 
+extern void nvic_table_fill_stubs(void);
+
 void arch_init(void) {
 	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 144000000);
 
 	SystemInit();
 	HAL_Init();
+
+	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 }

--- a/third-party/bsp/stmf4cube/arch.c
+++ b/third-party/bsp/stmf4cube/arch.c
@@ -13,16 +13,61 @@
 #include <hal/clock.h>
 
 #include <system_stm32f4xx.h>
+#include <stm32f4xx_hal.h>
+#include <stm32f4_discovery.h>
 #include <stm32f4xx_hal_cortex.h>
 
 #include <framework/mod/options.h>
 #include <module/embox/arch/system.h>
 
+static void SystemClock_Config(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
 
+  /* Enable Power Control clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet.  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* Enable HSE Oscillator and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = 8;
+  RCC_OscInitStruct.PLL.PLLN = 336;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLQ = 7;
+  HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+     clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5);
+
+  /* STM32F405x/407x/415x/417x Revision Z devices: prefetch is supported  */
+  if (HAL_GetREVID() == 0x1001)
+  {
+    /* Enable the Flash prefetch */
+    __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+  }
+}
 
 void arch_init(void) {
 	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 144000000);
+
 	SystemInit();
+	HAL_Init();
+
+	SystemClock_Config();
 }
 
 void arch_idle(void) {


### PR DESCRIPTION
Fix stm32f4-cube -- clock was not initizalized. That was leading to some unpredicted behavior, for instance, network crash