### PR TITLE
Initial support fot i.MX6 ECSPI controller

### DIFF
--- a/src/drivers/gpio/imx/Mybuild
+++ b/src/drivers/gpio/imx/Mybuild
@@ -1,0 +1,11 @@
+package embox.driver.gpio
+
+module imx extends api {
+	option number base_addr=0x0209c000
+	option number log_level=0
+
+	@IncludeExport(path="drivers/gpio")
+	source "imx.h"
+
+	source "imx.c"
+}

--- a/src/drivers/gpio/imx/imx.h
+++ b/src/drivers/gpio/imx/imx.h
@@ -1,0 +1,16 @@
+/**
+ * @file imx.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 13.06.2017
+ */
+
+#ifndef DRIVERS_GPIO_IMX_H_
+#define DRIVERS_GPIO_IMX_H_
+
+#include <stdint.h>
+
+typedef volatile uint32_t __gpio_mask_t;
+
+#endif /* DRIVERS_GPIO_IMX_H_ */

--- a/src/drivers/spi/imx6_ecspi/Mybuild
+++ b/src/drivers/spi/imx6_ecspi/Mybuild
@@ -1,0 +1,14 @@
+package embox.driver.spi
+
+module imx6_ecspi {
+	option number base_addr
+	option number log_level = 0
+
+	@IncludeExport(path="drivers/spi")
+	source "imx6_ecspi.h"
+
+	source "imx6_ecspi.c"
+
+	depends embox.driver.gpio.api
+	depends embox.driver.periph_memory
+}

--- a/src/drivers/spi/imx6_ecspi/imx6_ecspi.c
+++ b/src/drivers/spi/imx6_ecspi/imx6_ecspi.c
@@ -1,0 +1,143 @@
+/**
+ * @file imx6_ecspi.c
+ * @brief i.MX6 Enhanced Configurable SPI driver
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version 0.1
+ * @date 12.06.2017
+ */
+
+#include <drivers/common/memory.h>
+#include <drivers/gpio.h>
+#include <drivers/spi/imx6_ecspi.h>
+#include <embox/unit.h>
+#include <errno.h>
+#include <framework/mod/options.h>
+#include <hal/reg.h>
+#include <util/log.h>
+
+#define BASE_ADDR OPTION_GET(NUMBER, base_addr)
+
+#define ECSPI_RXDATA                      (BASE_ADDR + 0x00)
+#define ECSPI_TXDATA                      (BASE_ADDR + 0x04)
+#define ECSPI_CONREG                      (BASE_ADDR + 0x08)
+# define ECSPI_CONREG_EN	          (1 << 0)
+# define ECSPI_CONREG_XCH	          (1 << 2)
+# define ECSPI_CONREG_BURST_LENGTH_OFFT   20
+# define ECSPI_CONREG_BURST_LENGTH_MASK   0xFFF00000
+# define ECSPI_CONREG_CHANNEL_SELECT_OFFT 18
+# define ECSPI_CONREG_CHANNEL_SELECT_MASK 0x000C0000
+#define ECSPI_CONFIGREG                   (BASE_ADDR + 0x0C)
+#define ECSPI_INTREG                      (BASE_ADDR + 0x10)
+#define ECSPI_DMAREG                      (BASE_ADDR + 0x14)
+#define ECSPI_STATREG                     (BASE_ADDR + 0x18)
+# define ECSPI_STATREG_RR                 (1 << 3)
+#define ECSPI_PERIODREG                   (BASE_ADDR + 0x1C)
+#define ECSPI_TESTREG                     (BASE_ADDR + 0x20)
+#define ECSPI_MSGDATA                     (BASE_ADDR + 0x40)
+
+#define TIMEOUT_LIMIT		100000
+
+#define SPI_FIFO_LEN		64
+
+static const int imx6_ecspi_gpio_info[4][2] = /* Format is [gpio][port], more
+                                                 details in IMX6DQRM.pdf at page 426 */
+	{ {1, 30}, {2, 19}, {2, 24}, {2, 25} };
+
+/* State of controller */
+static int _ecspi_bus;
+static int _ecspi_cs;
+
+static int imx6_ecspi_init(void) {
+	/* Disable SPI block */
+	REG32_CLEAR(ECSPI_CONREG, ECSPI_CONREG_EN);
+	/* Enable clocks */
+	/* Put SPI out of reset */
+	REG32_ORIN(ECSPI_CONREG, ECSPI_CONREG_EN);
+	/* IOMUX configuration */
+	/* Configure ECSPI as a master */
+	REG32_ORIN(ECSPI_CONREG, 0xF << 4);
+	/* Set burst length to 8 bits so we work with bytes */
+	REG32_CLEAR(ECSPI_CONREG, ECSPI_CONREG_BURST_LENGTH_MASK);
+	REG32_ORIN(ECSPI_CONREG, 7 << ECSPI_CONREG_BURST_LENGTH_OFFT);
+
+	_ecspi_bus = 0;
+	_ecspi_cs = 0;
+
+	return 0;
+}
+EMBOX_UNIT_INIT(imx6_ecspi_init);
+
+static struct periph_memory_desc imx6_ecspi_mem = {
+	.start = BASE_ADDR,
+	.len   = 0x44,
+};
+PERIPH_MEMORY_DEFINE(imx6_ecspi_mem);
+
+static void imx6_ecspi_set_cs(int cs, int state) {
+	struct gpio *gpio;
+	int gpio_n = 0;
+	int port = 0;
+
+	cs &= 0x3;
+	REG32_CLEAR(ECSPI_CONREG, ECSPI_CONREG_CHANNEL_SELECT_MASK);
+	REG32_ORIN(ECSPI_CONREG, cs << ECSPI_CONREG_CHANNEL_SELECT_OFFT);
+
+	/* TODO config gpio in proper way for ECSPI2,3,4,5*/
+	gpio_n = imx6_ecspi_gpio_info[cs][0];
+	port   = imx6_ecspi_gpio_info[cs][1];
+
+	gpio = gpio_by_num(gpio_n);
+	gpio_settings(gpio, 1 << port, GPIO_MODE_OUTPUT);
+	gpio_set_level(gpio, 1 << port, state);
+}
+
+static uint8_t imx6_ecspi_transfer_byte(uint8_t val) {
+	int timeout;
+	REG32_STORE(ECSPI_TXDATA, val);
+	REG32_ORIN(ECSPI_CONREG, ECSPI_CONREG_XCH);
+
+	timeout = TIMEOUT_LIMIT;
+	while ((REG32_LOAD(ECSPI_CONREG) & ECSPI_CONREG_XCH) && timeout--);
+
+	if (timeout == 0)
+		log_debug("transmit timeout");
+
+	return REG32_LOAD(ECSPI_RXDATA);
+}
+
+int imx6_ecspi_select(int bus, int cs) {
+	if (bus != 0) {
+		log_error("Only bus 0 is supported!\n");
+		return -ENOSUPP;
+	}
+
+	if (cs < 0 || cs > 3) {
+		log_error("Only cs=0..3 are avalable!");
+		return -EINVAL;
+	}
+
+	_ecspi_bus = bus;
+	_ecspi_cs = cs;
+
+	return 0;
+}
+
+int imx6_ecspi_transfer(uint8_t *inbuf, uint8_t *outbuf, int count, int flags) {
+	int cs = _ecspi_cs;
+	uint8_t val;
+
+	if (flags & SPI_CS_ACTIVE)
+		imx6_ecspi_set_cs(cs, 1);
+
+	while (count--) {
+		val = inbuf ? *inbuf++ : 0;
+		val = imx6_ecspi_transfer_byte(val);
+		if (outbuf)
+			*outbuf++ = val;
+	}
+
+	if (flags & SPI_CS_INACTIVE)
+		imx6_ecspi_set_cs(cs, 0);
+
+	return 0;
+}

