### PR TITLE
ARM VFP/NEON support

### DIFF
--- a/src/arch/arm/armlib/context/Mybuild
+++ b/src/arch/arm/armlib/context/Mybuild
@@ -4,4 +4,6 @@ module context extends embox.arch.context {
 	source "context.c"
 	source "context.h"
 	source "context_switch.S"
+
+	depends embox.arch.arm.fpu.fpu
 }

--- a/src/arch/arm/armlib/context/context.c
+++ b/src/arch/arm/armlib/context/context.c
@@ -13,6 +13,8 @@
 
 #include <asm/modes.h>
 
+#include <arm/fpu.h>
+
 void context_init(struct context *ctx, unsigned int flags,
 		void (*routine_fn)(void), void *sp) {
 	ctx->lr = (uint32_t) routine_fn;
@@ -22,5 +24,7 @@ void context_init(struct context *ctx, unsigned int flags,
 	if (flags & CONTEXT_IRQDISABLE) {
 		ctx->cpsr |= I_BIT | F_BIT;
 	}
+
+	arm_fpu_context_init(&ctx->fpu_data);
 }
 

--- a/src/arch/arm/armlib/context/context.h
+++ b/src/arch/arm/armlib/context/context.h
@@ -12,15 +12,16 @@
 #ifndef __ASSEMBLER__
 
 #include <stdint.h>
+#include <arm/fpu.h>
 
 struct context {
 	uint32_t system_r[13];
 	uint32_t sp;
 	uint32_t lr;
 	uint32_t cpsr;
+	uint32_t fpu_data[FPU_DATA_LEN];
 };
 
 #endif /* __ASSEMBLER__ */
 
 #endif /* SRC_ARCH_ARM_CORTEXA8_KERNEL_CONTEXT_H_ */
-

--- a/src/arch/arm/armlib/context/context_switch.S
+++ b/src/arch/arm/armlib/context/context_switch.S
@@ -5,7 +5,7 @@
  * @author  Anton Kozlov
  * @date    25.10.2012
  */
-
+#include <arm/fpu.h>
 	.text
 	.global context_switch
 context_switch:
@@ -15,13 +15,17 @@ context_switch:
 
     stmia   r0!, {r0 - r14}
     mrs     r3, cpsr
-    stmia   r0, {r3}
+    stmia   r0!, {r3}
+    ARM_FPU_CONTEXT_SAVE_INC(r2, r0)
 
-    add     r1, r1, #60
+    mov     r4, r1
+    add     r1, r1, #60 /* Now r1 points to stored cpsr */
     ldm     r1, {r3}
     msr     cpsr, r3
-    ldmdb   r1, {r0 - r14}
+    add     r1, r1, #4 /* Now r1 points to stored fpu_data */
+    ARM_FPU_CONTEXT_LOAD_INC(r2, r1)
+    mov     r1, r4
+    ldmia   r1, {r0 - r14}
 
     nop
     mov	    pc, lr
-

--- a/src/arch/arm/armlib/entry.S
+++ b/src/arch/arm/armlib/entry.S
@@ -6,6 +6,7 @@
  * @author Anton Kozlov
  */
 
+#include <arm/fpu.h>
 #include <asm/modes.h>
 
 .text
@@ -17,7 +18,7 @@ irq_handler:
 	sub    LR, LR, #4
 
 	/* save temp register*/
-	stmfd  sp!, {r0}
+	stmfd  sp!, {r0, r1}
 	/* storing LP */
 	stmfd  sp!, {lr}
 	/*storing SPSR and valuable regs*/
@@ -27,24 +28,23 @@ irq_handler:
 	/* pointer to saved on special stack registers */
 	mov    r0, sp
 	/* return stack pointer to normal value */
-	add    sp, sp, #(4 * 3)
+	add    sp, sp, #(4 * (4))
 
 	/* return to previous CPU mode with disabled interrupts */
-	//orr    lr, lr, #I_BIT | F_BIT
-	//msr    CPSR, lr
 	msr    CPSR, #ARM_MODE_SYS | I_BIT | F_BIT
 
 	/* now we have previous mode and sp */
-	stmfd  sp!, {r1-r12, lr}
+	ARM_FPU_CONTEXT_SAVE_DEC(r1, sp)
+	stmfd  sp!, {r2-r12, lr}
 
 	/* restore spsr, lr, tmp reg */
 	ldmfd  r0!, {r1} /* spsr */
 	ldmfd  r0!, {r2} /* lr */
-	ldmfd  r0!, {r3} /* tmp reg */
+	ldmfd  r0!, {r3, r4} /* tmp reg */
 
-	stmfd  sp!, {r3}  /* store tmp reg on the stack */
+	stmfd  sp!, {r3, r4}  /* store tmp reg on the stack */
 	/* store sp */
-	add    r3, sp, #(14 * 4)
+	add    r3, sp, #((14 + FPU_DATA_LEN) * 4)
 	stmfd  sp!, {r3}
 
 	/* store lr */
@@ -61,6 +61,10 @@ irq_handler:
 	msr    CPSR, #ARM_MODE_IRQ | I_BIT | F_BIT
 
 	/* restore spsr */
+	add    r0, r0, #17 * 4
+	add    r0, r0, #4 * FPU_DATA_LEN
+	ARM_FPU_CONTEXT_LOAD_DEC(r1, r0)
+	sub    r0, r0, #17 * 4
 	ldmfd  r0!, {r1}
 	msr    SPSR, r1
 
@@ -71,11 +75,12 @@ irq_handler:
 	mov    sp, r0
 	/* restore sp */
 	ldmfd  sp!, {r3} /* only for balance */
+
 	/* restore tmp reg */
 	ldmfd  sp!, {r0}
 
 	ldmfd  sp!, {r1-r12, lr}
-
+	add    sp, sp, #FPU_DATA_LEN*4
 	msr    CPSR, #ARM_MODE_IRQ | I_BIT | F_BIT
 	stmfd  sp!, {lr}
 	/*regs & SPSR on theirs places, as before handler */

--- a/src/arch/arm/armlib/exception_table.S
+++ b/src/arch/arm/armlib/exception_table.S
@@ -102,6 +102,29 @@ reset_handler:
     b bootldr_start
 
 undef_handler:
+#ifdef __ARM_NEON__
+    sub r14, r14, #4
+
+    stmfd sp!, {r0-r2} /* Save temp regs */
+    mov r2, r14
+    mrs r1, SPSR
+    mov r0, sp         /* Pointer to saved regs */
+    add sp, sp, #12    /* Return SP to previous state */
+
+    msr CPSR, #ARM_MODE_SYS | I_BIT | F_BIT
+    stmfd sp!, {r1}    /* Store arguments for RFE instruction */
+    stmfd sp!, {r2}
+    ldmfd r0, {r0-r2}  /* Restore temp regs */
+
+    stmfd sp!, {r0-r12, r14}
+
+    bl arm_undefined_exception
+
+    ldmfd sp!, {r0-r12, r14}
+
+    rfe sp
+#endif /* __ARM_NEON__ */
+
 prefetch_abt_handler:
 fiq_handler:
     sub r14, r14, #4

--- a/src/arch/arm/fpu/Mybuild
+++ b/src/arch/arm/fpu/Mybuild
@@ -1,0 +1,19 @@
+package embox.arch.arm.fpu
+
+@DefaultImpl(fpu_stub)
+abstract module fpu {
+}
+
+module fpu_stub extends fpu {
+	@IncludeExport(path="arm",target_name="fpu.h")
+	source "stub.h"
+}
+
+module vfp extends fpu {
+	option number log_level = 0
+
+	@IncludeExport(path="arm",target_name="fpu.h")
+	source "vfp.h"
+
+	source "vfp.c"
+}

--- a/src/arch/arm/fpu/stub.h
+++ b/src/arch/arm/fpu/stub.h
@@ -1,0 +1,27 @@
+/**
+ * @file stub.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 28.03.2018
+ */
+
+#ifndef ARM_FPU_STUB_H_
+#define ARM_FPU_STUB_H_
+
+/* Do nothing on context switch */
+#define ARM_FPU_CONTEXT_SAVE_INC(tmp, stack)
+#define ARM_FPU_CONTEXT_LOAD_INC(tmp, stack)
+#define ARM_FPU_CONTEXT_SAVE_DEC(tmp, stack)
+#define ARM_FPU_CONTEXT_LOAD_DEC(tmp, stack)
+
+#define FPU_DATA_LEN 0
+
+#ifndef __ASSEMBLER__
+static inline void arm_fpu_context_init(void *opaque) {
+	/* Do nothing */
+}
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* ARM_FPU_STUB_H_ */

--- a/src/arch/arm/fpu/vfp.c
+++ b/src/arch/arm/fpu/vfp.c
@@ -1,0 +1,54 @@
+/**
+ * @file vfp.c
+ * @brief Floting point extension for CortexA9
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 27.03.2018
+ */
+
+#include <stdint.h>
+
+#include <util/log.h>
+#include <util/math.h>
+
+#include <embox/unit.h>
+#include <framework/mod/options.h>
+#include <kernel/printk.h>
+
+EMBOX_UNIT_INIT(vfp_init);
+
+static int vfp_init(void) {
+	uint32_t val;
+	uint32_t sid;
+	/* Allow access to c10 & c11 coprocessors */
+	asm volatile ("mrc p15, 0, %0, c1, c0, 2" : "=r" (val) :);
+	val |= 0xf << 20;
+	asm volatile ("mcr p15, 0, %0, c1, c0, 2" : : "r" (val));
+
+	val = 1 << 30;
+	/* Enable FPU extensions */
+	asm volatile ("VMSR FPEXC, %0" : : "r" (val));
+
+	asm volatile ("VMRS %0, FPEXC" : "=r" (sid));
+
+	log_info("VPF info:\n"
+			"\t\t\t %s\n"
+			"\t\t\t Implementer =        0x%02x (%s)\n"
+			"\t\t\t Subarch:             VFPv%d\n"
+			"\t\t\t Part number =        0x%02x\n"
+			"\t\t\t Variant     =        0x%02x\n"
+			"\t\t\t Revision    =        0x%02x",
+			(sid >> 23) & 1 ? "Software FP emulation" : "Hardware FP support",
+			sid >> 24, ((sid >> 24) == 0x41) ? "ARM" : "Unknown",
+			max((sid >> 16) & 0x7F, 3),
+			(sid >> 8) & 0xFF,
+			(sid >> 4) & 0xF,
+			sid & 0xF);
+
+	/* Disable access to c10 & c11 coprocessors */
+	asm volatile ("mrc p15, 0, %0, c1, c0, 2" : "=r" (val) :);
+	val &= ~(0xf << 20);
+	asm volatile ("mcr p15, 0, %0, c1, c0, 2" : : "r" (val));
+
+	return 0;
+}

--- a/src/arch/arm/fpu/vfp.h
+++ b/src/arch/arm/fpu/vfp.h
@@ -1,0 +1,68 @@
+/**
+ * @file vfp.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 28.03.2018
+ */
+
+#ifndef ARM_FPU_VFP_H_
+#define ARM_FPU_VFP_H_
+
+#define FPU_DATA_LEN 65 /* One word for coprocessor state
+			   and 64 words for VPF registers */
+
+#ifndef __ASSEMBLER__
+#include <string.h>
+static inline void arm_fpu_context_init(void *opaque) {
+	memset(opaque, 0, sizeof(uint32_t) * FPU_DATA_LEN);
+}
+#else /* __ASSEMBLER__ */
+
+/* Note: this functions do not change stack value */
+
+#define ARM_FPU_CONTEXT_SAVE_INC(tmp, stack) \
+	mrc       p15, 0, tmp, c1, c0, 2; \
+	stmia     stack!, {tmp}; \
+	ands      tmp, tmp, #0xF00000; \
+	beq       fpu_out_save_inc; \
+	vstmia stack!, {d0-d15}; \
+	vstmia stack!, {d16-d31}; \
+fpu_out_save_inc:
+
+#define ARM_FPU_CONTEXT_SAVE_DEC(tmp, stack) \
+	mrc       p15, 0, tmp, c1, c0, 2; \
+	stmfd     stack!, {tmp}; \
+	ands      tmp, tmp, #0xF00000; \
+	beq       fpu_skip_save_dec; \
+	vstmdb    stack!, {d0-d15}; \
+	vstmdb    stack!, {d16-d31}; \
+	b         fpu_out_save_dec; \
+fpu_skip_save_dec: \
+	sub       stack, stack, #4 * 64; \
+fpu_out_save_dec:
+
+#define ARM_FPU_CONTEXT_LOAD_INC(tmp, stack) \
+	ldmia     stack!, {tmp}; \
+	mcr       p15, 0, tmp, c1, c0, 2; \
+	ands      tmp, tmp, #0xF00000; \
+	beq       fpu_out_load_inc; \
+	vldmia    stack!, {d0-d15}; \
+	vldmia    stack!, {d16-d31}; \
+fpu_out_load_inc:
+
+#define ARM_FPU_CONTEXT_LOAD_DEC(tmp, stack) \
+	ldmdb     stack!, {tmp}; \
+	mcr       p15, 0, tmp, c1, c0, 2; \
+	ands      tmp, tmp, #0xF00000; \
+	beq       fpu_skip_load_dec; \
+	vldmdb    stack!, {d0-d15}; \
+	vldmdb    stack!, {d16-d31}; \
+	b         fpu_out_load_dec; \
+fpu_skip_load_dec: \
+        sub       stack, stack, #4 * 64; \
+fpu_out_load_dec:
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* ARM_FPU_VFP_H_ */

--- a/templates/arm/iwave_imx6/build.conf
+++ b/templates/arm/iwave_imx6/build.conf
@@ -8,6 +8,6 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g -mno-unaligned-access
 CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
-CFLAGS += -mfloat-abi=soft
+CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -12,6 +12,8 @@ configuration conf {
 	include embox.arch.arm.vfork
 	@Runlevel(0) include embox.driver.cache.pl310(base_addr=0x00A02000)
 
+	include embox.arch.arm.fpu.vfp
+	include embox.arch.arm.armlib.locore
 	include embox.arch.arm.imx.cpuinfo
 
 	@Runlevel(0) include embox.kernel.task.kernel_task

--- a/templates/arm/vexpress-a9/build.conf
+++ b/templates/arm/vexpress-a9/build.conf
@@ -10,6 +10,6 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
-CFLAGS += -mfloat-abi=soft
+CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g

--- a/templates/arm/vexpress-a9/mods.config
+++ b/templates/arm/vexpress-a9/mods.config
@@ -12,6 +12,7 @@ configuration conf {
 	@Runlevel(0) include embox.driver.cache.pl310(base_addr=0x1e00a000)
 
 	@Runlevel(0) include embox.arch.arm.mmu_small_page
+	@Runlevel(0) include embox.arch.arm.fpu.vfp
 
 	include embox.arch.arm.libarch
 	include embox.mem.bitmask(page_size=0x1000)
@@ -30,7 +31,7 @@ configuration conf {
 	@Runlevel(1) include embox.driver.net.lan9118_non_gpio_irq(base_address=0x4E000000,irq_nr=47,memory_region_size = 0x1000000)
 	//@Runlevel(2) include embox.driver.net.loopback
 
-	include embox.compat.libc.stdio.print(support_floating=0)
+	include embox.compat.libc.stdio.print(support_floating=1)
 
 	include embox.test.kernel.timer_test
 	include embox.test.mmu_double_map


### PR DESCRIPTION
Add support for VFP/NEON instructions. Currently it works only with NEON, but VFP is subset of NEON, so it's possible to cut it if necessary in future.