### PR TITLE
i.MX6 graphic support

### DIFF
--- a/src/drivers/clk/ccm_imx6/Mybuild
+++ b/src/drivers/clk/ccm_imx6/Mybuild
@@ -1,0 +1,10 @@
+package embox.driver.clk
+
+
+module ccm_imx6 {
+	option number log_level=0
+
+	option number base_addr=0x020C4000
+
+	source "ccm_imx6.c"
+}

--- a/src/drivers/clk/ccm_imx6/ccm_imx6.c
+++ b/src/drivers/clk/ccm_imx6/ccm_imx6.c
@@ -1,0 +1,213 @@
+/**
+ * @file
+ *
+ * @date 31.03.2017
+ * @author Anton Bondarev
+ */
+#include <stdint.h>
+#include <string.h>
+
+#include <drivers/common/memory.h>
+
+#include <hal/reg.h>
+
+#include <util/array.h>
+#include <util/log.h>
+
+#include <framework/mod/options.h>
+
+#define CCM_BASE           OPTION_GET(NUMBER, base_addr)
+
+#define MXC_CCM_CCR         (CCM_BASE + 0x00)
+#define MXC_CCM_CCDR        (CCM_BASE + 0x04)
+#define MXC_CCM_CSR         (CCM_BASE + 0x08)
+#define MXC_CCM_CCSR        (CCM_BASE + 0x0c)
+#define MXC_CCM_CACRR       (CCM_BASE + 0x10)
+#define MXC_CCM_CBCDR       (CCM_BASE + 0x14)
+#define MXC_CCM_CBCMR       (CCM_BASE + 0x18)
+#define MXC_CCM_CSCMR1      (CCM_BASE + 0x1c)
+#define MXC_CCM_CSCMR2      (CCM_BASE + 0x20)
+#define MXC_CCM_CSCDR1      (CCM_BASE + 0x24)
+#define MXC_CCM_CS1CDR      (CCM_BASE + 0x28)
+#define MXC_CCM_CS2CDR      (CCM_BASE + 0x2c)
+#define MXC_CCM_CDCDR       (CCM_BASE + 0x30)
+#define MXC_CCM_CHSCDR      (CCM_BASE + 0x34)
+#define MXC_CCM_CSCDR2      (CCM_BASE + 0x38)
+#define MXC_CCM_CSCDR3      (CCM_BASE + 0x3c)
+
+//#define MXC_CCM_CSCDR4     (CCM_BASE + 0x40)
+#define MXC_CCM_CWDR        (CCM_BASE + 0x44)
+#define MXC_CCM_CDHIPR      (CCM_BASE + 0x48)
+//#define MXC_CCM_CDCR       (CCM_BASE + 0x4c)
+//#define MXC_CCM_CTOR       (CCM_BASE + 0x50)
+//#define MXC_CCM_CLPCR      (CCM_BASE + 0x54)
+#define MXC_CCM_CISR        (CCM_BASE + 0x58)
+#define MXC_CCM_CIMR        (CCM_BASE + 0x5c)
+#define MXC_CCM_CCOSR       (CCM_BASE + 0x60)
+#define MXC_CCM_CGPR        (CCM_BASE + 0x64)
+#define MXC_CCM_CCGR0       (CCM_BASE + 0x68)
+#define MXC_CCM_CCGR1       (CCM_BASE + 0x6c)
+#define MXC_CCM_CCGR2       (CCM_BASE + 0x70)
+#define MXC_CCM_CCGR3       (CCM_BASE + 0x74)
+#define MXC_CCM_CCGR4       (CCM_BASE + 0x78)
+#define MXC_CCM_CCGR5       (CCM_BASE + 0x7c)
+#define MXC_CCM_CCGR6       (CCM_BASE + 0x80)
+//#define MXC_CCM_CCGR7      (CCM_BASE + 0x84)
+#define MXC_CCM_CMEOR       (CCM_BASE + 0x84)
+
+
+#define MXC_CCM_CHSCCDR_IPU1_DI1_PRE_CLK_SEL_MASK   (0x7 << 15)
+#define MXC_CCM_CHSCCDR_IPU1_DI1_PRE_CLK_SEL_OFFSET 15
+#define MXC_CCM_CHSCCDR_IPU1_DI1_PODF_MASK          (0x7 << 12)
+#define MXC_CCM_CHSCCDR_IPU1_DI1_PODF_OFFSET        12
+#define MXC_CCM_CHSCCDR_IPU1_DI1_CLK_SEL_MASK       (0x7 << 9)
+#define MXC_CCM_CHSCCDR_IPU1_DI1_CLK_SEL_OFFSET     9
+#define MXC_CCM_CHSCCDR_IPU1_DI0_PRE_CLK_SEL_MASK   (0x7 << 6)
+#define MXC_CCM_CHSCCDR_IPU1_DI0_PRE_CLK_SEL_OFFSET 6
+#define MXC_CCM_CHSCCDR_IPU1_DI0_PODF_MASK          (0x7 << 3)
+#define MXC_CCM_CHSCCDR_IPU1_DI0_PODF_OFFSET        3
+#define MXC_CCM_CHSCCDR_IPU1_DI0_CLK_SEL_MASK       (0x7)
+#define MXC_CCM_CHSCCDR_IPU1_DI0_CLK_SEL_OFFSET     0
+
+#define MXC_CCM_CHSCCDR_EPDC_PRE_CLK_SEL_MASK       (0x7 << 15)
+#define MXC_CCM_CHSCCDR_EPDC_PRE_CLK_SEL_OFFSET     15
+#define MXC_CCM_CHSCCDR_EPDC_PODF_MASK              (0x7 << 12)
+#define MXC_CCM_CHSCCDR_EPDC_PODF_OFFSET            12
+#define MXC_CCM_CHSCCDR_EPDC_CLK_SEL_MASK           (0x7 << 9)
+#define MXC_CCM_CHSCCDR_EPDC_CLK_SEL_OFFSET         9
+
+#define CHSCCDR_CLK_SEL_LDB_DI0                     3
+#define CHSCCDR_PODF_DIVIDE_BY_3                    2
+#define CHSCCDR_IPU_PRE_CLK_540M_PFD                5
+
+struct clk {
+	uint32_t reg_offset;
+	uint32_t bit_num;
+	const char *clk_name;
+};
+
+/* TODO pass clock mode as parameter?
+ *
+ * In registers binary values will be as follows (from manual):
+ *
+ * 00 Clock is off during all modes. Stop enter hardware handshake is disabled.
+ * 01 Clock is on in run mode, but off in WAIT and STOP modes
+ * 10 Not applicable (Reserved).
+ * 11 Clock is on during all modes, except STOP mode.
+ *
+ * Usually we just use 11 (i.e. 3 << offt).
+ */
+
+static const struct clk clks_repo[] = {
+	{ MXC_CCM_CCGR0, 3 << 24, "dcic1" },
+	{ MXC_CCM_CCGR0, 3 << 26, "dcic2" },
+	{ MXC_CCM_CCGR2, 1,       "iahb" },
+	{ MXC_CCM_CCGR2, 3 << 4,  "isfr" },
+	{ MXC_CCM_CCGR2, 0x33,    "hdmi" },
+	{ MXC_CCM_CCGR3, 3 << 0,  "ipu1" },
+	{ MXC_CCM_CCGR3, 3 << 2,  "ipu1_di0" },
+	{ MXC_CCM_CCGR3, 3 << 4,  "ipu1_di1" },
+	{ MXC_CCM_CCGR3, 3 << 6,  "ipu2" },
+	{ MXC_CCM_CCGR3, 3 << 8,  "ipu2_di0" },
+	{ MXC_CCM_CCGR3, 3 << 10, "ipu2_di1" },
+	{ MXC_CCM_CCGR3, 3 << 12, "ldb_di0" },
+	{ MXC_CCM_CCGR3, 3 << 14, "ldb_di1" },
+};
+
+int clk_enable(char *clk_name) {
+	int i;
+	log_debug("%s", clk_name);
+	for (i = 0; i < ARRAY_SIZE(clks_repo); i ++) {
+		if (0 == strcmp(clks_repo[i].clk_name, clk_name)) {
+			REG32_ORIN(clks_repo[i].reg_offset, clks_repo[i].bit_num);
+			while(REG32_LOAD(MXC_CCM_CDHIPR));
+
+			if (!strcmp(clk_name, "ldb_di0")) {
+				uint32_t reg = REG32_LOAD(MXC_CCM_CHSCDR);
+				reg &= ~((7 << 6) | (7 << 3) | 7);
+				reg |= (2 << 3);
+				reg |= (5 << 6);
+				REG32_STORE(MXC_CCM_CHSCDR, reg);
+				reg |= (3 << 0);
+				REG32_STORE(MXC_CCM_CHSCDR, reg);
+			}
+
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int clk_disable(char *clk_name) {
+	int i;
+
+	log_debug("%s", clk_name);
+	for (i = 0; i < ARRAY_SIZE(clks_repo); i ++) {
+		if (0 == strcmp(clks_repo[i].clk_name, clk_name)) {
+			REG32_CLEAR(clks_repo[i].reg_offset, clks_repo[i].bit_num);
+			while(REG32_LOAD(MXC_CCM_CDHIPR));
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+void clk_reg_dump(void) {
+	log_debug("=================== REGISTER DUMP =====================");
+	log_debug("MXC_CCM_CCR   =0x%08x", REG32_LOAD(MXC_CCM_CCR));
+	log_debug("MXC_CCM_CCDR  =0x%08x", REG32_LOAD(MXC_CCM_CCDR));
+	log_debug("MXC_CCM_CSR   =0x%08x", REG32_LOAD(MXC_CCM_CSR));
+	log_debug("MXC_CCM_CCOSR =0x%08x", REG32_LOAD(MXC_CCM_CCOSR));
+	log_debug("MXC_CCM_CCGR0 =0x%08x", REG32_LOAD(MXC_CCM_CCGR0));
+	log_debug("MXC_CCM_CCGR1 =0x%08x", REG32_LOAD(MXC_CCM_CCGR1));
+	log_debug("MXC_CCM_CCGR2 =0x%08x", REG32_LOAD(MXC_CCM_CCGR2));
+	log_debug("MXC_CCM_CCGR3 =0x%08x", REG32_LOAD(MXC_CCM_CCGR3));
+	log_debug("MXC_CCM_CCGR4 =0x%08x", REG32_LOAD(MXC_CCM_CCGR4));
+	log_debug("MXC_CCM_CCGR5 =0x%08x", REG32_LOAD(MXC_CCM_CCGR5));
+	log_debug("MXC_CCM_CCGR6 =0x%08x", REG32_LOAD(MXC_CCM_CCGR6));
+	log_debug("================= REGISTER DUMP END ===================");
+
+
+	for (int i = 0; i < 0x88 / 4 / 4; i++) {
+		log_debug("0x%08x 0x%08x 0x%08x 0x%08x",
+				REG32_LOAD(CCM_BASE + i * 4 * 4),
+				REG32_LOAD(CCM_BASE + i * 4 * 4 + 4),
+				REG32_LOAD(CCM_BASE + i * 4 * 4 + 8),
+				REG32_LOAD(CCM_BASE + i * 4 * 4 + 12));
+
+	}
+
+	log_debug("");
+	for (int i = 0x20C8000; i <= 0x20C817C; i+=4) {
+		log_debug("%p =0x%08x", i, REG32_LOAD(i));
+	}
+
+
+
+
+	static uint32_t vals[] = {
+		0x040110ff, 0x00000000, 0x00000038, 0x00000100,
+		0x00000000, 0x00018d00, 0x00010204, 0x0090a800,
+		0x02a12f06, 0x00490b00, 0x0ec102c1, 0x007312c1,
+		0x33e71f92, 0x00012093, 0x00012090, 0x00010841,
+		0x00010241, 0x00000000, 0x00000000, 0x00000003,
+		0x00000000, 0x00000078, 0x041a0000, 0xffffffff,
+		0x000e0101, 0x0000fe62, 0x0040000f, 0x00300000,
+		0x01ff0000, 0x3770300f, 0x000cf303, 0x00000003,
+	};
+	return;
+	for (int i = 0; i < 0x88 / 4; i++) {
+		if (i != 0x7c / 4)
+		REG32_STORE(CCM_BASE + i * 4, vals[i]);
+		log_debug("setup 0x%x\n", i * 4);
+	}
+}
+
+static struct periph_memory_desc ccm_mem = {
+	.start = CCM_BASE,
+	.len   = 0x100,
+};
+
+PERIPH_MEMORY_DEFINE(ccm_mem);

--- a/src/drivers/gpu/drm/dw_hdmi/Mybuild
+++ b/src/drivers/gpu/drm/dw_hdmi/Mybuild
@@ -1,0 +1,12 @@
+package embox.driver.video
+
+
+module dw_hdmi {
+	option number log_level=0
+
+	option number base_addr
+
+	source "dw_hdmi.c"
+
+	depends embox.driver.clk.ccm_imx6
+}

--- a/src/drivers/gpu/drm/dw_hdmi/dw_hdmi.c
+++ b/src/drivers/gpu/drm/dw_hdmi/dw_hdmi.c
@@ -1,0 +1,84 @@
+/**
+ * @file
+ *
+ * @date 30.03.2017
+ * @author Anton Bondarev
+ */
+#include <stdint.h>
+
+#include <drivers/common/memory.h>
+
+#include <hal/reg.h>
+
+#include <util/log.h>
+
+#include <embox/unit.h>
+
+#include "dw_hdmi.h"
+
+
+#include <framework/mod/options.h>
+
+#define DW_HDMI_BASE          OPTION_GET(NUMBER, base_addr)
+
+EMBOX_UNIT_INIT(dw_hdmi_init);
+
+extern int clk_enable(char *clk_name);
+
+struct dw_hdmi {
+	uint32_t regs;
+	uint8_t (*read)(struct dw_hdmi *hdmi, int offset);
+	void (*write)(struct dw_hdmi *hdmi, uint8_t val, int offset) ;
+};
+
+static struct dw_hdmi dw_hdmi;
+
+static void dw_hdmi_writeb(struct dw_hdmi *hdmi, uint8_t val, int offset)
+{
+	REG8_STORE(hdmi->regs + offset, val);
+}
+
+static uint8_t dw_hdmi_readb(struct dw_hdmi *hdmi, int offset)
+{
+	return REG8_LOAD(hdmi->regs + offset);
+}
+
+static inline void hdmi_writeb(struct dw_hdmi *hdmi, uint8_t val, int offset)
+{
+	hdmi->write(hdmi, val, offset);
+}
+
+static inline uint8_t hdmi_readb(struct dw_hdmi *hdmi, int offset)
+{
+	return hdmi->read(hdmi, offset);
+}
+
+static int dw_hdmi_init(void) {
+	struct dw_hdmi *hdmi;
+	hdmi = &dw_hdmi;
+
+	dw_hdmi.regs = DW_HDMI_BASE;
+	dw_hdmi.write = dw_hdmi_writeb;
+	dw_hdmi.read = dw_hdmi_readb;
+
+	if (-1 == clk_enable("isfr")) {
+		log_error("Clk 'isfr' didn't find");
+	}
+	if (-1 == clk_enable("iahb")) {
+		log_error("Clk 'iahb' didn't find");
+	}
+	log_debug("Detected HDMI controller 0x%x:0x%x:0x%x:0x%x\n",
+		 hdmi_readb(hdmi, HDMI_DESIGN_ID),
+		 hdmi_readb(hdmi, HDMI_REVISION_ID),
+		 hdmi_readb(hdmi, HDMI_PRODUCT_ID0),
+		 hdmi_readb(hdmi, HDMI_PRODUCT_ID1));
+	return 0;
+}
+
+static struct periph_memory_desc dw_hdmi_mem = {
+	.start = DW_HDMI_BASE,
+	.len   = 0x8000,
+};
+
+PERIPH_MEMORY_DEFINE(dw_hdmi_mem);
+

--- a/src/drivers/gpu/drm/dw_hdmi/dw_hdmi.h
+++ b/src/drivers/gpu/drm/dw_hdmi/dw_hdmi.h
@@ -1,0 +1,1032 @@
+/**
+ * @file
+ *
+ * @date 30.03.2017
+ * @author Anton Bondarev
+ */
+
+#ifndef DW_HDMI_H_
+#define DW_HDMI_H_
+
+
+/* Identification Registers */
+#define HDMI_DESIGN_ID                          0x0000
+#define HDMI_REVISION_ID                        0x0001
+#define HDMI_PRODUCT_ID0                        0x0002
+#define HDMI_PRODUCT_ID1                        0x0003
+#define HDMI_CONFIG0_ID                         0x0004
+#define HDMI_CONFIG1_ID                         0x0005
+#define HDMI_CONFIG2_ID                         0x0006
+#define HDMI_CONFIG3_ID                         0x0007
+
+/* Interrupt Registers */
+#define HDMI_IH_FC_STAT0                        0x0100
+#define HDMI_IH_FC_STAT1                        0x0101
+#define HDMI_IH_FC_STAT2                        0x0102
+#define HDMI_IH_AS_STAT0                        0x0103
+#define HDMI_IH_PHY_STAT0                       0x0104
+#define HDMI_IH_I2CM_STAT0                      0x0105
+#define HDMI_IH_CEC_STAT0                       0x0106
+#define HDMI_IH_VP_STAT0                        0x0107
+#define HDMI_IH_I2CMPHY_STAT0                   0x0108
+#define HDMI_IH_AHBDMAAUD_STAT0                 0x0109
+
+#define HDMI_IH_MUTE_FC_STAT0                   0x0180
+#define HDMI_IH_MUTE_FC_STAT1                   0x0181
+#define HDMI_IH_MUTE_FC_STAT2                   0x0182
+#define HDMI_IH_MUTE_AS_STAT0                   0x0183
+#define HDMI_IH_MUTE_PHY_STAT0                  0x0184
+#define HDMI_IH_MUTE_I2CM_STAT0                 0x0185
+#define HDMI_IH_MUTE_CEC_STAT0                  0x0186
+#define HDMI_IH_MUTE_VP_STAT0                   0x0187
+#define HDMI_IH_MUTE_I2CMPHY_STAT0              0x0188
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0            0x0189
+#define HDMI_IH_MUTE                            0x01FF
+
+/* Video Sample Registers */
+#define HDMI_TX_INVID0                          0x0200
+#define HDMI_TX_INSTUFFING                      0x0201
+#define HDMI_TX_GYDATA0                         0x0202
+#define HDMI_TX_GYDATA1                         0x0203
+#define HDMI_TX_RCRDATA0                        0x0204
+#define HDMI_TX_RCRDATA1                        0x0205
+#define HDMI_TX_BCBDATA0                        0x0206
+#define HDMI_TX_BCBDATA1                        0x0207
+
+/* Video Packetizer Registers */
+#define HDMI_VP_STATUS                          0x0800
+#define HDMI_VP_PR_CD                           0x0801
+#define HDMI_VP_STUFF                           0x0802
+#define HDMI_VP_REMAP                           0x0803
+#define HDMI_VP_CONF                            0x0804
+#define HDMI_VP_STAT                            0x0805
+#define HDMI_VP_INT                             0x0806
+#define HDMI_VP_MASK                            0x0807
+#define HDMI_VP_POL                             0x0808
+
+/* Frame Composer Registers */
+#define HDMI_FC_INVIDCONF                       0x1000
+#define HDMI_FC_INHACTV0                        0x1001
+#define HDMI_FC_INHACTV1                        0x1002
+#define HDMI_FC_INHBLANK0                       0x1003
+#define HDMI_FC_INHBLANK1                       0x1004
+#define HDMI_FC_INVACTV0                        0x1005
+#define HDMI_FC_INVACTV1                        0x1006
+#define HDMI_FC_INVBLANK                        0x1007
+#define HDMI_FC_HSYNCINDELAY0                   0x1008
+#define HDMI_FC_HSYNCINDELAY1                   0x1009
+#define HDMI_FC_HSYNCINWIDTH0                   0x100A
+#define HDMI_FC_HSYNCINWIDTH1                   0x100B
+#define HDMI_FC_VSYNCINDELAY                    0x100C
+#define HDMI_FC_VSYNCINWIDTH                    0x100D
+#define HDMI_FC_INFREQ0                         0x100E
+#define HDMI_FC_INFREQ1                         0x100F
+#define HDMI_FC_INFREQ2                         0x1010
+#define HDMI_FC_CTRLDUR                         0x1011
+#define HDMI_FC_EXCTRLDUR                       0x1012
+#define HDMI_FC_EXCTRLSPAC                      0x1013
+#define HDMI_FC_CH0PREAM                        0x1014
+#define HDMI_FC_CH1PREAM                        0x1015
+#define HDMI_FC_CH2PREAM                        0x1016
+#define HDMI_FC_AVICONF3                        0x1017
+#define HDMI_FC_GCP                             0x1018
+#define HDMI_FC_AVICONF0                        0x1019
+#define HDMI_FC_AVICONF1                        0x101A
+#define HDMI_FC_AVICONF2                        0x101B
+#define HDMI_FC_AVIVID                          0x101C
+#define HDMI_FC_AVIETB0                         0x101D
+#define HDMI_FC_AVIETB1                         0x101E
+#define HDMI_FC_AVISBB0                         0x101F
+#define HDMI_FC_AVISBB1                         0x1020
+#define HDMI_FC_AVIELB0                         0x1021
+#define HDMI_FC_AVIELB1                         0x1022
+#define HDMI_FC_AVISRB0                         0x1023
+#define HDMI_FC_AVISRB1                         0x1024
+#define HDMI_FC_AUDICONF0                       0x1025
+#define HDMI_FC_AUDICONF1                       0x1026
+#define HDMI_FC_AUDICONF2                       0x1027
+#define HDMI_FC_AUDICONF3                       0x1028
+#define HDMI_FC_VSDIEEEID0                      0x1029
+#define HDMI_FC_VSDSIZE                         0x102A
+#define HDMI_FC_VSDIEEEID1                      0x1030
+#define HDMI_FC_VSDIEEEID2                      0x1031
+#define HDMI_FC_VSDPAYLOAD0                     0x1032
+#define HDMI_FC_VSDPAYLOAD1                     0x1033
+#define HDMI_FC_VSDPAYLOAD2                     0x1034
+#define HDMI_FC_VSDPAYLOAD3                     0x1035
+#define HDMI_FC_VSDPAYLOAD4                     0x1036
+#define HDMI_FC_VSDPAYLOAD5                     0x1037
+#define HDMI_FC_VSDPAYLOAD6                     0x1038
+#define HDMI_FC_VSDPAYLOAD7                     0x1039
+#define HDMI_FC_VSDPAYLOAD8                     0x103A
+#define HDMI_FC_VSDPAYLOAD9                     0x103B
+#define HDMI_FC_VSDPAYLOAD10                    0x103C
+#define HDMI_FC_VSDPAYLOAD11                    0x103D
+#define HDMI_FC_VSDPAYLOAD12                    0x103E
+#define HDMI_FC_VSDPAYLOAD13                    0x103F
+#define HDMI_FC_VSDPAYLOAD14                    0x1040
+#define HDMI_FC_VSDPAYLOAD15                    0x1041
+#define HDMI_FC_VSDPAYLOAD16                    0x1042
+#define HDMI_FC_VSDPAYLOAD17                    0x1043
+#define HDMI_FC_VSDPAYLOAD18                    0x1044
+#define HDMI_FC_VSDPAYLOAD19                    0x1045
+#define HDMI_FC_VSDPAYLOAD20                    0x1046
+#define HDMI_FC_VSDPAYLOAD21                    0x1047
+#define HDMI_FC_VSDPAYLOAD22                    0x1048
+#define HDMI_FC_VSDPAYLOAD23                    0x1049
+#define HDMI_FC_SPDVENDORNAME0                  0x104A
+#define HDMI_FC_SPDVENDORNAME1                  0x104B
+#define HDMI_FC_SPDVENDORNAME2                  0x104C
+#define HDMI_FC_SPDVENDORNAME3                  0x104D
+#define HDMI_FC_SPDVENDORNAME4                  0x104E
+#define HDMI_FC_SPDVENDORNAME5                  0x104F
+#define HDMI_FC_SPDVENDORNAME6                  0x1050
+#define HDMI_FC_SPDVENDORNAME7                  0x1051
+#define HDMI_FC_SDPPRODUCTNAME0                 0x1052
+#define HDMI_FC_SDPPRODUCTNAME1                 0x1053
+#define HDMI_FC_SDPPRODUCTNAME2                 0x1054
+#define HDMI_FC_SDPPRODUCTNAME3                 0x1055
+#define HDMI_FC_SDPPRODUCTNAME4                 0x1056
+#define HDMI_FC_SDPPRODUCTNAME5                 0x1057
+#define HDMI_FC_SDPPRODUCTNAME6                 0x1058
+#define HDMI_FC_SDPPRODUCTNAME7                 0x1059
+#define HDMI_FC_SDPPRODUCTNAME8                 0x105A
+#define HDMI_FC_SDPPRODUCTNAME9                 0x105B
+#define HDMI_FC_SDPPRODUCTNAME10                0x105C
+#define HDMI_FC_SDPPRODUCTNAME11                0x105D
+#define HDMI_FC_SDPPRODUCTNAME12                0x105E
+#define HDMI_FC_SDPPRODUCTNAME13                0x105F
+#define HDMI_FC_SDPPRODUCTNAME14                0x1060
+#define HDMI_FC_SPDPRODUCTNAME15                0x1061
+#define HDMI_FC_SPDDEVICEINF                    0x1062
+#define HDMI_FC_AUDSCONF                        0x1063
+#define HDMI_FC_AUDSSTAT                        0x1064
+#define HDMI_FC_DATACH0FILL                     0x1070
+#define HDMI_FC_DATACH1FILL                     0x1071
+#define HDMI_FC_DATACH2FILL                     0x1072
+#define HDMI_FC_CTRLQHIGH                       0x1073
+#define HDMI_FC_CTRLQLOW                        0x1074
+#define HDMI_FC_ACP0                            0x1075
+#define HDMI_FC_ACP28                           0x1076
+#define HDMI_FC_ACP27                           0x1077
+#define HDMI_FC_ACP26                           0x1078
+#define HDMI_FC_ACP25                           0x1079
+#define HDMI_FC_ACP24                           0x107A
+#define HDMI_FC_ACP23                           0x107B
+#define HDMI_FC_ACP22                           0x107C
+#define HDMI_FC_ACP21                           0x107D
+#define HDMI_FC_ACP20                           0x107E
+#define HDMI_FC_ACP19                           0x107F
+#define HDMI_FC_ACP18                           0x1080
+#define HDMI_FC_ACP17                           0x1081
+#define HDMI_FC_ACP16                           0x1082
+#define HDMI_FC_ACP15                           0x1083
+#define HDMI_FC_ACP14                           0x1084
+#define HDMI_FC_ACP13                           0x1085
+#define HDMI_FC_ACP12                           0x1086
+#define HDMI_FC_ACP11                           0x1087
+#define HDMI_FC_ACP10                           0x1088
+#define HDMI_FC_ACP9                            0x1089
+#define HDMI_FC_ACP8                            0x108A
+#define HDMI_FC_ACP7                            0x108B
+#define HDMI_FC_ACP6                            0x108C
+#define HDMI_FC_ACP5                            0x108D
+#define HDMI_FC_ACP4                            0x108E
+#define HDMI_FC_ACP3                            0x108F
+#define HDMI_FC_ACP2                            0x1090
+#define HDMI_FC_ACP1                            0x1091
+#define HDMI_FC_ISCR1_0                         0x1092
+#define HDMI_FC_ISCR1_16                        0x1093
+#define HDMI_FC_ISCR1_15                        0x1094
+#define HDMI_FC_ISCR1_14                        0x1095
+#define HDMI_FC_ISCR1_13                        0x1096
+#define HDMI_FC_ISCR1_12                        0x1097
+#define HDMI_FC_ISCR1_11                        0x1098
+#define HDMI_FC_ISCR1_10                        0x1099
+#define HDMI_FC_ISCR1_9                         0x109A
+#define HDMI_FC_ISCR1_8                         0x109B
+#define HDMI_FC_ISCR1_7                         0x109C
+#define HDMI_FC_ISCR1_6                         0x109D
+#define HDMI_FC_ISCR1_5                         0x109E
+#define HDMI_FC_ISCR1_4                         0x109F
+#define HDMI_FC_ISCR1_3                         0x10A0
+#define HDMI_FC_ISCR1_2                         0x10A1
+#define HDMI_FC_ISCR1_1                         0x10A2
+#define HDMI_FC_ISCR2_15                        0x10A3
+#define HDMI_FC_ISCR2_14                        0x10A4
+#define HDMI_FC_ISCR2_13                        0x10A5
+#define HDMI_FC_ISCR2_12                        0x10A6
+#define HDMI_FC_ISCR2_11                        0x10A7
+#define HDMI_FC_ISCR2_10                        0x10A8
+#define HDMI_FC_ISCR2_9                         0x10A9
+#define HDMI_FC_ISCR2_8                         0x10AA
+#define HDMI_FC_ISCR2_7                         0x10AB
+#define HDMI_FC_ISCR2_6                         0x10AC
+#define HDMI_FC_ISCR2_5                         0x10AD
+#define HDMI_FC_ISCR2_4                         0x10AE
+#define HDMI_FC_ISCR2_3                         0x10AF
+#define HDMI_FC_ISCR2_2                         0x10B0
+#define HDMI_FC_ISCR2_1                         0x10B1
+#define HDMI_FC_ISCR2_0                         0x10B2
+#define HDMI_FC_DATAUTO0                        0x10B3
+#define HDMI_FC_DATAUTO1                        0x10B4
+#define HDMI_FC_DATAUTO2                        0x10B5
+#define HDMI_FC_DATMAN                          0x10B6
+#define HDMI_FC_DATAUTO3                        0x10B7
+#define HDMI_FC_RDRB0                           0x10B8
+#define HDMI_FC_RDRB1                           0x10B9
+#define HDMI_FC_RDRB2                           0x10BA
+#define HDMI_FC_RDRB3                           0x10BB
+#define HDMI_FC_RDRB4                           0x10BC
+#define HDMI_FC_RDRB5                           0x10BD
+#define HDMI_FC_RDRB6                           0x10BE
+#define HDMI_FC_RDRB7                           0x10BF
+#define HDMI_FC_STAT0                           0x10D0
+#define HDMI_FC_INT0                            0x10D1
+#define HDMI_FC_MASK0                           0x10D2
+#define HDMI_FC_POL0                            0x10D3
+#define HDMI_FC_STAT1                           0x10D4
+#define HDMI_FC_INT1                            0x10D5
+#define HDMI_FC_MASK1                           0x10D6
+#define HDMI_FC_POL1                            0x10D7
+#define HDMI_FC_STAT2                           0x10D8
+#define HDMI_FC_INT2                            0x10D9
+#define HDMI_FC_MASK2                           0x10DA
+#define HDMI_FC_POL2                            0x10DB
+#define HDMI_FC_PRCONF                          0x10E0
+
+#define HDMI_FC_GMD_STAT                        0x1100
+#define HDMI_FC_GMD_EN                          0x1101
+#define HDMI_FC_GMD_UP                          0x1102
+#define HDMI_FC_GMD_CONF                        0x1103
+#define HDMI_FC_GMD_HB                          0x1104
+#define HDMI_FC_GMD_PB0                         0x1105
+#define HDMI_FC_GMD_PB1                         0x1106
+#define HDMI_FC_GMD_PB2                         0x1107
+#define HDMI_FC_GMD_PB3                         0x1108
+#define HDMI_FC_GMD_PB4                         0x1109
+#define HDMI_FC_GMD_PB5                         0x110A
+#define HDMI_FC_GMD_PB6                         0x110B
+#define HDMI_FC_GMD_PB7                         0x110C
+#define HDMI_FC_GMD_PB8                         0x110D
+#define HDMI_FC_GMD_PB9                         0x110E
+#define HDMI_FC_GMD_PB10                        0x110F
+#define HDMI_FC_GMD_PB11                        0x1110
+#define HDMI_FC_GMD_PB12                        0x1111
+#define HDMI_FC_GMD_PB13                        0x1112
+#define HDMI_FC_GMD_PB14                        0x1113
+#define HDMI_FC_GMD_PB15                        0x1114
+#define HDMI_FC_GMD_PB16                        0x1115
+#define HDMI_FC_GMD_PB17                        0x1116
+#define HDMI_FC_GMD_PB18                        0x1117
+#define HDMI_FC_GMD_PB19                        0x1118
+#define HDMI_FC_GMD_PB20                        0x1119
+#define HDMI_FC_GMD_PB21                        0x111A
+#define HDMI_FC_GMD_PB22                        0x111B
+#define HDMI_FC_GMD_PB23                        0x111C
+#define HDMI_FC_GMD_PB24                        0x111D
+#define HDMI_FC_GMD_PB25                        0x111E
+#define HDMI_FC_GMD_PB26                        0x111F
+#define HDMI_FC_GMD_PB27                        0x1120
+
+#define HDMI_FC_DBGFORCE                        0x1200
+#define HDMI_FC_DBGAUD0CH0                      0x1201
+#define HDMI_FC_DBGAUD1CH0                      0x1202
+#define HDMI_FC_DBGAUD2CH0                      0x1203
+#define HDMI_FC_DBGAUD0CH1                      0x1204
+#define HDMI_FC_DBGAUD1CH1                      0x1205
+#define HDMI_FC_DBGAUD2CH1                      0x1206
+#define HDMI_FC_DBGAUD0CH2                      0x1207
+#define HDMI_FC_DBGAUD1CH2                      0x1208
+#define HDMI_FC_DBGAUD2CH2                      0x1209
+#define HDMI_FC_DBGAUD0CH3                      0x120A
+#define HDMI_FC_DBGAUD1CH3                      0x120B
+#define HDMI_FC_DBGAUD2CH3                      0x120C
+#define HDMI_FC_DBGAUD0CH4                      0x120D
+#define HDMI_FC_DBGAUD1CH4                      0x120E
+#define HDMI_FC_DBGAUD2CH4                      0x120F
+#define HDMI_FC_DBGAUD0CH5                      0x1210
+#define HDMI_FC_DBGAUD1CH5                      0x1211
+#define HDMI_FC_DBGAUD2CH5                      0x1212
+#define HDMI_FC_DBGAUD0CH6                      0x1213
+#define HDMI_FC_DBGAUD1CH6                      0x1214
+#define HDMI_FC_DBGAUD2CH6                      0x1215
+#define HDMI_FC_DBGAUD0CH7                      0x1216
+#define HDMI_FC_DBGAUD1CH7                      0x1217
+#define HDMI_FC_DBGAUD2CH7                      0x1218
+#define HDMI_FC_DBGTMDS0                        0x1219
+#define HDMI_FC_DBGTMDS1                        0x121A
+#define HDMI_FC_DBGTMDS2                        0x121B
+
+/* HDMI Source PHY Registers */
+#define HDMI_PHY_CONF0                          0x3000
+#define HDMI_PHY_TST0                           0x3001
+#define HDMI_PHY_TST1                           0x3002
+#define HDMI_PHY_TST2                           0x3003
+#define HDMI_PHY_STAT0                          0x3004
+#define HDMI_PHY_INT0                           0x3005
+#define HDMI_PHY_MASK0                          0x3006
+#define HDMI_PHY_POL0                           0x3007
+
+/* HDMI Master PHY Registers */
+#define HDMI_PHY_I2CM_SLAVE_ADDR                0x3020
+#define HDMI_PHY_I2CM_ADDRESS_ADDR              0x3021
+#define HDMI_PHY_I2CM_DATAO_1_ADDR              0x3022
+#define HDMI_PHY_I2CM_DATAO_0_ADDR              0x3023
+#define HDMI_PHY_I2CM_DATAI_1_ADDR              0x3024
+#define HDMI_PHY_I2CM_DATAI_0_ADDR              0x3025
+#define HDMI_PHY_I2CM_OPERATION_ADDR            0x3026
+#define HDMI_PHY_I2CM_INT_ADDR                  0x3027
+#define HDMI_PHY_I2CM_CTLINT_ADDR               0x3028
+#define HDMI_PHY_I2CM_DIV_ADDR                  0x3029
+#define HDMI_PHY_I2CM_SOFTRSTZ_ADDR             0x302a
+#define HDMI_PHY_I2CM_SS_SCL_HCNT_1_ADDR        0x302b
+#define HDMI_PHY_I2CM_SS_SCL_HCNT_0_ADDR        0x302c
+#define HDMI_PHY_I2CM_SS_SCL_LCNT_1_ADDR        0x302d
+#define HDMI_PHY_I2CM_SS_SCL_LCNT_0_ADDR        0x302e
+#define HDMI_PHY_I2CM_FS_SCL_HCNT_1_ADDR        0x302f
+#define HDMI_PHY_I2CM_FS_SCL_HCNT_0_ADDR        0x3030
+#define HDMI_PHY_I2CM_FS_SCL_LCNT_1_ADDR        0x3031
+#define HDMI_PHY_I2CM_FS_SCL_LCNT_0_ADDR        0x3032
+
+/* Audio Sampler Registers */
+#define HDMI_AUD_CONF0                          0x3100
+#define HDMI_AUD_CONF1                          0x3101
+#define HDMI_AUD_INT                            0x3102
+#define HDMI_AUD_CONF2                          0x3103
+#define HDMI_AUD_N1                             0x3200
+#define HDMI_AUD_N2                             0x3201
+#define HDMI_AUD_N3                             0x3202
+#define HDMI_AUD_CTS1                           0x3203
+#define HDMI_AUD_CTS2                           0x3204
+#define HDMI_AUD_CTS3                           0x3205
+#define HDMI_AUD_INPUTCLKFS                     0x3206
+#define HDMI_AUD_SPDIFINT			0x3302
+#define HDMI_AUD_CONF0_HBR                      0x3400
+#define HDMI_AUD_HBR_STATUS                     0x3401
+#define HDMI_AUD_HBR_INT                        0x3402
+#define HDMI_AUD_HBR_POL                        0x3403
+#define HDMI_AUD_HBR_MASK                       0x3404
+
+/*
+ * Generic Parallel Audio Interface Registers
+ * Not used as GPAUD interface is not enabled in hw
+ */
+#define HDMI_GP_CONF0                           0x3500
+#define HDMI_GP_CONF1                           0x3501
+#define HDMI_GP_CONF2                           0x3502
+#define HDMI_GP_STAT                            0x3503
+#define HDMI_GP_INT                             0x3504
+#define HDMI_GP_MASK                            0x3505
+#define HDMI_GP_POL                             0x3506
+
+/* Audio DMA Registers */
+#define HDMI_AHB_DMA_CONF0                      0x3600
+#define HDMI_AHB_DMA_START                      0x3601
+#define HDMI_AHB_DMA_STOP                       0x3602
+#define HDMI_AHB_DMA_THRSLD                     0x3603
+#define HDMI_AHB_DMA_STRADDR0                   0x3604
+#define HDMI_AHB_DMA_STRADDR1                   0x3605
+#define HDMI_AHB_DMA_STRADDR2                   0x3606
+#define HDMI_AHB_DMA_STRADDR3                   0x3607
+#define HDMI_AHB_DMA_STPADDR0                   0x3608
+#define HDMI_AHB_DMA_STPADDR1                   0x3609
+#define HDMI_AHB_DMA_STPADDR2                   0x360a
+#define HDMI_AHB_DMA_STPADDR3                   0x360b
+#define HDMI_AHB_DMA_BSTADDR0                   0x360c
+#define HDMI_AHB_DMA_BSTADDR1                   0x360d
+#define HDMI_AHB_DMA_BSTADDR2                   0x360e
+#define HDMI_AHB_DMA_BSTADDR3                   0x360f
+#define HDMI_AHB_DMA_MBLENGTH0                  0x3610
+#define HDMI_AHB_DMA_MBLENGTH1                  0x3611
+#define HDMI_AHB_DMA_STAT                       0x3612
+#define HDMI_AHB_DMA_INT                        0x3613
+#define HDMI_AHB_DMA_MASK                       0x3614
+#define HDMI_AHB_DMA_POL                        0x3615
+#define HDMI_AHB_DMA_CONF1                      0x3616
+#define HDMI_AHB_DMA_BUFFSTAT                   0x3617
+#define HDMI_AHB_DMA_BUFFINT                    0x3618
+#define HDMI_AHB_DMA_BUFFMASK                   0x3619
+#define HDMI_AHB_DMA_BUFFPOL                    0x361a
+
+/* Main Controller Registers */
+#define HDMI_MC_SFRDIV                          0x4000
+#define HDMI_MC_CLKDIS                          0x4001
+#define HDMI_MC_SWRSTZ                          0x4002
+#define HDMI_MC_OPCTRL                          0x4003
+#define HDMI_MC_FLOWCTRL                        0x4004
+#define HDMI_MC_PHYRSTZ                         0x4005
+#define HDMI_MC_LOCKONCLOCK                     0x4006
+#define HDMI_MC_HEACPHY_RST                     0x4007
+
+/* Color Space  Converter Registers */
+#define HDMI_CSC_CFG                            0x4100
+#define HDMI_CSC_SCALE                          0x4101
+#define HDMI_CSC_COEF_A1_MSB                    0x4102
+#define HDMI_CSC_COEF_A1_LSB                    0x4103
+#define HDMI_CSC_COEF_A2_MSB                    0x4104
+#define HDMI_CSC_COEF_A2_LSB                    0x4105
+#define HDMI_CSC_COEF_A3_MSB                    0x4106
+#define HDMI_CSC_COEF_A3_LSB                    0x4107
+#define HDMI_CSC_COEF_A4_MSB                    0x4108
+#define HDMI_CSC_COEF_A4_LSB                    0x4109
+#define HDMI_CSC_COEF_B1_MSB                    0x410A
+#define HDMI_CSC_COEF_B1_LSB                    0x410B
+#define HDMI_CSC_COEF_B2_MSB                    0x410C
+#define HDMI_CSC_COEF_B2_LSB                    0x410D
+#define HDMI_CSC_COEF_B3_MSB                    0x410E
+#define HDMI_CSC_COEF_B3_LSB                    0x410F
+#define HDMI_CSC_COEF_B4_MSB                    0x4110
+#define HDMI_CSC_COEF_B4_LSB                    0x4111
+#define HDMI_CSC_COEF_C1_MSB                    0x4112
+#define HDMI_CSC_COEF_C1_LSB                    0x4113
+#define HDMI_CSC_COEF_C2_MSB                    0x4114
+#define HDMI_CSC_COEF_C2_LSB                    0x4115
+#define HDMI_CSC_COEF_C3_MSB                    0x4116
+#define HDMI_CSC_COEF_C3_LSB                    0x4117
+#define HDMI_CSC_COEF_C4_MSB                    0x4118
+#define HDMI_CSC_COEF_C4_LSB                    0x4119
+
+/* HDCP Encryption Engine Registers */
+#define HDMI_A_HDCPCFG0                         0x5000
+#define HDMI_A_HDCPCFG1                         0x5001
+#define HDMI_A_HDCPOBS0                         0x5002
+#define HDMI_A_HDCPOBS1                         0x5003
+#define HDMI_A_HDCPOBS2                         0x5004
+#define HDMI_A_HDCPOBS3                         0x5005
+#define HDMI_A_APIINTCLR                        0x5006
+#define HDMI_A_APIINTSTAT                       0x5007
+#define HDMI_A_APIINTMSK                        0x5008
+#define HDMI_A_VIDPOLCFG                        0x5009
+#define HDMI_A_OESSWCFG                         0x500A
+#define HDMI_A_TIMER1SETUP0                     0x500B
+#define HDMI_A_TIMER1SETUP1                     0x500C
+#define HDMI_A_TIMER2SETUP0                     0x500D
+#define HDMI_A_TIMER2SETUP1                     0x500E
+#define HDMI_A_100MSCFG                         0x500F
+#define HDMI_A_2SCFG0                           0x5010
+#define HDMI_A_2SCFG1                           0x5011
+#define HDMI_A_5SCFG0                           0x5012
+#define HDMI_A_5SCFG1                           0x5013
+#define HDMI_A_SRMVERLSB                        0x5014
+#define HDMI_A_SRMVERMSB                        0x5015
+#define HDMI_A_SRMCTRL                          0x5016
+#define HDMI_A_SFRSETUP                         0x5017
+#define HDMI_A_I2CHSETUP                        0x5018
+#define HDMI_A_INTSETUP                         0x5019
+#define HDMI_A_PRESETUP                         0x501A
+#define HDMI_A_SRM_BASE                         0x5020
+
+/* CEC Engine Registers */
+#define HDMI_CEC_CTRL                           0x7D00
+#define HDMI_CEC_STAT                           0x7D01
+#define HDMI_CEC_MASK                           0x7D02
+#define HDMI_CEC_POLARITY                       0x7D03
+#define HDMI_CEC_INT                            0x7D04
+#define HDMI_CEC_ADDR_L                         0x7D05
+#define HDMI_CEC_ADDR_H                         0x7D06
+#define HDMI_CEC_TX_CNT                         0x7D07
+#define HDMI_CEC_RX_CNT                         0x7D08
+#define HDMI_CEC_TX_DATA0                       0x7D10
+#define HDMI_CEC_TX_DATA1                       0x7D11
+#define HDMI_CEC_TX_DATA2                       0x7D12
+#define HDMI_CEC_TX_DATA3                       0x7D13
+#define HDMI_CEC_TX_DATA4                       0x7D14
+#define HDMI_CEC_TX_DATA5                       0x7D15
+#define HDMI_CEC_TX_DATA6                       0x7D16
+#define HDMI_CEC_TX_DATA7                       0x7D17
+#define HDMI_CEC_TX_DATA8                       0x7D18
+#define HDMI_CEC_TX_DATA9                       0x7D19
+#define HDMI_CEC_TX_DATA10                      0x7D1a
+#define HDMI_CEC_TX_DATA11                      0x7D1b
+#define HDMI_CEC_TX_DATA12                      0x7D1c
+#define HDMI_CEC_TX_DATA13                      0x7D1d
+#define HDMI_CEC_TX_DATA14                      0x7D1e
+#define HDMI_CEC_TX_DATA15                      0x7D1f
+#define HDMI_CEC_RX_DATA0                       0x7D20
+#define HDMI_CEC_RX_DATA1                       0x7D21
+#define HDMI_CEC_RX_DATA2                       0x7D22
+#define HDMI_CEC_RX_DATA3                       0x7D23
+#define HDMI_CEC_RX_DATA4                       0x7D24
+#define HDMI_CEC_RX_DATA5                       0x7D25
+#define HDMI_CEC_RX_DATA6                       0x7D26
+#define HDMI_CEC_RX_DATA7                       0x7D27
+#define HDMI_CEC_RX_DATA8                       0x7D28
+#define HDMI_CEC_RX_DATA9                       0x7D29
+#define HDMI_CEC_RX_DATA10                      0x7D2a
+#define HDMI_CEC_RX_DATA11                      0x7D2b
+#define HDMI_CEC_RX_DATA12                      0x7D2c
+#define HDMI_CEC_RX_DATA13                      0x7D2d
+#define HDMI_CEC_RX_DATA14                      0x7D2e
+#define HDMI_CEC_RX_DATA15                      0x7D2f
+#define HDMI_CEC_LOCK                           0x7D30
+#define HDMI_CEC_WKUPCTRL                       0x7D31
+
+/* I2C Master Registers (E-DDC) */
+#define HDMI_I2CM_SLAVE                         0x7E00
+#define HDMI_I2CMESS                            0x7E01
+#define HDMI_I2CM_DATAO                         0x7E02
+#define HDMI_I2CM_DATAI                         0x7E03
+#define HDMI_I2CM_OPERATION                     0x7E04
+#define HDMI_I2CM_INT                           0x7E05
+#define HDMI_I2CM_CTLINT                        0x7E06
+#define HDMI_I2CM_DIV                           0x7E07
+#define HDMI_I2CM_SEGADDR                       0x7E08
+#define HDMI_I2CM_SOFTRSTZ                      0x7E09
+#define HDMI_I2CM_SEGPTR                        0x7E0A
+#define HDMI_I2CM_SS_SCL_HCNT_1_ADDR            0x7E0B
+#define HDMI_I2CM_SS_SCL_HCNT_0_ADDR            0x7E0C
+#define HDMI_I2CM_SS_SCL_LCNT_1_ADDR            0x7E0D
+#define HDMI_I2CM_SS_SCL_LCNT_0_ADDR            0x7E0E
+#define HDMI_I2CM_FS_SCL_HCNT_1_ADDR            0x7E0F
+#define HDMI_I2CM_FS_SCL_HCNT_0_ADDR            0x7E10
+#define HDMI_I2CM_FS_SCL_LCNT_1_ADDR            0x7E11
+#define HDMI_I2CM_FS_SCL_LCNT_0_ADDR            0x7E12
+
+
+/* IH_FC_INT2 field values */
+#define HDMI_IH_FC_INT2_OVERFLOW_MASK                0x03
+#define HDMI_IH_FC_INT2_LOW_PRIORITY_OVERFLOW        0x02
+#define HDMI_IH_FC_INT2_HIGH_PRIORITY_OVERFLOW       0x01
+
+/* IH_FC_STAT2 field values */
+#define HDMI_IH_FC_STAT2_OVERFLOW_MASK               0x03
+#define HDMI_IH_FC_STAT2_LOW_PRIORITY_OVERFLOW       0x02
+#define HDMI_IH_FC_STAT2_HIGH_PRIORITY_OVERFLOW      0x01
+
+/* IH_PHY_STAT0 field values */
+#define HDMI_IH_PHY_STAT0_RX_SENSE3                  0x20
+#define HDMI_IH_PHY_STAT0_RX_SENSE2                  0x10
+#define HDMI_IH_PHY_STAT0_RX_SENSE1                  0x08
+#define HDMI_IH_PHY_STAT0_RX_SENSE0                  0x04
+#define HDMI_IH_PHY_STAT0_TX_PHY_LOCK                0x02
+#define HDMI_IH_PHY_STAT0_HPD                        0x01
+
+/* IH_MUTE_I2CMPHY_STAT0 field values */
+#define HDMI_IH_MUTE_I2CMPHY_STAT0_I2CMPHYDONE       0x2
+#define HDMI_IH_MUTE_I2CMPHY_STAT0_I2CMPHYERROR      0x1
+
+/* IH_AHBDMAAUD_STAT0 field values */
+#define HDMI_IH_AHBDMAAUD_STAT0_ERROR                0x20
+#define HDMI_IH_AHBDMAAUD_STAT0_LOST                 0x10
+#define HDMI_IH_AHBDMAAUD_STAT0_RETRY                0x08
+#define HDMI_IH_AHBDMAAUD_STAT0_DONE                 0x04
+#define HDMI_IH_AHBDMAAUD_STAT0_BUFFFULL             0x02
+#define HDMI_IH_AHBDMAAUD_STAT0_BUFFEMPTY            0x01
+
+/* IH_MUTE_FC_STAT2 field values */
+#define HDMI_IH_MUTE_FC_STAT2_OVERFLOW_MASK          0x03
+#define HDMI_IH_MUTE_FC_STAT2_LOW_PRIORITY_OVERFLOW  0x02
+#define HDMI_IH_MUTE_FC_STAT2_HIGH_PRIORITY_OVERFLOW 0x01
+
+/* IH_MUTE_AHBDMAAUD_STAT0 field values */
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0_ERROR           0x20
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0_LOST            0x10
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0_RETRY           0x08
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0_DONE            0x04
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0_BUFFFULL        0x02
+#define HDMI_IH_MUTE_AHBDMAAUD_STAT0_BUFFEMPTY       0x01
+
+/* IH_MUTE field values */
+#define HDMI_IH_MUTE_MUTE_WAKEUP_INTERRUPT           0x2
+#define HDMI_IH_MUTE_MUTE_ALL_INTERRUPT              0x1
+
+/* TX_INVID0 field values */
+#define HDMI_TX_INVID0_INTERNAL_DE_GENERATOR_MASK    0x80
+#define HDMI_TX_INVID0_INTERNAL_DE_GENERATOR_ENABLE  0x80
+#define HDMI_TX_INVID0_INTERNAL_DE_GENERATOR_DISABLE 0x00
+#define HDMI_TX_INVID0_VIDEO_MAPPING_MASK            0x1F
+#define HDMI_TX_INVID0_VIDEO_MAPPING_OFFSET          0
+
+/* TX_INSTUFFING field values */
+#define HDMI_TX_INSTUFFING_BDBDATA_STUFFING_MASK         0x4
+#define HDMI_TX_INSTUFFING_BDBDATA_STUFFING_ENABLE       0x4
+#define HDMI_TX_INSTUFFING_BDBDATA_STUFFING_DISABLE      0x0
+#define HDMI_TX_INSTUFFING_RCRDATA_STUFFING_MASK         0x2
+#define HDMI_TX_INSTUFFING_RCRDATA_STUFFING_ENABLE       0x2
+#define HDMI_TX_INSTUFFING_RCRDATA_STUFFING_DISABLE      0x0
+#define HDMI_TX_INSTUFFING_GYDATA_STUFFING_MASK          0x1
+#define HDMI_TX_INSTUFFING_GYDATA_STUFFING_ENABLE        0x1
+#define HDMI_TX_INSTUFFING_GYDATA_STUFFING_DISABLE       0x0
+
+/* VP_PR_CD field values */
+#define HDMI_VP_PR_CD_COLOR_DEPTH_MASK                   0xF0
+#define HDMI_VP_PR_CD_COLOR_DEPTH_OFFSET                 4
+#define HDMI_VP_PR_CD_DESIRED_PR_FACTOR_MASK             0x0F
+#define HDMI_VP_PR_CD_DESIRED_PR_FACTOR_OFFSET           0
+
+/* VP_STUFF field values */
+#define HDMI_VP_STUFF_IDEFAULT_PHASE_MASK                0x20
+#define HDMI_VP_STUFF_IDEFAULT_PHASE_OFFSET              5
+#define HDMI_VP_STUFF_IFIX_PP_TO_LAST_MASK               0x10
+#define HDMI_VP_STUFF_IFIX_PP_TO_LAST_OFFSET             4
+#define HDMI_VP_STUFF_ICX_GOTO_P0_ST_MASK                0x8
+#define HDMI_VP_STUFF_ICX_GOTO_P0_ST_OFFSET              3
+#define HDMI_VP_STUFF_YCC422_STUFFING_MASK               0x04
+#define HDMI_VP_STUFF_YCC422_STUFFING_STUFFING_MODE      0x04
+#define HDMI_VP_STUFF_YCC422_STUFFING_DIRECT_MODE        0x00
+#define HDMI_VP_STUFF_PP_STUFFING_MASK                   0x02
+#define HDMI_VP_STUFF_PP_STUFFING_STUFFING_MODE          0x02
+#define HDMI_VP_STUFF_PP_STUFFING_DIRECT_MODE            0x00
+#define HDMI_VP_STUFF_PR_STUFFING_MASK                   0x01
+#define HDMI_VP_STUFF_PR_STUFFING_STUFFING_MODE          0x01
+#define HDMI_VP_STUFF_PR_STUFFING_DIRECT_MODE            0x00
+
+/* VP_CONF field values */
+#define HDMI_VP_CONF_BYPASS_EN_MASK                      0x40
+#define HDMI_VP_CONF_BYPASS_EN_ENABLE                    0x40
+#define HDMI_VP_CONF_BYPASS_EN_DISABLE                   0x00
+#define HDMI_VP_CONF_PP_EN_ENMASK                        0x20
+#define HDMI_VP_CONF_PP_EN_ENABLE                        0x20
+#define HDMI_VP_CONF_PP_EN_DISABLE                       0x00
+#define HDMI_VP_CONF_PR_EN_MASK                          0x10
+#define HDMI_VP_CONF_PR_EN_ENABLE                        0x10
+#define HDMI_VP_CONF_PR_EN_DISABLE                       0x00
+#define HDMI_VP_CONF_YCC422_EN_MASK                      0x08
+#define HDMI_VP_CONF_YCC422_EN_ENABLE                    0x08
+#define HDMI_VP_CONF_YCC422_EN_DISABLE                   0x00
+#define HDMI_VP_CONF_BYPASS_SELECT_MASK                  0x04
+#define HDMI_VP_CONF_BYPASS_SELECT_VID_PACKETIZER        0x04
+#define HDMI_VP_CONF_BYPASS_SELECT_PIX_REPEATER          0x00
+#define HDMI_VP_CONF_OUTPUT_SELECTOR_MASK                0x03
+#define HDMI_VP_CONF_OUTPUT_SELECTOR_BYPASS              0x03
+#define HDMI_VP_CONF_OUTPUT_SELECTOR_YCC422              0x01
+#define HDMI_VP_CONF_OUTPUT_SELECTOR_PP                  0x00
+
+/* VP_REMAP field values */
+#define HDMI_VP_REMAP_MASK                               0x3
+#define HDMI_VP_REMAP_YCC422_24bit                       0x2
+#define HDMI_VP_REMAP_YCC422_20bit                       0x1
+#define HDMI_VP_REMAP_YCC422_16bit                       0x0
+
+/* FC_INVIDCONF field values */
+#define HDMI_FC_INVIDCONF_HDCP_KEEPOUT_MASK                0x80
+#define HDMI_FC_INVIDCONF_HDCP_KEEPOUT_ACTIVE              0x80
+#define HDMI_FC_INVIDCONF_HDCP_KEEPOUT_INACTIVE            0x00
+#define HDMI_FC_INVIDCONF_VSYNC_IN_POLARITY_MASK           0x40
+#define HDMI_FC_INVIDCONF_VSYNC_IN_POLARITY_ACTIVE_HIGH    0x40
+#define HDMI_FC_INVIDCONF_VSYNC_IN_POLARITY_ACTIVE_LOW     0x00
+#define HDMI_FC_INVIDCONF_HSYNC_IN_POLARITY_MASK           0x20
+#define HDMI_FC_INVIDCONF_HSYNC_IN_POLARITY_ACTIVE_HIGH    0x20
+#define HDMI_FC_INVIDCONF_HSYNC_IN_POLARITY_ACTIVE_LOW     0x00
+#define HDMI_FC_INVIDCONF_DE_IN_POLARITY_MASK              0x10
+#define HDMI_FC_INVIDCONF_DE_IN_POLARITY_ACTIVE_HIGH       0x10
+#define HDMI_FC_INVIDCONF_DE_IN_POLARITY_ACTIVE_LOW        0x00
+#define HDMI_FC_INVIDCONF_DVI_MODEZ_MASK                   0x8
+#define HDMI_FC_INVIDCONF_DVI_MODEZ_HDMI_MODE              0x8
+#define HDMI_FC_INVIDCONF_DVI_MODEZ_DVI_MODE               0x0
+#define HDMI_FC_INVIDCONF_R_V_BLANK_IN_OSC_MASK            0x2
+#define HDMI_FC_INVIDCONF_R_V_BLANK_IN_OSC_ACTIVE_HIGH     0x2
+#define HDMI_FC_INVIDCONF_R_V_BLANK_IN_OSC_ACTIVE_LOW      0x0
+#define HDMI_FC_INVIDCONF_IN_I_P_MASK                      0x1
+#define HDMI_FC_INVIDCONF_IN_I_P_INTERLACED                0x1
+#define HDMI_FC_INVIDCONF_IN_I_P_PROGRESSIVE               0x0
+
+/* FC_AUDICONF0 field values */
+#define HDMI_FC_AUDICONF0_CC_OFFSET                        4
+#define HDMI_FC_AUDICONF0_CC_MASK                          0x70
+#define HDMI_FC_AUDICONF0_CT_OFFSET                        0
+#define HDMI_FC_AUDICONF0_CT_MASK                          0xF
+
+/* FC_AUDICONF1 field values */
+#define HDMI_FC_AUDICONF1_SS_OFFSET                       3
+#define HDMI_FC_AUDICONF1_SS_MASK                         0x18
+#define HDMI_FC_AUDICONF1_SF_OFFSET                       0
+#define HDMI_FC_AUDICONF1_SF_MASK                         0x7
+
+/* FC_AUDICONF3 field values */
+#define HDMI_FC_AUDICONF3_LFEPBL_OFFSET                   5
+#define HDMI_FC_AUDICONF3_LFEPBL_MASK                     0x60
+#define HDMI_FC_AUDICONF3_DM_INH_OFFSET                   4
+#define HDMI_FC_AUDICONF3_DM_INH_MASK                     0x10
+#define HDMI_FC_AUDICONF3_LSV_OFFSET                      0
+#define HDMI_FC_AUDICONF3_LSV_MASK                        0xF
+
+/* FC_AUDSCHNLS0 field values */
+#define HDMI_FC_AUDSCHNLS0_CGMSA_OFFSET                   4
+#define HDMI_FC_AUDSCHNLS0_CGMSA_MASK                     0x30
+#define HDMI_FC_AUDSCHNLS0_COPYRIGHT_OFFSET               0
+#define HDMI_FC_AUDSCHNLS0_COPYRIGHT_MASK                 0x01
+
+/* FC_AUDSCHNLS3-6 field values */
+#define HDMI_FC_AUDSCHNLS3_OIEC_CH0_OFFSET                0
+#define HDMI_FC_AUDSCHNLS3_OIEC_CH0_MASK                  0x0f
+#define HDMI_FC_AUDSCHNLS3_OIEC_CH1_OFFSET                4
+#define HDMI_FC_AUDSCHNLS3_OIEC_CH1_MASK                  0xf0
+#define HDMI_FC_AUDSCHNLS4_OIEC_CH2_OFFSET                0
+#define HDMI_FC_AUDSCHNLS4_OIEC_CH2_MASK                  0x0f
+#define HDMI_FC_AUDSCHNLS4_OIEC_CH3_OFFSET                4
+#define HDMI_FC_AUDSCHNLS4_OIEC_CH3_MASK                  0xf0
+
+#define HDMI_FC_AUDSCHNLS5_OIEC_CH0_OFFSET                0
+#define HDMI_FC_AUDSCHNLS5_OIEC_CH0_MASK                  0x0f
+#define HDMI_FC_AUDSCHNLS5_OIEC_CH1_OFFSET                4
+#define HDMI_FC_AUDSCHNLS5_OIEC_CH1_MASK                  0xf0
+#define HDMI_FC_AUDSCHNLS6_OIEC_CH2_OFFSET                0
+#define HDMI_FC_AUDSCHNLS6_OIEC_CH2_MASK                  0x0f
+#define HDMI_FC_AUDSCHNLS6_OIEC_CH3_OFFSET                4
+#define HDMI_FC_AUDSCHNLS6_OIEC_CH3_MASK                  0xf0
+
+/* HDMI_FC_AUDSCHNLS7 field values */
+#define HDMI_FC_AUDSCHNLS7_ACCURACY_OFFSET                4
+#define HDMI_FC_AUDSCHNLS7_ACCURACY_MASK                  0x30
+
+/* HDMI_FC_AUDSCHNLS8 field values */
+#define HDMI_FC_AUDSCHNLS8_ORIGSAMPFREQ_MASK              0xf0
+#define HDMI_FC_AUDSCHNLS8_ORIGSAMPFREQ_OFFSET            4
+#define HDMI_FC_AUDSCHNLS8_WORDLEGNTH_MASK                0x0f
+#define HDMI_FC_AUDSCHNLS8_WORDLEGNTH_OFFSET              0
+
+/* FC_AUDSCONF field values */
+#define HDMI_FC_AUDSCONF_AUD_PACKET_SAMPFIT_MASK          0xF0
+#define HDMI_FC_AUDSCONF_AUD_PACKET_SAMPFIT_OFFSET        4
+#define HDMI_FC_AUDSCONF_AUD_PACKET_LAYOUT_MASK           0x1
+#define HDMI_FC_AUDSCONF_AUD_PACKET_LAYOUT_OFFSET         0
+#define HDMI_FC_AUDSCONF_AUD_PACKET_LAYOUT_LAYOUT1        0x1
+#define HDMI_FC_AUDSCONF_AUD_PACKET_LAYOUT_LAYOUT0        0x0
+
+/* FC_STAT2 field values */
+#define HDMI_FC_STAT2_OVERFLOW_MASK                 0x03
+#define HDMI_FC_STAT2_LOW_PRIORITY_OVERFLOW         0x02
+#define HDMI_FC_STAT2_HIGH_PRIORITY_OVERFLOW        0x01
+
+/* FC_INT2 field values */
+#define HDMI_FC_INT2_OVERFLOW_MASK                  0x03
+#define HDMI_FC_INT2_LOW_PRIORITY_OVERFLOW          0x02
+#define HDMI_FC_INT2_HIGH_PRIORITY_OVERFLOW         0x01
+
+/* FC_MASK2 field values */
+#define HDMI_FC_MASK2_OVERFLOW_MASK        0x03
+#define HDMI_FC_MASK2_LOW_PRIORITY_OVERFLOW         0x02
+#define HDMI_FC_MASK2_HIGH_PRIORITY_OVERFLOW        0x01
+
+/* FC_PRCONF field values */
+#define HDMI_FC_PRCONF_INCOMING_PR_FACTOR_MASK      0xF0
+#define HDMI_FC_PRCONF_INCOMING_PR_FACTOR_OFFSET    4
+#define HDMI_FC_PRCONF_OUTPUT_PR_FACTOR_MASK        0x0F
+#define HDMI_FC_PRCONF_OUTPUT_PR_FACTOR_OFFSET      0
+
+/* FC_AVICONF0-FC_AVICONF3 field values */
+#define HDMI_FC_AVICONF0_PIX_FMT_MASK               0x03
+#define HDMI_FC_AVICONF0_PIX_FMT_RGB                0x00
+#define HDMI_FC_AVICONF0_PIX_FMT_YCBCR422           0x01
+#define HDMI_FC_AVICONF0_PIX_FMT_YCBCR444           0x02
+#define HDMI_FC_AVICONF0_ACTIVE_FMT_MASK            0x40
+#define HDMI_FC_AVICONF0_ACTIVE_FMT_INFO_PRESENT    0x40
+#define HDMI_FC_AVICONF0_ACTIVE_FMT_NO_INFO         0x00
+#define HDMI_FC_AVICONF0_BAR_DATA_MASK              0x0C
+#define HDMI_FC_AVICONF0_BAR_DATA_NO_DATA           0x00
+#define HDMI_FC_AVICONF0_BAR_DATA_VERT_BAR          0x04
+#define HDMI_FC_AVICONF0_BAR_DATA_HORIZ_BAR         0x08
+#define HDMI_FC_AVICONF0_BAR_DATA_VERT_HORIZ_BAR    0x0C
+#define HDMI_FC_AVICONF0_SCAN_INFO_MASK             0x30
+#define HDMI_FC_AVICONF0_SCAN_INFO_OVERSCAN         0x10
+#define HDMI_FC_AVICONF0_SCAN_INFO_UNDERSCAN        0x20
+#define HDMI_FC_AVICONF0_SCAN_INFO_NODATA           0x00
+
+#define HDMI_FC_AVICONF1_ACTIVE_ASPECT_RATIO_MASK      0x0F
+#define HDMI_FC_AVICONF1_ACTIVE_ASPECT_RATIO_USE_CODED 0x08
+#define HDMI_FC_AVICONF1_ACTIVE_ASPECT_RATIO_4_3       0x09
+#define HDMI_FC_AVICONF1_ACTIVE_ASPECT_RATIO_16_9      0x0A
+#define HDMI_FC_AVICONF1_ACTIVE_ASPECT_RATIO_14_9      0x0B
+#define HDMI_FC_AVICONF1_CODED_ASPECT_RATIO_MASK       0x30
+#define HDMI_FC_AVICONF1_CODED_ASPECT_RATIO_NO_DATA    0x00
+#define HDMI_FC_AVICONF1_CODED_ASPECT_RATIO_4_3        0x10
+#define HDMI_FC_AVICONF1_CODED_ASPECT_RATIO_16_9       0x20
+#define HDMI_FC_AVICONF1_COLORIMETRY_MASK              0xC0
+#define HDMI_FC_AVICONF1_COLORIMETRY_NO_DATA           0x00
+#define HDMI_FC_AVICONF1_COLORIMETRY_SMPTE             0x40
+#define HDMI_FC_AVICONF1_COLORIMETRY_ITUR              0x80
+#define HDMI_FC_AVICONF1_COLORIMETRY_EXTENDED_INFO     0xC0
+
+#define HDMI_FC_AVICONF2_SCALING_MASK                 0x03
+#define HDMI_FC_AVICONF2_SCALING_NONE                 0x00
+#define HDMI_FC_AVICONF2_SCALING_HORIZ                0x01
+#define HDMI_FC_AVICONF2_SCALING_VERT                 0x02
+#define HDMI_FC_AVICONF2_SCALING_HORIZ_VERT           0x03
+#define HDMI_FC_AVICONF2_RGB_QUANT_MASK               0x0C
+#define HDMI_FC_AVICONF2_RGB_QUANT_DEFAULT            0x00
+#define HDMI_FC_AVICONF2_RGB_QUANT_LIMITED_RANGE      0x04
+#define HDMI_FC_AVICONF2_RGB_QUANT_FULL_RANGE         0x08
+#define HDMI_FC_AVICONF2_EXT_COLORIMETRY_MASK         0x70
+#define HDMI_FC_AVICONF2_EXT_COLORIMETRY_XVYCC601     0x00
+#define HDMI_FC_AVICONF2_EXT_COLORIMETRY_XVYCC709     0x10
+#define HDMI_FC_AVICONF2_EXT_COLORIMETRY_SYCC601      0x20
+#define HDMI_FC_AVICONF2_EXT_COLORIMETRY_ADOBE_YCC601 0x30
+#define HDMI_FC_AVICONF2_EXT_COLORIMETRY_ADOBE_RGB    0x40
+#define HDMI_FC_AVICONF2_IT_CONTENT_MASK              0x80
+#define HDMI_FC_AVICONF2_IT_CONTENT_NO_DATA           0x00
+#define HDMI_FC_AVICONF2_IT_CONTENT_VALID             0x80
+
+#define HDMI_FC_AVICONF3_IT_CONTENT_TYPE_MASK      0x03
+#define HDMI_FC_AVICONF3_IT_CONTENT_TYPE_GRAPHICS  0x00
+#define HDMI_FC_AVICONF3_IT_CONTENT_TYPE_PHOTO     0x01
+#define HDMI_FC_AVICONF3_IT_CONTENT_TYPE_CINEMA    0x02
+#define HDMI_FC_AVICONF3_IT_CONTENT_TYPE_GAME      0x03
+#define HDMI_FC_AVICONF3_QUANT_RANGE_MASK          0x0C
+#define HDMI_FC_AVICONF3_QUANT_RANGE_LIMITED       0x00
+#define HDMI_FC_AVICONF3_QUANT_RANGE_FULL          0x04
+
+/* FC_DBGFORCE field values */
+#define HDMI_FC_DBGFORCE_FORCEAUDIO                0x10
+#define HDMI_FC_DBGFORCE_FORCEVIDEO                0x1
+
+/* PHY_CONF0 field values */
+#define HDMI_PHY_CONF0_PDZ_MASK                    0x80
+#define HDMI_PHY_CONF0_PDZ_OFFSET                  7
+#define HDMI_PHY_CONF0_ENTMDS_MASK                 0x40
+#define HDMI_PHY_CONF0_ENTMDS_OFFSET               6
+#define HDMI_PHY_CONF0_SPARECTRL_MASK              0x20
+#define HDMI_PHY_CONF0_SPARECTRL_OFFSET            5
+#define HDMI_PHY_CONF0_GEN2_PDDQ_MASK              0x10
+#define HDMI_PHY_CONF0_GEN2_PDDQ_OFFSET            4
+#define HDMI_PHY_CONF0_GEN2_TXPWRON_MASK           0x8
+#define HDMI_PHY_CONF0_GEN2_TXPWRON_OFFSET         3
+#define HDMI_PHY_CONF0_GEN2_ENHPDRXSENSE_MASK      0x4
+#define HDMI_PHY_CONF0_GEN2_ENHPDRXSENSE_OFFSET    2
+#define HDMI_PHY_CONF0_SELDATAENPOL_MASK           0x2
+#define HDMI_PHY_CONF0_SELDATAENPOL_OFFSET         1
+#define HDMI_PHY_CONF0_SELDIPIF_MASK               0x1
+#define HDMI_PHY_CONF0_SELDIPIF_OFFSET             0
+
+/* PHY_TST0 field values */
+#define HDMI_PHY_TST0_TSTCLR_MASK                  0x20
+#define HDMI_PHY_TST0_TSTCLR_OFFSET                5
+#define HDMI_PHY_TST0_TSTEN_MASK                   0x10
+#define HDMI_PHY_TST0_TSTEN_OFFSET                 4
+#define HDMI_PHY_TST0_TSTCLK_MASK                  0x1
+#define HDMI_PHY_TST0_TSTCLK_OFFSET                0
+
+/* PHY_STAT0 field values */
+#define HDMI_PHY_RX_SENSE3                         0x80
+#define HDMI_PHY_RX_SENSE2                         0x40
+#define HDMI_PHY_RX_SENSE1                         0x20
+#define HDMI_PHY_RX_SENSE0                         0x10
+#define HDMI_PHY_HPD                               0x02
+#define HDMI_PHY_TX_PHY_LOCK                       0x01
+
+/* PHY_I2CM_SLAVE_ADDR field values */
+#define HDMI_PHY_I2CM_SLAVE_ADDR_PHY_GEN2          0x69
+#define HDMI_PHY_I2CM_SLAVE_ADDR_HEAC_PHY          0x49
+
+/* PHY_I2CM_OPERATION_ADDR field values */
+#define HDMI_PHY_I2CM_OPERATION_ADDR_WRITE         0x10
+#define HDMI_PHY_I2CM_OPERATION_ADDR_READ          0x1
+
+/* HDMI_PHY_I2CM_INT_ADDR */
+#define HDMI_PHY_I2CM_INT_ADDR_DONE_POL            0x08
+#define HDMI_PHY_I2CM_INT_ADDR_DONE_MASK           0x04
+
+/* HDMI_PHY_I2CM_CTLINT_ADDR */
+#define HDMI_PHY_I2CM_CTLINT_ADDR_NAC_POL          0x80
+#define HDMI_PHY_I2CM_CTLINT_ADDR_NAC_MASK         0x40
+#define HDMI_PHY_I2CM_CTLINT_ADDR_ARBITRATION_POL  0x08
+#define HDMI_PHY_I2CM_CTLINT_ADDR_ARBITRATION_MASK 0x04
+
+/* AUD_CTS3 field values */
+#define HDMI_AUD_CTS3_N_SHIFT_OFFSET                5
+#define HDMI_AUD_CTS3_N_SHIFT_MASK                  0xe0
+#define HDMI_AUD_CTS3_N_SHIFT_1                     0
+#define HDMI_AUD_CTS3_N_SHIFT_16                    0x20
+#define HDMI_AUD_CTS3_N_SHIFT_32                    0x40
+#define HDMI_AUD_CTS3_N_SHIFT_64                    0x60
+#define HDMI_AUD_CTS3_N_SHIFT_128                   0x80
+#define HDMI_AUD_CTS3_N_SHIFT_256                   0xa0
+/* note that the CTS3 MANUAL bit has been removed
+   from our part. Can't set it  will read as 0. */
+#define HDMI_AUD_CTS3_CTS_MANUAL                    0x10
+#define HDMI_AUD_CTS3_AUDCTS19_16_MASK              0x0f
+
+/* AHB_DMA_CONF0 field values */
+#define HDMI_AHB_DMA_CONF0_SW_FIFO_RST_OFFSET       7
+#define HDMI_AHB_DMA_CONF0_SW_FIFO_RST_MASK         0x80
+#define HDMI_AHB_DMA_CONF0_HBR                      0x10
+#define HDMI_AHB_DMA_CONF0_EN_HLOCK_OFFSET          3
+#define HDMI_AHB_DMA_CONF0_EN_HLOCK_MASK            0x08
+#define HDMI_AHB_DMA_CONF0_INCR_TYPE_OFFSET         1
+#define HDMI_AHB_DMA_CONF0_INCR_TYPE_MASK           0x06
+#define HDMI_AHB_DMA_CONF0_INCR4                    0x0
+#define HDMI_AHB_DMA_CONF0_INCR8                    0x2
+#define HDMI_AHB_DMA_CONF0_INCR16                   0x4
+#define HDMI_AHB_DMA_CONF0_BURST_MODE               0x1
+
+/* HDMI_AHB_DMA_START field values */
+#define HDMI_AHB_DMA_START_START_OFFSET             0
+#define HDMI_AHB_DMA_START_START_MASK               0x01
+
+/* HDMI_AHB_DMA_STOP field values */
+#define HDMI_AHB_DMA_STOP_STOP_OFFSET               0
+#define HDMI_AHB_DMA_STOP_STOP_MASK                 0x01
+
+/* AHB_DMA_STAT  AHB_DMA_INT  AHB_DMA_MASK  AHB_DMA_POL field values */
+#define HDMI_AHB_DMA_DONE                           0x80
+#define HDMI_AHB_DMA_RETRY_SPLIT                    0x40
+#define HDMI_AHB_DMA_LOSTOWNERSHIP                  0x20
+#define HDMI_AHB_DMA_ERROR                          0x10
+#define HDMI_AHB_DMA_FIFO_THREMPTY                  0x04
+#define HDMI_AHB_DMA_FIFO_FULL                      0x02
+#define HDMI_AHB_DMA_FIFO_EMPTY                     0x01
+
+/* AHB_DMA_BUFFSTAT  AHB_DMA_BUFFINT AHB_DMA_BUFFMASK AHB_DMA_BUFFPOL values */
+#define HDMI_AHB_DMA_BUFFSTAT_FULL                   0x02
+#define HDMI_AHB_DMA_BUFFSTAT_EMPTY                  0x01
+
+/* MC_CLKDIS field values */
+#define HDMI_MC_CLKDIS_HDCPCLK_DISABLE               0x40
+#define HDMI_MC_CLKDIS_CECCLK_DISABLE                0x20
+#define HDMI_MC_CLKDIS_CSCCLK_DISABLE                0x10
+#define HDMI_MC_CLKDIS_AUDCLK_DISABLE                0x08
+#define HDMI_MC_CLKDIS_PREPCLK_DISABLE               0x04
+#define HDMI_MC_CLKDIS_TMDSCLK_DISABLE               0x02
+#define HDMI_MC_CLKDIS_PIXELCLK_DISABLE              0x01
+
+/* MC_SWRSTZ field values */
+#define HDMI_MC_SWRSTZ_TMDSSWRST_REQ                  0x02
+
+/* MC_FLOWCTRL field values */
+#define HDMI_MC_FLOWCTRL_FEED_THROUGH_OFF_MASK        0x1
+#define HDMI_MC_FLOWCTRL_FEED_THROUGH_OFF_CSC_IN_PATH 0x1
+#define HDMI_MC_FLOWCTRL_FEED_THROUGH_OFF_CSC_BYPASS  0x0
+
+/* MC_PHYRSTZ field values */
+#define HDMI_MC_PHYRSTZ_ASSERT                       0x0
+#define HDMI_MC_PHYRSTZ_DEASSERT                     0x1
+
+/* MC_HEACPHY_RST field values */
+#define HDMI_MC_HEACPHY_RST_ASSERT                   0x1
+#define HDMI_MC_HEACPHY_RST_DEASSERT                 0x0
+
+/* CSC_CFG field values */
+#define HDMI_CSC_CFG_INTMODE_MASK                    0x30
+#define HDMI_CSC_CFG_INTMODE_OFFSET                  4
+#define HDMI_CSC_CFG_INTMODE_DISABLE                 0x00
+#define HDMI_CSC_CFG_INTMODE_CHROMA_INT_FORMULA1     0x10
+#define HDMI_CSC_CFG_INTMODE_CHROMA_INT_FORMULA2     0x20
+#define HDMI_CSC_CFG_DECMODE_MASK                    0x03
+#define HDMI_CSC_CFG_DECMODE_OFFSET                  0
+#define HDMI_CSC_CFG_DECMODE_DISABLE                 0x00
+#define HDMI_CSC_CFG_DECMODE_CHROMA_INT_FORMULA1     0x01
+#define HDMI_CSC_CFG_DECMODE_CHROMA_INT_FORMULA2     0x02
+#define HDMI_CSC_CFG_DECMODE_CHROMA_INT_FORMULA3     0x03
+
+/* CSC_SCALE field values */
+#define HDMI_CSC_SCALE_CSC_COLORDE_PTH_MASK          0xF0
+#define HDMI_CSC_SCALE_CSC_COLORDE_PTH_24BPP         0x00
+#define HDMI_CSC_SCALE_CSC_COLORDE_PTH_30BPP         0x50
+#define HDMI_CSC_SCALE_CSC_COLORDE_PTH_36BPP         0x60
+#define HDMI_CSC_SCALE_CSC_COLORDE_PTH_48BPP         0x70
+#define HDMI_CSC_SCALE_CSCSCALE_MASK                 0x03
+
+/* A_HDCPCFG0 field values */
+#define HDMI_A_HDCPCFG0_ELVENA_MASK                  0x80
+#define HDMI_A_HDCPCFG0_ELVENA_ENABLE                0x80
+#define HDMI_A_HDCPCFG0_ELVENA_DISABLE               0x00
+#define HDMI_A_HDCPCFG0_I2CFASTMODE_MASK             0x40
+#define HDMI_A_HDCPCFG0_I2CFASTMODE_ENABLE           0x40
+#define HDMI_A_HDCPCFG0_I2CFASTMODE_DISABLE          0x00
+#define HDMI_A_HDCPCFG0_BYPENCRYPTION_MASK           0x20
+#define HDMI_A_HDCPCFG0_BYPENCRYPTION_ENABLE         0x20
+#define HDMI_A_HDCPCFG0_BYPENCRYPTION_DISABLE        0x00
+#define HDMI_A_HDCPCFG0_SYNCRICHECK_MASK             0x10
+#define HDMI_A_HDCPCFG0_SYNCRICHECK_ENABLE           0x10
+#define HDMI_A_HDCPCFG0_SYNCRICHECK_DISABLE          0x00
+#define HDMI_A_HDCPCFG0_AVMUTE_MASK                  0x08
+#define HDMI_A_HDCPCFG0_AVMUTE_ENABLE                0x08
+#define HDMI_A_HDCPCFG0_AVMUTE_DISABLE               0x00
+#define HDMI_A_HDCPCFG0_RXDETECT_MASK                0x04
+#define HDMI_A_HDCPCFG0_RXDETECT_ENABLE              0x04
+#define HDMI_A_HDCPCFG0_RXDETECT_DISABLE             0x00
+#define HDMI_A_HDCPCFG0_EN11FEATURE_MASK             0x02
+#define HDMI_A_HDCPCFG0_EN11FEATURE_ENABLE           0x02
+#define HDMI_A_HDCPCFG0_EN11FEATURE_DISABLE          0x00
+#define HDMI_A_HDCPCFG0_HDMIDVI_MASK                 0x01
+#define HDMI_A_HDCPCFG0_HDMIDVI_HDMI                 0x01
+#define HDMI_A_HDCPCFG0_HDMIDVI_DVI                  0x00
+
+/* A_HDCPCFG1 field values */
+#define HDMI_A_HDCPCFG1_DISSHA1CHECK_MASK            0x08
+#define HDMI_A_HDCPCFG1_DISSHA1CHECK_DISABLE         0x08
+#define HDMI_A_HDCPCFG1_DISSHA1CHECK_ENABLE          0x00
+#define HDMI_A_HDCPCFG1_PH2UPSHFTENC_MASK            0x04
+#define HDMI_A_HDCPCFG1_PH2UPSHFTENC_ENABLE          0x04
+#define HDMI_A_HDCPCFG1_PH2UPSHFTENC_DISABLE         0x00
+#define HDMI_A_HDCPCFG1_ENCRYPTIONDISABLE_MASK       0x02
+#define HDMI_A_HDCPCFG1_ENCRYPTIONDISABLE_DISABLE    0x02
+#define HDMI_A_HDCPCFG1_ENCRYPTIONDISABLE_ENABLE     0x00
+#define HDMI_A_HDCPCFG1_SWRESET_MASK                 0x01
+#define HDMI_A_HDCPCFG1_SWRESET_ASSERT               0x00
+
+/* A_VIDPOLCFG field values */
+#define HDMI_A_VIDPOLCFG_UNENCRYPTCONF_MASK         0x60
+#define HDMI_A_VIDPOLCFG_UNENCRYPTCONF_OFFSET       5
+#define HDMI_A_VIDPOLCFG_DATAENPOL_MASK             0x10
+#define HDMI_A_VIDPOLCFG_DATAENPOL_ACTIVE_HIGH      0x10
+#define HDMI_A_VIDPOLCFG_DATAENPOL_ACTIVE_LOW       0x00
+#define HDMI_A_VIDPOLCFG_VSYNCPOL_MASK              0x08
+#define HDMI_A_VIDPOLCFG_VSYNCPOL_ACTIVE_HIGH       0x08
+#define HDMI_A_VIDPOLCFG_VSYNCPOL_ACTIVE_LOW        0x00
+#define HDMI_A_VIDPOLCFG_HSYNCPOL_MASK              0x02
+#define HDMI_A_VIDPOLCFG_HSYNCPOL_ACTIVE_HIGH       0x02
+#define HDMI_A_VIDPOLCFG_HSYNCPOL_ACTIVE_LOW        0x00
+
+#endif /* DW_HDMI_H_ */

--- a/src/drivers/gpu/ipu_v3/Mybuild
+++ b/src/drivers/gpu/ipu_v3/Mybuild
@@ -1,0 +1,14 @@
+package embox.driver.gpu
+
+module ipu_v3 {
+	option number log_level=0
+
+	option number base_addr
+
+	source "ipuv3.c"
+	source "ipuv3_fb.c"
+	source "ipu_disp.c"
+
+	depends embox.driver.clk.ccm_imx6
+	depends embox.driver.video.fb
+}

--- a/src/drivers/gpu/ipu_v3/ipu_disp.c
+++ b/src/drivers/gpu/ipu_v3/ipu_disp.c
@@ -1,0 +1,278 @@
+#include <errno.h>
+#include <util/log.h>
+#include "uboot_ipu_compat.h"
+#include "ipu_regs.h"
+#include "ipu_priv.h"
+
+#define SYNC_WAVE 0
+#define NULL_WAVE (-1)
+
+#define DC_DISP_ID_SYNC(di)	(di)
+
+static void _ipu_di_data_wave_config(struct ipu_soc *ipu,
+				int di, int wave_gen,
+				int access_size, int component_size)
+{
+	u32 reg;
+	reg = (access_size << DI_DW_GEN_ACCESS_SIZE_OFFSET) |
+	    (component_size << DI_DW_GEN_COMPONENT_SIZE_OFFSET);
+	ipu_di_write(ipu, di, reg, DI_DW_GEN(wave_gen));
+}
+
+static void _ipu_di_data_pin_config(struct ipu_soc *ipu,
+			int di, int wave_gen, int di_pin, int set,
+			int up, int down)
+{
+	u32 reg;
+
+	reg = ipu_di_read(ipu, di, DI_DW_GEN(wave_gen));
+	reg &= ~(0x3 << (di_pin * 2));
+	reg |= set << (di_pin * 2);
+	ipu_di_write(ipu, di, reg, DI_DW_GEN(wave_gen));
+
+	ipu_di_write(ipu, di, (down << 16) | up, DI_DW_SET(wave_gen, set));
+}
+
+static void _ipu_di_sync_config(struct ipu_soc *ipu,
+				int di, int wave_gen,
+				int run_count, int run_src,
+				int offset_count, int offset_src,
+				int repeat_count, int cnt_clr_src,
+				int cnt_polarity_gen_en,
+				int cnt_polarity_clr_src,
+				int cnt_polarity_trigger_src,
+				int cnt_up, int cnt_down)
+{
+	u32 reg;
+
+	reg = (run_count << 19) | (++run_src << 16) |
+	    (offset_count << 3) | ++offset_src;
+	ipu_di_write(ipu, di, reg, DI_SW_GEN0(wave_gen));
+	reg = (cnt_polarity_gen_en << 29) | (++cnt_clr_src << 25) |
+	    (++cnt_polarity_trigger_src << 12) | (++cnt_polarity_clr_src << 9);
+	reg |= (cnt_down << 16) | cnt_up;
+	if (repeat_count == 0) {
+		/* Enable auto reload */
+		reg |= 0x10000000;
+	}
+	ipu_di_write(ipu, di, reg, DI_SW_GEN1(wave_gen));
+	reg = ipu_di_read(ipu, di, DI_STP_REP(wave_gen));
+	reg &= ~(0xFFFF << (16 * ((wave_gen - 1) & 0x1)));
+	reg |= repeat_count << (16 * ((wave_gen - 1) & 0x1));
+	ipu_di_write(ipu, di, reg, DI_STP_REP(wave_gen));
+}
+
+static void _ipu_dc_map_config(struct ipu_soc *ipu,
+		int map, int byte_num, int offset, int mask)
+{
+	log_debug("Enter %s", __func__);
+	int ptr = map * 3 + byte_num;
+	u32 reg;
+
+	reg = ipu_dc_read(ipu, DC_MAP_CONF_VAL(ptr));
+	reg &= ~(0xFFFF << (16 * (ptr & 0x1)));
+	reg |= ((offset << 8) | mask) << (16 * (ptr & 0x1));
+	ipu_dc_write(ipu, reg, DC_MAP_CONF_VAL(ptr));
+
+	reg = ipu_dc_read(ipu, DC_MAP_CONF_PTR(map));
+	reg &= ~(0x1F << ((16 * (map & 0x1)) + (5 * byte_num)));
+	reg |= ptr << ((16 * (map & 0x1)) + (5 * byte_num));
+	ipu_dc_write(ipu, reg, DC_MAP_CONF_PTR(map));
+}
+
+static void _ipu_dc_map_clear(struct ipu_soc *ipu, int map)
+{
+	log_debug("Enter %s", __func__);
+	u32 reg = ipu_dc_read(ipu, DC_MAP_CONF_PTR(map));
+	ipu_dc_write(ipu, reg & ~(0xFFFF << (16 * (map & 0x1))),
+		     DC_MAP_CONF_PTR(map));
+}
+
+static void _ipu_dc_write_tmpl(struct ipu_soc *ipu,
+			int word, u32 opcode, u32 operand, int map,
+			int wave, int glue, int sync, int stop)
+{
+	log_debug("Enter %s", __func__);
+	u32 reg;
+
+	if (opcode == WRG) {
+		reg = sync;
+		reg |= (glue << 4);
+		reg |= (++wave << 11);
+		reg |= ((operand & 0x1FFFF) << 15);
+		ipu_dc_tmpl_write(ipu, reg, word * 8);
+
+		reg = (operand >> 17);
+		reg |= opcode << 7;
+		reg |= (stop << 9);
+		ipu_dc_tmpl_write(ipu, reg, word * 8 + 4);
+	} else {
+		reg = sync;
+		reg |= (glue << 4);
+		reg |= (++wave << 11);
+		reg |= (++map << 15);
+		reg |= (operand << 20) & 0xFFF00000;
+		ipu_dc_tmpl_write(ipu, reg, word * 8);
+
+		reg = (operand >> 12);
+		reg |= opcode << 4;
+		reg |= (stop << 9);
+		ipu_dc_tmpl_write(ipu, reg, word * 8 + 4);
+	}
+
+	log_debug("Exit %s", __func__);
+}
+
+static void _ipu_dc_link_event(struct ipu_soc *ipu,
+		int chan, int event, int addr, int priority)
+{
+	u32 reg;
+	reg = ipu_dc_read(ipu, DC_RL_CH(chan, event));
+	reg &= ~(0xFFFF << (16 * (event & 0x1)));
+	reg |= ((addr << 8) | priority) << (16 * (event & 0x1));
+	ipu_dc_write(ipu, reg, DC_RL_CH(chan, event));
+}
+
+void _ipu_dc_init(struct ipu_soc *ipu, int dc_chan, int di, bool interlaced, uint32_t pixel_fmt)
+{
+	log_debug("enter %s, dc_chan=%d, di=%d\n", __func__, dc_chan, di);
+	u32 reg;
+
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NL, 5, 3);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_EOL, 6, 2);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NEW_DATA, 12, 1);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NF, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NFIELD, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_EOF, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_EOFIELD, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NEW_CHAN, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NEW_ADDR, 0, 0);
+
+	reg = 0x2;
+	reg |= DC_DISP_ID_SYNC(di) << DC_WR_CH_CONF_PROG_DISP_ID_OFFSET;
+	reg |= di << 2;
+
+	ipu_dc_write(ipu, reg, DC_WR_CH_CONF(dc_chan));
+
+	ipu_dc_write(ipu, 0x00000000, DC_WR_CH_ADDR(dc_chan));
+
+	ipu_dc_write(ipu, 0x00000084, DC_GEN);
+}
+
+void _ipu_dc_uninit(struct ipu_soc *ipu, int dc_chan)
+{
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NL, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_EOL, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NEW_DATA, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NF, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NFIELD, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_EOF, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_EOFIELD, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NEW_CHAN, 0, 0);
+	_ipu_dc_link_event(ipu, dc_chan, DC_EVT_NEW_ADDR, 0, 0);
+}
+
+void _ipu_dp_dc_enable(struct ipu_soc *ipu, ipu_channel_t channel)
+{
+	uint32_t reg;
+	uint32_t dc_chan = 5;
+
+	reg = ipu_cm_read(ipu, IPU_SRM_PRI2) | 0x8;
+	ipu_cm_write(ipu, reg, IPU_SRM_PRI2);
+
+	reg = ipu_dc_read(ipu, DC_WR_CH_CONF(dc_chan));
+	reg |= 4 << DC_WR_CH_CONF_PROG_TYPE_OFFSET;
+	ipu_dc_write(ipu, reg, DC_WR_CH_CONF(dc_chan));
+
+	clk_enable("ipu1_di0");
+}
+
+void _ipu_init_dc_mappings(struct ipu_soc *ipu)
+{
+	log_debug("Enter %s", __func__);
+	_ipu_dc_map_clear(ipu, 0);
+	_ipu_dc_map_config(ipu, 1, 0, 5, 0xFC);
+	_ipu_dc_map_config(ipu, 1, 1, 11, 0xFC);
+	_ipu_dc_map_config(ipu, 1, 2, 17, 0xFC);
+}
+
+int32_t ipu_init_sync_panel(struct ipu_soc *ipu, int disp,
+			    uint16_t width, uint16_t height,
+			    uint32_t pixel_fmt,
+			    uint16_t h_start_width, uint16_t h_sync_width,
+			    uint16_t v_sync_width)
+{
+	uint32_t reg;
+	uint32_t di_gen;
+	uint32_t div;
+	uint32_t h_total, v_total;
+	int map;
+
+	if ((v_sync_width == 0) || (h_sync_width == 0))
+		return -EINVAL;
+
+	h_total = width + h_sync_width + h_start_width ;
+	v_total = height + v_sync_width;
+
+	/* try ipu clk first*/
+	ipu_di_write(ipu, disp, 3 << 20, DI_GENERAL);
+
+	div = 1;
+
+	ipu_di_write(ipu, 0, div << 4, DI_BS_CLKGEN0);
+	ipu_di_write(ipu, 0, div << 16, DI_BS_CLKGEN1);
+
+	_ipu_di_data_wave_config(ipu, disp, SYNC_WAVE, div - 1, div - 1);
+	_ipu_di_data_pin_config(ipu, disp, SYNC_WAVE, DI_PIN15, 3, 0, div * 2);
+
+	map = 1;
+
+	/*clear DI*/
+	di_gen = ipu_di_read(ipu, disp, DI_GENERAL);
+	di_gen &= (0x3 << 20);
+	ipu_di_write(ipu, disp, di_gen, DI_GENERAL);
+	/* Setup internal HSYNC waveform */
+	_ipu_di_sync_config(ipu, disp, 1, h_total - 1, DI_SYNC_CLK,
+				0, DI_SYNC_NONE, 0, DI_SYNC_NONE, 0, DI_SYNC_NONE,
+				DI_SYNC_NONE, 0, 0);
+	/* Setup external (delayed) HSYNC waveform */
+	_ipu_di_sync_config(ipu, disp, DI_SYNC_HSYNC, h_total - 1,
+			    DI_SYNC_CLK, div * 0, DI_SYNC_CLK,
+			    0, DI_SYNC_NONE, 1, DI_SYNC_NONE,
+			    DI_SYNC_CLK, 0, h_sync_width * 2);
+	/* Setup VSYNC waveform */
+	_ipu_di_sync_config(ipu, disp, DI_SYNC_VSYNC, v_total - 1,
+			    DI_SYNC_INT_HSYNC, 0, DI_SYNC_NONE, 0,
+			    DI_SYNC_NONE, 1, DI_SYNC_NONE,
+			    DI_SYNC_INT_HSYNC, 0, v_sync_width * 2);
+	ipu_di_write(ipu, disp, v_total - 1, DI_SCR_CONF);
+
+	/* Setup active data waveform to sync with DC */
+	_ipu_di_sync_config(ipu, disp, 4, 0, DI_SYNC_HSYNC,
+			    v_sync_width, DI_SYNC_HSYNC, height,
+			    DI_SYNC_VSYNC, 0, DI_SYNC_NONE,
+			    DI_SYNC_NONE, 0, 0);
+	_ipu_di_sync_config(ipu, disp, 5, 0, DI_SYNC_CLK,
+			    h_sync_width + h_start_width, DI_SYNC_CLK,
+			    width, 4, 0, DI_SYNC_NONE, DI_SYNC_NONE, 0, 0);
+
+	_ipu_dc_write_tmpl(ipu, 5, WROD(0), 0, map, SYNC_WAVE, 8, 5, 1);
+	_ipu_dc_write_tmpl(ipu, 6, WROD(0), 0, map, SYNC_WAVE, 4, 5, 0);
+	_ipu_dc_write_tmpl(ipu, 7, WRG, 0, map, NULL_WAVE, 0, 0, 1);
+	_ipu_dc_write_tmpl(ipu, 12, WROD(0), 0, map, SYNC_WAVE, 0, 5, 1);
+
+	di_gen |= DI_GEN_POLARITY_DISP_CLK;
+	di_gen |= (1 << 20);
+	ipu_di_write(ipu, disp, di_gen, DI_GENERAL);
+
+	ipu_di_write(ipu, disp, (DI_SYNC_HSYNC << DI_VSYNC_SEL_OFFSET) |
+			0x00000002, DI_SYNC_AS_GEN);
+	reg = ipu_di_read(ipu, disp, DI_POL);
+	reg &= ~(DI_POL_DRDY_DATA_POLARITY | DI_POL_DRDY_POLARITY_15);
+	reg |= DI_POL_DRDY_POLARITY_15;
+	ipu_di_write(ipu, disp, reg, DI_POL);
+
+	ipu_dc_write(ipu, width, DC_DISP_CONF2(DC_DISP_ID_SYNC(disp)));
+
+	return 0;
+}

--- a/src/drivers/gpu/ipu_v3/ipu_param_mem.h
+++ b/src/drivers/gpu/ipu_v3/ipu_param_mem.h
@@ -1,0 +1,731 @@
+/*
+ * Copyright 2005-2013 Freescale Semiconductor, Inc. All Rights Reserved.
+ */
+
+/*
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+#ifndef __INCLUDE_IPU_PARAM_MEM_H__
+#define __INCLUDE_IPU_PARAM_MEM_H__
+
+#include "uboot_ipu_compat.h"
+#include "ipu_priv.h"
+#include <errno.h>
+#include <kernel/printk.h>
+
+#define dev_dbg(x, ...) printk(__VA_ARGS__)
+#define dev_warn(x, ...) printk(__VA_ARGS__)
+#define dev_err(x, ...) printk(__VA_ARGS__)
+
+extern u32 *ipu_cpmem_base;
+
+struct ipu_ch_param_word {
+	uint32_t data[5];
+	uint32_t res[3];
+};
+
+struct ipu_ch_param {
+	struct ipu_ch_param_word word[2];
+};
+
+#define ipu_ch_param_addr(ipu, ch) (((struct ipu_ch_param *)ipu->cpmem_base) + (ch))
+
+#define _param_word(base, w) \
+	(((struct ipu_ch_param *)(base))->word[(w)].data)
+
+#define ipu_ch_param_set_field(base, w, bit, size, v) { \
+	int i = (bit) / 32; \
+	int off = (bit) % 32; \
+	_param_word(base, w)[i] |= (v) << off; \
+	if (((bit)+(size)-1)/32 > i) { \
+		_param_word(base, w)[i + 1] |= (v) >> (off ? (32 - off) : 0); \
+	} \
+}
+
+#define ipu_ch_param_set_field_io(base, w, bit, size, v) { \
+	int i = (bit) / 32; \
+	int off = (bit) % 32; \
+	unsigned reg_offset; \
+	u32 temp; \
+	reg_offset = sizeof(struct ipu_ch_param_word) * w / 4; \
+	reg_offset += i; \
+	temp = readl((u32 *)base + reg_offset); \
+	temp |= (v) << off; \
+	writel(temp, (u32 *)base + reg_offset); \
+	if (((bit)+(size)-1)/32 > i) { \
+		reg_offset++; \
+		temp = readl((u32 *)base + reg_offset); \
+		temp |= (v) >> (off ? (32 - off) : 0); \
+		writel(temp, (u32 *)base + reg_offset); \
+	} \
+}
+
+#define ipu_ch_param_mod_field(base, w, bit, size, v) { \
+	int i = (bit) / 32; \
+	int off = (bit) % 32; \
+	u32 mask = (1UL << size) - 1; \
+	u32 temp = _param_word(base, w)[i]; \
+	temp &= ~(mask << off); \
+	_param_word(base, w)[i] = temp | (v) << off; \
+	if (((bit)+(size)-1)/32 > i) { \
+		temp = _param_word(base, w)[i + 1]; \
+		temp &= ~(mask >> (32 - off)); \
+		_param_word(base, w)[i + 1] = \
+			temp | ((v) >> (off ? (32 - off) : 0)); \
+	} \
+}
+
+#define ipu_ch_param_mod_field_io(base, w, bit, size, v) { \
+	int i = (bit) / 32; \
+	int off = (bit) % 32; \
+	u32 mask = (1UL << size) - 1; \
+	unsigned reg_offset; \
+	u32 temp; \
+	reg_offset = sizeof(struct ipu_ch_param_word) * w / 4; \
+	reg_offset += i; \
+	temp = readl((u32 *)base + reg_offset); \
+	temp &= ~(mask << off); \
+	temp |= (v) << off; \
+	writel(temp, (u32 *)base + reg_offset); \
+	if (((bit)+(size)-1)/32 > i) { \
+		reg_offset++; \
+		temp = readl((u32 *)base + reg_offset); \
+		temp &= ~(mask >> (32 - off)); \
+		temp |= ((v) >> (off ? (32 - off) : 0)); \
+		writel(temp, (u32 *)base + reg_offset); \
+	} \
+}
+
+#define ipu_ch_param_read_field(base, w, bit, size) ({ \
+	u32 temp2; \
+	int i = (bit) / 32; \
+	int off = (bit) % 32; \
+	u32 mask = (1UL << size) - 1; \
+	u32 temp1 = _param_word(base, w)[i]; \
+	temp1 = mask & (temp1 >> off); \
+	if (((bit)+(size)-1)/32 > i) { \
+		temp2 = _param_word(base, w)[i + 1]; \
+		temp2 &= mask >> (off ? (32 - off) : 0); \
+		temp1 |= temp2 << (off ? (32 - off) : 0); \
+	} \
+	temp1; \
+})
+
+#define ipu_ch_param_read_field_io(base, w, bit, size) ({ \
+	u32 temp1, temp2; \
+	int i = (bit) / 32; \
+	int off = (bit) % 32; \
+	u32 mask = (1UL << size) - 1; \
+	unsigned reg_offset; \
+	reg_offset = sizeof(struct ipu_ch_param_word) * w / 4; \
+	reg_offset += i; \
+	temp1 = readl((u32 *)base + reg_offset); \
+	temp1 = mask & (temp1 >> off); \
+	if (((bit)+(size)-1)/32 > i) { \
+		reg_offset++; \
+		temp2 = readl((u32 *)base + reg_offset); \
+		temp2 &= mask >> (off ? (32 - off) : 0); \
+		temp1 |= temp2 << (off ? (32 - off) : 0); \
+	} \
+	temp1; \
+})
+
+static inline int __ipu_ch_get_third_buf_cpmem_num(int ch)
+{
+	switch (ch) {
+	case 8:
+		return 64;
+	case 9:
+		return 65;
+	case 10:
+		return 66;
+	case 13:
+		return 67;
+	case 21:
+		return 68;
+	case 23:
+		return 69;
+	case 27:
+		return 70;
+	case 28:
+		return 71;
+	default:
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static inline void _ipu_ch_params_set_packing(struct ipu_ch_param *p,
+					      int red_width, int red_offset,
+					      int green_width, int green_offset,
+					      int blue_width, int blue_offset,
+					      int alpha_width, int alpha_offset)
+{
+	/* Setup red width and offset */
+	ipu_ch_param_set_field(p, 1, 116, 3, red_width - 1);
+	ipu_ch_param_set_field(p, 1, 128, 5, red_offset);
+	/* Setup green width and offset */
+	ipu_ch_param_set_field(p, 1, 119, 3, green_width - 1);
+	ipu_ch_param_set_field(p, 1, 133, 5, green_offset);
+	/* Setup blue width and offset */
+	ipu_ch_param_set_field(p, 1, 122, 3, blue_width - 1);
+	ipu_ch_param_set_field(p, 1, 138, 5, blue_offset);
+	/* Setup alpha width and offset */
+	ipu_ch_param_set_field(p, 1, 125, 3, alpha_width - 1);
+	ipu_ch_param_set_field(p, 1, 143, 5, alpha_offset);
+}
+
+static inline void _ipu_ch_param_dump(struct ipu_soc *ipu, int ch)
+{
+	struct ipu_ch_param *p = ipu_ch_param_addr(ipu, ch);
+	dev_dbg(ipu->dev, "ch %d word 0 - %08X %08X %08X %08X %08X\n", ch,
+		 p->word[0].data[0], p->word[0].data[1], p->word[0].data[2],
+		 p->word[0].data[3], p->word[0].data[4]);
+	dev_dbg(ipu->dev, "ch %d word 1 - %08X %08X %08X %08X %08X\n", ch,
+		 p->word[1].data[0], p->word[1].data[1], p->word[1].data[2],
+		 p->word[1].data[3], p->word[1].data[4]);
+	dev_dbg(ipu->dev, "PFS 0x%x, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 85, 4));
+	dev_dbg(ipu->dev, "BPP 0x%x, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 107, 3));
+	dev_dbg(ipu->dev, "NPB 0x%x\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 78, 7));
+
+	dev_dbg(ipu->dev, "FW %d, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 125, 13));
+	dev_dbg(ipu->dev, "FH %d, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 138, 12));
+	dev_dbg(ipu->dev, "EBA0 0x%x\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 0, 29) << 3);
+	dev_dbg(ipu->dev, "EBA1 0x%x\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 29, 29) << 3);
+	dev_dbg(ipu->dev, "Stride %d\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 102, 14));
+	dev_dbg(ipu->dev, "scan_order %d\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 113, 1));
+	dev_dbg(ipu->dev, "uv_stride %d\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 128, 14));
+	dev_dbg(ipu->dev, "u_offset 0x%x\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 46, 22) << 3);
+	dev_dbg(ipu->dev, "v_offset 0x%x\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 68, 22) << 3);
+
+	dev_dbg(ipu->dev, "Width0 %d+1, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 116, 3));
+	dev_dbg(ipu->dev, "Width1 %d+1, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 119, 3));
+	dev_dbg(ipu->dev, "Width2 %d+1, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 122, 3));
+	dev_dbg(ipu->dev, "Width3 %d+1, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 125, 3));
+	dev_dbg(ipu->dev, "Offset0 %d, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 128, 5));
+	dev_dbg(ipu->dev, "Offset1 %d, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 133, 5));
+	dev_dbg(ipu->dev, "Offset2 %d, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 138, 5));
+	dev_dbg(ipu->dev, "Offset3 %d\n",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 143, 5));
+}
+
+static inline void fill_cpmem(struct ipu_soc *ipu, int ch, struct ipu_ch_param *params)
+{
+	int i, w;
+	void *addr = ipu_ch_param_addr(ipu, ch);
+
+	/* 2 words, 5 valid data */
+	for (w = 0; w < 2; w++) {
+		for (i = 0; i < 5; i++) {
+			writel(params->word[w].data[i], addr);
+			addr += 4;
+		}
+		addr += 12;
+	}
+}
+
+static inline void _ipu_ch_param_init(struct ipu_soc *ipu, int ch,
+				      uint32_t pixel_fmt, uint32_t width,
+				      uint32_t height, uint32_t stride,
+				      uint32_t u, uint32_t v,
+				      uint32_t uv_stride, dma_addr_t addr0)
+{
+	uint32_t u_offset = 0;
+	uint32_t v_offset = 0;
+	struct ipu_ch_param params;
+
+	memset(&params, 0, sizeof(params));
+
+	ipu_ch_param_set_field(&params, 0, 125, 13, width - 1);
+
+	if ((ch == 8) || (ch == 9) || (ch == 10)) {
+		ipu_ch_param_set_field(&params, 0, 138, 12, (height / 2) - 1);
+		ipu_ch_param_set_field(&params, 1, 102, 14, (stride * 2) - 1);
+	} else {
+		/* note: for vdoa+vdi- ch8/9/10, always use band mode */
+		ipu_ch_param_set_field(&params, 0, 138, 12, height - 1);
+		ipu_ch_param_set_field(&params, 1, 102, 14, stride - 1);
+	}
+
+	/* EBA is 8-byte aligned */
+	ipu_ch_param_set_field(&params, 1, 0, 29, addr0 >> 3);
+	ipu_ch_param_set_field(&params, 1, 29, 29, 0);
+	if (addr0%8)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's EBA0 is not 8-byte aligned\n", ch);
+
+	ipu_ch_param_set_field(&params, 0, 107, 3, 3);	/* bits/pixel */
+	ipu_ch_param_set_field(&params, 1, 85, 4, 7);	/* pix format */
+	ipu_ch_param_set_field(&params, 1, 78, 7, 31);	/* burst size */
+	_ipu_ch_params_set_packing(&params, 5, 0, 6, 5, 5, 11, 8, 16);
+
+	if (uv_stride)
+		ipu_ch_param_set_field(&params, 1, 128, 14, uv_stride - 1);
+
+	/* Get the uv offset from user when need cropping */
+	if (u || v) {
+		u_offset = u;
+		v_offset = v;
+	}
+
+	/* UBO and VBO are 22-bit and 8-byte aligned */
+	if (u_offset/8 > 0x3fffff)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's U offset exceeds IPU limitation\n", ch);
+	if (v_offset/8 > 0x3fffff)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's V offset exceeds IPU limitation\n", ch);
+	if (u_offset%8)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's U offset is not 8-byte aligned\n", ch);
+	if (v_offset%8)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's V offset is not 8-byte aligned\n", ch);
+
+	ipu_ch_param_set_field(&params, 0, 46, 22, u_offset / 8);
+	ipu_ch_param_set_field(&params, 0, 68, 22, v_offset / 8);
+
+	dev_dbg(ipu->dev, "initializing idma ch %d @ %p\n", ch, ipu_ch_param_addr(ipu, ch));
+	fill_cpmem(ipu, ch, &params);
+};
+
+static inline void _ipu_ch_param_set_burst_size(struct ipu_soc *ipu,
+						uint32_t ch,
+						uint16_t burst_pixels)
+{
+	int32_t sub_ch = 0;
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 78, 7,
+			       burst_pixels - 1);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 78, 7,
+			       burst_pixels - 1);
+};
+
+static inline int _ipu_ch_param_get_burst_size(struct ipu_soc *ipu, uint32_t ch)
+{
+	return ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 78, 7) + 1;
+};
+
+static inline int _ipu_ch_param_get_bpp(struct ipu_soc *ipu, uint32_t ch)
+{
+	return ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 107, 3);
+};
+
+static inline void _ipu_ch_param_set_buffer(struct ipu_soc *ipu, uint32_t ch,
+					int bufNum, dma_addr_t phyaddr)
+{
+	if (bufNum == 2) {
+		ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+		if (ch <= 0)
+			return;
+		bufNum = 0;
+	}
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 29 * bufNum, 29,
+			       phyaddr / 8);
+};
+#if 0
+static inline void _ipu_ch_param_set_rotation(struct ipu_soc *ipu, uint32_t ch,
+					      ipu_rotate_mode_t rot)
+{
+	u32 temp_rot = bitrev8(rot) >> 5;
+	int32_t sub_ch = 0;
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 0, 119, 3, temp_rot);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 119, 3, temp_rot);
+};
+#endif
+static inline void _ipu_ch_param_set_block_mode(struct ipu_soc *ipu, uint32_t ch)
+{
+	int32_t sub_ch = 0;
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 0, 117, 2, 1);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 117, 2, 1);
+};
+
+static inline void _ipu_ch_param_set_alpha_use_separate_channel(struct ipu_soc *ipu,
+								uint32_t ch,
+								bool option)
+{
+	int32_t sub_ch = 0;
+
+	if (option) {
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 89, 1, 1);
+	} else {
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 89, 1, 0);
+	}
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+
+	if (option) {
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 89, 1, 1);
+	} else {
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 89, 1, 0);
+	}
+};
+
+static inline void _ipu_ch_param_set_alpha_condition_read(struct ipu_soc *ipu, uint32_t ch)
+{
+	int32_t sub_ch = 0;
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 149, 1, 1);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 149, 1, 1);
+};
+
+static inline void _ipu_ch_param_set_alpha_buffer_memory(struct ipu_soc *ipu, uint32_t ch)
+{
+	int alp_mem_idx;
+	int32_t sub_ch = 0;
+
+	switch (ch) {
+	case 14: /* PRP graphic */
+		alp_mem_idx = 0;
+		break;
+	case 15: /* PP graphic */
+		alp_mem_idx = 1;
+		break;
+	case 23: /* DP BG SYNC graphic */
+		alp_mem_idx = 4;
+		break;
+	case 27: /* DP FG SYNC graphic */
+		alp_mem_idx = 2;
+		break;
+	default:
+		dev_err(ipu->dev, "unsupported correlative channel of local "
+			"alpha channel\n");
+		return;
+	}
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 90, 3, alp_mem_idx);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 90, 3, alp_mem_idx);
+};
+
+static inline void _ipu_ch_param_set_interlaced_scan(struct ipu_soc *ipu, uint32_t ch)
+{
+	u32 stride;
+	int32_t sub_ch = 0;
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+
+	ipu_ch_param_set_field_io(ipu_ch_param_addr(ipu, ch), 0, 113, 1, 1);
+	if (sub_ch > 0)
+		ipu_ch_param_set_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 113, 1, 1);
+	stride = ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 1, 102, 14) + 1;
+	/* ILO is 20-bit and 8-byte aligned */
+	if (stride/8 > 0xfffff)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's ILO exceeds IPU limitation\n", ch);
+	if (stride%8)
+		dev_warn(ipu->dev,
+			 "IDMAC%d's ILO is not 8-byte aligned\n", ch);
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 58, 20, stride / 8);
+	if (sub_ch > 0)
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 58, 20,
+				       stride / 8);
+	stride *= 2;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 102, 14, stride - 1);
+	if (sub_ch > 0)
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 102, 14,
+				       stride - 1);
+};
+
+static inline void _ipu_ch_param_set_axi_id(struct ipu_soc *ipu, uint32_t ch, uint32_t id)
+{
+	int32_t sub_ch = 0;
+
+	id %= 4;
+
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 1, 93, 2, id);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 93, 2, id);
+};
+
+/* IDMAC U/V offset changing support */
+/* U and V input is not affected, */
+/* the update is done by new calculation according to */
+/* vertical_offset and horizontal_offset */
+static inline void _ipu_ch_offset_update(struct ipu_soc *ipu,
+					int ch,
+					uint32_t pixel_fmt,
+					uint32_t width,
+					uint32_t height,
+					uint32_t stride,
+					uint32_t u,
+					uint32_t v,
+					uint32_t uv_stride,
+					uint32_t vertical_offset,
+					uint32_t horizontal_offset)
+{
+	uint32_t u_offset = 0;
+	uint32_t v_offset = 0;
+	uint32_t old_offset = 0;
+	uint32_t u_fix = 0;
+	uint32_t v_fix = 0;
+	int32_t sub_ch = 0;
+
+	switch (pixel_fmt) {
+	case IPU_PIX_FMT_GENERIC:
+	case IPU_PIX_FMT_GENERIC_16:
+	case IPU_PIX_FMT_GENERIC_32:
+	case IPU_PIX_FMT_RGB565:
+	case IPU_PIX_FMT_BGR24:
+	case IPU_PIX_FMT_RGB24:
+	case IPU_PIX_FMT_YUV444:
+	case IPU_PIX_FMT_BGRA32:
+	case IPU_PIX_FMT_BGR32:
+	case IPU_PIX_FMT_RGBA32:
+	case IPU_PIX_FMT_RGB32:
+	case IPU_PIX_FMT_ABGR32:
+	case IPU_PIX_FMT_UYVY:
+	case IPU_PIX_FMT_YUYV:
+		break;
+
+	case IPU_PIX_FMT_YUV420P2:
+	case IPU_PIX_FMT_YUV420P:
+		if (uv_stride < stride / 2)
+			uv_stride = stride / 2;
+
+		u_offset = stride * (height - vertical_offset - 1) +
+					(stride - horizontal_offset) +
+					(uv_stride * vertical_offset / 2) +
+					horizontal_offset / 2;
+		v_offset = u_offset + (uv_stride * height / 2);
+		u_fix = u ? (u + (uv_stride * vertical_offset / 2) +
+					(horizontal_offset / 2) -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					u_offset;
+		v_fix = v ? (v + (uv_stride * vertical_offset / 2) +
+					(horizontal_offset / 2) -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					v_offset;
+
+		break;
+	case IPU_PIX_FMT_YVU420P:
+		if (uv_stride < stride / 2)
+			uv_stride = stride / 2;
+
+		v_offset = stride * (height - vertical_offset - 1) +
+					(stride - horizontal_offset) +
+					(uv_stride * vertical_offset / 2) +
+					horizontal_offset / 2;
+		u_offset = v_offset + (uv_stride * height / 2);
+		u_fix = u ? (u + (uv_stride * vertical_offset / 2) +
+					(horizontal_offset / 2) -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					u_offset;
+		v_fix = v ? (v + (uv_stride * vertical_offset / 2) +
+					(horizontal_offset / 2) -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					v_offset;
+
+		break;
+	case IPU_PIX_FMT_YVU422P:
+		if (uv_stride < stride / 2)
+			uv_stride = stride / 2;
+
+		v_offset = stride * (height - vertical_offset - 1) +
+					(stride - horizontal_offset) +
+					(uv_stride * vertical_offset) +
+					horizontal_offset / 2;
+		u_offset = v_offset + uv_stride * height;
+		u_fix = u ? (u + (uv_stride * vertical_offset) +
+					horizontal_offset / 2 -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					u_offset;
+		v_fix = v ? (v + (uv_stride * vertical_offset) +
+					horizontal_offset / 2 -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					v_offset;
+		break;
+	case IPU_PIX_FMT_YUV422P:
+		if (uv_stride < stride / 2)
+			uv_stride = stride / 2;
+
+		u_offset = stride * (height - vertical_offset - 1) +
+					(stride - horizontal_offset) +
+					(uv_stride * vertical_offset) +
+					horizontal_offset / 2;
+		v_offset = u_offset + uv_stride * height;
+		u_fix = u ? (u + (uv_stride * vertical_offset) +
+					horizontal_offset / 2 -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					u_offset;
+		v_fix = v ? (v + (uv_stride * vertical_offset) +
+					horizontal_offset / 2 -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					v_offset;
+		break;
+
+	case IPU_PIX_FMT_YUV444P:
+		uv_stride = stride;
+		u_offset = stride * (height - vertical_offset - 1) +
+					(stride - horizontal_offset) +
+					(uv_stride * vertical_offset) +
+					horizontal_offset;
+		v_offset = u_offset + uv_stride * height;
+		u_fix = u ? (u + (uv_stride * vertical_offset) +
+					horizontal_offset -
+					(stride * vertical_offset) -
+					(horizontal_offset)) :
+					u_offset;
+		v_fix = v ? (v + (uv_stride * vertical_offset) +
+					horizontal_offset -
+					(stride * vertical_offset) -
+					(horizontal_offset)) :
+					v_offset;
+		break;
+	case IPU_PIX_FMT_NV12:
+		uv_stride = stride;
+		u_offset = stride * (height - vertical_offset - 1) +
+					(stride - horizontal_offset) +
+					(uv_stride * vertical_offset / 2) +
+					horizontal_offset;
+		u_fix = u ? (u + (uv_stride * vertical_offset / 2) +
+					horizontal_offset -
+					(stride * vertical_offset) - (horizontal_offset)) :
+					u_offset;
+
+		break;
+	default:
+		dev_err(ipu->dev, "mxc ipu: unimplemented pixel format\n");
+		break;
+	}
+
+
+
+	if (u_fix > u_offset)
+		u_offset = u_fix;
+
+	if (v_fix > v_offset)
+		v_offset = v_fix;
+
+	/* UBO and VBO are 22-bit and 8-byte aligned */
+	if (u_offset/8 > 0x3fffff)
+		dev_warn(ipu->dev,
+			"IDMAC%d's U offset exceeds IPU limitation\n", ch);
+	if (v_offset/8 > 0x3fffff)
+		dev_warn(ipu->dev,
+			"IDMAC%d's V offset exceeds IPU limitation\n", ch);
+	if (u_offset%8)
+		dev_warn(ipu->dev,
+			"IDMAC%d's U offset is not 8-byte aligned\n", ch);
+	if (v_offset%8)
+		dev_warn(ipu->dev,
+			"IDMAC%d's V offset is not 8-byte aligned\n", ch);
+
+	old_offset = ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 46, 22);
+	if (old_offset != u_offset / 8)
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 0, 46, 22, u_offset / 8);
+	old_offset = ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 68, 22);
+	if (old_offset != v_offset / 8)
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, ch), 0, 68, 22, v_offset / 8);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	old_offset = ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 46, 22);
+	if (old_offset != u_offset / 8)
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 46, 22, u_offset / 8);
+	old_offset = ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 68, 22);
+	if (old_offset != v_offset / 8)
+		ipu_ch_param_mod_field_io(ipu_ch_param_addr(ipu, sub_ch), 0, 68, 22, v_offset / 8);
+};
+
+static inline void _ipu_ch_params_set_alpha_width(struct ipu_soc *ipu, uint32_t ch, int alpha_width)
+{
+	int32_t sub_ch = 0;
+
+	ipu_ch_param_set_field_io(ipu_ch_param_addr(ipu, ch), 1, 125, 3, alpha_width - 1);
+
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_set_field_io(ipu_ch_param_addr(ipu, sub_ch), 1, 125, 3, alpha_width - 1);
+};
+
+static inline void _ipu_ch_param_set_bandmode(struct ipu_soc *ipu,
+			uint32_t ch, uint32_t band_height)
+{
+	int32_t sub_ch = 0;
+
+	ipu_ch_param_set_field_io(ipu_ch_param_addr(ipu, ch),
+					0, 114, 3, band_height - 1);
+	sub_ch = __ipu_ch_get_third_buf_cpmem_num(ch);
+	if (sub_ch <= 0)
+		return;
+	ipu_ch_param_set_field_io(ipu_ch_param_addr(ipu, sub_ch),
+					0, 114, 3, band_height - 1);
+
+	dev_dbg(ipu->dev, "BNDM 0x%x, ",
+		 ipu_ch_param_read_field_io(ipu_ch_param_addr(ipu, ch), 0, 114, 3));
+}
+
+/*
+ * The IPUv3 IDMAC has a bug to read 32bpp pixels from a graphics plane
+ * whose alpha component is at the most significant 8 bits. The bug only
+ * impacts on cases in which the relevant separate alpha channel is enabled.
+ *
+ * Return true on bad alpha component position, otherwise, return false.
+ */
+static inline bool _ipu_ch_param_bad_alpha_pos(uint32_t pixel_fmt)
+{
+	switch (pixel_fmt) {
+	case IPU_PIX_FMT_BGRA32:
+	case IPU_PIX_FMT_BGR32:
+	case IPU_PIX_FMT_RGBA32:
+	case IPU_PIX_FMT_RGB32:
+		return true;
+	}
+
+	return false;
+}
+#endif

