### PR TITLE
Stm32cube examples import

### DIFF
--- a/platform/stm32f4_multibots/cmds/Mybuild
+++ b/platform/stm32f4_multibots/cmds/Mybuild
@@ -8,7 +8,7 @@ module spi_master {
 
 	source "spi_master.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends spi_lib
 }
 
@@ -20,7 +20,7 @@ module spi_slave {
 
 	source "spi_slave.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends spi_lib
 }
 
@@ -32,7 +32,7 @@ module nrf24_test {
 
 	source "nrf24_test.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends spi_lib
 }
 
@@ -44,7 +44,7 @@ module nrf24_tx {
 
 	source "nrf24_tx.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends nrf24_lib
 }
 
@@ -56,7 +56,7 @@ module nrf24_rx {
 
 	source "nrf24_rx_irq.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends nrf24_lib
 }
 
@@ -67,7 +67,7 @@ static module nrf24_lib {
 	source "nrf24.c",
 		"nrf24_hw.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends spi_lib
 }
 
@@ -77,7 +77,7 @@ static module spi_lib {
 
 	source "spi_lib.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 }
 
 @AutoCmd
@@ -86,7 +86,7 @@ static module spi_lib {
 module gy_30 {
 	source "gy_30.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends embox.driver.i2c.stm32f4.i2c
 }
 
@@ -96,7 +96,7 @@ module gy_30 {
 module i2c_master {
 	source "i2c_master.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends embox.driver.i2c.stm32f4.i2c
 }
 
@@ -106,6 +106,6 @@ module i2c_master {
 module i2c_slave {
 	source "i2c_slave.c"
 
-	depends third_party.bsp.stmf4cube.stm32f4_discovery
+	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 	depends embox.driver.i2c.stm32f4.i2c
 }

--- a/platform/stm32f7/cmds/Mybuild
+++ b/platform/stm32f7/cmds/Mybuild
@@ -6,7 +6,7 @@ package stm32f7.cmd
 module stm32f7_led_blinking {
 	source "stm32f7_led_blinking.c"
 
-	depends third_party.bsp.stmf7cube.stm32f7_discovery
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
 }
 
 @AutoCmd
@@ -15,8 +15,7 @@ module stm32f7_led_blinking {
 module stm32f7_lcd_test {
 	source "stm32f7_lcd_test.c"
 
-	depends third_party.bsp.stmf7cube.stm32f7_discovery
-	depends third_party.bsp.stmf7cube.stm32f7_discovery_lcd
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
 }
 
 @AutoCmd
@@ -25,8 +24,7 @@ module stm32f7_lcd_test {
 module stm32f7_ltdc_test {
 	source "stm32f7_ltdc_test.c"
 
-	depends third_party.bsp.stmf7cube.stm32f7_discovery
-	depends third_party.bsp.stmf7cube.stm32f7_discovery_lcd
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
 	depends stm32f7_ltdc_lib
 }
 
@@ -34,6 +32,5 @@ module stm32f7_ltdc_test {
 module stm32f7_ltdc_lib {
 	source "stm32f7_ltdc_lib.c"
 
-	depends third_party.bsp.stmf7cube.stm32f7_discovery
-	depends third_party.bsp.stmf7cube.stm32f7_discovery_lcd
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
 }

--- a/scripts/stm32/Mybuild_template
+++ b/scripts/stm32/Mybuild_template
@@ -1,0 +1,22 @@
+/* GENERATED FILE */
+
+package stm32_PLATFORM_.cmd
+
+@AutoCmd
+@Cmd(name="_EXAMPLE_", help="")
+@BuildDepends(third_party.bsp.stm_PLATFORM_cube.core)
+module _EXAMPLE_ {
+	source "Src/embox_main.c"
+	depends _EXAMPLE__Lib
+}
+
+@BuildDepends(third_party.bsp.stm_PLATFORM_cube.core)
+module _EXAMPLE__Lib {
+	@Cflags("-Wno-unused")
+	@IncludePath("$(ROOT_DIR)/platform/stm32_PLATFORM_/cmds/_EXAMPLE_/Inc")
+	_SOURCES_
+
+	depends third_party.bsp.stm_PLATFORM_cube.stm32_PLATFORM__discovery_bsp
+    depends third_party.bsp.stm_PLATFORM_cube.stm32_PLATFORM__discovery_components
+    depends third_party.bsp.stm_PLATFORM_cube.stm32_PLATFORM__discovery_utilities
+}

--- a/scripts/stm32/embox_main_template.c
+++ b/scripts/stm32/embox_main_template.c
@@ -1,0 +1,9 @@
+/**
+ * GENERATED FILE
+ */
+
+extern int _EXAMPLE__main(void);
+
+int main(int argc, char *argv[]) {
+	return _EXAMPLE__main();
+}

--- a/scripts/stm32/import_stm32_cube_example.py
+++ b/scripts/stm32/import_stm32_cube_example.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python2
+
+import sys
+import os
+import argparse
+import shutil
+import subprocess
+
+class ExampleInfo:
+	def __init__(self, src, dst, script_dir, example_name, platform):
+		self.src = src
+		self.dst = dst
+		self.script_dir = script_dir
+		self.example_name = example_name
+		self.platform = platform
+
+# We want to obtain something like this:
+#
+# ...
+# extern int embox_stm32_setup_irq_handlers(void);
+# int BSP_main(void){
+# 	uint8_t  lcd_status = LCD_OK;
+#
+# 	if (0 != embox_stm32_setup_irq_handlers()) {
+# 		printf("embox_stm32_setup_irq_handlers error!\n");
+# 	}
+# 	//CPU_CACHE_Enable();
+# 	//HAL_Init();
+# 	//SystemClock_Config();
+# ...
+def fix_main(info):
+	with open(info.dst + '/Src/main.c', 'r') as f:
+		lines = f.readlines()
+
+	def find_line(pattern):
+		l = [i for i in range(len(lines)) if pattern in lines[i]]
+		return l[0] if l else None
+
+	def comment_line_out_if_any(pattern):
+		id = find_line(pattern)
+		if id is not None:
+			lines[id] = '  //' + lines[id]
+
+	id = find_line('main(void)')
+	if id is not None:
+		lines[id] = 'int %s_main(void)' % info.example_name
+		lines.insert(id, 'extern int embox_stm32_setup_irq_handlers(void);\r\n')
+
+	id = find_line('HAL_Init();')
+	if id is not None:
+		lines.insert(id,
+					('  if (0 != embox_stm32_setup_irq_handlers()) {\r\n'
+					 '    printf("embox_stm32_setup_irq_handlers error!\\n");\r\n'
+					 '  }\r\n'))
+
+	comment_line_out_if_any('CPU_CACHE_Enable();')
+	comment_line_out_if_any('HAL_Init();')
+	comment_line_out_if_any('SystemClock_Config();')
+
+	with open(info.dst + '/Src/main.c', 'w') as f:
+		f.write(''.join(lines))
+
+def generate_Mybuild(info):
+	with open(info.script_dir + '/Mybuild_template', 'r') as f:
+		mybuild = f.read()
+
+	mybuild = mybuild.replace('_EXAMPLE_', info.example_name)
+	mybuild = mybuild.replace('_PLATFORM_', info.platform)
+
+	sources = 'source'
+	for file in os.listdir(info.src + '/Src'):
+		if file.endswith('.c'):
+			sources += '		"Src/%s",\n' % file
+	sources += '		"Src/embox_stm32%sxx_it.c"\n' % info.platform
+	mybuild = mybuild.replace('_SOURCES_', sources)
+
+	with open(info.dst + '/Mybuild', 'w') as f:
+		f.write(mybuild)
+
+def find_irq_handlers_in_file(info, file):
+	# Get path of STM32 Cube directory
+	stm32_path = info.src.rsplit('/Projects', 1)[0]
+
+	# First of all, we need to preprocess file
+	compiler = 'arm-none-eabi-cpp'
+	include = {'f7' :
+				' -DSTM32F746xx'											+ \
+				' -I_SRC_/Inc'												+ \
+				' -I_STM32_PATH_/Drivers/STM32F7xx_HAL_Driver/Inc'			+ \
+				' -I_STM32_PATH_/Drivers/BSP/STM32746G-Discovery'			+ \
+				' -I_STM32_PATH_/Drivers/CMSIS/Device/ST/STM32F7xx/Include'	+ \
+				' -I_STM32_PATH_/Drivers/CMSIS/Include',
+				'f4' :
+				' -DSTM32F407xx'											+ \
+				' -I_SRC_/Inc'												+ \
+				' -I_STM32_PATH_/Drivers/STM32F4xx_HAL_Driver/Inc'			+ \
+				' -I_STM32_PATH_/Drivers/BSP/STM32F4-Discovery'				+ \
+				' -I_STM32_PATH_/Drivers/CMSIS/Device/ST/STM32F4xx/Include'	+ \
+				' -I_STM32_PATH_/Drivers/CMSIS/Include'}[info.platform]
+	include = include.replace('_SRC_', info.src)
+	include = include.replace('_STM32_PATH_', stm32_path)
+	# Compile and find implementations of IRQHandler's, not declarations
+	command = compiler + ' ' + include + ' ' + file + ' | grep "IRQHandler(void)" | grep -v ";"'
+
+	# Search for 'IRQHandler' in the obtained preprocessed file
+	p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+	result = [w for w in p.stdout.read().replace('(', ' ').replace(')', ' ').split() if "IRQHandler" in w]
+
+	return result
+
+def generate_stm32_irq_handlers(info):
+	stm32_it_file = info.src + '/Src/stm32%sxx_it.c' % info.platform
+	irq_handlers = find_irq_handlers_in_file(info, stm32_it_file)
+
+	with open(info.script_dir + '/embox_stm32_it_template.c', 'r') as f:
+		stm32_it = f.read()
+
+	stm32_it = stm32_it.replace('_PLATFORM_', info.platform)
+
+	irq_attach = ''
+	irq_handlers_declare = ''
+	for h in irq_handlers:
+		prefix = h.rsplit('_IRQHandler', 1)[0]
+		irq_attach += '	res |= irq_attach(%s_IRQn + 16, embox_%s, 0, NULL, "%s");\n' % (prefix, h, h)
+		irq_handlers_declare += 'EMBOX_STM32_IRQ_HANDLER(%s)\n' % prefix
+
+	stm32_it = stm32_it.replace('_IRQ_HANDLERS_DECLARE_', irq_handlers_declare)
+	stm32_it = stm32_it.replace('_STM32_IRQ_ATTACH_', irq_attach)
+
+	with open(info.dst + '/Src/embox_stm32%sxx_it.c' % info.platform, 'w') as f:
+		f.write(stm32_it)
+
+def generate_new_main(info):
+	with open(info.script_dir + '/embox_main_template.c', 'r') as f:
+		embox_main = f.read()
+
+	embox_main = embox_main.replace('_EXAMPLE_', info.example_name)
+
+	with open(info.dst + '/Src/embox_main.c', 'w') as f:
+		f.write(embox_main)
+
+def import_example(info):
+	if os.path.exists(info.dst):
+		print 'Destination directory %s is already exists' % info.dst
+		return
+	elif not os.path.exists(info.src):
+		print 'Source directory %s does not exist' % info.src
+		return
+
+	shutil.copytree(info.src + '/Src', info.dst + '/Src')
+	shutil.copytree(info.src + '/Inc', info.dst + '/Inc')
+	shutil.copyfile(info.src + '/readme.txt', info.dst + '/readme.txt')
+
+	fix_main(info)
+	generate_Mybuild(info)
+	generate_stm32_irq_handlers(info)
+	generate_new_main(info)
+
+def main():
+	parser = argparse.ArgumentParser(description='Import STM32 Cube Example into Embox')
+	parser.add_argument('platform', help='f4 or f7')
+	parser.add_argument('src', help='Source folder containing Cube example')
+	parser.add_argument('dest', nargs='?', default='', help='Destination folder. Default value is')
+	args = parser.parse_args()
+
+	platform = args.platform
+
+	if args.dest == '':
+		args.dest = os.getcwd() + '/platform/stm32%s/cmds' % platform
+
+	src = os.path.normpath(args.src)
+	example_name = os.path.basename(src)
+	dst = '%s/%s' % (os.path.normpath(args.dest), example_name)
+	script_dir = os.path.dirname(sys.argv[0])
+
+	print "src=%s, dest=%s, platform=%s" % (src, dst, platform)
+	info = ExampleInfo(src, dst, script_dir, example_name, platform)
+
+	import_example(info)
+
+if __name__ == "__main__":
+	main()

--- a/src/drivers/clock/cortexm_systick.c
+++ b/src/drivers/clock/cortexm_systick.c
@@ -36,8 +36,14 @@
 
 #define RELOAD_VALUE (SYS_CLOCK / (CLOCK_DIVIDER * 1000))
 
+/* It is used for STM32 Cube */
+void (*cortexm_external_clock_hnd)(void);
+
 static struct clock_source this_clock_source;
 static irq_return_t clock_handler(unsigned int irq_nr, void *data) {
+	if (cortexm_external_clock_hnd) {
+		cortexm_external_clock_hnd();
+	}
 	clock_tick_handler(irq_nr, data);
 	return IRQ_HANDLED;
 }

--- a/src/drivers/video/stm32f7_lcd/Mybuild
+++ b/src/drivers/video/stm32f7_lcd/Mybuild
@@ -3,8 +3,7 @@ package embox.driver.video
 @BuildDepends(third_party.bsp.stmf7cube.core)
 module stm32f7_lcd {
 	depends embox.driver.video.fb
-	depends third_party.bsp.stmf7cube.stm32f7_discovery
-	depends third_party.bsp.stmf7cube.stm32f7_discovery_lcd
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
 
 	source "stm32f7_lcd.c"
 }

--- a/third-party/bsp/stmf4cube/Mybuild
+++ b/third-party/bsp/stmf4cube/Mybuild
@@ -108,10 +108,12 @@ static module system_init {
 
 @Build(stage=1,script="true")
 @BuildDepends(core)
-static module stm32f4_discovery {
+static module stm32f4_discovery_bsp {
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf4cube/core")
-	source "./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery.c"
+	source "./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery.c",
+			"./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery_accelerometer.c",
+			"./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery_audio.c"
 }
 
 @Build(stage=1,script="true")

--- a/third-party/bsp/stmf7cube/Mybuild
+++ b/third-party/bsp/stmf7cube/Mybuild
@@ -100,19 +100,30 @@ static module system_init {
 
 @Build(stage=1,script="true")
 @BuildDepends(core)
-static module stm32f7_discovery {
+static module stm32f7_discovery_bsp {
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/core")
 	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery.c",
-		"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_sdram.c"
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_sdram.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_lcd.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_audio.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_camera.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_eeprom.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_qspi.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_sd.c",
+			"./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_ts.c"
 }
 
 @Build(stage=1,script="true")
 @BuildDepends(core)
-static module stm32f7_discovery_lcd {
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery")
+static module stm32f7_discovery_components {
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ft5336")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/core")
-    source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/STM32746G-Discovery/stm32746g_discovery_lcd.c"
+	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ft5336/ft5336.c"
+
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/wm8994")
+    @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/core")
+	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/wm8994/wm8994.c"
 }
 
 @Build(stage=1,script="true")

--- a/third-party/bsp/stmf7cube/Mybuild
+++ b/third-party/bsp/stmf7cube/Mybuild
@@ -1,7 +1,7 @@
 package third_party.bsp.stmf7cube
 
 @Build(stage=1,script="$(EXTERNAL_MAKE) download extract patch")
-@BuildArtifactPath(cppflags="-DSTM32F746xx -I$(ROOT_DIR)/third-party/bsp/stmf7cube/ $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/,Drivers/STM32F7xx_HAL_Driver/Inc  Drivers/BSP/STM32746G-Discovery/ Drivers/CMSIS/Device/ST/STM32F7xx/Include Drivers/CMSIS/Include Projects/STM32746G-Discovery/Examples/BSP/Inc)")
+@BuildArtifactPath(cppflags="-DSTM32F746xx -I$(ROOT_DIR)/third-party/bsp/stmf7cube/ $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/,Drivers/STM32F7xx_HAL_Driver/Inc  Drivers/BSP/STM32746G-Discovery/ Drivers/CMSIS/Device/ST/STM32F7xx/Include Drivers/CMSIS/Include Projects/STM32746G-Discovery/Examples/BSP/Inc Utilities/Log)")
 static module core extends third_party.bsp.st_bsp_api {
 
 	option number hse_freq_hz = 8000000 /* STM32F3Discovery oscillator */
@@ -124,6 +124,18 @@ static module stm32f7_discovery_components {
     @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/wm8994")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/core")
 	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/wm8994/wm8994.c"
+
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ov9655")
+    @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/core")
+	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ov9655/ov9655.c"
+}
+
+@Build(stage=1,script="true")
+@BuildDepends(core)
+static module stm32f7_discovery_utilities {
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Utilities/Log")
+    @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/core")
+	source "./STM32Cube_FW_F7_V1.5.0/Utilities/Log/lcd_log.c"
 }
 
 @Build(stage=1,script="true")


### PR DESCRIPTION
The goal of this contribution is to simplify an importing STM32Cube examples  into Embox. scripts/stm32/import_stm32_cube_example.py imports Cube example and creates all required files in Embox to make it usual Embox module.

Example:
./scripts/stm32/import_stm32_cube_example.py f7 build/extbld/third_party/bsp/stmf7cube/core/STM32Cube_FW_F7_V1.5.0/Projects/STM32746G-Discovery/Examples/BSP/

Now you can see:
$ ls platform/stm32f7/cmds/BSP/
Inc  Mybuild  readme.txt  Src