### PR TITLE
arm/imx: Initial implementation for cpuinfo module

### DIFF
--- a/src/arch/arm/imx/Mybuild
+++ b/src/arch/arm/imx/Mybuild
@@ -1,0 +1,13 @@
+package embox.arch.arm.imx
+
+module cpuinfo {
+	@IncludeExport(path="arch/arm/imx")
+	source "cpuinfo.h"
+
+	source "cpuinfo.c"
+
+	option number usb_analog_base=0x20C8000
+
+	depends embox.compat.libc.stdio.open
+	depends embox.driver.periph_memory
+}

--- a/src/arch/arm/imx/cpuinfo.c
+++ b/src/arch/arm/imx/cpuinfo.c
@@ -1,0 +1,85 @@
+/**
+ * @file cpuinfo.c
+ * @brief This module helps to detect the revision and stuff i.MX6 CPU
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 22.05.2017
+ */
+
+#include <stdio.h>
+
+#include <arch/arm/imx/cpuinfo.h>
+#include <drivers/common/memory.h>
+#include <embox/unit.h>
+#include <hal/reg.h>
+#include <kernel/printk.h>
+
+EMBOX_UNIT_INIT(imx_cpuinfo_init);
+
+/* Chip identifaction data is stored in USB registers, so we map and use it */
+
+#define USB_ANALOG_BASE OPTION_GET(NUMBER,usb_analog_base)
+
+#define REV_REG (USB_ANALOG_BASE + 0x260)
+
+static uint32_t _imx_revision(void) {
+	return REG32_LOAD(REV_REG);
+}
+
+const char *_imx_type(uint32_t id)
+{
+	switch (id) {
+	case MXC_CPU_MX7S:
+		return "7S";
+	case MXC_CPU_MX7D:
+		return "7D";
+	case MXC_CPU_MX6QP:
+		return "6QP";
+	case MXC_CPU_MX6DP:
+		return "6DP";
+	case MXC_CPU_MX6Q:
+		return "6Q";
+	case MXC_CPU_MX6D:
+		return "6D";
+	case MXC_CPU_MX6DL:
+		return "6DL";
+	case MXC_CPU_MX6SOLO:
+		return "6SOLO";
+	case MXC_CPU_MX6SL:
+		return "6SL";
+	case MXC_CPU_MX6SLL:
+		return "6SLL";
+	case MXC_CPU_MX6SX:
+		return "6SX";
+	case MXC_CPU_MX6UL:
+		return "6UL";
+	case MXC_CPU_MX6ULL:
+		return "6ULL";
+	case MXC_CPU_MX51:
+		return "51";
+	case MXC_CPU_MX53:
+		return "53";
+	default:
+		return "??";
+	}
+}
+
+void print_imx_cpuinfo() {
+	uint32_t rev = _imx_revision();
+	printk("\t\tCPU identification:\n");
+	printk("\t\t    i.MX%s\n", _imx_type((rev >> 16) & 0xFF));
+	printk("\t\t    Revision: %d.%d\n", (rev >> 8) & 0xFF, rev & 0xFF);
+}
+
+static int imx_cpuinfo_init(void) {
+	printk("\n");
+	print_imx_cpuinfo();
+	return 0;
+}
+
+static struct periph_memory_desc imx_usb_mem = {
+	.start = USB_ANALOG_BASE,
+	.len   = 0x300,
+};
+
+PERIPH_MEMORY_DEFINE(imx_usb_mem);

--- a/src/arch/arm/imx/cpuinfo.h
+++ b/src/arch/arm/imx/cpuinfo.h
@@ -1,0 +1,38 @@
+/**
+ * @file cpuinfo.h
+ * @brief This module helps to detect the revision and stuff i.MX6 CPU
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 22.05.2017
+ */
+
+#ifndef ARCH_ARM_IMX_CPUINFO_H_
+#define ARCH_ARM_IMX_CPUINFO_H_
+
+#define MXC_CPU_MX23		0x23
+#define MXC_CPU_MX25		0x25
+#define MXC_CPU_MX27		0x27
+#define MXC_CPU_MX28		0x28
+#define MXC_CPU_MX31		0x31
+#define MXC_CPU_MX35		0x35
+#define MXC_CPU_MX51		0x51
+#define MXC_CPU_MX53		0x53
+#define MXC_CPU_MX6SL		0x60
+#define MXC_CPU_MX6DL		0x61
+#define MXC_CPU_MX6SX		0x62
+#define MXC_CPU_MX6Q		0x63
+#define MXC_CPU_MX6UL		0x64
+#define MXC_CPU_MX6ULL		0x65
+#define MXC_CPU_MX6SOLO		0x66 /* dummy */
+#define MXC_CPU_MX6SLL		0x67
+#define MXC_CPU_MX6D		0x6A
+#define MXC_CPU_MX6DP		0x68
+#define MXC_CPU_MX6QP		0x69
+#define MXC_CPU_MX7S		0x71 /* dummy ID */
+#define MXC_CPU_MX7D		0x72
+#define MXC_CPU_MX7ULP		0x81 /* Temporally hard code */
+#define MXC_CPU_VF610		0xF6 /* dummy ID */
+
+void print_imx_cpuinfo(void);
+
+#endif /* ARCH_ARM_IMX_CPUINFO_H_ */

--- a/templates/arm/imx6/mods.config
+++ b/templates/arm/imx6/mods.config
@@ -11,6 +11,8 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.stackframe
 	include embox.arch.arm.vfork
 
+	include embox.arch.arm.imx.cpuinfo
+
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	//@Runlevel(0) include embox.arch.arm.mmu_section(domain_access=1)

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -11,6 +11,8 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.stackframe
 	include embox.arch.arm.vfork
 
+	include embox.arch.arm.imx.cpuinfo
+
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	//@Runlevel(0) include embox.arch.arm.mmu_section(domain_access=1)


### PR DESCRIPTION
Now on system start there's info about current CPU model and revision.