### PR TITLE
mk: Improve topsort diagnostic messages

### DIFF
--- a/mk/tsortdiag.awk
+++ b/mk/tsortdiag.awk
@@ -1,0 +1,16 @@
+# don't care of anything not labeled by "tsort:" diag output
+$1 != "tsort:" {
+	print
+	next
+}
+
+# Two options
+# "tsort: -: ..."
+# "tsort: .bld502x"
+{
+	e = e " " ($2 == "-:" ?  "newcycle" : $2)
+}
+
+END {
+	system("E=\"" e "\" make -f ./mk/tsortdiag.mk 1>&2")
+}

--- a/mk/tsortdiag.mk
+++ b/mk/tsortdiag.mk
@@ -1,0 +1,7 @@
+
+include mk/script/script-common.mk
+
+$(foreach e,$E,\
+	$(if $(findstring newcycle,$e),\
+		$(info Error: modules dependency cycle:),\
+		$(info $(\t)$(call get,$(call get,$e,type),qualifiedName))))


### PR DESCRIPTION
Messages contain info about cycles found, but in mybuild internal
format. The patch turns this output
```
tsort: -: input contains a loop:
tsort: .bld502x
tsort: .bld429x
```
to this
```
Error: modules dependency cycle:
        embox.compat.posix.proc.exit
        embox.compat.posix.proc.vfork_exchanged
```
Every cycle is actually is a error in mybuild, but we aren't consider
them so for now. The patch also adds fatal_mode, which, when enabled,
produces next and halts build
```
Error: modules dependency cycle:
	...
Error: stop after finding cycle(s)
mk/script/build/build-gen.mk:338: *** Mybuild stop.  Stop.
```
The mode should be considered as transitional, and should be
enabled from some point in time till forever.