--- a/src/drivers/gpu/ipu_v3/ipu_priv.h
+++ b/src/drivers/gpu/ipu_v3/ipu_priv.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2005-2013 Freescale Semiconductor, Inc. All Rights Reserved.
+ */
+
+/*
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+#ifndef __INCLUDE_IPU_PRV_H__
+#define __INCLUDE_IPU_PRV_H__
+#include <kernel/irq.h>
+#include "uboot_ipu_compat.h"
+#include <util/log.h>
+/* Globals */
+extern int dmfc_type_setup;
+
+#define IDMA_CHAN_INVALID	0xFF
+#define HIGH_RESOLUTION_WIDTH	1024
+
+struct ipu_irq_node {
+	irq_return_t (*handler) (int, void *);    /*!< the ISR */
+	const char *name;       /*!< device associated with the interrupt */
+	void *dev_id;           /*!< some unique information for the ISR */
+	uint32_t flags;            /*!< not used */
+};
+
+
+enum csc_type_t {
+	RGB2YUV = 0,
+	YUV2RGB,
+	RGB2RGB,
+	YUV2YUV,
+	CSC_NONE,
+	CSC_NUM
+};
+
+enum imx_ipu_type {
+	IMX6Q_IPU,
+};
+
+struct ipu_pltfm_data {
+	u32 id;
+	u32 devtype;
+	int (*init) (int);
+	void (*pg) (int);
+
+	/*
+	 * Bypass reset to avoid display channel being
+	 * stopped by probe since it may starts to work
+	 * in bootloader.
+	 */
+	bool bypass_reset;
+};
+
+struct ipu_soc {
+	/*reg*/
+	void  *cm_reg;
+	void  *idmac_reg;
+	void  *dp_reg;
+	void  *ic_reg;
+	void  *dc_reg;
+	void  *dc_tmpl_reg;
+	void  *dmfc_reg;
+	void  *di_reg[2];
+	void  *smfc_reg;
+	void  *csi_reg[2];
+	void  *cpmem_base;
+	void  *tpmem_base;
+	void  *disp_base[2];
+	void  *vdi_reg;
+
+	struct device *dev;
+
+	ipu_channel_t csi_channel[2];
+	ipu_channel_t using_ic_dirct_ch;
+	unsigned char dc_di_assignment[10];
+	uint32_t channel_enable_mask;
+};
+
+static inline u32 ipu_cm_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->cm_reg + offset);
+}
+
+static inline void ipu_cm_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->cm_reg + offset);
+}
+
+static inline u32 ipu_idmac_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->idmac_reg + offset);
+}
+
+static inline void ipu_idmac_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->idmac_reg + offset);
+}
+
+static inline u32 ipu_dc_read(struct ipu_soc *ipu, unsigned offset) {
+	log_debug("%p", (void*) offset);
+	return readl(ipu->dc_reg + offset);
+}
+
+static inline void ipu_dc_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset) {
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->dc_reg + offset);
+}
+
+static inline u32 ipu_dc_tmpl_read(struct ipu_soc *ipu, unsigned offset) {
+	log_debug("%p", (void*) offset);
+	return readl(ipu->dc_tmpl_reg + offset);
+}
+
+static inline void ipu_dc_tmpl_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->dc_tmpl_reg + offset);
+}
+
+static inline u32 ipu_dmfc_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->dmfc_reg + offset);
+}
+
+static inline void ipu_dmfc_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->dmfc_reg + offset);
+}
+
+static inline u32 ipu_dp_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->dp_reg + offset);
+}
+
+static inline void ipu_dp_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->dp_reg + offset);
+}
+
+static inline u32 ipu_di_read(struct ipu_soc *ipu, int di, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->di_reg[di] + offset);
+}
+
+static inline void ipu_di_write(struct ipu_soc *ipu, int di,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->di_reg[di] + offset);
+}
+
+static inline u32 ipu_csi_read(struct ipu_soc *ipu, int csi, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->csi_reg[csi] + offset);
+}
+
+static inline void ipu_csi_write(struct ipu_soc *ipu, int csi,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->csi_reg[csi] + offset);
+}
+
+static inline u32 ipu_smfc_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->smfc_reg + offset);
+}
+
+static inline void ipu_smfc_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->smfc_reg + offset);
+}
+
+static inline u32 ipu_vdi_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->vdi_reg + offset);
+}
+
+static inline void ipu_vdi_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->vdi_reg + offset);
+}
+
+static inline u32 ipu_ic_read(struct ipu_soc *ipu, unsigned offset)
+{
+	log_debug("%p", (void*) offset);
+	return readl(ipu->ic_reg + offset);
+}
+
+static inline void ipu_ic_write(struct ipu_soc *ipu,
+		u32 value, unsigned offset)
+{
+	log_debug("0x%x->%p", value, (void*) offset);
+	writel(value, ipu->ic_reg + offset);
+}
+
+#endif				/* __INCLUDE_IPU_PRV_H__ */

