### PR TITLE
Fix cortexm irq handling

### DIFF
--- a/src/drivers/interrupt/Mybuild
+++ b/src/drivers/interrupt/Mybuild
@@ -48,6 +48,7 @@ module mb_intc extends irqctrl_api {
 module cortexm_nvic extends irqctrl_api {
 	option number irq_table_size = 16
 	source "cortexm_nvic.c", "cortexm_nvic.h"
+	source "cortexm_irq_handle.S"
 }
 
 module raspi extends irqctrl_api {

--- a/src/drivers/interrupt/cortexm_irq_handle.S
+++ b/src/drivers/interrupt/cortexm_irq_handle.S
@@ -17,15 +17,11 @@ interrupt_handle_enter:
     # due to ARMv7-M manual (see AAPCS 5.2.1.2)
     sub    sp, #64
     str    r0, [sp, #56]
-    stmia  sp, {r0 - r12}
-    str    lr, [sp, #52]
+    stmia  sp, {r0 - r12, lr}
 
     mov    r0, sp
     bl     interrupt_handle
 
-.text
-.thumb
-.syntax unified
 .global __irq_trampoline
 __irq_trampoline:
 
@@ -35,9 +31,6 @@ __irq_trampoline:
     ldr    r14, [r0, #36]
     bx     r14
 
-.text
-.thumb
-.syntax unified
 .global __pendsv_handle
 __pendsv_handle:
 
@@ -45,9 +38,6 @@ __pendsv_handle:
     add    sp, #32
     bx     r14
 
-.text
-.thumb
-.syntax unified
 .global __pending_handle
 __pending_handle:
 

--- a/src/drivers/interrupt/cortexm_irq_handle.S
+++ b/src/drivers/interrupt/cortexm_irq_handle.S
@@ -1,0 +1,67 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alex Kalmuk
+ * @date    27.03.2017
+ */
+
+.text
+.thumb
+.syntax unified
+.global interrupt_handle_enter
+interrupt_handle_enter:
+
+    mov    r0, sp
+    sub    sp, #58
+    str    r0, [sp, #56]
+    stmia  sp, {r0 - r12}
+    str    lr, [sp, #52]
+
+    mov    r0, sp
+    bl     interrupt_handle
+
+.text
+.thumb
+.syntax unified
+.global __irq_trampoline
+__irq_trampoline:
+
+    cpsid  i
+    # r0 is a pointer to struct irq_saved_state
+    ldr    sp,  [r0, #32]
+    ldr    r14, [r0, #36]
+    bx     r14
+
+.text
+.thumb
+.syntax unified
+.global __pendsv_handle
+__pendsv_handle:
+
+    # 32 == sizeof (struct cpu_saved_ctx)
+    add    sp, #32
+    bx     r14
+
+.text
+.thumb
+.syntax unified
+.global __pending_handle
+__pending_handle:
+
+    # push initial saved context (state.ctx) on top of the stack
+    add    r0, #32
+    ldmdb  r0, {r4 - r11}
+    push   {r4 - r11}
+
+    add    r1, r1, #52
+    ldmdb  r1, {r2 - r12}
+
+    cpsie  i
+    bl     critical_dispatch_pending
+    cpsid  i
+
+    bl     nvic_set_pendsv
+    cpsie  i
+    # DO NOT RETURN
+1: b       1

--- a/src/drivers/interrupt/cortexm_irq_handle.S
+++ b/src/drivers/interrupt/cortexm_irq_handle.S
@@ -13,7 +13,9 @@
 interrupt_handle_enter:
 
     mov    r0, sp
-    sub    sp, #58
+    # It should be a size of struct context, but we align it up to multiple of 8
+    # due to ARMv7-M manual (see AAPCS 5.2.1.2)
+    sub    sp, #64
     str    r0, [sp, #56]
     stmia  sp, {r0 - r12}
     str    lr, [sp, #52]

--- a/src/drivers/interrupt/cortexm_irq_handle.S
+++ b/src/drivers/interrupt/cortexm_irq_handle.S
@@ -26,22 +26,25 @@ interrupt_handle_enter:
 __irq_trampoline:
 
     cpsid  i
-    # r0 is a pointer to struct irq_saved_state
-    ldr    sp,  [r0, #32]
-    ldr    r14, [r0, #36]
-    bx     r14
+    # r0 contains SP stored on interrupt handler entry. So we keep some data
+    # behind SP for a while, but interrupts are disabled by 'cpsid i'
+    mov    sp,  r0
+    # Return from interrupt handling to usual mode
+    bx     r1
 
 .global __pendsv_handle
 __pendsv_handle:
 
     # 32 == sizeof (struct cpu_saved_ctx)
     add    sp, #32
+    # Return to the place we were interrupted at,
+    # i.e. before interrupt_handle_enter
     bx     r14
 
 .global __pending_handle
 __pending_handle:
 
-    # push initial saved context (state.ctx) on top of the stack
+    # Push initial saved context (state.ctx) on top of the stack
     add    r0, #32
     ldmdb  r0, {r4 - r11}
     push   {r4 - r11}
@@ -52,7 +55,7 @@ __pending_handle:
     cpsie  i
     bl     critical_dispatch_pending
     cpsid  i
-
+    # Generate PendSV interrupt
     bl     nvic_set_pendsv
     cpsie  i
     # DO NOT RETURN

--- a/src/drivers/interrupt/cortexm_nvic.c
+++ b/src/drivers/interrupt/cortexm_nvic.c
@@ -68,7 +68,7 @@ struct irq_saved_state {
 	uint32_t lr;
 };
 
-extern void __irq_trampoline(struct irq_saved_state *state, struct context *regs);
+extern void __irq_trampoline(uint32_t sp, uint32_t lr);
 extern void __pending_handle(void);
 extern void __pendsv_handle(void);
 extern void interrupt_handle_enter(void);
@@ -134,7 +134,7 @@ void interrupt_handle(struct context *regs) {
 	ctx->pc = ctx->lr;
 
 	/* Now return from interrupt context into __pending_handle */
-	__irq_trampoline(&state, regs);
+	__irq_trampoline(state.sp, state.lr);
 }
 
 void nvic_set_pendsv(void) {

--- a/src/drivers/interrupt/cortexm_nvic.c
+++ b/src/drivers/interrupt/cortexm_nvic.c
@@ -79,9 +79,9 @@ extern void interrupt_handle_enter(void);
  *         |
  *         |
  *         v
- *         |--------> interrupt_handle (irq context)
- *                        |
- *         <--------------|
+ *         |----irq enter----> interrupt_handle (irq context)
+ *                                |
+ *         <----irq exit----------|
  *         |
  *         |
  *         v
@@ -91,14 +91,14 @@ extern void interrupt_handle_enter(void);
  *         |
  *         |
  *         v
- *         |---------> interrupt_handle (irq context)
+ *         |---irq enter------> interrupt_handle (irq context)
  *                        |
  *                        |
- *               __irq_trampoline------------> __pending_handle (non-irq context)
+ *               __irq_trampoline---- irq exit--------> __pending_handle (non-irq context)
  *                                                   |
- *                                                   |----------> __pendsv_handle (irq context)
- *                                                                         |
- *          <--------------------------------------------------------------|
+ *                                                   |----irq enter------> __pendsv_handle (irq context)
+ *                                                                                 |
+ *          <--------------------------irq exit------------------------------------|
  *          |
  *          |
  *          v
@@ -149,6 +149,7 @@ static int nvic_init(void) {
 	for (i = 0; i < EXCEPTION_TABLE_SZ; i++) {
 		exception_table[i] = ((int) interrupt_handle_enter) | 1;
 	}
+	assert(EXCEPTION_TABLE_SZ >= 14);
 	exception_table[14] = ((int) __pendsv_handle) | 1;
 
 	/* load head from bootstrap table */

--- a/src/drivers/interrupt/cortexm_nvic.c
+++ b/src/drivers/interrupt/cortexm_nvic.c
@@ -8,10 +8,12 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <kernel/critical.h>
 #include <hal/reg.h>
 #include <hal/ipl.h>
+#include <hal/context.h>
 #include <drivers/irqctrl.h>
 
 #include <kernel/irq.h>
@@ -26,10 +28,15 @@
 #define NVIC_PRIOR_BASE (NVIC_BASE + 0x300)
 
 #define SCB_BASE 0xe000ed00
-#define SCB_ICSR (SCB_BASE + 0x04)
-#define SCB_VTOR (SCB_BASE + 0x08)
+#define SCB_ICSR  (SCB_BASE + 0x04)
+#define SCB_VTOR  (SCB_BASE + 0x08)
+#define SCB_SHPR1 (SCB_BASE + 0x18)
+#define SCB_SHPR3 (SCB_BASE + 0x20)
 
 #define EXCEPTION_TABLE_SZ OPTION_GET(NUMBER,irq_table_size)
+
+// Table 2.17. Exception return behavior in Cortex-M4 doc
+#define interrupted_from_fpu_mode(lr) ((lr & 0xF0) == 0xE0)
 
 /**
  * ENABLE, CLEAR, SET_PEND, CLR_PEND, ACTIVE is a base of bit arrays
@@ -48,8 +55,58 @@ static uint32_t exception_table[EXCEPTION_TABLE_SZ] __attribute__ ((aligned (128
 extern void *trap_table_start;
 extern void *trap_table_end;
 
-void interrupt_handle(void) {
+struct cpu_saved_ctx {
+	uint32_t r[5];
+	uint32_t lr;
+	uint32_t pc;
+	uint32_t psr;
+};
+
+struct irq_saved_state {
+	struct cpu_saved_ctx ctx;
+	uint32_t sp;
+	uint32_t lr;
+};
+
+extern void __irq_trampoline(struct irq_saved_state *state, struct context *regs);
+extern void __pending_handle(void);
+extern void __pendsv_handle(void);
+extern void interrupt_handle_enter(void);
+
+/*
+ * Usual interrupt handling:
+ *     execution flow
+ *         |
+ *         |
+ *         v
+ *         |--------> interrupt_handle (irq context)
+ *                        |
+ *         <--------------|
+ *         |
+ *         |
+ *         v
+ *
+ * This method:
+ *     execution flow
+ *         |
+ *         |
+ *         v
+ *         |---------> interrupt_handle (irq context)
+ *                        |
+ *                        |
+ *               __irq_trampoline------------> __pending_handle (non-irq context)
+ *                                                   |
+ *                                                   |----------> __pendsv_handle (irq context)
+ *                                                                         |
+ *          <--------------------------------------------------------------|
+ *          |
+ *          |
+ *          v
+ */
+void interrupt_handle(struct context *regs) {
 	uint32_t source;
+	struct irq_saved_state state;
+	struct cpu_saved_ctx *ctx;
 
 	source = REG_LOAD(SCB_ICSR) & 0x1ff;
 
@@ -61,8 +118,27 @@ void interrupt_handle(void) {
 
 	critical_leave(CRITICAL_IRQ_HANDLER);
 
-	critical_dispatch_pending();
+	state.sp = regs->sp;
+	state.lr = regs->lr;
+	assert(!interrupted_from_fpu_mode(state.lr));
+	ctx = (struct cpu_saved_ctx*) state.sp;
+	memcpy(&state.ctx, ctx, sizeof *ctx);
 
+	/* It does not matter what value of psr is, just set up sime correct value.
+	 * This value is only used to go further, after return from interrupt_handle.
+	 * 0x01000000 is a default value of psr and (ctx->psr & 0xFF) is irq number if any. */
+	ctx->psr = 0x01000000 | (ctx->psr & 0xFF);
+	ctx->r[0] = (uint32_t) &state; // we want pass the state to __pending_handle()
+	ctx->r[1] = (uint32_t) regs; // we want pass the registers to __pending_handle()
+	ctx->lr = (uint32_t) __pending_handle;
+	ctx->pc = ctx->lr;
+
+	/* Now return from interrupt context into __pending_handle */
+	__irq_trampoline(&state, regs);
+}
+
+void nvic_set_pendsv(void) {
+	REG_STORE(SCB_ICSR, 1 << 28);
 }
 
 static int nvic_init(void) {
@@ -71,8 +147,9 @@ static int nvic_init(void) {
 	void *ptr;
 
 	for (i = 0; i < EXCEPTION_TABLE_SZ; i++) {
-		exception_table[i] = ((int) interrupt_handle) | 1;
+		exception_table[i] = ((int) interrupt_handle_enter) | 1;
 	}
+	exception_table[14] = ((int) __pendsv_handle) | 1;
 
 	/* load head from bootstrap table */
 	for (ptr = &trap_table_start, i = 0; ptr != &trap_table_end; ptr += 4, i++) {
@@ -85,6 +162,7 @@ static int nvic_init(void) {
 			(int) exception_table);
 
 	ipl_restore(ipl);
+
 	return 0;
 }
 

--- a/src/tests/kernel/sched/Mybuild
+++ b/src/tests/kernel/sched/Mybuild
@@ -4,3 +4,7 @@ package embox.test.kernel.sched
 module waitq {
 	source "waitq.c"
 }
+
+module running_threads_test {
+	source "running_threads_test.c"
+}

--- a/src/tests/kernel/sched/running_threads_test.c
+++ b/src/tests/kernel/sched/running_threads_test.c
@@ -1,0 +1,59 @@
+/**
+ * @file
+ *
+ * @date 28.03.2017
+ * @author Alex Kalmuk
+ */
+
+#include <embox/test.h>
+#include <kernel/thread.h>
+#include <kernel/printk.h>
+#include <hal/reg.h>
+#include <kernel/time/ktime.h>
+
+EMBOX_TEST_SUITE("Two running threads sheduling test");
+
+static void *t1_run(void *arg);
+static void *t2_run(void *arg);
+
+static int flag1 = 0, flag2 = 0;
+
+TEST_CASE("two_running_threads_test") {
+	struct thread *t1, *t2;
+
+	t1 = thread_create(THREAD_FLAG_SUSPENDED, t1_run, NULL);
+	t2 = thread_create(THREAD_FLAG_SUSPENDED, t2_run, NULL);
+
+	thread_launch(t1);
+	test_assert_zero(thread_detach(t1));
+
+	thread_launch(t2);
+	test_assert_zero(thread_detach(t2));
+
+	ksleep(2000);
+
+	thread_terminate(t1);
+	thread_terminate(t2);
+}
+
+static void *t1_run(void *arg) {
+	int i = 0;
+
+	flag1 = 1;
+	while (i++ < 10000000)
+		;
+	test_assert(flag2 != 0);
+
+	return NULL;
+}
+
+static void *t2_run(void *arg) {
+	int i = 0;
+
+	flag2 = 1;
+	while (i++ < 10000000)
+		;
+	test_assert(flag1 != 0);
+
+	return NULL;
+}


### PR DESCRIPTION
There is a problem with interrupts handling on cortex-m. When we are inside an interrupt handler, another interrupts of the same priority (including the current one) are locked. The only way to enable it is to exit interrupt handle. One can check the issue using the test proposed in this PR and see that without this changes thread2 started only after thread1 finished.

This PR was tested on stm32f4-discovery with httpd and telnetd also