### PR TITLE
Xen exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ third-party/ti/syslink_2_21_01_05
 # Vagrant
 /.vagrant
 /*-console.log
+# Idea and Cmake
+.idea/
+CMakeLists.txt
+backup/
+cmake-build-debug/
+src/.idea/
+src/CMakeLists.txt
+src/cmake-build-debug/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ Vagrant.configure("2") do |config|
 
     xen.vm.provision "shell", inline: <<-SHELL
     DEBIAN_FRONTEND=noninteractive \
+	  apt-get -y update
+    DEBIAN_FRONTEND=noninteractive \
 	  apt-get -y install \
 		  xen-hypervisor-amd64
 

--- a/src/arch/xen/include/traps.h
+++ b/src/arch/xen/include/traps.h
@@ -1,0 +1,78 @@
+/*
+ ****************************************************************************
+ * (C) 2005 - Grzegorz Milos - Intel Reseach Cambridge
+ ****************************************************************************
+ *
+ *        File: traps.h
+ *      Author: Grzegorz Milos (gm281@cam.ac.uk)
+ *
+ *        Date: Jun 2005
+ *
+ * Environment: Xen Minimal OS
+ * Description: Deals with traps
+ *
+ ****************************************************************************
+ */
+
+#ifndef _TRAPS_H_
+#define _TRAPS_H_
+
+#ifdef __i386__
+struct pt_regs {
+	long ebx;
+	long ecx;
+	long edx;
+	long esi;
+	long edi;
+	long ebp;
+	long eax;
+	int  xds;
+	int  xes;
+	long orig_eax;
+	long eip;
+	int  xcs;
+	long eflags;
+	long esp;
+	int  xss;
+};
+#elif __x86_64__
+
+struct pt_regs {
+	unsigned long r15;
+	unsigned long r14;
+	unsigned long r13;
+	unsigned long r12;
+	unsigned long rbp;
+	unsigned long rbx;
+/* arguments: non interrupts/non tracing syscalls only save upto here*/
+ 	unsigned long r11;
+	unsigned long r10;
+	unsigned long r9;
+	unsigned long r8;
+	unsigned long rax;
+	unsigned long rcx;
+	unsigned long rdx;
+	unsigned long rsi;
+	unsigned long rdi;
+	unsigned long orig_rax;
+/* end of arguments */
+/* cpu exception frame or undefined */
+	unsigned long rip;
+	unsigned long cs;
+	unsigned long eflags;
+	unsigned long rsp;
+	unsigned long ss;
+/* top of stack page */
+};
+
+
+#endif
+
+//void dump_regs(struct pt_regs *regs);
+//void stack_walk(void);
+
+//#define TRAP_PF_PROT   0x1
+//#define TRAP_PF_WRITE  0x2
+//#define TRAP_PF_USER   0x4
+
+#endif /* _TRAPS_H_ */

