### PR TITLE
help: Fix ugly output

### DIFF
--- a/src/cmds/help.c
+++ b/src/cmds/help.c
@@ -8,6 +8,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <framework/cmd/api.h>
 
@@ -17,7 +18,8 @@ static void print_usage(void) {
 
 int main(int argc, char **argv) {
 	const struct cmd *cmd;
-	int opt;
+	int opt, tab = 10;
+	char fmt[15];
 
 	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "h"))) {
@@ -31,9 +33,17 @@ int main(int argc, char **argv) {
 		}
 	}
 
+	cmd_foreach(cmd) {
+		if (strlen(cmd_name(cmd)) > tab) {
+			tab = strlen(cmd_name(cmd));
+		}
+	}
+
+	snprintf(fmt, sizeof(fmt), "%%%ds - %%s\n", tab + 1);
+
 	printf("Available commands: \n");
 	cmd_foreach(cmd) {
-		printf("%11s - %s\n", cmd_name(cmd), cmd_brief(cmd));
+		printf(fmt, cmd_name(cmd), cmd_brief(cmd));
 	}
 
 	return 0;


### PR DESCRIPTION
Now `help` works well with long-name commands