### PR TITLE
Implement support for multiple UARTS on i.MX6

### DIFF
--- a/src/drivers/serial/imx_uart/Mybuild
+++ b/src/drivers/serial/imx_uart/Mybuild
@@ -1,9 +1,9 @@
 package embox.driver.serial
 
 module imx_uart {
-	option number base_addr=0x02020000
-	option number irq_num=58
+	option number num=1
 	option number baud_rate=115200
+	option number iomuxc_base=0x020e0000
 
 	source "imx_uart.c"
 

--- a/src/drivers/serial/imx_uart/imx_uart.c
+++ b/src/drivers/serial/imx_uart/imx_uart.c
@@ -67,6 +67,7 @@ EMBOX_UNIT_INIT(uart_init);
 #define ONEMS		0xB0
 #define UTS		0xB4
 # define UTS_RST	(1 << 0)
+# define UTS_TXEMPTY	(1 << 6)
 #define UMCR		0xB8
 
 #include <kernel/printk.h>
@@ -155,7 +156,7 @@ static int imxuart_getc(struct uart *dev) {
 static int imxuart_putc(struct uart *dev, int ch) {
 	UART(TXR) = ch;
 
-	while (!(UART(UTS) & (1 << 6))) {
+	while (!(UART(UTS) & UTS_TXEMPTY)) {
 	}
 
 	return 0;

--- a/src/drivers/serial/imx_uart/imx_uart.c
+++ b/src/drivers/serial/imx_uart/imx_uart.c
@@ -11,40 +11,124 @@
 #include <drivers/serial/diag_serial.h>
 #include <embox/unit.h>
 #include <framework/mod/options.h>
+#include <hal/reg.h>
 
 EMBOX_UNIT_INIT(uart_init);
 
-#define UART_BASE OPTION_GET(NUMBER, base_addr)
-#define UART(x)   (*(volatile unsigned long *)(UART_BASE + (x)))
-#define IRQ_NUM OPTION_GET(NUMBER, irq_num)
+#define IOMUXC_BASE	OPTION_GET(NUMBER,iomuxc_base)
+#define UART_NUM	OPTION_GET(NUMBER,num)
+#define IRQ_NUM		(58 + UART_NUM)
 
-#define USR2_RDR   1
-#define USR2_TXFE (1 << 14)
+#if UART_NUM == 0
+#define UART_BASE 0x02020000
+#elif UART_NUM == 1
+#define UART_BASE 0x021E8000
+#elif UART_NUM == 2
+#define UART_BASE 0x021EC000
+#elif UART_NUM == 3
+#define UART_BASE 0x021F0000
+#elif UART_NUM == 4
+#define UART_BASE 0x021F4000
+#else
+#error Wrong UART number!
+#endif
 
-#define RXR  0x00
-#define TXR  0x40
-#define UCR1 0x80
-#define UCR2 0x84
-#define UCR3 0x88
-#define UCR4 0x8C
-#define UFCR 0x90
-#define USR1 0x94 /* Status Register 1 */
-#define USR2 0x98
-#define UBIR 0xA4
-#define UBMR 0xA8
+#define UART(x)		(*(volatile uint32_t *)(UART_BASE + (x)))
 
-#define UCR1_UARTEN (1 << 0)
-#define UCR2_TXEN   (1 << 2)
-#define UCR2_RXEN   (1 << 1)
-#define UCR1_RRDYEN (1 << 9)
-#define USR1_RRDY   (1 << 9)
-#define USR1_RTSD       (1<<12) /* RTS delta */
+#define RXR		0x00
+#define TXR		0x40
+#define UCR1		0x80
+# define UCR1_UARTEN	(1 << 0)
+# define UCR1_RRDYEN	(1 << 9)
+#define UCR2		0x84
+# define UCR2_NORESET	(1 << 0)
+# define UCR2_RXEN	(1 << 1)
+# define UCR2_TXEN	(1 << 2)
+# define UCR2_WORDSIZE	(1 << 5)
+# define UCR2_IRTS	(1 << 14)
+#define UCR3		0x88
+# define UCR3_RXDMUXSEL (1 << 2)
+# define UCR3_RI	(1 << 8)
+# define UCR3_DSR	(1 << 9)
+# define UCR3_DCD	(1 << 10)
+#define UCR4		0x8C
+#define UFCR		0x90
+# define UFCR_RFDIF	7
+#define USR1		0x94
+# define USR1_RRDY	(1 << 9)
+# define USR1_RTSD	(1 << 12)
+#define USR2		0x98
+# define USR2_RDR	1
+# define USR2_TXFE	(1 << 14)
+#define UESC		0x9C
+#define UTIM		0xA0
+#define UBIR		0xA4
+#define UBMR		0xA8
+#define ONEMS		0xB0
+#define UTS		0xB4
+# define UTS_RST	(1 << 0)
+#define UMCR		0xB8
+
+#include <kernel/printk.h>
+
+#define UART_SELECT_PIN(n)	(IOMUXC_BASE + 0x920 + n * 8)
+#define MUX_PIN_CTL_TX(n)	(IOMUXC_BASE + 0x2a8 + n * 8)
+#define MUX_PIN_CTL_RX(n)	(IOMUXC_BASE + 0x2ac + n * 8)a
+
+static void imxuart_configure_pins(void) {
+	/* We need to configure UART pins to use them as
+	 * RXD/TXD. To do it, we need first to config MUX mode register
+	 * and then set source for the UART like follows; look manual for
+	 * more details */
+
+	switch(UART_NUM) {
+	case 0:
+		/* TX */
+		REG32_STORE(IOMUXC_BASE + 0x2A8, 1);
+		REG32_STORE(IOMUXC_BASE + 0x920, 2);
+		/* RX */
+		REG32_STORE(IOMUXC_BASE + 0x2AC, 1);
+		REG32_STORE(IOMUXC_BASE + 0x920, 3);
+		break;
+	case 1:
+		/* Nothing to done */
+	case 2:
+		/* TX */
+		REG32_STORE(IOMUXC_BASE + 0x0B4, 2);
+		REG32_STORE(IOMUXC_BASE + 0x930, 0);
+		/* RX */
+		REG32_STORE(IOMUXC_BASE + 0x0B4, 2);
+		REG32_STORE(IOMUXC_BASE + 0x930, 1);
+		break;
+	case 3:
+		/* TX */
+		REG32_STORE(IOMUXC_BASE + 0x1F8, 4);
+		REG32_STORE(IOMUXC_BASE + 0x938, 0);
+		/* RX */
+		REG32_STORE(IOMUXC_BASE + 0x1FC, 4);
+		REG32_STORE(IOMUXC_BASE + 0x938, 1);
+		break;
+	}
+
+	return;
+}
 
 static int imxuart_setup(struct uart *dev, const struct uart_params *params) {
-	//UART(UCR1) = UCR1_UARTEN;
-	//UART(UCR2) = 0x2127;//|= UCR2_RXEN | UCR2_TXEN;
-	//UART(UCR3) = 0x0704;
-	//UART(UCR4) = 0x7C00;
+	imxuart_configure_pins();
+
+	/* Reset */
+	UART(UCR2) = 0;
+	while(UART(UTS) & UTS_RST);
+
+	UART(UCR1) = UCR1_UARTEN;
+	UART(UCR2) = UCR2_NORESET | UCR2_RXEN | UCR2_TXEN | UCR2_WORDSIZE | UCR2_IRTS;
+	UART(UCR3) = UCR3_RXDMUXSEL | UCR3_RI | UCR3_DCD | UCR3_DSR;
+	UART(UCR4) = 0;
+	UART(UFCR) = 4 << UFCR_RFDIF;
+	UART(UBIR) = 0x0F;
+	UART(UBMR) = 0x015b;
+	UART(UMCR) = 0;
+
 	if (params->irq) {
 		uint32_t reg;
 
@@ -69,49 +153,49 @@ static int imxuart_getc(struct uart *dev) {
 }
 
 static int imxuart_putc(struct uart *dev, int ch) {
-	while (!(UART(USR2) & USR2_TXFE)) {
-	}
-
 	UART(TXR) = ch;
+
+	while (!(UART(UTS) & (1 << 6))) {
+	}
 
 	return 0;
 }
 
 static const struct uart_ops imxuart_uart_ops = {
-		.uart_getc = imxuart_getc,
-		.uart_putc = imxuart_putc,
-		.uart_hasrx = imxuart_has_symbol,
-		.uart_setup = imxuart_setup,
+	.uart_getc = imxuart_getc,
+	.uart_putc = imxuart_putc,
+	.uart_hasrx = imxuart_has_symbol,
+	.uart_setup = imxuart_setup,
 };
 
 static struct uart uart0 = {
-		.uart_ops = &imxuart_uart_ops,
-		.irq_num = IRQ_NUM,
-		.base_addr = UART_BASE,
+	.uart_ops = &imxuart_uart_ops,
+	.irq_num = IRQ_NUM,
+	.base_addr = UART_BASE,
 };
 
 static const struct uart_params uart_defparams = {
-		.baud_rate = OPTION_GET(NUMBER,baud_rate),
-		.parity = 0,
-		.n_stop = 1,
-		.n_bits = 8,
-		.irq = true,
+	.baud_rate = OPTION_GET(NUMBER,baud_rate),
+	.parity = 0,
+	.n_stop = 1,
+	.n_bits = 8,
+	.irq = true,
 };
 
 static const struct uart_params uart_diag_params = {
-		.baud_rate = OPTION_GET(NUMBER,baud_rate),
-		.parity = 0,
-		.n_stop = 1,
-		.n_bits = 8,
-		.irq = false,
+	.baud_rate = OPTION_GET(NUMBER,baud_rate),
+	.parity = 0,
+	.n_stop = 1,
+	.n_bits = 8,
+	.irq = false,
 };
 
 const struct uart_diag DIAG_IMPL_NAME(__EMBUILD_MOD__) = {
-		.diag = {
-			.ops = &uart_diag_ops,
-		},
-		.uart = &uart0,
-		.params = &uart_diag_params,
+	.diag = {
+		.ops = &uart_diag_ops,
+	},
+	.uart = &uart0,
+	.params = &uart_diag_params,
 };
 
 static int uart_init(void) {

--- a/templates/arm/imx6/mods.config
+++ b/templates/arm/imx6/mods.config
@@ -23,8 +23,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0x00A00100,distributor_base_addr=0x00A01000,log_level=4)
 	@Runlevel(0) include embox.kernel.stack(stack_size=131076)
-	@Runlevel(0) include embox.driver.serial.imx_uart(base_addr=0x02020000, irq_num=58)
-	//@Runlevel(0) include embox.driver.serial.imx_uart(base_addr=0x21E8000, irq_num=59)
+	@Runlevel(0) include embox.driver.serial.imx_uart(num=0)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__imx_uart")
 	@Runlevel(0) include embox.driver.clock.cortexa9(periph_base_addr=0x00a00000,irq_num=29)
 

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -23,8 +23,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0x00A00100,distributor_base_addr=0x00A01000,log_level=4)
 	@Runlevel(0) include embox.kernel.stack(stack_size=131076)
-	//@Runlevel(0) include embox.driver.serial.imx_uart(base_addr=0x02020000, irq_num=58)
-	@Runlevel(0) include embox.driver.serial.imx_uart(base_addr=0x21E8000, irq_num=59)
+	@Runlevel(0) include embox.driver.serial.imx_uart(num=1)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__imx_uart")
 	@Runlevel(0) include embox.driver.clock.cortexa9(periph_base_addr=0x00a00000,irq_num=29)
 


### PR DESCRIPTION
Configure pins on iwave rainbow g15s to use UARTs on 84-pin extension.