### PR TITLE
Stm32f4 i2c

### DIFF
--- a/platform/stm32f4_multibots/cmds/Mybuild
+++ b/platform/stm32f4_multibots/cmds/Mybuild
@@ -79,3 +79,33 @@ static module spi_lib {
 
 	depends third_party.bsp.stmf4cube.stm32f4_discovery
 }
+
+@AutoCmd
+@Cmd(name="gy_30", help="GY-30")
+@BuildDepends(third_party.bsp.stmf4cube.core)
+module gy_30 {
+	source "gy_30.c"
+
+	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends embox.driver.i2c.stm32f4.i2c
+}
+
+@AutoCmd
+@Cmd(name="i2c_master", help="I2C")
+@BuildDepends(third_party.bsp.stmf4cube.core)
+module i2c_master {
+	source "i2c_master.c"
+
+	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends embox.driver.i2c.stm32f4.i2c
+}
+
+@AutoCmd
+@Cmd(name="i2c_slave", help="I2C")
+@BuildDepends(third_party.bsp.stmf4cube.core)
+module i2c_slave {
+	source "i2c_slave.c"
+
+	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends embox.driver.i2c.stm32f4.i2c
+}

--- a/platform/stm32f4_multibots/cmds/gy_30.c
+++ b/platform/stm32f4_multibots/cmds/gy_30.c
@@ -1,0 +1,85 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    29.03.2017
+ * @author  Alex Kalmuk
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <kernel/irq.h>
+#include <embox/unit.h>
+
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_i2c.h"
+#include "stm32f4_discovery.h"
+
+#include <drivers/i2c/stm32f4/stm32f4_i2c.h>
+
+#define GY30_ADDR       0x46
+
+#define BH1750_CONTINUOUS_HIGH_RES_MODE  0x10
+
+static I2C_HandleTypeDef I2cHandle;
+
+static void init_leds(void) {
+	BSP_LED_Init(LED3);
+	BSP_LED_Init(LED4);
+	BSP_LED_Init(LED5);
+	BSP_LED_Init(LED6);
+}
+
+static void stm32f4_delay(int i) {
+	while(--i > 0)
+		;
+}
+
+static uint16_t gy_30_read_light_level(void) {
+	uint16_t level = 0;
+
+	do {
+		while (HAL_I2C_Master_Receive_IT(&I2cHandle, (uint16_t)GY30_ADDR, (void *) &level, 2) != HAL_OK)
+			;
+	} while(HAL_I2C_GetError(&I2cHandle) == HAL_I2C_ERROR_AF);
+
+	return level;
+}
+
+static int gy_30_config(uint8_t mode) {
+	do {
+		while (HAL_I2C_Master_Transmit_IT(&I2cHandle, (uint16_t)GY30_ADDR, (void *) &mode, 1) != HAL_OK)
+			;
+		while (HAL_I2C_GetState(&I2cHandle) != HAL_I2C_STATE_READY)
+			;
+	} while(HAL_I2C_GetError(&I2cHandle) == HAL_I2C_ERROR_AF);
+	stm32f4_delay(5000000);
+	printf("%s\n", "> gy_30_config OK\n");
+	return 0;
+}
+
+int main(int argc, char *argv[]) {
+	int res;
+	uint16_t level = 0;
+
+	printf("GY-30 running\n");
+
+	init_leds();
+	res = stm32f4_i2c_init(&I2cHandle, GY30_ADDR);
+	if (res < 0) {
+		return -1;
+	}
+	BSP_LED_Toggle(LED3);
+
+	gy_30_config(BH1750_CONTINUOUS_HIGH_RES_MODE);
+
+	while (1) {
+		level = gy_30_read_light_level();
+		printf("level: %d\n", (level * 5) / 6);
+		stm32f4_delay(5000000);
+	}
+
+	return 0;
+}

