### PR TITLE
Fix static irq

### DIFF
--- a/src/arch/arm/armmlib/exception_table.S
+++ b/src/arch/arm/armmlib/exception_table.S
@@ -30,9 +30,13 @@ trap_table_start:
     .word 0 /* Reserved */
     .word 0 /* Reserved */
     .word 0 /* Reserved */
+#if 0
+    /* we use static_irq_attach for these handlers and below
+     * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0497a/Babefdjc.html */
     .word exp_default_entry /* SVCall */
     .word 0 /* Reserved for debug */
     .word 0 /* Reserved */
+#endif
 trap_table_end:
 
 

--- a/src/arch/arm/embox.lds.S
+++ b/src/arch/arm/embox.lds.S
@@ -20,9 +20,9 @@ _ram_size = LENGTH(RAM);
 
 SECTIONS {
 	.text : {
-		STATIC_IRQ_TABLE
 		*(.trap_table)
 		*(.monitor_trap_table)
+		STATIC_IRQ_TABLE
 
 		*(.flash)
 

--- a/src/include/asm-generic/static_irq.h
+++ b/src/include/asm-generic/static_irq.h
@@ -18,14 +18,10 @@
 	. = n * 4; \
 	*(.trap_table.routine_##n);
 
+/* Currently, we allow to define handlers starting from
+ * SVCall, please take a look at exception_table.S and
+ * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHIGCIF.html */
 #define STATIC_IRQ_TABLE \
-	SIRQ_TABLE_ENTRY(4) \
-	SIRQ_TABLE_ENTRY(5) \
-	SIRQ_TABLE_ENTRY(6) \
-	SIRQ_TABLE_ENTRY(7) \
-	SIRQ_TABLE_ENTRY(8) \
-	SIRQ_TABLE_ENTRY(9) \
-	SIRQ_TABLE_ENTRY(10) \
 	SIRQ_TABLE_ENTRY(11) \
 	SIRQ_TABLE_ENTRY(12) \
 	SIRQ_TABLE_ENTRY(13) \


### PR DESCRIPTION
Extend the common part of trap table for all cortex-m for both static and dynamic irqs. It is required bacause we want to have informative exceptions handlers for any Embox configuration. So we just extend the trap table.