--- a/src/drivers/gpu/ipu_v3/ipu_regs.h
+++ b/src/drivers/gpu/ipu_v3/ipu_regs.h
@@ -1,0 +1,1032 @@
+/**
+ * @file
+ *
+ * @data Sep 15, 2017
+ * @author Anton Bondarev
+ */
+
+#ifndef SRC_DRIVERS_GPU_IPU_V3_IPU_REGS_H_
+#define SRC_DRIVERS_GPU_IPU_V3_IPU_REGS_H_
+
+#include "uboot_ipu_compat.h"
+
+/*!
+ * Enumeration of VDI MOTION select
+ */
+typedef enum {
+	MED_MOTION = 0,
+	LOW_MOTION = 1,
+	HIGH_MOTION = 2,
+} ipu_motion_sel;
+
+/*!
+ * Enumeration of DI ports for ADC.
+ */
+typedef enum {
+	DISP0,
+	DISP1,
+	DISP2,
+	DISP3
+} display_port_t;
+
+/*  IPU Pixel format definitions */
+/*  Four-character-code (FOURCC) */
+#define fourcc(a, b, c, d)\
+	 (((__u32)(a)<<0)|((__u32)(b)<<8)|((__u32)(c)<<16)|((__u32)(d)<<24))
+
+/*!
+ * @name IPU Pixel Formats
+ *
+ * Pixel formats are defined with ASCII FOURCC code. The pixel format codes are
+ * the same used by V4L2 API.
+ */
+
+/*! @{ */
+/*! @name Generic or Raw Data Formats */
+/*! @{ */
+#define IPU_PIX_FMT_GENERIC fourcc('I', 'P', 'U', '0')	/*!< IPU Generic Data */
+#define IPU_PIX_FMT_GENERIC_32 fourcc('I', 'P', 'U', '1')	/*!< IPU Generic Data */
+#define IPU_PIX_FMT_GENERIC_16 fourcc('I', 'P', 'U', '2')	/*!< IPU Generic Data */
+#define IPU_PIX_FMT_LVDS666 fourcc('L', 'V', 'D', '6')	/*!< IPU Generic Data */
+#define IPU_PIX_FMT_LVDS888 fourcc('L', 'V', 'D', '8')	/*!< IPU Generic Data */
+/*! @} */
+/*! @name RGB Formats */
+/*! @{ */
+#define IPU_PIX_FMT_RGB332  fourcc('R', 'G', 'B', '1')	/*!<  8  RGB-3-3-2    */
+#define IPU_PIX_FMT_RGB555  fourcc('R', 'G', 'B', 'O')	/*!< 16  RGB-5-5-5    */
+#define IPU_PIX_FMT_RGB565  fourcc('R', 'G', 'B', 'P')	/*!< 1 6  RGB-5-6-5   */
+#define IPU_PIX_FMT_RGB666  fourcc('R', 'G', 'B', '6')	/*!< 18  RGB-6-6-6    */
+#define IPU_PIX_FMT_BGR666  fourcc('B', 'G', 'R', '6')	/*!< 18  BGR-6-6-6    */
+#define IPU_PIX_FMT_BGR24   fourcc('B', 'G', 'R', '3')	/*!< 24  BGR-8-8-8    */
+#define IPU_PIX_FMT_RGB24   fourcc('R', 'G', 'B', '3')	/*!< 24  RGB-8-8-8    */
+#define IPU_PIX_FMT_GBR24   fourcc('G', 'B', 'R', '3')	/*!< 24  GBR-8-8-8    */
+#define IPU_PIX_FMT_BGR32   fourcc('B', 'G', 'R', '4')	/*!< 32  BGR-8-8-8-8  */
+#define IPU_PIX_FMT_BGRA32  fourcc('B', 'G', 'R', 'A')	/*!< 32  BGR-8-8-8-8  */
+#define IPU_PIX_FMT_RGB32   fourcc('R', 'G', 'B', '4')	/*!< 32  RGB-8-8-8-8  */
+#define IPU_PIX_FMT_RGBA32  fourcc('R', 'G', 'B', 'A')	/*!< 32  RGB-8-8-8-8  */
+#define IPU_PIX_FMT_ABGR32  fourcc('A', 'B', 'G', 'R')	/*!< 32  ABGR-8-8-8-8 */
+/*! @} */
+/*! @name YUV Interleaved Formats */
+/*! @{ */
+#define IPU_PIX_FMT_YUYV    fourcc('Y', 'U', 'Y', 'V')	/*!< 16 YUV 4:2:2 */
+#define IPU_PIX_FMT_UYVY    fourcc('U', 'Y', 'V', 'Y')	/*!< 16 YUV 4:2:2 */
+#define IPU_PIX_FMT_YVYU    fourcc('Y', 'V', 'Y', 'U')  /*!< 16 YVYU 4:2:2 */
+#define IPU_PIX_FMT_VYUY    fourcc('V', 'Y', 'U', 'Y')  /*!< 16 VYYU 4:2:2 */
+#define IPU_PIX_FMT_Y41P    fourcc('Y', '4', '1', 'P')	/*!< 12 YUV 4:1:1 */
+#define IPU_PIX_FMT_YUV444  fourcc('Y', '4', '4', '4')	/*!< 24 YUV 4:4:4 */
+#define IPU_PIX_FMT_VYU444  fourcc('V', '4', '4', '4')	/*!< 24 VYU 4:4:4 */
+/* two planes -- one Y, one Cb + Cr interleaved  */
+#define IPU_PIX_FMT_NV12    fourcc('N', 'V', '1', '2') /* 12  Y/CbCr 4:2:0  */
+/* two planes -- 12  tiled Y/CbCr 4:2:0  */
+#define IPU_PIX_FMT_TILED_NV12    fourcc('T', 'N', 'V', 'P')
+#define IPU_PIX_FMT_TILED_NV12F   fourcc('T', 'N', 'V', 'F')
+
+/*! @} */
+/*! @name YUV Planar Formats */
+/*! @{ */
+#define IPU_PIX_FMT_GREY    fourcc('G', 'R', 'E', 'Y')	/*!< 8  Greyscale */
+#define IPU_PIX_FMT_YVU410P fourcc('Y', 'V', 'U', '9')	/*!< 9  YVU 4:1:0 */
+#define IPU_PIX_FMT_YUV410P fourcc('Y', 'U', 'V', '9')	/*!< 9  YUV 4:1:0 */
+#define IPU_PIX_FMT_YVU420P fourcc('Y', 'V', '1', '2')	/*!< 12 YVU 4:2:0 */
+#define IPU_PIX_FMT_YUV420P fourcc('I', '4', '2', '0')	/*!< 12 YUV 4:2:0 */
+#define IPU_PIX_FMT_YUV420P2 fourcc('Y', 'U', '1', '2')	/*!< 12 YUV 4:2:0 */
+#define IPU_PIX_FMT_YVU422P fourcc('Y', 'V', '1', '6')	/*!< 16 YVU 4:2:2 */
+#define IPU_PIX_FMT_YUV422P fourcc('4', '2', '2', 'P')	/*!< 16 YUV 4:2:2 */
+/* non-interleaved 4:4:4 */
+#define IPU_PIX_FMT_YUV444P fourcc('4', '4', '4', 'P')	/*!< 24 YUV 4:4:4 */
+/*! @} */
+#define IPU_PIX_FMT_TILED_NV12_MBALIGN	(16)
+#define TILED_NV12_FRAME_SIZE(w, h)	\
+		(ALIGN((w) * (h), SZ_4K) + ALIGN((w) * (h) / 2, SZ_4K))
+/* IPU device */
+typedef enum {
+	RGB_CS,
+	YUV_CS,
+	NULL_CS
+} cs_t;
+
+struct ipu_pos {
+	u32 x;
+	u32 y;
+};
+
+struct ipu_crop {
+	struct ipu_pos pos;
+	u32 w;
+	u32 h;
+};
+
+struct ipu_deinterlace {
+	bool	enable;
+	u8	motion; /*see ipu_motion_sel*/
+#define IPU_DEINTERLACE_FIELD_TOP	0
+#define IPU_DEINTERLACE_FIELD_BOTTOM	1
+#define IPU_DEINTERLACE_FIELD_MASK	\
+		(IPU_DEINTERLACE_FIELD_TOP | IPU_DEINTERLACE_FIELD_BOTTOM)
+	/* deinterlace frame rate double flags */
+#define IPU_DEINTERLACE_RATE_EN		0x80
+#define IPU_DEINTERLACE_RATE_FRAME1	0x40
+#define IPU_DEINTERLACE_RATE_MASK	\
+		(IPU_DEINTERLACE_RATE_EN | IPU_DEINTERLACE_RATE_FRAME1)
+#define IPU_DEINTERLACE_MAX_FRAME	2
+	u8	field_fmt;
+};
+
+struct ipu_input {
+	u32 width;
+	u32 height;
+	u32 format;
+	struct ipu_crop crop;
+	dma_addr_t paddr;
+
+	struct ipu_deinterlace deinterlace;
+	dma_addr_t paddr_n; /*valid when deinterlace enable*/
+};
+
+struct ipu_alpha {
+#define IPU_ALPHA_MODE_GLOBAL	0
+#define IPU_ALPHA_MODE_LOCAL	1
+	u8 mode;
+	u8 gvalue; /* 0~255 */
+	dma_addr_t loc_alp_paddr;
+};
+
+struct ipu_colorkey {
+	bool enable;
+	u32 value; /* RGB 24bit */
+};
+
+struct ipu_overlay {
+	u32	width;
+	u32	height;
+	u32	format;
+	struct ipu_crop crop;
+	struct ipu_alpha alpha;
+	struct ipu_colorkey colorkey;
+	dma_addr_t paddr;
+};
+
+struct ipu_output {
+	u32	width;
+	u32	height;
+	u32	format;
+	u8	rotate;
+	struct ipu_crop crop;
+	dma_addr_t paddr;
+};
+
+struct ipu_task {
+	struct ipu_input input;
+	struct ipu_output output;
+
+	bool overlay_en;
+	struct ipu_overlay overlay;
+
+#define IPU_TASK_PRIORITY_NORMAL 0
+#define IPU_TASK_PRIORITY_HIGH	1
+	u8	priority;
+
+#define	IPU_TASK_ID_ANY	0
+#define	IPU_TASK_ID_VF	1
+#define	IPU_TASK_ID_PP	2
+#define	IPU_TASK_ID_MAX 3
+	u8	task_id;
+
+	int	timeout;
+};
+
+enum {
+	IPU_CHECK_OK = 0,
+	IPU_CHECK_WARN_INPUT_OFFS_NOT8ALIGN = 0x1,
+	IPU_CHECK_WARN_OUTPUT_OFFS_NOT8ALIGN = 0x2,
+	IPU_CHECK_WARN_OVERLAY_OFFS_NOT8ALIGN = 0x4,
+	IPU_CHECK_ERR_MIN,
+	IPU_CHECK_ERR_INPUT_CROP,
+	IPU_CHECK_ERR_OUTPUT_CROP,
+	IPU_CHECK_ERR_OVERLAY_CROP,
+	IPU_CHECK_ERR_INPUT_OVER_LIMIT,
+	IPU_CHECK_ERR_OV_OUT_NO_FIT,
+	IPU_CHECK_ERR_OVERLAY_WITH_VDI,
+	IPU_CHECK_ERR_PROC_NO_NEED,
+	IPU_CHECK_ERR_SPLIT_INPUTW_OVER,
+	IPU_CHECK_ERR_SPLIT_INPUTH_OVER,
+	IPU_CHECK_ERR_SPLIT_OUTPUTW_OVER,
+	IPU_CHECK_ERR_SPLIT_OUTPUTH_OVER,
+	IPU_CHECK_ERR_SPLIT_WITH_ROT,
+	IPU_CHECK_ERR_NOT_SUPPORT,
+	IPU_CHECK_ERR_NOT16ALIGN,
+	IPU_CHECK_ERR_W_DOWNSIZE_OVER,
+	IPU_CHECK_ERR_H_DOWNSIZE_OVER,
+};
+
+#define IPU1_ERROR_IRQ  37
+#define IPU1_SYNC_IRQ   38
+#define IPU2_ERROR_IRQ  39
+#define IPU2_SYNC_IRQ   40
+
+#define IPU_BASE OPTION_MODULE_GET( \
+		embox__driver__gpu__ipu_v3, \
+		NUMBER,   \
+		base_addr)
+
+enum imx_ipu_rev {
+	IPU_V3DEX = 2,
+	IPU_V3M,
+	IPU_V3H,
+};
+
+/*
+ * hw_rev 2: IPUV3DEX
+ * hw_rev 3: IPUV3M
+ * hw_rev 4: IPUV3H
+ */
+static const int g_ipu_hw_rev = 4;
+
+#define IPU_MAX_VDI_IN_WIDTH	({g_ipu_hw_rev >= 3 ? \
+				   (968) : \
+				   (720); })
+#define IPU_DISP0_BASE		0x00000000
+#define IPU_MCU_T_DEFAULT	8
+#define IPU_DISP1_BASE		({g_ipu_hw_rev < 4 ? \
+				(IPU_MCU_T_DEFAULT << 25) : \
+				(0x00000000); })
+#define IPUV3DEX_REG_BASE	0x1E000000
+#define IPUV3M_REG_BASE		0x06000000
+#define IPUV3H_REG_BASE		0x00200000
+
+#define IPU_CM_REG_BASE		0x00000000
+#define IPU_IDMAC_REG_BASE	0x00008000
+#define IPU_ISP_REG_BASE	0x00010000
+#define IPU_DP_REG_BASE		0x00018000
+#define IPU_IC_REG_BASE		0x00020000
+#define IPU_IRT_REG_BASE	0x00028000
+#define IPU_CSI0_REG_BASE	0x00030000
+#define IPU_CSI1_REG_BASE	0x00038000
+#define IPU_DI0_REG_BASE	0x00040000
+#define IPU_DI1_REG_BASE	0x00048000
+#define IPU_SMFC_REG_BASE	0x00050000
+#define IPU_DC_REG_BASE		0x00058000
+#define IPU_DMFC_REG_BASE	0x00060000
+#define IPU_VDI_REG_BASE	0x00068000
+#define IPU_CPMEM_REG_BASE 	({g_ipu_hw_rev >= 4 ? \
+				   (0x00100000) : \
+				   (0x01000000); })
+#define IPU_LUT_REG_BASE	0x01020000
+#define IPU_SRM_REG_BASE 	({g_ipu_hw_rev >= 4 ? \
+				   (0x00140000) : \
+				   (0x01040000); })
+#define IPU_TPM_REG_BASE 	({g_ipu_hw_rev >= 4 ? \
+				   (0x00160000) : \
+				   (0x01060000); })
+#define IPU_DC_TMPL_REG_BASE	0x00180000/* ({g_ipu_hw_rev >= 4 ? \
+				   (0x00180000) : \
+				   (0x01080000); }) */
+#define IPU_ISP_TBPR_REG_BASE	0x010C0000
+
+/* Register addresses */
+/* IPU Common registers */
+#define IPU_CM_REG(offset)		(offset)
+
+#define IPU_CONF			IPU_CM_REG(0)
+#define IPU_SRM_PRI1			IPU_CM_REG(0x00A0)
+#define IPU_SRM_PRI2			IPU_CM_REG(0x00A4)
+#define IPU_FS_PROC_FLOW1		IPU_CM_REG(0x00A8)
+#define IPU_FS_PROC_FLOW2		IPU_CM_REG(0x00AC)
+#define IPU_FS_PROC_FLOW3		IPU_CM_REG(0x00B0)
+#define IPU_FS_DISP_FLOW1		IPU_CM_REG(0x00B4)
+#define IPU_FS_DISP_FLOW2		IPU_CM_REG(0x00B8)
+#define IPU_SKIP			IPU_CM_REG(0x00BC)
+#define IPU_DISP_ALT_CONF		IPU_CM_REG(0x00C0)
+#define IPU_DISP_GEN			IPU_CM_REG(0x00C4)
+#define IPU_DISP_ALT1			IPU_CM_REG(0x00C8)
+#define IPU_DISP_ALT2			IPU_CM_REG(0x00CC)
+#define IPU_DISP_ALT3			IPU_CM_REG(0x00D0)
+#define IPU_DISP_ALT4			IPU_CM_REG(0x00D4)
+#define IPU_SNOOP			IPU_CM_REG(0x00D8)
+#define IPU_MEM_RST			IPU_CM_REG(0x00DC)
+#define IPU_PM				IPU_CM_REG(0x00E0)
+#define IPU_GPR				IPU_CM_REG(0x00E4)
+#define IPU_CHA_DB_MODE_SEL(ch)		IPU_CM_REG(0x0150 + 4 * ((ch) / 32))
+#define IPU_ALT_CHA_DB_MODE_SEL(ch)	IPU_CM_REG(0x0168 + 4 * ((ch) / 32))
+/*
+ * IPUv3D doesn't support triple buffer, so point
+ * IPU_CHA_TRB_MODE_SEL, IPU_CHA_TRIPLE_CUR_BUF and
+ * IPU_CHA_BUF2_RDY to readonly
+ * IPU_ALT_CUR_BUF0 for IPUv3D.
+ */
+#define IPU_CHA_TRB_MODE_SEL(ch) IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0178 + 4 * ((ch) / 32)) : \
+					    (0x012C); })
+#define IPU_CHA_TRIPLE_CUR_BUF(ch) IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					      (0x0258 + \
+					       4 * (((ch) * 2) / 32)) : \
+					      (0x012C); })
+#define IPU_CHA_BUF2_RDY(ch)	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0288 + 4 * ((ch) / 32)) : \
+					    (0x012C); })
+#define IPU_CHA_CUR_BUF(ch)	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x023C + 4 * ((ch) / 32)) : \
+					    (0x0124 + 4 * ((ch) / 32)); })
+#define IPU_ALT_CUR_BUF0	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0244) : \
+					    (0x012C); })
+#define IPU_ALT_CUR_BUF1	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0248) : \
+					    (0x0130); })
+#define IPU_SRM_STAT		IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x024C) : \
+					    (0x0134); })
+#define IPU_PROC_TASK_STAT	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0250) : \
+					    (0x0138); })
+#define IPU_DISP_TASK_STAT	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0254) : \
+					    (0x013C); })
+#define IPU_CHA_BUF0_RDY(ch)	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0268 + 4 * ((ch) / 32)) : \
+					    (0x0140 + 4 * ((ch) / 32)); })
+#define IPU_CHA_BUF1_RDY(ch)	IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0270 + 4 * ((ch) / 32)) : \
+					    (0x0148 + 4 * ((ch) / 32)); })
+#define IPU_ALT_CHA_BUF0_RDY(ch) IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					     (0x0278 + 4 * ((ch) / 32)) : \
+					     (0x0158 + 4 * ((ch) / 32)); })
+#define IPU_ALT_CHA_BUF1_RDY(ch) IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					     (0x0280 + 4 * ((ch) / 32)) : \
+					     (0x0160 + 4 * ((ch) / 32)); })
+
+#define IPU_INT_CTRL(n)		IPU_CM_REG(0x003C + 4 * ((n) - 1))
+#define IPU_INT_STAT(n)		IPU_CM_REG({g_ipu_hw_rev >= 2 ? \
+					    (0x0200 + 4 * ((n) - 1)) : \
+					    (0x00E8 + 4 * ((n) - 1)); })
+
+#define IPUIRQ_2_STATREG(irq)	IPU_CM_REG(IPU_INT_STAT(1) + 4 * ((irq) / 32))
+#define IPUIRQ_2_CTRLREG(irq)	IPU_CM_REG(IPU_INT_CTRL(1) + 4 * ((irq) / 32))
+#define IPUIRQ_2_MASK(irq)	(1UL << ((irq) & 0x1F))
+
+/* IPU VDI registers */
+#define IPU_VDI_REG(offset)	(offset)
+
+#define VDI_FSIZE		IPU_VDI_REG(0)
+#define VDI_C			IPU_VDI_REG(0x0004)
+
+/* IPU CSI Registers */
+#define IPU_CSI_REG(offset)	(offset)
+
+#define CSI_SENS_CONF		IPU_CSI_REG(0)
+#define CSI_SENS_FRM_SIZE	IPU_CSI_REG(0x0004)
+#define CSI_ACT_FRM_SIZE	IPU_CSI_REG(0x0008)
+#define CSI_OUT_FRM_CTRL	IPU_CSI_REG(0x000C)
+#define CSI_TST_CTRL		IPU_CSI_REG(0x0010)
+#define CSI_CCIR_CODE_1		IPU_CSI_REG(0x0014)
+#define CSI_CCIR_CODE_2		IPU_CSI_REG(0x0018)
+#define CSI_CCIR_CODE_3		IPU_CSI_REG(0x001C)
+#define CSI_MIPI_DI		IPU_CSI_REG(0x0020)
+#define CSI_SKIP		IPU_CSI_REG(0x0024)
+#define CSI_CPD_CTRL		IPU_CSI_REG(0x0028)
+#define CSI_CPD_RC(n)		IPU_CSI_REG(0x002C + 4 * (n))
+#define CSI_CPD_RS(n)		IPU_CSI_REG(0x004C + 4 * (n))
+#define CSI_CPD_GRC(n)		IPU_CSI_REG(0x005C + 4 * (n))
+#define CSI_CPD_GRS(n)		IPU_CSI_REG(0x007C + 4 * (n))
+#define CSI_CPD_GBC(n)		IPU_CSI_REG(0x008C + 4 * (n))
+#define CSI_CPD_GBS(n)		IPU_CSI_REG(0x00AC + 4 * (n))
+#define CSI_CPD_BC(n)		IPU_CSI_REG(0x00BC + 4 * (n))
+#define CSI_CPD_BS(n)		IPU_CSI_REG(0x00DC + 4 * (n))
+#define CSI_CPD_OFFSET1		IPU_CSI_REG(0x00EC)
+#define CSI_CPD_OFFSET2		IPU_CSI_REG(0x00F0)
+
+/* IPU SMFC Registers */
+#define IPU_SMFC_REG(offset)	(offset)
+
+#define SMFC_MAP		IPU_SMFC_REG(0)
+#define SMFC_WMC		IPU_SMFC_REG(0x0004)
+#define SMFC_BS			IPU_SMFC_REG(0x0008)
+
+/* IPU IC Registers */
+#define IPU_IC_REG(offset)	(offset)
+
+#define IC_CONF			IPU_IC_REG(0)
+#define IC_PRP_ENC_RSC		IPU_IC_REG(0x0004)
+#define IC_PRP_VF_RSC		IPU_IC_REG(0x0008)
+#define IC_PP_RSC		IPU_IC_REG(0x000C)
+#define IC_CMBP_1		IPU_IC_REG(0x0010)
+#define IC_CMBP_2		IPU_IC_REG(0x0014)
+#define IC_IDMAC_1		IPU_IC_REG(0x0018)
+#define IC_IDMAC_2		IPU_IC_REG(0x001C)
+#define IC_IDMAC_3		IPU_IC_REG(0x0020)
+#define IC_IDMAC_4		IPU_IC_REG(0x0024)
+
+/* IPU IDMAC Registers */
+#define IPU_IDMAC_REG(offset)	(offset)
+
+#define IDMAC_CONF		IPU_IDMAC_REG(0x0000)
+#define IDMAC_CHA_EN(ch)	IPU_IDMAC_REG(0x0004 + 4 * ((ch) / 32))
+#define IDMAC_SEP_ALPHA		IPU_IDMAC_REG(0x000C)
+#define IDMAC_ALT_SEP_ALPHA	IPU_IDMAC_REG(0x0010)
+#define IDMAC_CHA_PRI(ch)	IPU_IDMAC_REG(0x0014 + 4 * ((ch) / 32))
+#define IDMAC_WM_EN(ch)		IPU_IDMAC_REG(0x001C + 4 * ((ch) / 32))
+#define IDMAC_CH_LOCK_EN_1	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0024) : 0; })
+#define IDMAC_CH_LOCK_EN_2	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0028) : \
+					       (0x0024); })
+#define IDMAC_SUB_ADDR_0	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x002C) : \
+					       (0x0028); })
+#define IDMAC_SUB_ADDR_1	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0030) : \
+					       (0x002C); })
+#define IDMAC_SUB_ADDR_2	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0034) : \
+					       (0x0030); })
+/*
+ * IPUv3D doesn't support IDMAC_SUB_ADDR_3 and IDMAC_SUB_ADDR_4,
+ * so point them to readonly IDMAC_CHA_BUSY1 for IPUv3D.
+ */
+#define IDMAC_SUB_ADDR_3	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0038) : \
+					       (0x0040); })
+#define IDMAC_SUB_ADDR_4	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x003C) : \
+					       (0x0040); })
+#define IDMAC_BAND_EN(ch)	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0040 + 4 * ((ch) / 32)) : \
+					       (0x0034 + 4 * ((ch) / 32)); })
+#define IDMAC_CHA_BUSY(ch)	IPU_IDMAC_REG({g_ipu_hw_rev >= 2 ? \
+					       (0x0100 + 4 * ((ch) / 32)) : \
+					       (0x0040 + 4 * ((ch) / 32)); })
+
+/* IPU DI Registers */
+#define IPU_DI_REG(offset)	(offset)
+
+#define DI_GENERAL		IPU_DI_REG(0)
+#define DI_BS_CLKGEN0		IPU_DI_REG(0x0004)
+#define DI_BS_CLKGEN1		IPU_DI_REG(0x0008)
+#define DI_SW_GEN0(gen)		IPU_DI_REG(0x000C + 4 * ((gen) - 1))
+#define DI_SW_GEN1(gen)		IPU_DI_REG(0x0030 + 4 * ((gen) - 1))
+#define DI_STP_REP(gen)		IPU_DI_REG(0x0148 + 4 * (((gen) - 1) / 2))
+#define DI_SYNC_AS_GEN		IPU_DI_REG(0x0054)
+#define DI_DW_GEN(gen)		IPU_DI_REG(0x0058 + 4 * (gen))
+#define DI_DW_SET(gen, set)	IPU_DI_REG(0x0088 + 4 * ((gen) + 0xC * (set)))
+#define DI_SER_CONF		IPU_DI_REG(0x015C)
+#define DI_SSC			IPU_DI_REG(0x0160)
+#define DI_POL			IPU_DI_REG(0x0164)
+#define DI_AW0			IPU_DI_REG(0x0168)
+#define DI_AW1			IPU_DI_REG(0x016C)
+#define DI_SCR_CONF		IPU_DI_REG(0x0170)
+#define DI_STAT			IPU_DI_REG(0x0174)
+
+/* IPU DMFC Registers */
+#define IPU_DMFC_REG(offset)	(offset)
+
+#define DMFC_RD_CHAN		IPU_DMFC_REG(0)
+#define DMFC_WR_CHAN		IPU_DMFC_REG(0x0004)
+#define DMFC_WR_CHAN_DEF	IPU_DMFC_REG(0x0008)
+#define DMFC_DP_CHAN		IPU_DMFC_REG(0x000C)
+#define DMFC_DP_CHAN_DEF	IPU_DMFC_REG(0x0010)
+#define DMFC_GENERAL1		IPU_DMFC_REG(0x0014)
+#define DMFC_GENERAL2		IPU_DMFC_REG(0x0018)
+#define DMFC_IC_CTRL		IPU_DMFC_REG(0x001C)
+#define DMFC_STAT		IPU_DMFC_REG(0x0020)
+
+/* IPU DC Registers */
+#define IPU_DC_REG(offset)	(offset)
+
+#define DC_MAP_CONF_PTR(n)	IPU_DC_REG(0x0108 + ((n) & ~0x1) * 2)
+#define DC_MAP_CONF_VAL(n)	IPU_DC_REG(0x0144 + ((n) & ~0x1) * 2)
+
+#define _RL_CH_2_OFFSET(ch)	(((ch) == 0) ? 8 : ( \
+				 ((ch) == 1) ? 0x24 : ( \
+				 ((ch) == 2) ? 0x40 : ( \
+				 ((ch) == 5) ? 0x64 : ( \
+				 ((ch) == 6) ? 0x80 : ( \
+				 ((ch) == 8) ? 0x9C : ( \
+				 ((ch) == 9) ? 0xBC : (-1))))))))
+#define DC_RL_CH(ch, evt)	IPU_DC_REG(_RL_CH_2_OFFSET(ch) + \
+					   ((evt) & ~0x1) * 2)
+
+#define DC_EVT_NF		0
+#define DC_EVT_NL		1
+#define DC_EVT_EOF		2
+#define DC_EVT_NFIELD		3
+#define DC_EVT_EOL		4
+#define DC_EVT_EOFIELD		5
+#define DC_EVT_NEW_ADDR		6
+#define DC_EVT_NEW_CHAN		7
+#define DC_EVT_NEW_DATA		8
+
+#define DC_EVT_NEW_ADDR_W_0	0
+#define DC_EVT_NEW_ADDR_W_1	1
+#define DC_EVT_NEW_CHAN_W_0	2
+#define DC_EVT_NEW_CHAN_W_1	3
+#define DC_EVT_NEW_DATA_W_0	4
+#define DC_EVT_NEW_DATA_W_1	5
+#define DC_EVT_NEW_ADDR_R_0	6
+#define DC_EVT_NEW_ADDR_R_1	7
+#define DC_EVT_NEW_CHAN_R_0	8
+#define DC_EVT_NEW_CHAN_R_1	9
+#define DC_EVT_NEW_DATA_R_0	10
+#define DC_EVT_NEW_DATA_R_1	11
+#define DC_EVEN_UGDE0 		12
+#define DC_ODD_UGDE0 		13
+#define DC_EVEN_UGDE1 		14
+#define DC_ODD_UGDE1 		15
+#define DC_EVEN_UGDE2 		16
+#define DC_ODD_UGDE2 		17
+#define DC_EVEN_UGDE3 		18
+#define DC_ODD_UGDE3 		19
+
+#define dc_ch_offset(ch) \
+({ \
+	const u8 _offset[] = { \
+		0, 0x1C, 0x38, 0x54, 0x58, 0x5C, 0x78, 0, 0x94, 0xB4}; \
+	_offset[ch]; \
+})
+#define DC_WR_CH_CONF(ch)	IPU_DC_REG(dc_ch_offset(ch))
+#define DC_WR_CH_ADDR(ch)	IPU_DC_REG(dc_ch_offset(ch) + 4)
+
+#define DC_WR_CH_CONF_1		IPU_DC_REG(0x001C)
+#define DC_WR_CH_ADDR_1		IPU_DC_REG(0x0020)
+#define DC_WR_CH_CONF_5		IPU_DC_REG(0x005C)
+#define DC_WR_CH_ADDR_5		IPU_DC_REG(0x0060)
+#define DC_GEN			IPU_DC_REG(0x00D4)
+#define DC_DISP_CONF1(disp)	IPU_DC_REG(0x00D8 + 4 * (disp))
+#define DC_DISP_CONF2(disp)	IPU_DC_REG(0x00E8 + 4 * (disp))
+#define DC_STAT			IPU_DC_REG(0x01C8)
+#define DC_UGDE_0(evt)		IPU_DC_REG(0x0174 + 16 * (evt))
+#define DC_UGDE_1(evt)		IPU_DC_REG(0x0178 + 16 * (evt))
+#define DC_UGDE_2(evt)		IPU_DC_REG(0x017C + 16 * (evt))
+#define DC_UGDE_3(evt)		IPU_DC_REG(0x0180 + 16 * (evt))
+
+/* IPU DP Registers */
+#define IPU_DP_REG(offset)		(offset)
+
+#define DP_SYNC				0
+#define DP_ASYNC0			0x60
+#define DP_ASYNC1			0xBC
+#define DP_COM_CONF(flow)		IPU_DP_REG(flow)
+#define DP_GRAPH_WIND_CTRL(flow)	IPU_DP_REG(0x0004 + (flow))
+#define DP_FG_POS(flow)			IPU_DP_REG(0x0008 + (flow))
+#define DP_GAMMA_C(flow, i)		IPU_DP_REG(0x0014 + (flow) + 4 * (i))
+#define DP_GAMMA_S(flow, i)		IPU_DP_REG(0x0034 + (flow) + 4 * (i))
+#define DP_CSC_A_0(flow)		IPU_DP_REG(0x0044 + (flow))
+#define DP_CSC_A_1(flow)		IPU_DP_REG(0x0048 + (flow))
+#define DP_CSC_A_2(flow)		IPU_DP_REG(0x004C + (flow))
+#define DP_CSC_A_3(flow)		IPU_DP_REG(0x0050 + (flow))
+#define DP_CSC_0(flow)			IPU_DP_REG(0x0054 + (flow))
+#define DP_CSC_1(flow)			IPU_DP_REG(0x0058 + (flow))
+
+enum {
+	IPU_CONF_CSI0_EN = 0x00000001,
+	IPU_CONF_CSI1_EN = 0x00000002,
+	IPU_CONF_IC_EN = 0x00000004,
+	IPU_CONF_ROT_EN = 0x00000008,
+	IPU_CONF_ISP_EN = 0x00000010,
+	IPU_CONF_DP_EN = 0x00000020,
+	IPU_CONF_DI0_EN = 0x00000040,
+	IPU_CONF_DI1_EN = 0x00000080,
+	IPU_CONF_DMFC_EN = 0x00000400,
+	IPU_CONF_SMFC_EN = 0x00000100,
+	IPU_CONF_DC_EN = 0x00000200,
+	IPU_CONF_VDI_EN = 0x00001000,
+	IPU_CONF_IDMAC_DIS = 0x00400000,
+	IPU_CONF_IC_DMFC_SEL = 0x02000000,
+	IPU_CONF_IC_DMFC_SYNC = 0x04000000,
+	IPU_CONF_VDI_DMFC_SYNC = 0x08000000,
+	IPU_CONF_CSI0_DATA_SOURCE = 0x10000000,
+	IPU_CONF_CSI0_DATA_SOURCE_OFFSET = 28,
+	IPU_CONF_CSI1_DATA_SOURCE = 0x20000000,
+	IPU_CONF_IC_INPUT = 0x40000000,
+	IPU_CONF_CSI_SEL = 0x80000000,
+
+	DI0_COUNTER_RELEASE = 0x01000000,
+	DI1_COUNTER_RELEASE = 0x02000000,
+
+	DI_DW_GEN_ACCESS_SIZE_OFFSET = 24,
+	DI_DW_GEN_COMPONENT_SIZE_OFFSET = 16,
+
+	DI_GEN_DI_CLK_EXT = 0x100000,
+	DI_GEN_POLARITY_DISP_CLK = 0x00020000,
+	DI_GEN_POLARITY_1 = 0x00000001,
+	DI_GEN_POLARITY_2 = 0x00000002,
+	DI_GEN_POLARITY_3 = 0x00000004,
+	DI_GEN_POLARITY_4 = 0x00000008,
+	DI_GEN_POLARITY_5 = 0x00000010,
+	DI_GEN_POLARITY_6 = 0x00000020,
+	DI_GEN_POLARITY_7 = 0x00000040,
+	DI_GEN_POLARITY_8 = 0x00000080,
+
+	DI_POL_DRDY_DATA_POLARITY = 0x00000080,
+	DI_POL_DRDY_POLARITY_15 = 0x00000010,
+
+	DI_VSYNC_SEL_OFFSET = 13,
+
+	DC_WR_CH_CONF_FIELD_MODE = 0x00000200,
+	DC_WR_CH_CONF_PROG_TYPE_OFFSET = 5,
+	DC_WR_CH_CONF_PROG_TYPE_MASK = 0x000000E0,
+	DC_WR_CH_CONF_PROG_DI_ID = 0x00000004,
+	DC_WR_CH_CONF_PROG_DISP_ID_OFFSET = 3,
+	DC_WR_CH_CONF_PROG_DISP_ID_MASK = 0x00000018,
+
+	DC_UGDE_0_ODD_EN = 0x02000000,
+	DC_UGDE_0_ID_CODED_MASK = 0x00000007,
+	DC_UGDE_0_ID_CODED_OFFSET = 0,
+	DC_UGDE_0_EV_PRIORITY_MASK = 0x00000078,
+	DC_UGDE_0_EV_PRIORITY_OFFSET = 3,
+
+	DP_COM_CONF_FG_EN = 0x00000001,
+	DP_COM_CONF_GWSEL = 0x00000002,
+	DP_COM_CONF_GWAM = 0x00000004,
+	DP_COM_CONF_GWCKE = 0x00000008,
+	DP_COM_CONF_CSC_DEF_MASK = 0x00000300,
+	DP_COM_CONF_CSC_DEF_OFFSET = 8,
+	DP_COM_CONF_CSC_DEF_FG = 0x00000300,
+	DP_COM_CONF_CSC_DEF_BG = 0x00000200,
+	DP_COM_CONF_CSC_DEF_BOTH = 0x00000100,
+	DP_COM_CONF_GAMMA_EN = 0x00001000,
+	DP_COM_CONF_GAMMA_YUV_EN = 0x00002000,
+
+	DI_SER_CONF_LLA_SER_ACCESS = 0x00000020,
+	DI_SER_CONF_SERIAL_CLK_POL = 0x00000010,
+	DI_SER_CONF_SERIAL_DATA_POL = 0x00000008,
+	DI_SER_CONF_SERIAL_RS_POL = 0x00000004,
+	DI_SER_CONF_SERIAL_CS_POL = 0x00000002,
+	DI_SER_CONF_WAIT4SERIAL = 0x00000001,
+};
+
+enum di_pins {
+	DI_PIN11 = 0,
+	DI_PIN12 = 1,
+	DI_PIN13 = 2,
+	DI_PIN14 = 3,
+	DI_PIN15 = 4,
+	DI_PIN16 = 5,
+	DI_PIN17 = 6,
+	DI_PIN_CS = 7,
+
+	DI_PIN_SER_CLK = 0,
+	DI_PIN_SER_RS = 1,
+};
+
+enum di_sync_wave {
+	DI_SYNC_NONE = -1,
+	DI_SYNC_CLK = 0,
+	DI_SYNC_INT_HSYNC = 1,
+	DI_SYNC_HSYNC = 2,
+	DI_SYNC_VSYNC = 3,
+	DI_SYNC_DE = 5,
+};
+
+/* DC template opcodes */
+#define WROD(lf)		(0x18 | (lf << 1))
+#define WRG	        	(0x01)
+
+/* IPU Driver channels definitions.	*/
+/* Note these are different from IDMA channels */
+#define IPU_MAX_CH	32
+#define _MAKE_CHAN(num, v_in, g_in, a_in, out) \
+	((num << 24) | (v_in << 18) | (g_in << 12) | (a_in << 6) | out)
+#define _MAKE_ALT_CHAN(ch)		(ch | (IPU_MAX_CH << 24))
+#define IPU_CHAN_ID(ch)			(ch >> 24)
+#define IPU_CHAN_ALT(ch)		(ch & 0x02000000)
+#define IPU_CHAN_ALPHA_IN_DMA(ch)	((uint32_t) (ch >> 6) & 0x3F)
+#define IPU_CHAN_GRAPH_IN_DMA(ch)	((uint32_t) (ch >> 12) & 0x3F)
+#define IPU_CHAN_VIDEO_IN_DMA(ch)	((uint32_t) (ch >> 18) & 0x3F)
+#define IPU_CHAN_OUT_DMA(ch)		((uint32_t) (ch & 0x3F))
+#define NO_DMA 0x3F
+#define ALT	1
+/*!
+ * Enumeration of IPU logical channels. An IPU logical channel is defined as a
+ * combination of an input (memory to IPU), output (IPU to memory), and/or
+ * secondary input IDMA channels and in some cases an Image Converter task.
+ * Some channels consist of only an input or output.
+ */
+typedef enum {
+	CHAN_NONE = -1,
+	MEM_ROT_ENC_MEM = _MAKE_CHAN(1, 45, NO_DMA, NO_DMA, 48),
+	MEM_ROT_VF_MEM = _MAKE_CHAN(2, 46, NO_DMA, NO_DMA, 49),
+	MEM_ROT_PP_MEM = _MAKE_CHAN(3, 47, NO_DMA, NO_DMA, 50),
+
+	MEM_PRP_ENC_MEM = _MAKE_CHAN(4, 12, 14, 17, 20),
+	MEM_PRP_VF_MEM = _MAKE_CHAN(5, 12, 14, 17, 21),
+	MEM_PP_MEM = _MAKE_CHAN(6, 11, 15, 18, 22),
+
+	MEM_DC_SYNC = _MAKE_CHAN(7, 28, NO_DMA, NO_DMA, NO_DMA),
+	MEM_DC_ASYNC = _MAKE_CHAN(8, 41, NO_DMA, NO_DMA, NO_DMA),
+	MEM_BG_SYNC = _MAKE_CHAN(9, 23, NO_DMA, NO_DMA, NO_DMA),
+	MEM_FG_SYNC = _MAKE_CHAN(10, 27, NO_DMA, 31, NO_DMA),
+
+	MEM_BG_ASYNC0 = _MAKE_CHAN(11, 24, NO_DMA, 52, NO_DMA),
+	MEM_FG_ASYNC0 = _MAKE_CHAN(12, 29, NO_DMA, 33, NO_DMA),
+	MEM_BG_ASYNC1 = _MAKE_ALT_CHAN(MEM_BG_ASYNC0),
+	MEM_FG_ASYNC1 = _MAKE_ALT_CHAN(MEM_FG_ASYNC0),
+
+	DIRECT_ASYNC0 = _MAKE_CHAN(13, NO_DMA, NO_DMA, NO_DMA, NO_DMA),
+	DIRECT_ASYNC1 = _MAKE_CHAN(14, NO_DMA, NO_DMA, NO_DMA, NO_DMA),
+
+	CSI_MEM0 = _MAKE_CHAN(15, NO_DMA, NO_DMA, NO_DMA, 0),
+	CSI_MEM1 = _MAKE_CHAN(16, NO_DMA, NO_DMA, NO_DMA, 1),
+	CSI_MEM2 = _MAKE_CHAN(17, NO_DMA, NO_DMA, NO_DMA, 2),
+	CSI_MEM3 = _MAKE_CHAN(18, NO_DMA, NO_DMA, NO_DMA, 3),
+
+	CSI_MEM = CSI_MEM0,
+
+	CSI_PRP_ENC_MEM = _MAKE_CHAN(19, NO_DMA, NO_DMA, NO_DMA, 20),
+	CSI_PRP_VF_MEM = _MAKE_CHAN(20, NO_DMA, NO_DMA, NO_DMA, 21),
+
+	/* for vdi mem->vdi->ic->mem , add graphics plane and alpha*/
+	MEM_VDI_PRP_VF_MEM_P = _MAKE_CHAN(21, 8, 14, 17, 21),
+	MEM_VDI_PRP_VF_MEM = _MAKE_CHAN(22, 9, 14, 17, 21),
+	MEM_VDI_PRP_VF_MEM_N = _MAKE_CHAN(23, 10, 14, 17, 21),
+
+	/* for vdi mem->vdi->mem */
+	MEM_VDI_MEM_P = _MAKE_CHAN(24, 8, NO_DMA, NO_DMA, 5),
+	MEM_VDI_MEM = _MAKE_CHAN(25, 9, NO_DMA, NO_DMA, 5),
+	MEM_VDI_MEM_N = _MAKE_CHAN(26, 10, NO_DMA, NO_DMA, 5),
+
+	/* fake channel for vdoa to link with IPU */
+	MEM_VDOA_MEM =  _MAKE_CHAN(27, NO_DMA, NO_DMA, NO_DMA, NO_DMA),
+
+	MEM_PP_ADC = CHAN_NONE,
+	ADC_SYS2 = CHAN_NONE,
+
+} ipu_channel_t;
+
+/*!
+ * Enumeration of types of buffers for a logical channel.
+ */
+typedef enum {
+	IPU_OUTPUT_BUFFER = 0,	/*!< Buffer for output from IPU */
+	IPU_ALPHA_IN_BUFFER = 1,	/*!< Buffer for input to IPU */
+	IPU_GRAPH_IN_BUFFER = 2,	/*!< Buffer for input to IPU */
+	IPU_VIDEO_IN_BUFFER = 3,	/*!< Buffer for input to IPU */
+	IPU_INPUT_BUFFER = IPU_VIDEO_IN_BUFFER,
+	IPU_SEC_INPUT_BUFFER = IPU_GRAPH_IN_BUFFER,
+} ipu_buffer_t;
+
+#define IPU_PANEL_SERIAL		1
+#define IPU_PANEL_PARALLEL		2
+
+/*!
+ * Enumeration of ADC channel operation mode.
+ */
+typedef enum {
+	Disable,
+	WriteTemplateNonSeq,
+	ReadTemplateNonSeq,
+	WriteTemplateUnCon,
+	ReadTemplateUnCon,
+	WriteDataWithRS,
+	WriteDataWoRS,
+	WriteCmd
+} mcu_mode_t;
+
+/*!
+ * Enumeration of ADC channel addressing mode.
+ */
+typedef enum {
+	FullWoBE,
+	FullWithBE,
+	XY
+} display_addressing_t;
+
+enum v4l2_field {
+	V4L2_FIELD_ANY           = 0, /* driver can choose from none,
+					 top, bottom, interlaced
+					 depending on whatever it thinks
+					 is approximate ... */
+	V4L2_FIELD_NONE          = 1, /* this device has no fields ... */
+	V4L2_FIELD_TOP           = 2, /* top field only */
+	V4L2_FIELD_BOTTOM        = 3, /* bottom field only */
+	V4L2_FIELD_INTERLACED    = 4, /* both fields interlaced */
+	V4L2_FIELD_SEQ_TB        = 5, /* both fields sequential into one
+					 buffer, top-bottom order */
+	V4L2_FIELD_SEQ_BT        = 6, /* same as above + bottom-top order */
+	V4L2_FIELD_ALTERNATE     = 7, /* both fields alternating into
+					 separate buffers */
+	V4L2_FIELD_INTERLACED_TB = 8, /* both fields interlaced, top field
+					 first and the top field is
+					 transmitted first */
+	V4L2_FIELD_INTERLACED_BT = 9, /* both fields interlaced, top field
+					 first and the bottom field is
+					 transmitted first */
+};
+
+
+/*!
+ * Union of initialization parameters for a logical channel.
+ */
+typedef union {
+	struct {
+		uint32_t csi;
+		uint32_t mipi_id;
+		uint32_t mipi_vc;
+		bool mipi_en;
+		bool interlaced;
+	} csi_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		uint32_t outh_resize_ratio;
+		uint32_t outv_resize_ratio;
+		uint32_t csi;
+		uint32_t mipi_id;
+		uint32_t mipi_vc;
+		bool mipi_en;
+	} csi_prp_enc_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		uint32_t outh_resize_ratio;
+		uint32_t outv_resize_ratio;
+	} mem_prp_enc_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+	} mem_rot_enc_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		uint32_t outh_resize_ratio;
+		uint32_t outv_resize_ratio;
+		bool graphics_combine_en;
+		bool global_alpha_en;
+		bool key_color_en;
+		uint32_t in_g_pixel_fmt;
+		uint8_t alpha;
+		uint32_t key_color;
+		bool alpha_chan_en;
+		ipu_motion_sel motion_sel;
+		enum v4l2_field field_fmt;
+		uint32_t csi;
+		uint32_t mipi_id;
+		uint32_t mipi_vc;
+		bool mipi_en;
+	} csi_prp_vf_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		bool graphics_combine_en;
+		bool global_alpha_en;
+		bool key_color_en;
+		display_port_t disp;
+		uint32_t out_left;
+		uint32_t out_top;
+	} csi_prp_vf_adc;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		uint32_t outh_resize_ratio;
+		uint32_t outv_resize_ratio;
+		bool graphics_combine_en;
+		bool global_alpha_en;
+		bool key_color_en;
+		uint32_t in_g_pixel_fmt;
+		uint8_t alpha;
+		uint32_t key_color;
+		bool alpha_chan_en;
+		ipu_motion_sel motion_sel;
+		enum v4l2_field field_fmt;
+	} mem_prp_vf_mem;
+	struct {
+		uint32_t temp;
+	} mem_prp_vf_adc;
+	struct {
+		uint32_t temp;
+	} mem_rot_vf_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		uint32_t outh_resize_ratio;
+		uint32_t outv_resize_ratio;
+		bool graphics_combine_en;
+		bool global_alpha_en;
+		bool key_color_en;
+		uint32_t in_g_pixel_fmt;
+		uint8_t alpha;
+		uint32_t key_color;
+		bool alpha_chan_en;
+	} mem_pp_mem;
+	struct {
+		uint32_t temp;
+	} mem_rot_mem;
+	struct {
+		uint32_t in_width;
+		uint32_t in_height;
+		uint32_t in_pixel_fmt;
+		uint32_t out_width;
+		uint32_t out_height;
+		uint32_t out_pixel_fmt;
+		bool graphics_combine_en;
+		bool global_alpha_en;
+		bool key_color_en;
+		display_port_t disp;
+		uint32_t out_left;
+		uint32_t out_top;
+	} mem_pp_adc;
+	struct {
+		uint32_t di;
+		bool interlaced;
+		uint32_t in_pixel_fmt;
+		uint32_t out_pixel_fmt;
+	} mem_dc_sync;
+	struct {
+		uint32_t temp;
+	} mem_sdc_fg;
+	struct {
+		uint32_t di;
+		bool interlaced;
+		uint32_t in_pixel_fmt;
+		uint32_t out_pixel_fmt;
+		bool alpha_chan_en;
+	} mem_dp_bg_sync;
+	struct {
+		uint32_t temp;
+	} mem_sdc_bg;
+	struct {
+		uint32_t di;
+		bool interlaced;
+		uint32_t in_pixel_fmt;
+		uint32_t out_pixel_fmt;
+		bool alpha_chan_en;
+	} mem_dp_fg_sync;
+	struct {
+		uint32_t di;
+	} direct_async;
+	struct {
+		display_port_t disp;
+		mcu_mode_t ch_mode;
+		uint32_t out_left;
+		uint32_t out_top;
+	} adc_sys1;
+	struct {
+		display_port_t disp;
+		mcu_mode_t ch_mode;
+		uint32_t out_left;
+		uint32_t out_top;
+	} adc_sys2;
+} ipu_channel_params_t;
+
+#define IPU_IRQF_NONE		0x00000000
+#define IPU_IRQF_ONESHOT	0x00000001
+
+struct ipu_soc;
+
+extern int ipu_probe();
+
+struct ipu_soc *ipu_get();
+void ipu_uninit_channel(struct ipu_soc *ipu, ipu_channel_t channel);
+void ipu_disable_hsp_clk(struct ipu_soc *ipu);
+
+extern int32_t ipu_init_channel_buffer(struct ipu_soc *ipu, ipu_channel_t channel,
+				ipu_buffer_t type,
+				uint32_t pixel_fmt,
+				uint16_t width, uint16_t height,
+				uint32_t stride,
+				dma_addr_t phyaddr_0);
+
+extern int32_t ipu_init_sync_panel(struct ipu_soc *ipu, int disp,
+			    uint16_t width, uint16_t height,
+			    uint32_t pixel_fmt,
+			    uint16_t h_start_width, uint16_t h_sync_width,
+			    uint16_t v_sync_width);
+
+extern  int32_t ipu_init_channel(struct ipu_soc *ipu, ipu_channel_t channel, ipu_channel_params_t *params);
+
+extern int32_t ipu_enable_channel(struct ipu_soc *ipu, ipu_channel_t channel);
+extern int32_t ipu_disable_channel(struct ipu_soc *ipu, ipu_channel_t channel, bool wait_for_stop);
+
+int ipu_request_irq(struct ipu_soc *ipu, uint32_t irq,
+		    irqreturn_t(*handler) (int, void *),
+		    uint32_t irq_flags, const char *devname, void *dev_id);
+
+void ipu_uninit_sync_panel(struct ipu_soc *ipu, int disp);
+#endif /* SRC_DRIVERS_GPU_IPU_V3_IPU_REGS_H_ */