--- a/platform/stm32f4_multibots/cmds/i2c_master.c
+++ b/platform/stm32f4_multibots/cmds/i2c_master.c
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    29.03.2017
+ * @author  Alex Kalmuk
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <kernel/irq.h>
+#include <embox/unit.h>
+
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_i2c.h"
+#include "stm32f4_discovery.h"
+
+#include <drivers/i2c/stm32f4/stm32f4_i2c.h>
+
+#define SLAVE_ADDR       0x23
+#define OWN_ADDR         0x22
+
+#define TXBUFFERSIZE  16
+#define RXBUFFERSIZE  TXBUFFERSIZE
+
+static uint8_t tx_buff[TXBUFFERSIZE];
+static uint8_t rx_buff[RXBUFFERSIZE];
+
+static I2C_HandleTypeDef I2cHandle;
+
+static void init_leds(void) {
+	BSP_LED_Init(LED3);
+	BSP_LED_Init(LED4);
+	BSP_LED_Init(LED5);
+	BSP_LED_Init(LED6);
+}
+
+static void i2c_master_run(void) {
+	uint32_t i = 0, j = 0;
+
+	for (j = 0; j < 10; j++) {
+		for (i = 0; i < TXBUFFERSIZE; i++) {
+			tx_buff[i] = 0xAB;
+			rx_buff[i] = 0x00;
+		}
+
+		do {
+			while (HAL_I2C_Master_Transmit_IT(&I2cHandle, (uint16_t)SLAVE_ADDR, tx_buff, TXBUFFERSIZE) != HAL_OK)
+				;
+			while (HAL_I2C_GetState(&I2cHandle) != HAL_I2C_STATE_READY)
+				;
+		} while(HAL_I2C_GetError(&I2cHandle) == HAL_I2C_ERROR_AF);
+		printf("%s\n", ">> HAL_I2C_Master_Transmit_IT OK\n");
+
+		do {
+			while (HAL_I2C_Master_Receive_IT(&I2cHandle, (uint16_t)SLAVE_ADDR, rx_buff, RXBUFFERSIZE) != HAL_OK)
+				;
+		} while(HAL_I2C_GetError(&I2cHandle) == HAL_I2C_ERROR_AF);
+		printf("%s\n", ">> HAL_I2C_Master_Receive_IT OK\n");
+
+		printf("rx_buf: ");
+		for (i = 0; i < RXBUFFERSIZE; i++) {
+			printf(" %02x ", rx_buff[i]);
+		}
+		printf("\n");
+	}
+}
+
+int main(int argc, char *argv[]) {
+	int res;
+
+	printf("I2C master running\n");
+
+	init_leds();
+	res = stm32f4_i2c_init(&I2cHandle, OWN_ADDR);
+	if (res < 0) {
+		return -1;
+	}
+	BSP_LED_Toggle(LED3);
+
+	i2c_master_run();
+
+	return 0;
+}

--- a/platform/stm32f4_multibots/cmds/i2c_slave.c
+++ b/platform/stm32f4_multibots/cmds/i2c_slave.c
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    29.03.2017
+ * @author  Alex Kalmuk
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <kernel/irq.h>
+#include <embox/unit.h>
+
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_i2c.h"
+#include "stm32f4_discovery.h"
+
+#include <drivers/i2c/stm32f4/stm32f4_i2c.h>
+
+#define I2CADDR       0x23
+#define TXBUFFERSIZE  16
+#define RXBUFFERSIZE  TXBUFFERSIZE
+
+static uint8_t tx_buff[TXBUFFERSIZE];
+static uint8_t rx_buff[RXBUFFERSIZE];
+
+static I2C_HandleTypeDef I2cHandle;
+
+static void init_leds(void) {
+	BSP_LED_Init(LED3);
+	BSP_LED_Init(LED4);
+	BSP_LED_Init(LED5);
+	BSP_LED_Init(LED6);
+}
+
+static void i2c_slave_run(void) {
+	uint32_t i = 0;
+
+	while (1) {
+		for (i = 0; i < TXBUFFERSIZE; i++) {
+			tx_buff[i] = 0xCD;
+			rx_buff[i] = 0x01;
+		}
+
+		if (HAL_I2C_Slave_Receive_IT(&I2cHandle, (uint8_t *)rx_buff, RXBUFFERSIZE) != HAL_OK) {
+			printf("%s\n", ">> HAL_I2C_Slave_Receive_IT error\n");
+		}
+
+		while (HAL_I2C_GetState(&I2cHandle) != HAL_I2C_STATE_READY)
+			;
+
+		if (HAL_I2C_Slave_Transmit_IT(&I2cHandle, (uint8_t*)tx_buff, TXBUFFERSIZE)!= HAL_OK) {
+			printf("%s\n", ">> HAL_I2C_Slave_Transmit_IT error\n");
+		}
+
+		while (HAL_I2C_GetState(&I2cHandle) != HAL_I2C_STATE_READY)
+			;
+	}
+}
+
+int main(int argc, char *argv[]) {
+	int res;
+
+	printf("I2C slave running\n");
+
+	init_leds();
+	res = stm32f4_i2c_init(&I2cHandle, I2CADDR);
+	if (res < 0) {
+		return -1;
+	}
+	BSP_LED_Toggle(LED5);
+
+	i2c_slave_run();
+
+	return 0;
+}

