### PR TITLE
(travis) Build fresh uncrustify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ matrix:
   include:
   - env: UNCRUSTIFY
     before_install:
-      - travis_retry sudo apt-get update -qq
-    install:
-      - travis_retry sudo apt-get install -qq uncrustify
-    before_script:
       - true
+    install:
+      - SRC=$PWD/uncrustify INSTALL=$PWD/uncrustify/dist ./scripts/codestyle/install_uncrustify.sh
+    before_script:
+      - export PATH=$PWD/uncrustify/dist/bin:$PATH
     script:
+      - uncrustify -v
       - ./scripts/codestyle/travis_uncrustify.sh
 
 before_install:

--- a/scripts/codestyle/install_uncrustify.sh
+++ b/scripts/codestyle/install_uncrustify.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -xe
+
+RELEASE=0.65
+
+mkdir -p $SRC
+cd $SRC
+
+wget -c https://github.com/uncrustify/uncrustify/archive/uncrustify-${RELEASE}.tar.gz
+tar axf uncrustify-${RELEASE}.tar.gz
+
+mkdir build
+cd build
+
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL ../uncrustify-uncrustify-${RELEASE}
+
+make install


### PR DESCRIPTION
Following https://github.com/embox/embox/pull/1102#issuecomment-318363959
Newer version of uncrustify doesn't produce such warning.

With this we could always get most fresh version. However, current release is hardcoded to avoid meeting with regressions in uncrustify