### PR TITLE
Fix anon munmap

### DIFF
--- a/src/mem/phymem.c
+++ b/src/mem/phymem.c
@@ -48,6 +48,5 @@ void *phymem_alloc(size_t page_number) {
 }
 
 void phymem_free(void *page, size_t page_number) {
-	munmap(page, PAGE_SIZE() * page_number);
 	page_free(__phymem_allocator, page, page_number);
 }

--- a/templates/x86/qemu/mods.config
+++ b/templates/x86/qemu/mods.config
@@ -82,7 +82,7 @@ configuration conf {
 	@Runlevel(1) include embox.test.math.math_test
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap
-	//@Runlevel(1) include embox.test.mem.mmap
+	@Runlevel(1) include embox.test.mem.mmap
 	@Runlevel(1) include embox.test.util.hashtable_test
 
 	@Runlevel(2) include embox.cmd.sh.tish(prompt="%u@%h:%w%$", rich_prompt_support=1, builtin_commands="exit logout cd export mount umount")


### PR DESCRIPTION
After many unsucessfull atempts to embed anonymous maps along with normal maps, the most straightforward way appear to be just explicitly handle them in mmaps.

* anon mmaps and device_mem maps are only ways to create new map for now. 
* Anon mmap is handled almost outside of vmem subsystem, it's just interface for phymem_alloc
* anon mmaps can't be added to vmem maps for various reasons:
  * phymem is mmaped, so anon mmap should get VMA outside of phymem to munmap later
  * vmem (marea explicitly) can't handle different VMA and PA
  * vmem_create_space while allocating pages to be used for new mapping unable to track not-linear sequence of pages in marea, unusable
  * and finally, anyway, the only place `is_allocated` flag of marea handled is munmap itself. 

In general, I've failed to do it in "proper" way. This "proper" way, as I imagine it, will just mmap a portion of phymem into free virtual space. That will not make any positive difference, but will add some overhead. So there is no apparent reasons for me to do so.