--- a/src/drivers/i2c/stm32f4/Mybuild
+++ b/src/drivers/i2c/stm32f4/Mybuild
@@ -1,0 +1,15 @@
+package embox.driver.i2c.stm32f4
+
+@BuildDepends(third_party.bsp.stmf4cube.core)
+module i2c {
+	option number i2cx=1
+	option number log_level=4
+
+	@IncludeExport(path="drivers/i2c/stm32f4")
+	source "stm32f4_i2c.h"
+
+	source "stm32f4_i2c.c"
+	source "i2c_hal_msp_f4.c"
+
+	depends third_party.bsp.stmf4cube.core
+}

--- a/src/drivers/i2c/stm32f4/i2c_hal_msp_f4.c
+++ b/src/drivers/i2c/stm32f4/i2c_hal_msp_f4.c
@@ -1,0 +1,111 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    29.03.2017
+ * @author  Alex Kalmuk
+ */
+
+/**
+  ******************************************************************************
+  * @file    I2C/I2C_TwoBoards_ComPolling/Src/stm32f4xx_hal_msp.c
+  * @author  MCD Application Team
+  * @version V1.2.6
+  * @date    06-May-2016
+  * @brief   HAL MSP module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+#include "stm32_i2c_conf_f4.h"
+#include <util/log.h>
+#include <kernel/irq.h>
+
+static irq_return_t i2c_ev_irq_handler(unsigned int irq_nr, void *data) {
+	I2C_HandleTypeDef *I2cHandle = (I2C_HandleTypeDef *) data;
+	HAL_I2C_EV_IRQHandler(I2cHandle);
+	return IRQ_HANDLED;
+}
+
+static irq_return_t i2c_er_irq_handler(unsigned int irq_nr, void *data) {
+	I2C_HandleTypeDef *I2cHandle = (I2C_HandleTypeDef *) data;
+	HAL_I2C_ER_IRQHandler(I2cHandle);
+	return IRQ_HANDLED;
+}
+
+/**
+  * @brief I2C MSP Initialization 
+  *        This function configures the hardware resources used in this example:
+  *           - Peripheral's clock enable
+  *           - Peripheral's GPIO Configuration
+  *           - DMA configuration for transmission request by peripheral
+  *           - NVIC configuration for DMA interrupt request enable
+  * @param hi2c: I2C handle pointer
+  * @retval None
+  */
+void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c) {
+	int res;
+
+	GPIO_InitTypeDef  GPIO_InitStruct;
+
+	log_info(">>> HAL_I2C_MspInit\n");
+
+	/*##-1- Enable GPIO Clocks #################################################*/
+	/* Enable GPIO TX/RX clock */
+	I2Cx_SCL_GPIO_CLK_ENABLE();
+	I2Cx_SDA_GPIO_CLK_ENABLE();
+
+	/*##-2- Configure peripheral GPIO ##########################################*/
+	/* I2C TX GPIO pin configuration  */
+	GPIO_InitStruct.Pin       = I2Cx_SCL_PIN;
+	GPIO_InitStruct.Mode      = GPIO_MODE_AF_OD;
+	GPIO_InitStruct.Pull      = GPIO_PULLUP;
+	GPIO_InitStruct.Speed     = GPIO_SPEED_FAST;
+	GPIO_InitStruct.Alternate = I2Cx_SCL_AF;
+	HAL_GPIO_Init(I2Cx_SCL_GPIO_PORT, &GPIO_InitStruct);
+
+	/* I2C RX GPIO pin configuration  */
+	GPIO_InitStruct.Pin = I2Cx_SDA_PIN;
+	GPIO_InitStruct.Alternate = I2Cx_SDA_AF;
+	HAL_GPIO_Init(I2Cx_SDA_GPIO_PORT, &GPIO_InitStruct);
+
+	/*##-3- Enable I2C peripheral Clock ########################################*/
+	/* Enable I2C1 clock */
+	I2Cx_CLK_ENABLE();
+
+	res = irq_attach(I2Cx_EV_IRQn, i2c_ev_irq_handler, 0, hi2c, "I2C events");
+	if (res < 0) {
+		log_error(">>> HAL_I2C_MspInit error irq_attach\n");
+	}
+	res = irq_attach(I2Cx_ER_IRQn, i2c_er_irq_handler, 0, hi2c, "I2C errors");
+	if (res < 0) {
+		log_error(">>> HAL_I2C_MspInit error irq_attach\n");
+	}
+	log_info(">>> HAL_I2C_MspInit finished\n");
+}