--- a/src/drivers/gpu/ipu_v3/ipuv3.c
+++ b/src/drivers/gpu/ipu_v3/ipuv3.c
@@ -1,0 +1,240 @@
+/**
+ * @file
+ *
+ * @data Sep 15, 2017
+ * @author Anton Bondarev
+ */
+#include <hal/reg.h>
+#include <drivers/common/memory.h>
+#include <drivers/video/fb.h>
+#include <kernel/irq.h>
+#include <string.h>
+#include <util/log.h>
+
+#include "ipu_regs.h"
+#include "ipu_priv.h"
+#include "ipu_param_mem.h"
+
+extern void _ipu_dc_init(struct ipu_soc *ipu, int dc_chan, int di, bool interlaced, uint32_t pixel_fmt);
+extern void _ipu_dc_uninit(struct ipu_soc *ipu, int dc_chan);
+extern void _ipu_init_dc_mappings(struct ipu_soc *ipu);
+extern void _ipu_dp_dc_enable(struct ipu_soc *ipu, ipu_channel_t channel);
+
+static struct ipu_soc ipu_soc;
+
+#define dev_dbg(x, ...) printk(__VA_ARGS__)
+
+#define idma_mask(ch)		(1UL << (ch & 0x1F))
+#define idma_is_set(ipu, reg, dma)	(ipu_idmac_read(ipu, reg(dma)) & idma_mask(dma))
+
+static int ipu_mem_reset(struct ipu_soc *ipu) {
+	ipu_cm_write(ipu, 0x807FFFFF, IPU_MEM_RST);
+
+	int i = 1000000;
+
+	while (i-- > 0) {
+		if (!(ipu_cm_read(ipu, IPU_MEM_RST) & (1 << 31)))
+			break;
+	}
+
+	if (i <= 0) {
+		log_error("Failed to reset IPU internal memories");
+	}
+
+	return 0;
+}
+
+struct ipu_soc *ipu_get() {
+	return &ipu_soc;
+}
+
+int ipu_probe() {
+	struct ipu_soc *ipu = ipu_get();
+
+	clk_enable("ipu1");
+	memset(ipu, 0, sizeof(struct ipu_soc));
+
+	ipu->cm_reg		= (void*) IPU_BASE + IPU_CM_REG_BASE;
+	ipu->ic_reg		= (void*) IPU_BASE + IPU_IC_REG_BASE;
+	ipu->idmac_reg		= (void*) IPU_BASE + IPU_IDMAC_REG_BASE;
+	ipu->dp_reg		= (void*) IPU_BASE + IPU_SRM_REG_BASE;
+	ipu->dc_reg		= (void*) IPU_BASE + IPU_DC_REG_BASE;
+	ipu->dmfc_reg		= (void*) IPU_BASE + IPU_DMFC_REG_BASE;
+	ipu->di_reg[0]		= (void*) IPU_BASE + IPU_DI0_REG_BASE;
+	ipu->di_reg[1]		= (void*) IPU_BASE + IPU_DI1_REG_BASE;
+	ipu->smfc_reg		= (void*) IPU_BASE + IPU_SMFC_REG_BASE;
+	ipu->cpmem_base		= (void*) IPU_BASE + IPU_CPMEM_REG_BASE;
+	ipu->tpmem_base		= (void*) IPU_BASE + IPU_TPM_REG_BASE;
+	ipu->dc_tmpl_reg	= (void*) IPU_BASE + IPU_DC_TMPL_REG_BASE;
+	ipu->vdi_reg		= (void*) IPU_BASE + IPU_VDI_REG_BASE;
+	ipu->disp_base[1]	= (void*) IPU_BASE + IPU_DISP1_BASE;
+
+	clk_enable("ipu1");
+	clk_enable("ipu1_di0");
+	clk_enable("ldb_di0");
+
+	ipu_mem_reset(ipu);
+
+	_ipu_init_dc_mappings(ipu);
+
+	/* Enable error interrupts by default */
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(5));
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(6));
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(9));
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(10));
+
+	return 0;
+}
+
+int32_t ipu_init_channel(struct ipu_soc *ipu, ipu_channel_t channel, ipu_channel_params_t *params)
+{
+	int ret = 0;
+
+	dev_dbg(ipu->dev, "init channel = %d\n", IPU_CHAN_ID(channel));
+	ret = 0;
+	/* Re-enable error interrupts every time a channel is initialized */
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(5));
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(6));
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(9));
+	ipu_cm_write(ipu, 0xFFFFFFFF, IPU_INT_CTRL(10));
+
+	ipu->dc_di_assignment[5] = 0;
+	_ipu_dc_init(ipu, 5, 0, 0, IPU_PIX_FMT_RGB666);
+
+	return ret;
+}
+
+void ipu_uninit_channel(struct ipu_soc *ipu, ipu_channel_t channel) {
+	uint32_t ipu_conf;
+
+	_ipu_dc_uninit(ipu, 5);
+
+	ipu_conf = ipu_cm_read(ipu, IPU_CONF);
+	ipu_conf &= ~IPU_CONF_DC_EN;
+	ipu_conf &= ~IPU_CONF_DP_EN;
+	ipu_conf &= ~IPU_CONF_DMFC_EN;
+	ipu_conf &= ~IPU_CONF_DI0_EN;
+	ipu_cm_write(ipu, ipu_conf, IPU_CONF);
+}
+
+int32_t ipu_init_channel_buffer(struct ipu_soc *ipu, ipu_channel_t channel,
+				ipu_buffer_t type,
+				uint32_t pixel_fmt,
+				uint16_t width, uint16_t height,
+				uint32_t stride,
+				dma_addr_t phyaddr_0) {
+	uint32_t dma_chan = 23;
+
+	_ipu_ch_param_init(ipu, dma_chan, pixel_fmt, width, height, stride, 0, 0, 0,
+			   phyaddr_0);
+
+	return 0;
+}
+
+int32_t ipu_enable_channel(struct ipu_soc *ipu, ipu_channel_t channel) {
+	uint32_t reg;
+	uint32_t ipu_conf;
+	uint32_t in_dma = 23;
+
+	ipu_conf = IPU_CONF_DP_EN | IPU_CONF_DC_EN | IPU_CONF_DMFC_EN;
+	ipu_conf |= IPU_CONF_DI0_EN;
+	ipu_cm_write(ipu, ipu_conf, IPU_CONF);
+
+	reg = ipu_idmac_read(ipu, IDMAC_CHA_EN(in_dma));
+	ipu_idmac_write(ipu, reg | idma_mask(in_dma), IDMAC_CHA_EN(in_dma));
+	reg = ipu_idmac_read(ipu, IDMAC_WM_EN(in_dma));
+	ipu_idmac_write(ipu, reg | idma_mask(in_dma), IDMAC_WM_EN(in_dma));
+
+	_ipu_dp_dc_enable(ipu, channel);
+
+	ipu_cm_write(ipu, 0x1400000, IPU_DISP_GEN);
+
+	return 0;
+}
+
+void _ipu_clear_buffer_ready(struct ipu_soc *ipu, ipu_channel_t channel, ipu_buffer_t type,
+		uint32_t bufNum) {
+	uint32_t dma_ch = 23;
+
+	ipu_cm_write(ipu, 0xF0300000, IPU_GPR); /* write one to clear */
+	ipu_cm_write(ipu, idma_mask(dma_ch), IPU_CHA_BUF0_RDY(dma_ch));
+	ipu_cm_write(ipu, 0x0, IPU_GPR); /* write one to set */
+}
+
+void ipu_clear_buffer_ready(struct ipu_soc *ipu, ipu_channel_t channel, ipu_buffer_t type,
+		uint32_t bufNum) {
+	_ipu_clear_buffer_ready(ipu, channel, type, bufNum);
+}
+
+int32_t ipu_disable_channel(struct ipu_soc *ipu, ipu_channel_t channel, bool wait_for_stop) {
+	uint32_t reg;
+	uint32_t in_dma = 23;
+
+	reg = ipu_idmac_read(ipu, IDMAC_WM_EN(in_dma));
+	ipu_idmac_write(ipu, reg & ~idma_mask(in_dma), IDMAC_WM_EN(in_dma));
+
+	reg = ipu_idmac_read(ipu, IDMAC_CHA_EN(in_dma));
+	ipu_idmac_write(ipu, reg & ~idma_mask(in_dma), IDMAC_CHA_EN(in_dma));
+	ipu_cm_write(ipu, idma_mask(in_dma), IPU_CHA_CUR_BUF(in_dma));
+
+	_ipu_clear_buffer_ready(ipu, channel, IPU_VIDEO_IN_BUFFER, 0);
+
+	return 0;
+}
+
+void ipu_disable_irq(struct ipu_soc *ipu, uint32_t irq) {
+	uint32_t reg;
+
+	reg = ipu_cm_read(ipu, IPUIRQ_2_CTRLREG(irq));
+	reg &= ~IPUIRQ_2_MASK(irq);
+	ipu_cm_write(ipu, reg, IPUIRQ_2_CTRLREG(irq));
+}
+
+void ipu_clear_irq(struct ipu_soc *ipu, uint32_t irq) {
+	ipu_cm_write(ipu, IPUIRQ_2_MASK(irq), IPUIRQ_2_STATREG(irq));
+}
+
+int ipu_request_irq(struct ipu_soc *ipu, uint32_t irq,
+		    irqreturn_t(*handler) (int, void *),
+		    uint32_t irq_flags, const char *devname, void *dev_id) {
+	uint32_t reg;
+
+	ipu_cm_write(ipu, IPUIRQ_2_MASK(irq), IPUIRQ_2_STATREG(irq));
+	reg = ipu_cm_read(ipu, IPUIRQ_2_CTRLREG(irq));
+	reg |= IPUIRQ_2_MASK(irq);
+	ipu_cm_write(ipu, reg, IPUIRQ_2_CTRLREG(irq));
+
+	return 0;
+}
+
+void ipu_free_irq(struct ipu_soc *ipu, uint32_t irq, void *dev_id) {
+	uint32_t reg;
+
+	reg = ipu_cm_read(ipu, IPUIRQ_2_CTRLREG(irq));
+	reg &= ~IPUIRQ_2_MASK(irq);
+	ipu_cm_write(ipu, reg, IPUIRQ_2_CTRLREG(irq));
+}
+
+static struct periph_memory_desc ipu_mem = {
+	.start = IPU_BASE,
+	.len   = 0x200000,
+};
+
+PERIPH_MEMORY_DEFINE(ipu_mem);
+
+#define DCIC1_BASE 0x20E4000
+#define DCIC2_BASE 0x20E8000
+
+static struct periph_memory_desc dcic1_mem = {
+	.start = DCIC1_BASE,
+	.len   = 0x20,
+};
+
+PERIPH_MEMORY_DEFINE(dcic1_mem);
+
+static struct periph_memory_desc dcic2_mem = {
+	.start = DCIC2_BASE,
+	.len   = 0x20,
+};
+
+PERIPH_MEMORY_DEFINE(dcic2_mem);