--- a/src/drivers/spi/imx6_ecspi/imx6_ecspi.h
+++ b/src/drivers/spi/imx6_ecspi/imx6_ecspi.h
@@ -1,0 +1,20 @@
+/**
+ * @file imx6_ecspi.h
+ * @brief Interface for i.MX6 SPI
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 12.06.2017
+ */
+
+#ifndef IMX6_ECSPI_H_
+#define IMX6_ECSPI_H_
+
+#include <stdint.h>
+
+#define SPI_CS_ACTIVE   (1 << 0)
+#define SPI_CS_INACTIVE (1 << 1)
+
+int imx6_ecspi_transfer(uint8_t *inbuf, uint8_t *outbuf, int count, int flags);
+int imx6_ecspi_select(int bus, int cs);
+
+#endif /* IMX6_ECSPI_H_ */

--- a/src/tests/spi/Mybuild
+++ b/src/tests/spi/Mybuild
@@ -1,0 +1,7 @@
+package embox.test.spi
+
+module imx6_test {
+	source "imx6_spi.c"
+
+	depends embox.driver.spi.imx6_ecspi
+}

--- a/src/tests/spi/imx6_spi.c
+++ b/src/tests/spi/imx6_spi.c
@@ -1,0 +1,30 @@
+/**
+ * @file imx6_spi.c
+ * @brief Basic test for SPI-flash JEDEC read operation
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 14.06.2017
+ */
+
+#include <drivers/spi/imx6_ecspi.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("Basic i.MX6 SPI flash test");
+
+#define SPI_FLASH_BUS 0
+#define SPI_FLASH_CS  0
+
+TEST_CASE("Read JEDEC ID") {
+	uint8_t _spi_out[] = {0x9f, 0x9f, 0x9f, 0x9f}; /* JEDEC ID */
+	uint8_t _spi_in[4];
+
+	int res = imx6_ecspi_select(SPI_FLASH_BUS, SPI_FLASH_CS);
+
+	test_assert(res == 0);
+
+	res = imx6_ecspi_transfer(_spi_out, _spi_in, 4, SPI_CS_ACTIVE | SPI_CS_INACTIVE);
+
+	test_assert(res == 0 &&
+	            _spi_in[0] == 0x00 && _spi_in[1] == 0xbf &&
+	            _spi_in[2] == 0x25 && _spi_in[3] == 0x41);
+}

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -25,6 +25,8 @@ configuration conf {
 
 	@Runlevel(0) include embox.kernel.critical
 
+	@Runlevel(0) include embox.driver.gpio.imx
+	@Runlevel(1) include embox.driver.spi.imx6_ecspi(base_addr=0x02008000)
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0x00A00100,distributor_base_addr=0x00A01000,log_level=4)
 	@Runlevel(0) include embox.kernel.stack(stack_size=131076)
 	@Runlevel(0) include embox.driver.serial.imx_uart(num=1)
@@ -48,6 +50,7 @@ configuration conf {
 	include embox.compat.posix.passwd
 	include embox.compat.libc.stdio.print(support_floating=0)
 
+	include embox.test.spi.imx6_test
 	include embox.test.kernel.timer_test
 	include embox.kernel.task.resource.errno
 


### PR DESCRIPTION
Initial implementation for SPI driver. To make it work properly following things were done as well:

- Initial support for i.MX6 GPIO (it is required for some SPI devices to keep CS signal active)
- Simple test for SST25VF016B flash via SPI
- iwave_imx6 template is updated