### PR TITLE
Fixed condtitions

### DIFF
--- a/src/cmds/sys/Uname.my
+++ b/src/cmds/sys/Uname.my
@@ -28,6 +28,7 @@ module uname {
 
 	option string system = "Embox-OS"
 	option string platform = ""
+	option string processor = "unknown"
 
 	depends embox.compat.posix.util.utsname
 	depends embox.framework.LibFramework

--- a/src/cmds/sys/uname.c
+++ b/src/cmds/sys/uname.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
 		args.with_s = 1;
 
 	uname(&info);
-	processor = NULL;
+	processor = OPTION_STRING_GET(processor);
 	platform = OPTION_STRING_GET(platform);
 	system = OPTION_STRING_GET(system);
 

--- a/src/net/lib/pop3.c
+++ b/src/net/lib/pop3.c
@@ -224,7 +224,7 @@ int pop3_ok(struct pop3_session *p3s) {
 		return -EINVAL;
 	}
 
-	return p3s != NULL ? p3s->ok : 0;
+	return p3s->ok;
 }
 
 const char * pop3_status(struct pop3_session *p3s) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
embox/src/net/lib/pop3.c	227	warn	V547 Expression 'p3s != NULL' is always true.
embox/src/cmds/sys/uname.c	78	warn	V560 A part of conditional expression is always false: processor.
embox/src/cmds/sys/uname.c	79	warn	V547 Expression 'processor' is always false.
