### PR TITLE
Fix ARM MMU flags

### DIFF
--- a/src/arch/arm/include/asm/hal/mmu.h
+++ b/src/arch/arm/include/asm/hal/mmu.h
@@ -21,4 +21,10 @@
 #define L1D_NG      0x20000 /* not global */
 #define L1D_BASE(n) (0x100000 + n) /* section base address */
 
+#define L1D_TEX_OFFSET	5
+#define L1D_TEX_MASK	(0x7 << L1D_TEX_OFFSET)
+#define L1D_TEX_B	(1 << L1D_TEX_OFFSET)
+#define L1D_TEX_C	(2 << L1D_TEX_OFFSET)
+#define L1D_TEX_USE	(4 << L1D_TEX_OFFSET)
+
 #endif /* ARM_HAL_MMU_H_ */

--- a/src/arch/arm/mmu/mmu_small_page.c
+++ b/src/arch/arm/mmu/mmu_small_page.c
@@ -35,7 +35,7 @@ void mmu_pmd_set(mmu_pgd_t *pmd, mmu_pmd_t *pte) {
 
 void mmu_pte_set(mmu_pte_t *pte, mmu_paddr_t addr) {
 	*pte = (mmu_pte_t) ((((uint32_t)addr) & ~MMU_PAGE_MASK)
-			| 0x030 | L1D_TYPE_SD | L1D_B);
+			| 0x030 | L1D_TYPE_SD);
 }
 
 void mmu_pgd_unset(mmu_pgd_t *pgd) {
@@ -67,11 +67,12 @@ void mmu_pte_set_writable(mmu_pte_t *pte, int value) {
 }
 
 void mmu_pte_set_cacheable(mmu_pte_t *pte, int value) {
+	*pte &= ~(L1D_TEX_MASK | L1D_B | L1D_C);
 	if (value & VMEM_PAGE_CACHEABLE) {
-		*pte &= ~L1D_B;
-		*pte |= L1D_C;// | (7 << 6);
+		*pte |= L1D_TEX_USE;
+		*pte |= L1D_TEX_B | L1D_TEX_C;
+		*pte |= L1D_C | L1D_B;
 	} else {
-		*pte &= ~L1D_C;
 		*pte |= L1D_B;
 	}
 }


### PR DESCRIPTION
Use normal memory for code and data with write-back cache and device
memory for peripheral devices