--- a/src/drivers/gpu/ipu_v3/ipuv3_fb.c
+++ b/src/drivers/gpu/ipu_v3/ipuv3_fb.c
@@ -1,0 +1,111 @@
+/**
+ * @file ipuv3_fb.c
+ * @brief Framebuffer for IPU (no regs/cloks/etc here)
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 05.10.2017
+ */
+
+#include <embox/unit.h>
+#include <drivers/video/fb.h>
+#include <string.h>
+#include <util/log.h>
+#include "ipu_regs.h"
+#include "ipu_priv.h"
+
+#define IPU_MAX_WIDTH	1280
+#define IPU_MAX_HEIGHT	800
+
+static uint16_t ipu_fb[IPU_MAX_WIDTH * IPU_MAX_HEIGHT]
+			__attribute__ ((aligned (0x8)));
+
+struct mxcfb_info {
+	ipu_channel_t ipu_ch;
+	int ipu_id;
+	int ipu_di;
+	void *ipu;
+
+	struct fb_info *fbi;
+};
+
+static struct mxcfb_info mxc_fbi;
+
+static int mxcfb_set_par(struct fb_info *fbi, const struct fb_var_screeninfo *var) {
+	ipu_disable_channel(mxc_fbi.ipu, mxc_fbi.ipu_ch, 0);
+	ipu_uninit_channel(mxc_fbi.ipu, mxc_fbi.ipu_ch);
+
+	if (mxc_fbi.ipu_ch != MEM_BG_SYNC)
+		return 0;
+
+	fbi->screen_base = (void*) ipu_fb;
+	fbi->screen_size = IPU_MAX_WIDTH * IPU_MAX_HEIGHT * 2;
+
+	memset((char *)fbi->screen_base, 0x00, fbi->screen_size);
+
+	ipu_init_channel(mxc_fbi.ipu, mxc_fbi.ipu_ch, 0);
+
+	ipu_cm_write(mxc_fbi.ipu, 0x300000, IPU_CONF);
+
+	fbi->var.xres           = IPU_MAX_WIDTH;
+	fbi->var.yres           = IPU_MAX_HEIGHT;
+	fbi->var.bits_per_pixel = 16;
+	fbi->var.xoffset        = fbi->var.yoffset = 0;
+
+	ipu_init_sync_panel(mxc_fbi.ipu, mxc_fbi.ipu_di,
+				fbi->var.xres, fbi->var.yres,
+				IPU_PIX_FMT_RGB666,
+				0, 200, 3);
+
+
+	ipu_init_channel_buffer(mxc_fbi.ipu,
+					 mxc_fbi.ipu_ch, IPU_INPUT_BUFFER,
+					 IPU_PIX_FMT_RGB565,
+					 fbi->var.xres, fbi->var.yres,
+					 fbi->var.xres * fbi->var.bits_per_pixel / 8,
+					 (dma_addr_t) fbi->screen_base);
+
+	ipu_enable_channel(mxc_fbi.ipu, mxc_fbi.ipu_ch);
+
+	return 0;
+}
+
+static struct fb_ops mxcfb_ops = {
+	.fb_set_var = mxcfb_set_par,
+};
+
+extern void dcache_flush(const void *p, size_t size);
+static irqreturn_t mxcfb_irq_handler(unsigned int irq, void *data) {
+	struct ipu_soc *ipu = mxc_fbi.ipu;
+	int i;
+	uint32_t int_stat, int_ctrl;
+	const int int_reg[] = { 1, 2, 3, 4, 11, 12, 13, 14, 15, 0 };
+
+	dcache_flush(ipu_fb, sizeof(ipu_fb) * 2);
+
+	for (i = 0; int_reg[i] != 0; i++) {
+		int_stat = ipu_cm_read(ipu, IPU_INT_STAT(int_reg[i]));
+		int_ctrl = ipu_cm_read(ipu, IPU_INT_CTRL(int_reg[i]));
+		int_stat &= int_ctrl;
+		ipu_cm_write(ipu, int_stat, IPU_INT_STAT(int_reg[i]));
+	}
+
+	return IRQ_HANDLED;
+}
+
+static int ipu_init(void) {
+	ipu_probe();
+
+	mxc_fbi.fbi    = fb_create(&mxcfb_ops,
+			              (char *) ipu_fb,
+				      2 * IPU_MAX_WIDTH * IPU_MAX_HEIGHT);
+	mxc_fbi.ipu    = ipu_get();
+	mxc_fbi.ipu_ch = MEM_BG_SYNC;
+
+	irq_attach(IPU1_SYNC_IRQ, mxcfb_irq_handler, 0, NULL, "IPU framebuffer");
+	ipu_request_irq(ipu_get(), 23, NULL, 0, "", NULL);
+
+	mxcfb_set_par(mxc_fbi.fbi, &mxc_fbi.fbi->var);
+
+	return 0;
+}
+EMBOX_UNIT_INIT(ipu_init);

