### PR TITLE
Fix arm data_abt_handler

### DIFF
--- a/src/arch/arm/armlib/exception_table.S
+++ b/src/arch/arm/armlib/exception_table.S
@@ -62,14 +62,11 @@ fiq_handler_addr:
 
 data_abt_prepare:
 	/* Prepare stack and call handler */
-	stmfd r13!, {r14}
+	stmfd r13!, {r0-r3, r14}
 	add r14, pc, #0
 	ldr pc, data_abt_handler_addr
-	ldmfd r13!, {r14}
-	mrs r0, cpsr
-	orr r0, r0, #0x1F
-	msr cpsr_c, r0
-	mov pc, r14
+	ldmfd r13!, {r0-r3, r14}
+	subs pc, lr, #8 // exception return
 
 .text
 .global start


### PR DESCRIPTION
This is quick fix for arm data_abt_prepare:
1. data_abt_handler_addr holds arbitrary C function address, at least caller save register should be saved (r0-r3). 
But these are still not resolved: 
 - abt_handler called still called in system ARM mode, 
 - on IRQ stack
 - without args (but set_fault_handler function of fault_handler_t type, which takes 2 arguments)
These all are wrong.
2. Exception return sequence was incorrect:
 - should not kill `r0`.
 - should return to `r14 - 8`, not r14 (ARM ARMv7 B1.8.3, Table B1-7)
 - should atomically restore CPSR from SPSR during jump (interrupt mask either not reasserted or not restored). S flag in SUBS does this.