### PR TITLE
Fix PHY initialization for 1Gbit links

### DIFF
--- a/src/drivers/net/fec/fec.c
+++ b/src/drivers/net/fec/fec.c
@@ -269,21 +269,6 @@ static void _reset(struct net_device *dev) {
 
 	fec_mdio_init(dev);
 
-	/* MII or RMII mode, as indicated by the RMII_MODE field. */
-#if FEC_SPEED == 1000
-	REG32_STORE(ENET_RCR, 0x5ee0000 | ENET_RCR_RGMII_EN);
-	REG32_STORE(ENET_ECR, 0xF0000100 | ENET_SPEED);
-#elif FEC_SPEED == 100
-	REG32_STORE(ENET_RCR, 0x5ee0000 | ENET_RCR_RGMII_EN);
-	REG32_STORE(ENET_ECR, 0xF0000100);
-#elif FEC_SPEED == 10
-	REG32_STORE(ENET_RCR, 0x5ee0000 | ENET_RCR_RMII_10T |
-			ENET_RCR_RGMII_EN);
-	REG32_STORE(ENET_ECR, 0xF0000100);
-#else
-#error "Wrong FEC speed"
-#endif
-
 	/* Enables 10-Mbit/s mode of the RMII or RGMII ?*/
 	/* Maximum Receive Buffer Size Register
 	 * Receive buffer size in bytes. This value, concatenated with the four
@@ -294,13 +279,7 @@ static void _reset(struct net_device *dev) {
 	fec_rbd_init(dev->priv, RX_BUF_FRAMES, 0x600);
 
 	fec_tbd_init(dev->priv);
-#if 0
-#if FEC_SPEED == 1000
-	REG32_STORE(ENET_ECR, 0xF0000100 | ENET_SPEED);
-#else
-	REG32_STORE(ENET_ECR, 0xF0000100);
-#endif
-#endif
+
 	/* Transmit FIFO Write 64 bytes */
 	REG32_STORE(ENET_TFWR, 0x100);
 
@@ -496,7 +475,7 @@ static void fec_set_phyid(struct net_device *dev, uint8_t phyid) {
 static int fec_set_speed(struct net_device *dev, int speed) {
 	speed = net_to_mbps(speed);
 
-	if (speed != FEC_SPEED) {
+	if (speed != FEC_SPEED && FEC_SPEED != 0) {
 		log_error("Can't set %dmbps as driver is configured "
 				"to force %dmbps", speed, FEC_SPEED);
 		return -1;

--- a/src/include/net/mii.h
+++ b/src/include/net/mii.h
@@ -119,6 +119,8 @@
 #define NET_1000HALF  (1 << 4)
 #define NET_1000FULL  (1 << 5)
 
+#define NET_GBIT      (NET_1000HALF | NET_1000FULL)
+
 static inline int net_speed_to_adv(int speed) {
 	int res = 0;
 	if (speed & NET_10HALF) { res |= ADVERTISE_10HALF; }
@@ -131,14 +133,17 @@ static inline int net_speed_to_adv(int speed) {
 	return res;
 }
 
-static inline int adv_to_net_speed(int adv) {
+static inline int adv_to_net_speed(int adv, int is_gigabit) {
 	int res = 0;
-	if (adv & ADVERTISE_10HALF) { res |= NET_10HALF; }
-	if (adv & ADVERTISE_10FULL) { res |= NET_10FULL; }
-	if (adv & ADVERTISE_100HALF) { res |= NET_100HALF; }
-	if (adv & ADVERTISE_100FULL) { res |= NET_100FULL; }
-	if (adv & ADVERTISE_1000XHALF) { res |= NET_1000HALF; }
-	if (adv & ADVERTISE_1000XFULL) { res |= NET_1000FULL; }
+	if (is_gigabit) {
+		if (adv & ADVERTISE_1000XHALF) { res |= NET_1000HALF; }
+		if (adv & ADVERTISE_1000XFULL) { res |= NET_1000FULL; }
+	} else {
+		if (adv & ADVERTISE_10HALF) { res |= NET_10HALF; }
+		if (adv & ADVERTISE_10FULL) { res |= NET_10FULL; }
+		if (adv & ADVERTISE_100HALF) { res |= NET_100HALF; }
+		if (adv & ADVERTISE_100FULL) { res |= NET_100FULL; }
+	}
 
 	return res;
 }


### PR DESCRIPTION
Issues were related to bit-field interleaving

Also fixed FEC driver options to be able to select best speed