### PR TITLE
arm: Zero bss in assembly, without memset()

### DIFF
--- a/src/arch/arm/head.S
+++ b/src/arch/arm/head.S
@@ -8,6 +8,8 @@
 .weak software_init_hook
 .weak kernel_start
 
+.syntax unified /* To make `subs' instruction available on Thumb16 */
+
 .global bootldr_start
 .type bootldr_start, %function
 
@@ -22,14 +24,23 @@ sw_init_hook:
     ldr	    r0, =_bss_vma
     mov	    r1, #0
     ldr	    r2, =_bss_len
-    bl	    memset
+bss_loop:
+    str     r1, [r0]
+    add     r0, r0, #4
+    subs    r2, r2, #4
+    bne     bss_loop
 
 /* copy data section */
     ldr     r0, =_data_vma
     ldr     r1, =_data_lma
     ldr     r2, =_data_len
-
-    bl	    memcpy
+data_loop:
+    ldr     r3, [r1]
+    str     r3, [r0]
+    add     r0, r0, #4
+    add     r1, r1, #4
+    subs    r2, r2, #4
+    bne     data_loop
 
     ldr     r0, =software_init_hook
     cmp	    r0, #0


### PR DESCRIPTION
It turned out that memset() is 10 times slower than simple loop in assembly. This change allows to speed up the way more faster.