--- a/src/drivers/i2c/stm32f4/stm32_i2c_conf_f4.h
+++ b/src/drivers/i2c/stm32f4/stm32_i2c_conf_f4.h
@@ -1,0 +1,40 @@
+/**
+ * @file
+ *
+ * @data 29.03.2017
+ * @author Alex Kalmuk
+ */
+
+#ifndef SRC_DRIVERS_I2C__STM32F4_STM32_USART_STM32_USART_CONF_F4_H_
+#define SRC_DRIVERS_I2C__STM32F4_STM32_USART_STM32_USART_CONF_F4_H_
+
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_i2c.h"
+#include "stm32f4_discovery.h"
+
+#include <framework/mod/options.h>
+#define MODOPS_I2CX OPTION_GET(NUMBER, i2cx)
+
+#if MODOPS_I2CX == 1
+#define I2Cx                             I2C1
+#define I2Cx_CLK_ENABLE()                __HAL_RCC_I2C1_CLK_ENABLE()
+#define I2Cx_SDA_GPIO_CLK_ENABLE()       __HAL_RCC_GPIOB_CLK_ENABLE()
+#define I2Cx_SCL_GPIO_CLK_ENABLE()       __HAL_RCC_GPIOB_CLK_ENABLE()
+
+#define I2Cx_FORCE_RESET()               __HAL_RCC_I2C1_FORCE_RESET()
+#define I2Cx_RELEASE_RESET()             __HAL_RCC_I2C1_RELEASE_RESET()
+
+/* Definition for I2Cx Pins */
+#define I2Cx_SCL_PIN                    GPIO_PIN_6
+#define I2Cx_SCL_GPIO_PORT              GPIOB
+#define I2Cx_SCL_AF                     GPIO_AF4_I2C1
+#define I2Cx_SDA_PIN                    GPIO_PIN_9
+#define I2Cx_SDA_GPIO_PORT              GPIOB
+#define I2Cx_SDA_AF                     GPIO_AF4_I2C1
+
+#define I2Cx_EV_IRQn                    47
+#define I2Cx_ER_IRQn                    48
+
+#endif
+
+#endif /* SRC_DRIVERS_I2C__STM32F4_STM32_USART_STM32_USART_CONF_F4_H_ */

--- a/src/drivers/i2c/stm32f4/stm32f4_i2c.c
+++ b/src/drivers/i2c/stm32f4/stm32f4_i2c.c
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    29.03.2017
+ * @author  Alex Kalmuk
+ */
+
+#include <string.h>
+#include <util/log.h>
+
+#include "stm32_i2c_conf_f4.h"
+
+int stm32f4_i2c_init(I2C_HandleTypeDef *I2cHandle, uint8_t slave_addr) {
+	I2cHandle->Instance             = I2Cx;
+
+	I2cHandle->Init.AddressingMode  = I2C_ADDRESSINGMODE_7BIT;
+	I2cHandle->Init.ClockSpeed      = 400000;
+	I2cHandle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+	I2cHandle->Init.DutyCycle       = I2C_DUTYCYCLE_16_9;
+	I2cHandle->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+	I2cHandle->Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
+	I2cHandle->Init.OwnAddress1     = slave_addr;
+	I2cHandle->Init.OwnAddress2     = 0;
+
+	if (HAL_I2C_Init(I2cHandle) != HAL_OK) {
+		log_error("STM32F4 I2C initialization error\n");
+		return -1;
+	}
+
+	return 0;
+}

--- a/src/drivers/i2c/stm32f4/stm32f4_i2c.h
+++ b/src/drivers/i2c/stm32f4/stm32f4_i2c.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * @data 29.03.2017
+ * @author Alex Kalmuk
+ */
+
+#ifndef SRC_DRIVERS_I2C__STM32F4_STM32_USART_STM32F4_I2C_H_
+#define SRC_DRIVERS_I2C__STM32F4_STM32_USART_STM32F4_I2C_H_
+
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_i2c.h"
+#include "stm32f4_discovery.h"
+
+extern int stm32f4_i2c_init(I2C_HandleTypeDef *I2cHandle, uint8_t slave_addr);
+
+#endif /* SRC_DRIVERS_I2C__STM32F4_STM32_USART_STM32F4_I2C_H_ */


### PR DESCRIPTION
Add 2 examples of stm32f4 i2c, based on the initial i2c support derived from ST Cube:
* master/slave (two boards)
* GY-30 light sensor