### PR TITLE
QEMU Stellaris lm3s811

### DIFF
--- a/platform/stellaris/templates/lm3s811evb/build.conf
+++ b/platform/stellaris/templates/lm3s811evb/build.conf
@@ -1,0 +1,15 @@
+
+TARGET = embox
+
+PLATFORM = lm3s811evb
+
+ARCH = arm
+
+CROSS_COMPILE = arm-none-eabi-
+
+CFLAGS += -Os -g
+CFLAGS += -mthumb -mlittle-endian -march=armv7-m -mcpu=cortex-m3 -ffreestanding
+
+CFLAGS += -msoft-float
+
+LDFLAGS += -N -g

--- a/platform/stellaris/templates/lm3s811evb/lds.conf
+++ b/platform/stellaris/templates/lm3s811evb/lds.conf
@@ -1,0 +1,13 @@
+/*
+ * Linkage configuration.
+ */
+
+/* region (origin, length) */
+ROM (0x00000000, 64K)
+RAM (0x20000000, 8K)
+
+/* section (region[, lma_region]) */
+text   (ROM)
+rodata (ROM)
+data   (RAM, ROM)
+bss    (RAM)

--- a/platform/stellaris/templates/lm3s811evb/mods.config
+++ b/platform/stellaris/templates/lm3s811evb/mods.config
@@ -1,0 +1,63 @@
+
+package genconfig
+
+configuration conf {
+	@Runlevel(0) include embox.arch.system(core_freq=8000000)
+	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
+	@Runlevel(0) include embox.arch.generic.arch
+	include embox.arch.arm.libarch
+	@Runlevel(0) include embox.kernel.stack(stack_size=2048,alignment=4)
+
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic
+	@Runlevel(1) include embox.driver.clock.cortexm_systick
+
+	@Runlevel(2) include embox.driver.serial.pl011(base_addr=0x4000c000, irq_num=37, baud_rate=115200)
+	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__pl011")
+	include embox.driver.serial.core_notty
+
+	include embox.kernel.critical
+	include embox.kernel.irq_static
+	include embox.kernel.spinlock(spin_debug=false)
+	include embox.kernel.task.single
+	include embox.kernel.task.resource.idesc_table(idesc_table_size=12)
+	include embox.kernel.task.task_no_table
+
+	@Runlevel(1) include embox.kernel.timer.sys_timer(timer_quantity=2)
+	@Runlevel(1) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+	@Runlevel(1) include embox.kernel.timer.itimer(itimer_quantity=0)
+	include embox.kernel.timer.sleep_nosched
+
+	include embox.driver.tty.task_breaking_disable
+	include embox.driver.char_dev_stub
+
+	/* Cooperative-only scheduling */
+	@Runlevel(2) include embox.kernel.sched.boot_light
+	@Runlevel(2) include embox.kernel.sched.timing.none
+
+	include embox.cmd.sys.version
+	include embox.cmd.help
+	include embox.cmd.testing.ticker
+
+	@Runlevel(2) include embox.cmd.shell
+	include embox.init.setup_tty_diag
+	@Runlevel(3) include embox.init.start_script(shell_name="diag_shell")
+
+	include embox.kernel.thread.thread_local_none
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.thread.stack_none
+	include embox.kernel.thread.signal_stub
+	include embox.kernel.thread.thread_wait_stub
+
+	@Runlevel(1) include embox.kernel.lthread.lthread
+	@Runlevel(2) include embox.kernel.sched.sched
+	@Runlevel(2) include embox.kernel.sched.idle_light
+	@Runlevel(2) include embox.kernel.sched.sched_ticker_stub
+	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
+
+	include embox.driver.periph_memory_stub
+
+	include embox.util.DList
+	include embox.framework.embuild_light(use_mod_names=true)
+	include embox.compat.libc.stdio.print(support_floating=0)
+}

--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -149,6 +149,8 @@ guess_machine() {
 				echo "-M vexpress-a9"
 			elif cat $BUILD_CONF | gcc -P -E - | grep "sabrelite" > /dev/null; then
 				echo "-M sabrelite"
+			elif cat $BUILD_CONF | gcc -P -E - | grep "lm3s811evb" > /dev/null; then
+				echo "-M lm3s811evb"
 			fi
 			;;
 		microblaze)

--- a/src/drivers/common/Mybuild
+++ b/src/drivers/common/Mybuild
@@ -14,8 +14,11 @@ module common {
 	depends embox.util.indexator
 }
 