--- a/src/arch/xen/include/traps.h
+++ b/src/arch/xen/include/traps.h
@@ -45,7 +45,7 @@ struct pt_regs {
 	unsigned long rbp;
 	unsigned long rbx;
 /* arguments: non interrupts/non tracing syscalls only save upto here*/
- 	unsigned long r11;
+	unsigned long r11;
 	unsigned long r10;
 	unsigned long r9;
 	unsigned long r8;
@@ -65,14 +65,16 @@ struct pt_regs {
 /* top of stack page */
 };
 
-
 #endif
 
-//void dump_regs(struct pt_regs *regs);
-//void stack_walk(void);
+/* unused */
+#if 0
+void dump_regs(struct pt_regs *regs);
+void stack_walk(void);
 
-//#define TRAP_PF_PROT   0x1
-//#define TRAP_PF_WRITE  0x2
-//#define TRAP_PF_USER   0x4
+#define TRAP_PF_PROT   0x1
+#define TRAP_PF_WRITE  0x2
+#define TRAP_PF_USER   0x4
+#endif
 
 #endif /* _TRAPS_H_ */

--- a/src/arch/xen/kernel_init.c
+++ b/src/arch/xen/kernel_init.c
@@ -19,6 +19,8 @@
 extern void kernel_start(void);
 
 /* Xen interface */
+extern void trap_init(void);
+
 uint8_t xen_features[XENFEAT_NR_SUBMAPS * 32];
 
 extern shared_info_t xen_shared_info;
@@ -35,6 +37,8 @@ void xen_kernel_start(start_info_t * start_info) {
 	HYPERVISOR_shared_info = &xen_shared_info;
 	
 	init_events();
+
+	trap_init();
 
 	kernel_start();
 }

--- a/src/arch/xen/traps.c
+++ b/src/arch/xen/traps.c
@@ -1,7 +1,19 @@
+
 #include <stdint.h>
 #include <xen/xen.h>
+#include <kernel/printk.h>
 
+extern shared_info_t xen_shared_info;
+
+#if defined(__i386__)
 #include <xen_hypercall-x86_32.h>
+//#elif defined(__x86_64__)
+//#include <hypercall-x86_64.h>
+//#elif defined(__arm__) || defined(__aarch64__)
+//#include <hypercall-arm.h>
+#else
+#error "Unsupported architecture"
+#endif
 
 /*
  * These are assembler stubs in entry.S.
@@ -27,23 +39,25 @@ void spurious_interrupt_bug(void);
 void machine_check(void);
 
 /* Dummy implementation.  Should actually do something */
-void do_divide_error(void) {}
-void do_debug(void) {}
-void do_int3(void) {}
-void do_overflow(void) {}
-void do_bounds(void) {}
-void do_invalid_op(void) {}
-void do_device_not_available(void) {}
-void do_coprocessor_segment_overrun(void) {}
-void do_invalid_TSS(void) {}
-void do_segment_not_present(void) {}
-void do_stack_segment(void) {}
-void do_general_protection(void) {}
-void do_page_fault(void) {}
-void do_coprocessor_error(void) {}
-void do_simd_coprocessor_error(void) {}
-void do_alignment_check(void) {}
-void do_spurious_interrupt_bug(void) {}
+void do_divide_error(void) {
+    printk("DIVIDE ERROR called\n");
+}
+void do_debug(void) {printk ("ERROR_1\n");}
+void do_int3(void) {printk ("ERROR_2\n");}
+void do_overflow(void) {printk ("ERROR_3\n");}
+void do_bounds(void) {printk ("ERROR_4\n");}
+void do_invalid_op(void) {printk ("ERROR_5\n");}
+void do_device_not_available(void) {printk ("ERROR_6\n");}
+void do_coprocessor_segment_overrun(void) {printk ("ERROR_7\n");}
+void do_invalid_TSS(void) {printk ("ERROR_8\n");}
+void do_segment_not_present(void) {printk ("ERROR_9\n");}
+void do_stack_segment(void) {printk ("ERROR_10\n");}
+void do_general_protection(void) {printk ("ERROR_11\n");}
+void do_page_fault(void) {printk ("ERROR_12\n");   }
+void do_coprocessor_error(void) {printk ("ERROR_13\n");}
+void do_simd_coprocessor_error(void) {printk ("ERROR_14\n");}
+void do_alignment_check(void) {printk ("ERROR_15\n");}
+void do_spurious_interrupt_bug(void) {printk ("ERROR_16\n");}
 void do_machine_check(void) {}
 
 /*
@@ -73,8 +87,21 @@ static trap_info_t trap_table[] = {
     {  0, 0,           0, 0                           }
 };
 
+/* Assembler interface fns in entry.S. */
+void hypervisor_callback(void);
+void failsafe_callback(void);
+
 void trap_init(void)
 {
-    HYPERVISOR_set_trap_table(trap_table);    
-}
+    HYPERVISOR_set_trap_table(trap_table);
 
+#ifdef __i386__
+    HYPERVISOR_set_callbacks(
+		    FLAT_KERNEL_CS, (unsigned long)hypervisor_callback,
+		    FLAT_KERNEL_CS, (unsigned long)failsafe_callback);
+#else
+    HYPERVISOR_set_callbacks(
+		    (unsigned long)hypervisor_callback,
+		    (unsigned long)failsafe_callback, 0);
+#endif
+}