--- a/src/drivers/gpu/ipu_v3/uboot_ipu_compat.h
+++ b/src/drivers/gpu/ipu_v3/uboot_ipu_compat.h
@@ -1,0 +1,101 @@
+#ifndef UBOOT_IPU_COMPAT_H_
+#define UBOOT_IPU_COMPAT_H_
+#include <hal/reg.h>
+#include <kernel/irq.h>
+#include <stdint.h>
+
+typedef uint32_t resource_size_t;
+
+#define __raw_readl(addr) REG32_LOAD(addr)
+#define readl(addr) REG32_LOAD(addr)
+#define __raw_writel(value, addr) REG32_STORE(addr, value)
+#define writel(value, addr) REG32_STORE(addr, value)
+
+/*  IPU Pixel format definitions */
+#define fourcc(a, b, c, d)\
+	(((__u32)(a)<<0)|((__u32)(b)<<8)|((__u32)(c)<<16)|((__u32)(d)<<24))
+
+/*
+ * Pixel formats are defined with ASCII FOURCC code. The pixel format codes are
+ * the same used by V4L2 API.
+ */
+
+#define IPU_PIX_FMT_GENERIC fourcc('I', 'P', 'U', '0')
+#define IPU_PIX_FMT_GENERIC_32 fourcc('I', 'P', 'U', '1')
+#define IPU_PIX_FMT_LVDS666 fourcc('L', 'V', 'D', '6')
+#define IPU_PIX_FMT_LVDS888 fourcc('L', 'V', 'D', '8')
+
+#define IPU_PIX_FMT_RGB332  fourcc('R', 'G', 'B', '1')	/*<  8  RGB-3-3-2    */
+#define IPU_PIX_FMT_RGB555  fourcc('R', 'G', 'B', 'O')	/*< 16  RGB-5-5-5    */
+#define IPU_PIX_FMT_RGB565  fourcc('R', 'G', 'B', 'P')	/*< 1 6  RGB-5-6-5   */
+#define IPU_PIX_FMT_RGB666  fourcc('R', 'G', 'B', '6')	/*< 18  RGB-6-6-6    */
+#define IPU_PIX_FMT_BGR666  fourcc('B', 'G', 'R', '6')	/*< 18  BGR-6-6-6    */
+#define IPU_PIX_FMT_BGR24   fourcc('B', 'G', 'R', '3')	/*< 24  BGR-8-8-8    */
+#define IPU_PIX_FMT_RGB24   fourcc('R', 'G', 'B', '3')	/*< 24  RGB-8-8-8    */
+#define IPU_PIX_FMT_BGR32   fourcc('B', 'G', 'R', '4')	/*< 32  BGR-8-8-8-8  */
+#define IPU_PIX_FMT_BGRA32  fourcc('B', 'G', 'R', 'A')	/*< 32  BGR-8-8-8-8  */
+#define IPU_PIX_FMT_RGB32   fourcc('R', 'G', 'B', '4')	/*< 32  RGB-8-8-8-8  */
+#define IPU_PIX_FMT_RGBA32  fourcc('R', 'G', 'B', 'A')	/*< 32  RGB-8-8-8-8  */
+#define IPU_PIX_FMT_ABGR32  fourcc('A', 'B', 'G', 'R')	/*< 32  ABGR-8-8-8-8 */
+
+/* YUV Interleaved Formats */
+#define IPU_PIX_FMT_YUYV    fourcc('Y', 'U', 'Y', 'V')	/*< 16 YUV 4:2:2 */
+#define IPU_PIX_FMT_UYVY    fourcc('U', 'Y', 'V', 'Y')	/*< 16 YUV 4:2:2 */
+#define IPU_PIX_FMT_Y41P    fourcc('Y', '4', '1', 'P')	/*< 12 YUV 4:1:1 */
+#define IPU_PIX_FMT_YUV444  fourcc('Y', '4', '4', '4')	/*< 24 YUV 4:4:4 */
+
+/* two planes -- one Y, one Cb + Cr interleaved  */
+#define IPU_PIX_FMT_NV12    fourcc('N', 'V', '1', '2') /* 12  Y/CbCr 4:2:0  */
+
+#define IPU_PIX_FMT_GREY    fourcc('G', 'R', 'E', 'Y')	/*< 8  Greyscale */
+#define IPU_PIX_FMT_YVU410P fourcc('Y', 'V', 'U', '9')	/*< 9  YVU 4:1:0 */
+#define IPU_PIX_FMT_YUV410P fourcc('Y', 'U', 'V', '9')	/*< 9  YUV 4:1:0 */
+#define IPU_PIX_FMT_YVU420P fourcc('Y', 'V', '1', '2')	/*< 12 YVU 4:2:0 */
+#define IPU_PIX_FMT_YUV420P fourcc('I', '4', '2', '0')	/*< 12 YUV 4:2:0 */
+#define IPU_PIX_FMT_YUV420P2 fourcc('Y', 'U', '1', '2')	/*< 12 YUV 4:2:0 */
+#define IPU_PIX_FMT_YVU422P fourcc('Y', 'V', '1', '6')	/*< 16 YVU 4:2:2 */
+#define IPU_PIX_FMT_YUV422P fourcc('4', '2', '2', 'P')	/*< 16 YUV 4:2:2 */
+
+typedef uint32_t dma_addr_t;
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+
+extern void ipu_dmfc_set_wait4eot(int dma_chan, int width);
+extern void ipu_dmfc_init(int dmfc_type, int first);
+#define debug log_debug
+
+#define DEBUG
+
+#define HIGH_RESOLUTION_WIDTH   1024
+#define IDMA_CHAN_INVALID       0xFF
+
+enum ipu_dmfc_type {
+	DMFC_NORMAL = 0,
+	DMFC_HIGH_RESOLUTION_DC,
+	DMFC_HIGH_RESOLUTION_DP,
+	DMFC_HIGH_RESOLUTION_ONLY_DP,
+};
+
+static __inline__ int test_bit(int nr, const volatile void *addr)
+{
+	return ((1UL << (nr & 31)) & (((const unsigned int *) addr)[nr >> 5])) != 0;
+}
+
+static __inline__ unsigned long ffz(unsigned long word)
+{
+        unsigned long result = 0;
+
+        while (word & 1) {
+                result++;
+                word >>= 1;
+        }
+        return result;
+}
+
+#define irqreturn_t irq_return_t
+
+extern int clk_enable(char *clk_name);
+extern int clk_disable(char *clk_name);
+
+#endif /* UBOOT_IPU_COMPAT_H_ */

