### PR TITLE
Fix x86/user_apps template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - TEMPLATE=arm/stm32_f4
     - TEMPLATE=x86/qemu
     - TEMPLATE=x86/smp
+    - TEMPLATE=x86/user_apps
     - TEMPLATE=x86/test/lang
     - TEMPLATE=x86/test/fs
     - TEMPLATE=x86/test/net

--- a/scripts/continuous/run.sh
+++ b/scripts/continuous/run.sh
@@ -37,6 +37,7 @@ atml2run=(
 	['arm/qemu']=default_run
 	['x86/qemu']=default_run
 	['x86/smp']=default_run
+	['x86/user_apps']=default_run
 	['x86/test/lang']=default_run
 	['x86/test/fs']="$(dirname $0)/fs/run.sh $ATML"
 	['x86/test/net']="$(dirname $0)/net/run.sh $ATML"

--- a/src/mem/mmap/Mybuild
+++ b/src/mem/mmap/Mybuild
@@ -22,8 +22,7 @@ module mmap_mmu extends mmap_api {
 	
 	depends embox.kernel.task.resource.mmap
 	depends embox.kernel.task.resource.mmap_notify
-	/* TODO tsort loop
+	/* TODO tsort loop: mmap_init calls for vmem_init_context, which must be initialized */
 	depends embox.mem.vmem
-	*/
 	depends embox.arch.mmu
 }

--- a/templates/x86/user_apps/mods.config
+++ b/templates/x86/user_apps/mods.config
@@ -67,7 +67,7 @@ configuration conf {
 	@Runlevel(1) include embox.test.util.tree_test
 
 	@Runlevel(2) include embox.cmd.sh.tish
-	@Runlevel(3) include embox.init.start_script(shell_name="tish",tty_dev="ttyS0",shell_start=1)
+	@Runlevel(3) include embox.init.start_script(shell_name="tish",tty_dev="ttyS0",shell_start=1,stop_on_error=true)
 	include embox.cmd.net.arp
 	include embox.cmd.net.arping
 	include embox.cmd.net.ifconfig

--- a/templates/x86/user_apps/mods.config
+++ b/templates/x86/user_apps/mods.config
@@ -114,8 +114,9 @@ configuration conf {
 	include embox.cmd.load_app
 	include embox.kernel.usermode
 	include embox.arch.x86.kernel.usermode
-    include embox.mem.mmap_mmu
-    include embox.arch.x86.mmu
+	include embox.mem.mmap_mmu
+	include embox.arch.x86.mmu
+	include embox.arch.x86.vfork
 	include embox.lib.LibExec
 
 

--- a/templates/x86/user_apps/start_script.inc
+++ b/templates/x86/user_apps/start_script.inc
@@ -4,3 +4,4 @@
 "route add 10.0.2.0 netmask 255.255.255.0 eth0",
 "route add default gw 10.0.2.10 eth0",
 "date -s 201206011922.40",
+"forkexec hello",


### PR DESCRIPTION
For x86/user_apps:
* add `vfork` module in template
* restore dependency, omitting resulted in crash during boot, some allocator was not properply initialized prior calling allocation function
* add template to travis