### PR TITLE
(mk) Fix gcc version determination

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -203,7 +203,7 @@ else
 	# application, we decided to keep explicit null checks and disable the warning.
 	override COMMON_CCFLAGS += -Wno-nonnull-compare
 
-	override GCC_VERSION := $(word 3,$(shell $(CC) -v 2>&1 | grep -e "^gcc"))
+	override GCC_VERSION := $(word 3,$(shell $(CC) --version 2>&1 | grep -e "^gcc"))
 	override GCC_VERSION_MAJOR := $(word 1,$(subst ., ,$(GCC_VERSION)))
 
 ifeq ($(GCC_VERSION_MAJOR),7)


### PR DESCRIPTION
Gcc should be called with --version flag to get machine-readable version
specifier.

Fixes #1093 

`gcc -v` gives hard-to-parse version format
```
$ GCC_VER="-v"; for loc in ru_RU fi_FI en_US; do echo == $loc; LANG=${loc}.UTF-8 gcc $GCC_VER 2>&1 | grep -e '^gcc' ; done
== ru_RU
gcc версия 7.1.1 20170528 (GCC) 
== fi_FI
gcc-versio 7.1.1 20170528 (GCC) 
== en_US
gcc version 7.1.1 20170528 (GCC) 
```

Using `gcc --version` gives better results
```
$ GCC_VER="--version"; for loc in ru_RU fi_FI en_US; do echo == $loc; LANG=${loc}.UTF-8 gcc $GCC_VER 2>&1 | grep -e '^gcc' ; done
== ru_RU
gcc (GCC) 7.1.1 20170528
== fi_FI
gcc (GCC) 7.1.1 20170528
== en_US
gcc (GCC) 7.1.1 20170528
```