--- a/src/drivers/gpu/ldb/Mybuild
+++ b/src/drivers/gpu/ldb/Mybuild
@@ -1,0 +1,12 @@
+package embox.driver.gpu
+
+module ldb {
+	option number log_level=0
+
+	option number base_addr=0x20e0008
+
+	source "ldb.c"
+
+	depends embox.driver.clk.ccm_imx6
+	depends embox.driver.video.fb
+}

--- a/src/drivers/gpu/ldb/ldb.c
+++ b/src/drivers/gpu/ldb/ldb.c
@@ -1,0 +1,107 @@
+/**
+ * @file ldb.c
+ * @brief LVDS Display Bridge
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 07.10.2017
+ */
+
+#include <drivers/common/memory.h>
+#include <embox/unit.h>
+#include <hal/reg.h>
+#include <framework/mod/options.h>
+#include <util/log.h>
+
+static int ldb_init(void);
+EMBOX_UNIT_INIT(ldb_init);
+
+#define LDB_CTRL	OPTION_GET(NUMBER,base_addr)
+
+#define LDB_CH0_OFF     0x0
+#define LDB_CH0_DI0     0x1
+#define LDB_CH0_DI1     0x3
+
+#define LDB_CH1_OFF     0x0
+#define LDB_CH1_DI0     0x4
+#define LDB_CH1_DI1     0xC
+
+#define IOMUXC_GPR2	0x20E0008
+#define IOMUXC_GPR3	0x20E000C
+
+#define CCM_ANALOG_MISC1 0x20C8160
+
+
+#define LDB_BGREF_RMODE_MASK		0x00008000
+#define LDB_BGREF_RMODE_INT		0x00008000
+#define LDB_BGREF_RMODE_EXT		0x0
+
+#define LDB_DI1_VS_POL_MASK		0x00000400
+#define LDB_DI1_VS_POL_ACT_LOW		0x00000400
+#define LDB_DI1_VS_POL_ACT_HIGH		0x0
+#define LDB_DI0_VS_POL_MASK		0x00000200
+#define LDB_DI0_VS_POL_ACT_LOW		0x00000200
+#define LDB_DI0_VS_POL_ACT_HIGH		0x0
+
+#define LDB_BIT_MAP_CH1_MASK		0x00000100
+#define LDB_BIT_MAP_CH1_JEIDA		0x00000100
+#define LDB_BIT_MAP_CH1_SPWG		0x0
+#define LDB_BIT_MAP_CH0_MASK		0x00000040
+#define LDB_BIT_MAP_CH0_JEIDA		0x00000040
+#define LDB_BIT_MAP_CH0_SPWG		0x0
+
+#define LDB_DATA_WIDTH_CH1_MASK		0x00000080
+#define LDB_DATA_WIDTH_CH1_24		0x00000080
+#define LDB_DATA_WIDTH_CH1_18		0x0
+#define LDB_DATA_WIDTH_CH0_MASK		0x00000020
+#define LDB_DATA_WIDTH_CH0_24		0x00000020
+#define LDB_DATA_WIDTH_CH0_18		0x0
+
+#define LDB_CH1_MODE_MASK		0x0000000C
+#define LDB_CH1_MODE_EN_TO_DI1		0x0000000C
+#define LDB_CH1_MODE_EN_TO_DI0		0x00000004
+#define LDB_CH1_MODE_DISABLE		0x0
+#define LDB_CH0_MODE_MASK		0x00000003
+#define LDB_CH0_MODE_EN_TO_DI1		0x00000003
+#define LDB_CH0_MODE_EN_TO_DI0		0x00000001
+#define LDB_CH0_MODE_DISABLE		0x0
+
+#define LDB_SPLIT_MODE_EN		0x00000010
+
+extern int clk_enable(char *clk_name);
+static int ldb_init(void) {
+	uint32_t reg;
+
+	REG32_CLEAR(IOMUXC_GPR3, 3 << 6);
+
+	reg = REG32_LOAD(LDB_CTRL);
+
+	reg &= ~LDB_BGREF_RMODE_MASK;
+	reg |= LDB_BGREF_RMODE_EXT;
+	reg &= ~(LDB_BIT_MAP_CH0_MASK | LDB_BIT_MAP_CH1_MASK);
+	reg |= LDB_BIT_MAP_CH0_SPWG | LDB_BIT_MAP_CH1_SPWG;
+	reg &= ~(LDB_CH0_MODE_MASK | LDB_CH1_MODE_MASK);
+	reg &= ~(LDB_DATA_WIDTH_CH0_MASK | LDB_DATA_WIDTH_CH1_MASK);
+	reg |= LDB_DATA_WIDTH_CH0_18 | LDB_DATA_WIDTH_CH1_18;
+	reg &= ~LDB_SPLIT_MODE_EN;
+	reg |= LDB_CH0_MODE_EN_TO_DI0;
+	reg &= ~LDB_DATA_WIDTH_CH1_18;
+
+	REG32_STORE(LDB_CTRL, reg);
+	clk_enable("ldb_di0");
+
+	return 0;
+}
+
+static struct periph_memory_desc ldb_iomux_mem = {
+	.start = 0x20E0000,
+	.len   = 0x1000,
+};
+
+PERIPH_MEMORY_DEFINE(ldb_iomux_mem);
+
+static struct periph_memory_desc ccm_analog_mem = {
+	.start = 0x20C8000,
+	.len   = 0x200,
+};
+
+PERIPH_MEMORY_DEFINE(ccm_analog_mem);

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -16,25 +16,30 @@ configuration conf {
 
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
-	//@Runlevel(0) include embox.arch.arm.mmu_section(domain_access=1)
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
 	@Runlevel(0) include embox.mem.vmem_alloc(pgd_align=0x4000,pmd_align=0x1000,pte_align=0x1000)
 	@Runlevel(0) include embox.mem.vmem
+
+	include embox.kernel.thread.core(thread_stack_size=0x200000)
 
 	include embox.arch.arm.libarch
 
 	@Runlevel(0) include embox.kernel.critical
 
 	@Runlevel(0) include embox.driver.gpio.imx
-	@Runlevel(1) include embox.driver.spi.imx6_ecspi(base_addr=0x02008000)
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0x00A00100,distributor_base_addr=0x00A01000,log_level=4)
-	@Runlevel(0) include embox.kernel.stack(stack_size=131076)
+	@Runlevel(0) include embox.kernel.stack(stack_size=0x200000)
 	@Runlevel(0) include embox.driver.serial.imx_uart(num=1)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__imx_uart")
 	@Runlevel(0) include embox.driver.clock.cortexa9(periph_base_addr=0x00a00000,irq_num=29)
 
 	@Runlevel(2) include embox.driver.net.fec(log_level=0, speed=1000)
 	@Runlevel(2) include embox.driver.net.loopback
