### PR TITLE
Add missing dependencies to ide_drive

### DIFF
--- a/src/drivers/block_dev/Mybuild
+++ b/src/drivers/block_dev/Mybuild
@@ -23,6 +23,7 @@ module block {
 
 	depends embox.fs.buffer_cache
 	depends embox.fs.buffer_crypt_api
+	depends embox.fs.rootfs
 	depends embox.fs.core
 	depends embox.util.LibUtil
 	depends embox.util.indexator

--- a/src/drivers/block_dev/ide/Mybuild
+++ b/src/drivers/block_dev/ide/Mybuild
@@ -10,6 +10,7 @@ module ide {
 	@IncludeExport(path="drivers")
 	source "ide.h"
 
+	depends embox.driver.block
 	depends embox.util.LibUtil
 	depends embox.driver.block_common
 	depends embox.util.indexator


### PR DESCRIPTION
Ide drive registers itself during initialization via block_dev, and block_dev responsible to create entry in `/dev` corresponding to the drive.
However, `/dev` created by rootfs and if ide_drive initilized before rootfs, ide_drive entry is not created in dev.
The reason is in missing dependencies ide_drive -> block_dev and block_dev -> root_fs
Before the patch
```
$ make confload-x86/qemu && make && ./auto_qemu -hda some.img
embox> ls /dev
 /dev/null
 /dev/zero
 /dev/ram0
 /dev/ram1
 /dev/ttyS0
```

After the patch
```
$ ./auto_qemu -hda some.img
embox> ls /dev
 /dev/null
 /dev/zero
 /dev/hda
 /dev/cd0
 /dev/ram0
 /dev/ram1
 /dev/ttyS0
```