--- a/src/arch/xen/traps.c
+++ b/src/arch/xen/traps.c
@@ -7,10 +7,12 @@ extern shared_info_t xen_shared_info;
 
 #if defined(__i386__)
 #include <xen_hypercall-x86_32.h>
-//#elif defined(__x86_64__)
-//#include <hypercall-x86_64.h>
-//#elif defined(__arm__) || defined(__aarch64__)
-//#include <hypercall-arm.h>
+/*
+#elif defined(__x86_64__)
+#include <hypercall-x86_64.h>
+#elif defined(__arm__) || defined(__aarch64__)
+#include <hypercall-arm.h>
+*/
 #else
 #error "Unsupported architecture"
 #endif
@@ -40,25 +42,58 @@ void machine_check(void);
 
 /* Dummy implementation.  Should actually do something */
 void do_divide_error(void) {
-    printk("DIVIDE ERROR called\n");
+	printk("DIVIDE ERROR called\n");
 }
-void do_debug(void) {printk ("ERROR_1\n");}
-void do_int3(void) {printk ("ERROR_2\n");}
-void do_overflow(void) {printk ("ERROR_3\n");}
-void do_bounds(void) {printk ("ERROR_4\n");}
-void do_invalid_op(void) {printk ("ERROR_5\n");}
-void do_device_not_available(void) {printk ("ERROR_6\n");}
-void do_coprocessor_segment_overrun(void) {printk ("ERROR_7\n");}
-void do_invalid_TSS(void) {printk ("ERROR_8\n");}
-void do_segment_not_present(void) {printk ("ERROR_9\n");}
-void do_stack_segment(void) {printk ("ERROR_10\n");}
-void do_general_protection(void) {printk ("ERROR_11\n");}
-void do_page_fault(void) {printk ("ERROR_12\n");   }
-void do_coprocessor_error(void) {printk ("ERROR_13\n");}
-void do_simd_coprocessor_error(void) {printk ("ERROR_14\n");}
-void do_alignment_check(void) {printk ("ERROR_15\n");}
-void do_spurious_interrupt_bug(void) {printk ("ERROR_16\n");}
-void do_machine_check(void) {}
+void do_debug(void) {
+	printk("ERROR_1\n");
+}
+void do_int3(void) {
+	printk("ERROR_2\n");
+}
+void do_overflow(void) {
+	printk("ERROR_3\n");
+}
+void do_bounds(void) {
+	printk("ERROR_4\n");
+}
+void do_invalid_op(void) {
+	printk("ERROR_5\n");
+}
+void do_device_not_available(void) {
+	printk("ERROR_6\n");
+}
+void do_coprocessor_segment_overrun(void) {
+	printk("ERROR_7\n");
+}
+void do_invalid_TSS(void) {
+	printk("ERROR_8\n");
+}
+void do_segment_not_present(void) {
+	printk("ERROR_9\n");
+}
+void do_stack_segment(void) {
+	printk("ERROR_10\n");
+}
+void do_general_protection(void) {
+	printk("ERROR_11\n");
+}
+void do_page_fault(void) {
+	printk("ERROR_12\n");
+}
+void do_coprocessor_error(void) {
+	printk("ERROR_13\n");
+}
+void do_simd_coprocessor_error(void) {
+	printk("ERROR_14\n");
+}
+void do_alignment_check(void) {
+	printk("ERROR_15\n");
+}
+void do_spurious_interrupt_bug(void) {
+	printk("ERROR_16\n");
+}
+void do_machine_check(void) {
+}
 
 /*
  * Submit a virtual IDT to teh hypervisor. This consists of tuples

--- a/src/drivers/interrupt/Mybuild
+++ b/src/drivers/interrupt/Mybuild
@@ -97,6 +97,7 @@ module no_interrupts extends irqctrl_api {
 module xen extends irqctrl_api {
 	source "xen.h"
 	source "xen.c"
+	depends embox.arch.xen.traps
 }
 
 

--- a/src/drivers/interrupt/Mybuild
+++ b/src/drivers/interrupt/Mybuild
@@ -94,6 +94,12 @@ module no_interrupts extends irqctrl_api {
 	source "no_interrupts.c"
 }
 
+module xen extends irqctrl_api {
+	source "xen.h"
+	source "xen.c"
+}
+
+
 module integratorcp_pic extends irqctrl_api {
 	source "integratorcp_pic.c", "integratorcp_pic.h"
 }

--- a/src/drivers/interrupt/xen.c
+++ b/src/drivers/interrupt/xen.c
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date
+ * @author
+ */
+
+#include <kernel/irq.h>
+#include <embox/unit.h>
+#include <kernel/printk.h>
+
+#include <drivers/irqctrl.h>
+
+EMBOX_UNIT_INIT(xen_int_init);
+
+static int xen_int_init(void) {
+	return 0;
+}
+
+void irqctrl_enable(unsigned int irq) {
+}
+
+void irqctrl_disable(unsigned int irq) {
+}
+
+void irqctrl_force(unsigned int irq) {
+}
+
+void interrupt_handle(void) {
+}