+
+	//@Runlevel(2) include embox.driver.video.dw_hdmi(base_addr=0x00120000,log_level=4)
+	@Runlevel(2) include embox.driver.gpu.ipu_v3(base_addr=0x02600000,log_level=0)
+	@Runlevel(2) include embox.driver.gpu.ldb(log_level=0)
+
 
 	include embox.fs.syslib.file_system_none
 	include embox.fs.syslib.perm_stub
@@ -47,10 +52,6 @@ configuration conf {
 	include embox.fs.driver.initfs_dvfs
 	@Runlevel(2) include embox.fs.rootfs_dvfs
 
-	include embox.compat.posix.passwd
-	include embox.compat.libc.stdio.print(support_floating=0)
-
-	include embox.test.spi.imx6_test
 	include embox.test.kernel.timer_test
 	include embox.kernel.task.resource.errno
 
@@ -80,4 +81,27 @@ configuration conf {
 
 	@Runlevel(2) include embox.mem.static_heap(heap_size=64000000)
 	@Runlevel(2) include embox.mem.heap_bm(heap_size=32000000)
+
+	@Runlevel(1) include embox.driver.spi.imx6_ecspi(base_addr=0x02008000)
+
+	include embox.compat.posix.passwd
+	include embox.compat.libc.stdio.print(support_floating=0)
+	include embox.test.spi.imx6_test
+
+	include embox.driver.clk.ccm_imx6(log_level=4)
+
+	@Runlevel(2) include embox.util.LibUtil
+	@Runlevel(2) include embox.framework.LibFramework
+	@Runlevel(2) include embox.compat.libc.all
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.fs.rewinddir_stub
+
+	include embox.cmd.fb_devfs_access
+	include embox.cmd.fb_direct_access
+	include embox.compat.atomic.pseudo_atomic
+
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.fs.rewinddir_stub
 }


### PR DESCRIPTION
Add support for graphic for i.MX6 board, this includes:
* LVDS driver for video output
* IPU driver for image processing
* CCM driver to configure clock

However, HDMI driver was not finished.