-module periph_memory {
-	@IncludeExport(path="drivers/common")
+@DefaultImpl(periph_memory_mmap)
+abstract module periph_memory { }
+
+module periph_memory_mmap extends periph_memory {
+	@IncludeExport(path="drivers/common", target_name="memory.h")
 	source "memory.h"
 
 	source "memory.c"
@@ -23,4 +26,9 @@ module periph_memory {
 	depends embox.arch.mmu
 	depends embox.mem.mmap_api
 	depends embox.util.Array
+}
+
+module periph_memory_stub extends periph_memory {
+	@IncludeExport(path="drivers/common", target_name="memory.h")
+	source "memory_impl_stub.h"
 }

--- a/src/drivers/common/memory_impl_stub.h
+++ b/src/drivers/common/memory_impl_stub.h
@@ -1,0 +1,21 @@
+/**
+ * @file memory.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 2016-08-11
+ */
+
+#ifndef _DRIVERS_COMMON_MEMORY_H
+#define _DRIVERS_COMMON_MEMORY_H
+
+#include <stdint.h>
+
+struct periph_memory_desc {
+	uint32_t start;
+	uint32_t len;
+};
+
+#define PERIPH_MEMORY_DEFINE(_mem_desc)
+
+#endif /* _DRIVERS_COMMON_MEMORY_H */

--- a/src/drivers/serial/Mybuild
+++ b/src/drivers/serial/Mybuild
@@ -27,6 +27,18 @@ module core_old extends core {
 	@NoRuntime depends embox.driver.tty.serial_oldfs
 }
 
+module core_notty extends core {
+	option number uart_max_n = 4
+
+	source "uart_dev.c"
+
+	@IncludeExport(path="drivers/serial")
+	source "uart_device.h"
+
+	@NoRuntime depends embox.util.indexator
+	@NoRuntime depends embox.driver.tty.serial_stub
+}
+
 module diag {
 	source "diag_serial.c"
 

--- a/src/drivers/serial/pl011/pl011.c
+++ b/src/drivers/serial/pl011/pl011.c
@@ -105,7 +105,7 @@ static int uart_init(void) {
 	return uart_register(&uart0, &uart_defparams);
 }
 
-static struct periph_memory_desc pl011_mem = {
+static const struct periph_memory_desc pl011_mem = {
 	.start = UART_BASE,
 	.len   = 0x48,
 };

--- a/src/drivers/serial/pl011/pl011.c
+++ b/src/drivers/serial/pl011/pl011.c
@@ -5,7 +5,6 @@
  * @author: Anton Bondarev
  */
 #include <stdint.h>
-#include <sys/mman.h>
 
 #include <hal/reg.h>
 #include <drivers/common/memory.h>

--- a/src/drivers/tty/serial/Mybuild
+++ b/src/drivers/tty/serial/Mybuild
@@ -32,3 +32,7 @@ module serial_oldfs {
 	depends tty
 	depends embox.driver.char_dev_old
 }
+
+module serial_stub {
+	source "ttys_stub.c"
+}

--- a/src/drivers/tty/serial/ttys_stub.c
+++ b/src/drivers/tty/serial/ttys_stub.c
@@ -1,0 +1,11 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    26.08.2018
+ */
+
+int ttys_register(const char *name, void *dev_info) {
+	return 0;
+}

--- a/src/framework/mod/Mybuild
+++ b/src/framework/mod/Mybuild
@@ -34,6 +34,7 @@ module embuild_full extends embuild {
 }
 
 module embuild_light extends embuild {
+	option boolean use_mod_names = false
 
 	source "embuild_light_impl.h"
 }

--- a/src/framework/mod/embuild_light_impl.h
+++ b/src/framework/mod/embuild_light_impl.h
@@ -9,6 +9,9 @@
 #ifndef FRAMEWORK_MOD_EMBUILD_LIGHT_IMPL_H_
 #define FRAMEWORK_MOD_EMBUILD_LIGHT_IMPL_H_
 
+#define USE_MOD_NAMES \
+	OPTION_MODULE_GET(embox__framework__embuild_light,BOOLEAN,use_mod_names)
+
 #if 1 /* switch some mod_def to tottaly empty will help estimate how much
 		 mod_def is taking space */
 #define __MOD_DEF(mod_nm) \
@@ -39,7 +42,16 @@
 		.name    = cmd_name, \
 	}
 
+#if USE_MOD_NAMES
+#define __MOD_BUILDINFO_DEF(_mod_nm, _package_name, _mod_name) \
+	const struct mod_build_info __MOD_BUILDINFO(_mod_nm) = { \
+		.pkg_name   = _package_name,                         \
+		.mod_name   = _mod_name,                             \
+	}
+#else
 #define __MOD_BUILDINFO_DEF(_mod_nm, _package_name, _mod_name)
+#endif
+
 #define __MOD_DEP_DEF(mod_nm, dep_nm)
 #define __MOD_CONTENTS_DEF(mod_nm, content_nm)
 #define __MOD_AFTER_DEP_DEF(mod_nm, dep_nm)


### PR DESCRIPTION
Add lm3s811evb (Cortex-M3), which is emulated by QEMU.

`make confload-platform/stellaris/lm3s811evb `

```
$ ./scripts/qemu/auto_qemu
qemu-system-arm -M lm3s811evb -kernel ./build/base/bin/embox -m 128 -nographic

Embox kernel start
runlevel: init level is 0
	unit: initializing embox.driver.clock.cortexm_systick: done
	unit: initializing embox.kernel.time.kernel_time: done
	unit: initializing embox.kernel.time.jiffies: done
	unit: initializing embox.kernel.sched.sched: done
	unit: initializing embox.kernel.time.timer_handler: done
runlevel: init level is 1
	unit: initializing embox.kernel.task.task_resource: done
	unit: initializing embox.kernel.task.kernel_task: done
	unit: initializing embox.cmd.shell: done
	unit: initializing embox.driver.serial.pl011: done
runlevel: init level is 2
	unit: initializing embox.init.start_script: 
Started shell [diag_shell] on device []
loading start script:

Welcome to Embox and have a lot 
embox>ticker -c 10 -i 1
of fun!1 sec
2 sec
3 sec
4 sec
```