--- a/src/drivers/interrupt/xen.c
+++ b/src/drivers/interrupt/xen.c
@@ -11,6 +11,10 @@
 #include <kernel/printk.h>
 
 #include <drivers/irqctrl.h>
+#include <xen/event.h>
+
+extern shared_info_t xen_shared_info;
+extern void do_divide_error(void);
 
 EMBOX_UNIT_INIT(xen_int_init);
 
@@ -22,9 +26,14 @@ void irqctrl_enable(unsigned int irq) {
 }
 
 void irqctrl_disable(unsigned int irq) {
+	printk("in disable\n");
 }
 
 void irqctrl_force(unsigned int irq) {
+	printk("xen force interrupt %d\n", irq);
+	int x = 0;
+	int y = 100 / x; /* make div-by-zero execption */
+	printk("%d\n", y); /* avoid optimizing out by compiler */
 }
 
 void interrupt_handle(void) {

--- a/src/drivers/interrupt/xen.h
+++ b/src/drivers/interrupt/xen.h
@@ -1,0 +1,14 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date
+ * @author
+ */
+
+#ifndef IRQCTRL_XEN_IMPL_H_
+#define IRQCTRL_XEN_IMPL_H_
+
+#define __IRQCTRL_IRQS_TOTAL 32
+
+#endif /* IRQCTRL_XEN_IMPL_H_ */

--- a/templates/xen/debug/mods.config
+++ b/templates/xen/debug/mods.config
@@ -9,8 +9,7 @@ configuration conf {
 //	include embox.arch.x86.libarch
 	include embox.arch.xen.libarch
 	include embox.arch.generic.arch
-	include embox.driver.interrupt.no_interrupts
-	include embox.kernel.no_irq
+	include embox.driver.interrupt.xen
 	include embox.kernel.critical
 	include embox.arch.generic.nosmp
 	include embox.kernel.spinlock(spin_debug=false)
@@ -23,4 +22,6 @@ configuration conf {
 	@Runlevel(2) include embox.util.LibUtil
 	@Runlevel(2) include embox.framework.LibFramework
 	@Runlevel(2) include embox.compat.libc.stdio.print(support_floating=0)
+
+	@Runlevel(2) include embox.test.kernel.irq_test
 }


### PR DESCRIPTION
Exception generated and first stubs called. The output is 
```
Embox kernel start
runlevel: init level is 0
runlevel: init level is 1
        unit: initializing embox.driver.interrupt.xen: done
        test: running embox.test.kernel.irq_test xen force interrupt 10
DIVIDE ERROR called
ERROR_11
ERROR_11
ERROR_12
ERROR_12
ERROR_12
ERROR_12
ERROR_12
ERROR_12
ERROR_12
ERROR_12
ERROR_12
ERROR_12
...
```

To avoid exception disabling `irq_test` in config is sufficient. Probably behavior with exception is good as it shows point of further improvement