### PR TITLE
Add extra args option to docker run

### DIFF
--- a/scripts/docker/docker_rc.sh
+++ b/scripts/docker/docker_rc.sh
@@ -9,5 +9,11 @@ dr() {
 	local tty_opt=
 	[ -t 0 ] && tty_opt="-t"
 
-	docker exec -u user -i $tty_opt emdocker bash -lc "$*"
+	docker exec \
+		-u user \
+		-i \
+		$tty_opt \
+		$EMDOCKER_EXEC_EXTRA_ARGS \
+		emdocker \
+		bash -lc "$*"
 }


### PR DESCRIPTION
Docker exec bins specific keys to detach from running process (Ctrl-p
Ctrl-q by default). Ctrl-p is emacs up, also is up in readline,
also shell previous command. To make use of container's interactive
shell more plesant, this commit adds abillity to pass extra args to
docker exec, thus remap detach keys to something else, like:

	$ . ./scripts/docker/docker_rc.sh
	$ EMDOCKER_EXEC_EXTRA_ARGS="--detach-keys ctrl-_"