### PR TITLE
Pjsip stm32f4 cube

### DIFF
--- a/platform/pjsip/templates/stm32f4cube/build.conf
+++ b/platform/pjsip/templates/stm32f4cube/build.conf
@@ -1,0 +1,13 @@
+
+TARGET = embox
+
+PLATFORM = stm32f4
+
+ARCH = arm
+
+CROSS_COMPILE = arm-none-eabi-
+
+CFLAGS += -Os -g -Wno-maybe-uninitialized
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+
+LDFLAGS += -N -g

--- a/platform/pjsip/templates/stm32f4cube/lds.conf
+++ b/platform/pjsip/templates/stm32f4cube/lds.conf
@@ -1,0 +1,15 @@
+/*
+ * Linkage configuration.
+ */
+
+/* region (origin, length) */
+ROM (0x08000000, 1M)
+RAM (0x20000000, 128K)
+region(SRAM_CCM, 0x10000000, 64K)
+
+/* section (region[, lma_region]) */
+text   (ROM)
+rodata (ROM)
+data   (RAM, ROM)
+bss    (RAM)
+__section(heap, SRAM_CCM, )

--- a/platform/pjsip/templates/stm32f4cube/mods.config
+++ b/platform/pjsip/templates/stm32f4cube/mods.config
@@ -1,0 +1,106 @@
+
+package genconfig
+
+configuration conf {
+	@Runlevel(0) include embox.arch.system(core_freq=144000000)
+	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
+	@Runlevel(0) include third_party.bsp.stmf4cube.arch
+
+	@Runlevel(0) include embox.kernel.stack(stack_size=7200,alignment=4)
+
+	@Runlevel(0) include embox.arch.arm.armmlib.interrupt_prio
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
+	/*@Runlevel(1) include embox.driver.interrupt.cmsis_nvic*/
+	@Runlevel(1) include embox.driver.clock.cortexm_systick
+
+	@Runlevel(1) include embox.driver.serial.stm_usart_f4(baud_rate=115200, usartx=6)
+	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f4")
+
+	include embox.driver.serial.core_notty
+
+	@Runlevel(2) include embox.driver.net.stm32f4cube_eth
+
+	@Runlevel(2) include embox.driver.audio.stm32f4_pa_cube(sample_rate=8000,volume=70)
+
+	include embox.kernel.task.single
+	include embox.kernel.task.resource.idesc_table(idesc_table_size=8)
+
+	include embox.net.util.protoent(max_aliases_num=0)
+	include embox.net.util.servent(max_aliases_num=0)
+	include embox.net.util.hostent(max_aliases_num=0,max_addrs_num=0)
+
+	include embox.compat.posix.proc.exec_stub
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.timer.sys_timer(timer_quantity=2)
+	include embox.kernel.sched.sched
+	include embox.kernel.sched.idle_light
+
+	include embox.net.skbuff(amount_skb=3)
+	include embox.net.skbuff_data(amount_skb_data=3,data_size=810)
+	include embox.net.sock_noxattr
+	include embox.net.af_inet(amount_inet_sock=5)
+	include embox.compat.posix.net.getaddrinfo(addrinfo_pool_size=1)
+	@Runlevel(2) include embox.net.core(amount_interface=2)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev(netdev_quantity=2)
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.ipv4(max_uncomplete_cnt=0)
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.neighbour(neighbour_amount=2)
+	@Runlevel(2) include embox.net.netfilter(amount_rules=0)
+
+	include embox.kernel.lthread.lthread
+	include embox.kernel.thread.core(thread_pool_size=2,thread_stack_size=3600)
+	include embox.kernel.thread.signal.siginfoq(pool_sz=1)
+
+	/* tty requires */
+	include embox.kernel.thread.mutex
+	include embox.driver.char_dev_stub
+	include embox.driver.tty.task_breaking_disable
+
+	include embox.fs.syslib.file_system_full(flock_quantity=0)
+	include embox.fs.driver.fs_driver(drivers_quantity=0)
+	include embox.fs.filesystem(fs_quantity=0, mount_desc_quantity=0)
+	include embox.fs.file_desc(fdesc_quantity=0)
+	include embox.fs.node(fnode_quantity=1)
+	include embox.fs.core
+
+	@Runlevel(2) include embox.cmd.shell(history_size=2)
+	include embox.init.setup_tty_diag
+	@Runlevel(3) include embox.init.start_script(shell_name="diag_shell")
+
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.route
+	include embox.cmd.net.arp
+	include embox.util.log
+	include embox.util.hashtable
+	include embox.kernel.critical
+
+	include embox.kernel.irq_static
+	include embox.kernel.irq_stack_protection
+	include embox.mem.pool_adapter
+
+	include embox.framework.embuild
+	include embox.arch.arm.libarch
+
+	include embox.compat.libc.stdio.print(support_floating=1)
+	include embox.compat.libc.math_openlibm
+	include embox.compat.libc.stdio.file_pool(file_quantity=0)
+
+	include embox.mem.heap_bm
+	include embox.mem.static_heap(heap_size=0x10000,section="")
+	include embox.mem.static_heap2(heap_size=57800)
+	include embox.mem.bitmask(page_size=64)
+
+	/*include third_party.pjproject.streamutil*/
+	/*include third_party.pjproject.pjsua*/
+	include third_party.pjproject.simpleua
+	include embox.compat.posix.proc.vfork_stub
+	include embox.compat.posix.proc.exec_stub
+
+	include third_party.bsp.stmf4cube.core(eth_rx_packet_count=3, eth_tx_packet_count=0)
+	include third_party.bsp.stmf4cube.cmsis
+	include third_party.bsp.stmf4cube.stm32f4_discovery_bsp
+}

--- a/platform/pjsip/templates/stm32f4cube/start_script.inc
+++ b/platform/pjsip/templates/stm32f4cube/start_script.inc
@@ -1,0 +1,6 @@
+"ifconfig lo 127.0.0.1 netmask 255.0.0.0 up",
+"route add 127.0.0.0 netmask 255.0.0.0 lo",
+
+"ifconfig eth0 192.168.1.128 netmask 255.255.255.0 up",
+"route add 192.168.1.0 netmask 255.255.255.0 eth0",
+"pjsip_simpleua",

--- a/platform/pjsip/templates/stm32f4discovery/mods.config
+++ b/platform/pjsip/templates/stm32f4discovery/mods.config
@@ -13,6 +13,8 @@ configuration conf {
 	@Runlevel(1) include embox.driver.clock.cortexm_systick
 	@Runlevel(1) include embox.driver.serial.stm_usart(baud_rate=115200,usartx=6)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart")
+	include embox.driver.serial.core_notty
+
 	@Runlevel(2) include embox.driver.net.stm32f4_eth
 	//@Runlevel(2) include embox.driver.net.loopback
 	@Runlevel(2) include embox.driver.audio.stm32f4_pa(sample_rate=8000,volume=70)

--- a/src/arch/arm/armlib/boot/reset_handler.S
+++ b/src/arch/arm/armlib/boot/reset_handler.S
@@ -6,6 +6,7 @@
  */
 #include <asm/modes.h>
 #include <asm/regs.h>
+#include <asm/cp15.h>
 #include <framework/mod/options.h>
 
 /* OPTION_GET(NUMBER,irq_stack_size) */

--- a/src/arch/arm/armmlib/Mybuild
+++ b/src/arch/arm/armmlib/Mybuild
@@ -13,6 +13,13 @@ module interrupt extends embox.arch.interrupt {
 	depends locore
 }
 
+/* This module setup the greater priority for faults (UsageFault, BusFault, MemFault)
+ * and lower priority for any other interrupts and exceptions. */
+module interrupt_prio extends embox.arch.interrupt {
+	source "ipl_impl_prio.h"
+	depends locore
+}
+
 module context extends embox.arch.context {
 	source "context.c",
 		"context.h",

--- a/src/arch/arm/armmlib/exception_handlers.c
+++ b/src/arch/arm/armmlib/exception_handlers.c
@@ -10,16 +10,20 @@
 #include <kernel/panic.h>
 #include <kernel/printk.h>
 #include <hal/context.h>
+#include <hal/reg.h>
 
-#define NMI        2
-#define HARD_FAULT 3
+/* SCB - System Control Block */
+#define SCB_BASE 0xe000ed00
+#define SCB_CONF_FAULT_STATUS (SCB_BASE + 0x28)
+#define SCB_HARD_FAULT_STATUS  (SCB_BASE + 0x2C)
 
-static void nmi_handler(void) {
-	panic("\n%s\n", __func__);
-}
+static void print_fault_status(void) {
+	uint32_t conf_faults = REG_LOAD(SCB_CONF_FAULT_STATUS);
 
-static void hard_fault(void) {
-	panic("\n%s\n", __func__);
+	printk("Memory Management Fault Status register = %x\n", conf_faults & 0xf);
+	printk("Bus Fault Status register = %x\n", (conf_faults >> 8) & 0xf);
+	printk("Usage Fault Status register = %x\n", (conf_faults >> 16) & 0xff);
+	printk("Hard Fault Status register = %lx\n", REG_LOAD(SCB_HARD_FAULT_STATUS));
 }
 
 /* Print exception info and return */
@@ -27,20 +31,13 @@ void exc_default_handler(struct exc_saved_base_ctx *ctx, int xpsr) {
 	int exp_nr = xpsr & 0xFF;
 
 	printk("\nEXCEPTION (0x%x):\n"
-			"r0=%08x r1=%08x r2=%08x r3=%08x\n"
-			"r12=%08x lr=%08x pc=%08x xPSR=%08x\n",
+			"Exception saved context:\n"
+			"  r0=%08x r1=%08x r2=%08x r3=%08x\n"
+			"  r12=%08x lr=%08x pc=%08x xPSR=%08x\n",
 			exp_nr,
 			ctx->r[0], ctx->r[1], ctx->r[2], ctx->r[3],
 			ctx->r[4], ctx->lr, ctx->pc, ctx->psr);
 
-	switch (exp_nr) {
-	case NMI:
-		nmi_handler();
-		break;
-	case HARD_FAULT:
-		hard_fault();
-		break;
-	default:
-		break;
-	}
+	print_fault_status();
+	panic("\n%s\n", __func__);
 }

--- a/src/arch/arm/armmlib/ipl_impl_prio.h
+++ b/src/arch/arm/armmlib/ipl_impl_prio.h
@@ -1,0 +1,49 @@
+/**
+ * @file
+ *
+ * @date 29.08.18
+ * @author Alexander Kalmuk
+ */
+
+#ifndef HAL_IPL_H_
+# error "Do not include this file directly!"
+#endif /* HAL_IPL_H_ */
+
+#include <stdint.h>
+
+#include <cortexm/arch.h>
+
+#define IRQ_MIN_NONFAULT_PRIO (1 << IRQ_PRIO_SHIFT)
+
+typedef uint32_t __ipl_t;
+
+static inline void ipl_init(void) {
+	uint32_t ipl = 0;
+	__asm__ __volatile__ (
+		"cpsie i \n\t");
+
+	__asm__ __volatile__ (
+		"msr BASEPRI, %0;\n\t"
+		:
+		: "r"(ipl));
+}
+
+static inline __ipl_t ipl_save(void) {
+	uint32_t r;
+	uint32_t prio = IRQ_MIN_NONFAULT_PRIO;
+	__asm__ __volatile__ (
+		"mrs %0, BASEPRI;\n\t"
+		: "=r"(r));
+	__asm__ __volatile__ (
+		"msr BASEPRI, %0;\n\t"
+		:
+		: "r"(prio));
+	return r;
+}
+
+static inline void ipl_restore(__ipl_t ipl) {
+	__asm__ __volatile__ (
+		"msr BASEPRI, %0;\n\t"
+		:
+		: "r"(ipl));
+}

--- a/src/arch/arm/include/asm/regs.h
+++ b/src/arch/arm/include/asm/regs.h
@@ -20,8 +20,6 @@
 
 #endif /* __ASSEMBLER__ */
 
-#include <asm/cp15.h>
-
 /**
  * c1, Auxiliary Control Register
  * read: MRC p15, 0, <Rd>, c1, c0, 1

--- a/src/drivers/audio/portaudio/Mybuild
+++ b/src/drivers/audio/portaudio/Mybuild
@@ -33,6 +33,25 @@ module stm32f4_pa extends portaudio_api {
 	depends embox.kernel.irq_api
 }
 
+@BuildDepends(third_party.bsp.stmf4cube.core)
+module stm32f4_pa_cube extends portaudio_api {
+	option number volume=70
+	option number sample_rate
+	option number buf_cnt=0x4
+	source "stm32f4_pa_cube.c"
+
+	@IncludeExport(path="drivers/audio")
+	source "portaudio.h"
+
+	depends third_party.bsp.stmf4cube.core
+	depends embox.util.DList
+	depends embox.compat.libc.assert
+	depends embox.compat.posix.util.sleep
+	depends embox.mem.pool
+	depends embox.mem.heap_api
+	depends embox.kernel.irq_api
+}
+
 module portaudio_stub extends portaudio_api {
 	source "portaudio_stub.c"
 

--- a/src/drivers/audio/portaudio/stm32f4_pa_cube.c
+++ b/src/drivers/audio/portaudio/stm32f4_pa_cube.c
@@ -1,0 +1,333 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 25.09.14
+ * @author Ilia Vaprol
+ * @author Alexander Kalmuk
+ *           Adaptation for STM32F4 Cube
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <linux/byteorder.h>
+#include <util/err.h>
+
+#include <framework/mod/options.h>
+#include <kernel/irq.h>
+#include <kernel/thread.h>
+#include <kernel/thread/thread_sched_wait.h>
+#include <kernel/panic.h>
+#include <kernel/printk.h>
+#include <mem/misc/pool.h>
+#include <util/dlist.h>
+#include <util/bit.h>
+
+#include <drivers/audio/portaudio.h>
+
+#include "stm32f4_discovery_audio.h"
+
+extern void Audio_MAL_I2S_IRQHandler(void);
+
+#define MODOPS_VOLUME      OPTION_GET(NUMBER, volume)
+#define MODOPS_SAMPLE_RATE OPTION_GET(NUMBER, sample_rate)
+#define MODOPS_BUF_CNT     OPTION_GET(NUMBER, buf_cnt)
+
+#define D(fmt, ...) \
+	do { \
+		printk("%s" fmt "\n", __VA_ARGS__); \
+	} while (0)
+
+#define STM32F4_AUDIO_I2S_DMA_IRQ (I2S3_DMAx_IRQ + 16)
+
+#define MAX_BUF_LEN (160 * 6)
+#define OUTPUT_CHAN_N 2
+#define BUF_N 2
+
+struct pa_strm {
+	int started;
+	int paused;
+	int completed;
+	int sample_format;
+	PaStreamCallback *callback;
+	void *callback_data;
+	size_t chan_buf_len;
+	uint16_t in_buf[MAX_BUF_LEN];
+	uint16_t out_buf[MAX_BUF_LEN * OUTPUT_CHAN_N * BUF_N];
+	volatile unsigned char out_buf_empty_mask;
+};
+static_assert(BUF_N <= 8);
+
+static struct thread *pa_thread;
+static struct pa_strm pa_stream;
+
+static irq_return_t stm32f4_audio_i2s_dma_interrupt(unsigned int irq_num, void *dev_id);
+
+static void strm_get_data(struct pa_strm *strm, int buf_index) {
+	uint16_t *buf;
+	int i_in, rc;
+
+	rc = strm->callback(NULL, strm->in_buf, strm->chan_buf_len, NULL, 0, strm->callback_data);
+	if (rc == paComplete) {
+		strm->completed = 1;
+	}
+	else assert(rc == paContinue);
+
+	buf = strm->out_buf + buf_index * strm->chan_buf_len * OUTPUT_CHAN_N;
+	for (i_in = 0; i_in < strm->chan_buf_len; ++i_in) {
+		const uint16_t hw_frame = le16_to_cpu(strm->in_buf[i_in]);
+		int i_out;
+
+		for (i_out = 0; i_out < OUTPUT_CHAN_N; ++i_out) {
+			buf[i_in * OUTPUT_CHAN_N + i_out] = hw_frame;
+		}
+	}
+}
+
+static void *pa_thread_hnd(void *arg) {
+	struct pa_strm *strm = arg;
+
+	while (1) {
+		SCHED_WAIT(strm->out_buf_empty_mask);
+
+		if (!strm->completed) {
+			unsigned char empty_mask;
+			int buf_index;
+
+			empty_mask = strm->out_buf_empty_mask;
+
+			static_assert(BUF_N == 2);
+			if (empty_mask < 3) {
+				/* 0 - impossible; 1 -> 0; 2 -> 1 */
+				buf_index = empty_mask >> 1;
+			} else {
+				/* there are some empty buffers, but should be 1 */
+				printk("stm32f4_pa: underrun!\n");
+				buf_index = bit_ffs(empty_mask);
+			}
+
+			if (buf_index == 1) {
+				BSP_AUDIO_OUT_Play(strm->out_buf,
+						strm->chan_buf_len * OUTPUT_CHAN_N * BUF_N * sizeof(uint16_t));
+			}
+
+			strm_get_data(strm, buf_index);
+
+			irq_lock();
+			strm->out_buf_empty_mask &= ~(1 << buf_index);
+			irq_unlock();
+		} else {
+			BSP_AUDIO_OUT_Stop(CODEC_PDWN_HW);
+		}
+	}
+
+	return NULL;
+}
+
+PaError Pa_Initialize(void) {
+	D("", __func__);
+
+	return paNoError;
+}
+
+PaError Pa_Terminate(void) {
+	D("", __func__);
+
+	return paNoError;
+}
+
+PaHostApiIndex Pa_GetHostApiCount(void) { return 1; }
+PaDeviceIndex Pa_GetDeviceCount(void) { return 1; }
+PaDeviceIndex Pa_GetDefaultOutputDevice(void) { return 0; }
+
+const char * Pa_GetErrorText(PaError errorCode) {
+	D(": %d", __func__, errorCode);
+	return "Pa_GetErrorText not implemented";
+}
+
+const PaDeviceInfo * Pa_GetDeviceInfo(PaDeviceIndex device) {
+	static const PaDeviceInfo info = {
+		.structVersion = 1,
+		.name = "stm32f4_audio",
+		.hostApi = 0,
+		.maxInputChannels = 1,
+		.maxOutputChannels = 1,
+		.defaultLowInputLatency = 0,
+		.defaultLowOutputLatency = 0,
+		.defaultHighInputLatency = 0,
+		.defaultHighOutputLatency = 0,
+		.defaultSampleRate = MODOPS_SAMPLE_RATE
+	};
+
+	D(": %d = %p", __func__, device, device == 0 ? &info : NULL);
+	return device == 0 ? &info : NULL;
+}
+
+const PaHostApiInfo * Pa_GetHostApiInfo(PaHostApiIndex hostApi) {
+	D(": %d = NULL", __func__, hostApi);
+	return NULL;
+}
+
+const PaStreamInfo * Pa_GetStreamInfo(PaStream *stream) {
+	static PaStreamInfo info = {
+		.structVersion = 1,
+		.inputLatency = 0,
+		.outputLatency = 0,
+		.sampleRate = MODOPS_SAMPLE_RATE
+	};
+
+	D(": %p = %p", __func__, stream, stream != NULL ? &info : NULL);
+	return stream != NULL ? &info : NULL;
+}
+
+PaError Pa_OpenStream(PaStream** stream,
+		const PaStreamParameters *inputParameters,
+		const PaStreamParameters *outputParameters,
+		double sampleRate, unsigned long framesPerBuffer,
+		PaStreamFlags streamFlags, PaStreamCallback *streamCallback,
+		void *userData) {
+	struct pa_strm *strm;
+
+	assert(stream != NULL);
+	/*assert(inputParameters == NULL);*/
+	assert(outputParameters != NULL);
+	assert(outputParameters->device == 0);
+	assert(outputParameters->channelCount == 1);
+	assert(outputParameters->sampleFormat == paInt16);
+	assert(outputParameters->hostApiSpecificStreamInfo == 0);
+	assert(streamFlags == paNoFlag || streamFlags == paClipOff);
+	assert(streamCallback != NULL);
+	assert(framesPerBuffer <= MAX_BUF_LEN);
+
+	D(": %p %p %p %f %lu %lu %p %p", __func__, stream, inputParameters,
+			outputParameters, sampleRate, framesPerBuffer, streamFlags, streamCallback, userData);
+
+	strm = &pa_stream;
+	strm->started = 0;
+	strm->paused = 0;
+	strm->completed = 0;
+	strm->sample_format = outputParameters->sampleFormat;
+	strm->chan_buf_len = (MAX_BUF_LEN / framesPerBuffer) * framesPerBuffer;
+	strm->callback = streamCallback;
+	strm->callback_data = userData;
+	strm->out_buf_empty_mask = 0;
+
+	pa_thread = thread_create(0, pa_thread_hnd, strm);
+	if (err(pa_thread)) {
+		goto err_out;
+	}
+
+	if (0 != irq_attach(STM32F4_AUDIO_I2S_DMA_IRQ, stm32f4_audio_i2s_dma_interrupt,
+				0, strm, "stm32f4_audio")) {
+		goto err_thread_free;
+	}
+
+	if (0 != BSP_AUDIO_OUT_Init(OUTPUT_DEVICE_HEADPHONE, MODOPS_VOLUME,
+				sampleRate)) {
+		goto err_irq_detach;
+	}
+
+	*stream = &pa_stream;
+	return paNoError;
+
+err_irq_detach:
+	irq_detach(STM32F4_AUDIO_I2S_DMA_IRQ, NULL);
+err_thread_free:
+	thread_delete(pa_thread);
+	pa_thread = NULL;
+err_out:
+	return paUnanticipatedHostError;
+}
+
+PaError Pa_CloseStream(PaStream *stream) {
+	D(": %p", __func__, stream);
+
+	BSP_AUDIO_OUT_Stop(CODEC_PDWN_HW);
+
+	irq_detach(STM32F4_AUDIO_I2S_DMA_IRQ, NULL);
+
+	thread_delete(pa_thread);
+	pa_thread = NULL;
+
+	return paNoError;
+}
+
+PaError Pa_StartStream(PaStream *stream) {
+	struct pa_strm *strm;
+
+	D(": %p", __func__, stream);
+
+	assert(stream != NULL);
+	strm = (struct pa_strm *)stream;
+
+	assert(!strm->started || strm->paused);
+
+	if (!strm->started) {
+		strm->out_buf_empty_mask = 0;
+
+		if (0 != BSP_AUDIO_OUT_Play(strm->out_buf,
+					strm->chan_buf_len * OUTPUT_CHAN_N * BUF_N * sizeof(uint16_t))) {
+			return paInternalError;
+		}
+		printk("playing\n");
+		strm->started = 1;
+	} else {
+		assert(strm->paused);
+
+		if (0 != BSP_AUDIO_OUT_Resume()) {
+			return paInternalError;
+		}
+		strm->paused = 0;
+	}
+
+	return paNoError;
+}
+
+PaError Pa_StopStream(PaStream *stream) {
+	struct pa_strm *strm;
+
+	D(": %p", __func__, stream);
+
+	assert(stream != NULL);
+	strm = (struct pa_strm *)stream;
+
+	assert(strm->started && !strm->paused);
+
+	if (0 != BSP_AUDIO_OUT_Pause()) {
+		return paInternalError;
+	}
+
+	strm->paused = 1;
+
+	return paNoError;
+}
+
+void Pa_Sleep(long msec) {
+	D(" %ld", __func__, msec);
+	usleep(msec * USEC_PER_MSEC);
+}
+
+static void stm32f4_audio_irq_fill_buffer(int buf_index) {
+	pa_stream.out_buf_empty_mask |= 1 << buf_index;
+	sched_wakeup(&pa_thread->schedee);
+}
+
+void BSP_AUDIO_OUT_HalfTransfer_CallBack(void) {
+	stm32f4_audio_irq_fill_buffer(0);
+}
+
+void BSP_AUDIO_OUT_TransferComplete_CallBack(void) {
+	stm32f4_audio_irq_fill_buffer(1);
+}
+
+static irq_return_t stm32f4_audio_i2s_dma_interrupt(unsigned int irq_num, void *dev_id) {
+	/* struct pa_strm *strm = dev_id; */
+	extern I2S_HandleTypeDef hAudioOutI2s;
+
+	HAL_DMA_IRQHandler(hAudioOutI2s.hdmatx);
+	return IRQ_HANDLED;
+}
+
+static_assert(63 == STM32F4_AUDIO_I2S_DMA_IRQ);
+STATIC_IRQ_ATTACH(63, stm32f4_audio_i2s_dma_interrupt, &pa_stream);

--- a/src/drivers/net/stm32cube/Mybuild
+++ b/src/drivers/net/stm32cube/Mybuild
@@ -5,7 +5,7 @@ module stm32f4cube_eth {
 	source "stm32cube_eth.c"
 	source "stm32f4cube_eth.c"
 	@IncludeExport(path="drivers/net", target_name="stm32cube_eth.h")
-	source"stm32f4cube_eth.h"
+	source "stm32f4cube_eth.h"
 
 	option number log_level=0
 	depends embox.net.skbuff
@@ -22,7 +22,7 @@ module stm32f7cube_eth {
 	source "stm32f7cube_eth.c"
 	source "stm32cube_eth.c"
 	@IncludeExport(path="drivers/net", target_name="stm32cube_eth.h")
-	source"stm32f7cube_eth.h"
+	source "stm32f7cube_eth.h"
 
 	option number log_level=0
 	depends embox.net.skbuff

--- a/src/kernel/Irq.my
+++ b/src/kernel/Irq.my
@@ -8,6 +8,7 @@ module irq_static extends irq_api {
 	source "irq_static.h"
 	source "arm_m_irq.S"
 	depends irq_lock
+	depends irq_stack
 }
 
 module no_irq extends irq_api {

--- a/src/kernel/irq_static.h
+++ b/src/kernel/irq_static.h
@@ -12,12 +12,20 @@
 #define STATIC_IRQ_EXTENTION
 
 #include <asm-generic/static_irq.h>
+#include <asm/regs.h>
+
+#ifndef __ASSEMBLER__
+#include <assert.h>
+#include <kernel/irq_stack.h>
+#endif
 
 #define STATIC_IRQ_ATTACH(_irq_nr, _hnd, _data) \
 	__STATIC_IRQ_ATTACH(_irq_nr, __static_irq__ ## _irq_nr, _hnd, _data)
 
 #define __STATIC_IRQ_ATTACH(_irq_nr, _static_hnd, _hnd, _data) \
 	static void _static_hnd(void) { \
+		assertf(irq_stack_protection() == 0, \
+			"Stack overflow detected on irq handler %s\n", __func__); \
 		_hnd(_irq_nr, _data); \
 	} \
 	ARM_M_IRQ_HANDLER_DEF(_irq_nr, _static_hnd);

--- a/third-party/bsp/stmf4cube/Makefile
+++ b/third-party/bsp/stmf4cube/Makefile
@@ -1,5 +1,6 @@
 
 PKG_NAME := stm32f4
+PKG_PATCHES := patch.txt
 
 PKG_SOURCES := https://www.dropbox.com/s/kglgqpgw186ho6r/stm32cubef4.zip?dl=0
 PKG_ARCHIVE_NAME :=stm32cubef4.zip

--- a/third-party/bsp/stmf4cube/Mybuild
+++ b/third-party/bsp/stmf4cube/Mybuild
@@ -5,6 +5,8 @@ package third_party.bsp.stmf4cube
 static module core extends third_party.bsp.st_bsp_api {
 
 	option number hse_freq_hz = 8000000 /* STM32F3Discovery oscillator */
+	option number eth_rx_packet_count = 4
+	option number eth_tx_packet_count = 2
 
 	@Cflags("-Wno-unused")
 	@Cflags("-Wno-undef")
@@ -45,6 +47,7 @@ static module core extends third_party.bsp.st_bsp_api {
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c",
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c_ex.c",
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2s.c",
+		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2s_ex.c",
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_irda.c",
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_iwdg.c",
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_lptim.c",
@@ -81,7 +84,6 @@ static module core extends third_party.bsp.st_bsp_api {
 		"STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
 		"STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM324xG_EVAL/stm324xg_eval_sd.c"
 
-
 		@IncludeExport(path="")
 		source "stm32f4xx_hal_conf.h"
 }
@@ -114,13 +116,28 @@ static module stm32f4_discovery_bsp {
 	source "./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery.c",
 			"./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery_accelerometer.c",
 			"./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/STM32F4-Discovery/stm32f4_discovery_audio.c"
+
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Drivers/BSP/Components/cs43l22")
+	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf4cube/core")
+	source "./STM32Cube_FW_F4_V1.13.0/Drivers/BSP/Components/cs43l22/cs43l22.c"
+
+	depends pdm_filter_stub
 }
 
 @Build(stage=1,script="true")
 @BuildDepends(core)
 module arch extends embox.arch.arch {
 	source "arch.c"
+	@IncludeExport(path="cortexm/", target_name="arch.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Drivers/CMSIS/Device/ST/STM32F4xx/Include/")
+	source "arch.h"
 
 	depends system_init
 }
 
+@Build(stage=1,script="true")
+@BuildDepends(core)
+static module pdm_filter_stub {
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Middlewares/ST/STM32_Audio/Addons/PDM")
+	source "pdm_filter_stub.c"
+}

--- a/third-party/bsp/stmf4cube/arch.h
+++ b/third-party/bsp/stmf4cube/arch.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexamder Kalmuk
+ * @date    29.08.2018
+ */
+
+#ifndef STM32F4_ARCH_H_
+#define STM32F4_ARCH_H_
+
+/* Derive it from core_cm4.h */
+#define NVIC_PRIO_BITS 4
+
+#define IRQ_PRIO_SHIFT NVIC_PRIO_BITS
+
+#endif /* STM32F4_ARCH_H_ */

--- a/third-party/bsp/stmf4cube/patch.txt
+++ b/third-party/bsp/stmf4cube/patch.txt
@@ -1,0 +1,19 @@
+diff -aur -x configure ../STM32Cube_FW_F4_V1.13.0-orig/STM32Cube_FW_F4_V1.13.0/Drivers/CMSIS/Include/core_cm4.h STM32Cube_FW_F4_V1.13.0/Drivers/CMSIS/Include/core_cm4.h
+--- ../STM32Cube_FW_F4_V1.13.0-orig/STM32Cube_FW_F4_V1.13.0/Drivers/CMSIS/Include/core_cm4.h	2016-06-27 14:19:18.000000000 +0300
++++ STM32Cube_FW_F4_V1.13.0/Drivers/CMSIS/Include/core_cm4.h	2018-08-29 19:42:46.826045481 +0300
+@@ -1697,6 +1697,7 @@
+  */
+ __STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+ {
++#if 0
+   if ((int32_t)(IRQn) < 0)
+   {
+     SCB->SHP[(((uint32_t)(int32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+@@ -1705,6 +1706,7 @@
+   {
+     NVIC->IP[((uint32_t)(int32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+   }
++#endif
+ }
+ 
+ 

--- a/third-party/bsp/stmf4cube/pdm_filter_stub.c
+++ b/third-party/bsp/stmf4cube/pdm_filter_stub.c
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    24.08.2018
+ */
+
+#include <assert.h>
+
+#include <stm32f4_discovery.h>
+
+#include <pdm_filter.h>
+
+void PDM_Filter_Init(PDMFilter_InitStruct * Filter) {
+	assert(0);
+}
+
+int32_t PDM_Filter_64_MSB(uint8_t* data, uint16_t* dataOut,
+		uint16_t MicGain, PDMFilter_InitStruct * Filter) {
+	assert(0);
+	return -1;
+}
+
+int32_t PDM_Filter_64_LSB(uint8_t* data, uint16_t* dataOut,
+		uint16_t MicGain, PDMFilter_InitStruct * Filter) {
+	assert(0);
+	return -1;
+}

--- a/third-party/bsp/stmf4cube/stm32f4xx_hal_conf.h
+++ b/third-party/bsp/stmf4cube/stm32f4xx_hal_conf.h
@@ -177,8 +177,14 @@
 /* Definition of the Ethernet driver buffers size and count */
 #define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
 #define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
-#define ETH_RXBUFNB                    ((uint32_t)4)       /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
-#define ETH_TXBUFNB                    ((uint32_t)2)       /* 2 Tx buffers of size ETH_TX_BUF_SIZE  */
+
+#include <framework/mod/options.h>
+#include <module/third_party/bsp/stmf4cube/core.h>
+
+#define ETH_RXBUFNB \
+	OPTION_MODULE_GET(third_party__bsp__stmf4cube__core, NUMBER, eth_rx_packet_count)
+#define ETH_TXBUFNB \
+	OPTION_MODULE_GET(third_party__bsp__stmf4cube__core, NUMBER, eth_tx_packet_count)
 
 
 /* Section 2: PHY configuration section */

--- a/third-party/bsp/stmf7cube/Mybuild
+++ b/third-party/bsp/stmf7cube/Mybuild
@@ -5,6 +5,8 @@ package third_party.bsp.stmf7cube
 static module core extends third_party.bsp.st_bsp_api {
 
 	option number hse_freq_hz = 8000000 /* STM32F3Discovery oscillator */
+	option number eth_rx_packet_count = 5
+	option number eth_tx_packet_count = 5
 
 	@Cflags("-Wno-unused")
 	@DefineMacro("STM32F746xx")
@@ -78,6 +80,9 @@ static module core extends third_party.bsp.st_bsp_api {
 		"STM32Cube_FW_F7_V1.5.0/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_sdmmc.c",
 		"STM32Cube_FW_F7_V1.5.0/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c",
 		"STM32Cube_FW_F7_V1.5.0/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_ltdc.c"
+
+		@IncludeExport(path="")
+		source "stm32f7xx_hal_conf.h"
 }
 
 @BuildDepends(core)

--- a/third-party/bsp/stmf7cube/stm32f7xx_hal_conf.h
+++ b/third-party/bsp/stmf7cube/stm32f7xx_hal_conf.h
@@ -1,0 +1,431 @@
+/**
+  ******************************************************************************
+  * @file    BSP/inc/stm32f7xx_hal_conf.h
+  * @author  MCD Application Team
+  * @version V1.0.3
+  * @date    22-April-2016 
+  * @brief   HAL configuration file. 
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F7xx_HAL_CONF_H
+#define __STM32F7xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+#define HAL_MODULE_ENABLED  
+/* #define HAL_ADC_MODULE_ENABLED    */  
+/* #define HAL_CAN_MODULE_ENABLED    */  
+/* #define HAL_CRC_MODULE_ENABLED    */  
+/* #define HAL_CRYP_MODULE_ENABLED   */ 
+/* #define HAL_DAC_MODULE_ENABLED    */  
+#define HAL_DCMI_MODULE_ENABLED 
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_DMA2D_MODULE_ENABLED 
+/* #define HAL_ETH_MODULE_ENABLED    */ 
+#define HAL_FLASH_MODULE_ENABLED 
+/* #define HAL_NAND_MODULE_ENABLED   */
+#define HAL_NOR_MODULE_ENABLED
+/* #define HAL_PCCARD_MODULE_ENABLED */
+#define HAL_SRAM_MODULE_ENABLED
+#define HAL_SDRAM_MODULE_ENABLED
+/* #define HAL_HASH_MODULE_ENABLED   */ 
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_I2S_MODULE_ENABLED
+/* #define HAL_IWDG_MODULE_ENABLED   */ 
+#define HAL_LTDC_MODULE_ENABLED 
+#define HAL_PWR_MODULE_ENABLED   
+#define HAL_QSPI_MODULE_ENABLED   
+#define HAL_RCC_MODULE_ENABLED 
+/* #define HAL_RNG_MODULE_ENABLED    */  
+/* #define HAL_RTC_MODULE_ENABLED    */
+#define HAL_SAI_MODULE_ENABLED
+#define HAL_SD_MODULE_ENABLED
+/* #define HAL_SPDIFRX_MODULE_ENABLED */
+/* #define HAL_SPI_MODULE_ENABLED    */
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED 
+/* #define HAL_USART_MODULE_ENABLED  */ 
+/* #define HAL_IRDA_MODULE_ENABLED   */ 
+/* #define HAL_SMARTCARD_MODULE_ENABLED */
+/* #define HAL_WWDG_MODULE_ENABLED   */ 
+#define HAL_CORTEX_MODULE_ENABLED
+/* #define HAL_PCD_MODULE_ENABLED    */
+/* #define HAL_HCD_MODULE_ENABLED    */
+
+
+/* ########################## HSE/HSI Values adaptation ##################### */
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)25000000U) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100U)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE) 
+ #define LSI_VALUE  ((uint32_t)32000U)       /*!< LSI Typical Value in Hz*/    
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768U)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000U)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source 
+  *        frequency, this source is inserted directly through I2S_CKIN pad. 
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)12288000U) /*!< Value of the Internal oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
+#define  VDD_VALUE                    ((uint32_t)3300U) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0x0FU) /*!< tick interrupt priority */
+#define  USE_RTOS                     0U
+#define  PREFETCH_ENABLE              1U
+#define  ART_ACCLERATOR_ENABLE        1U /* To enable instruction cache and prefetch */
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1 */
+
+/* ################## Ethernet peripheral configuration ##################### */
+
+/* Section 1 : Ethernet peripheral configuration */
+
+/* MAC ADDRESS: MAC_ADDR0:MAC_ADDR1:MAC_ADDR2:MAC_ADDR3:MAC_ADDR4:MAC_ADDR5 */
+#define MAC_ADDR0   2U
+#define MAC_ADDR1   0U
+#define MAC_ADDR2   0U
+#define MAC_ADDR3   0U
+#define MAC_ADDR4   0U
+#define MAC_ADDR5   0U
+
+/* Definition of the Ethernet driver buffers size and count */   
+#define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
+#define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
+
+#include <framework/mod/options.h>
+#include <module/third_party/bsp/stmf7cube/core.h>
+
+#define ETH_RXBUFNB \
+	OPTION_MODULE_GET(third_party__bsp__stmf7cube__core, NUMBER, eth_rx_packet_count)
+#define ETH_TXBUFNB \
+	OPTION_MODULE_GET(third_party__bsp__stmf7cube__core, NUMBER, eth_tx_packet_count)
+
+/* Section 2: PHY configuration section */
+/* LAN8742A PHY Address*/
+#define LAN8742A_PHY_ADDRESS            0x00U
+/* PHY Reset delay these values are based on a 1 ms Systick interrupt*/ 
+#define PHY_RESET_DELAY                 ((uint32_t)0x00000FFFU)
+/* PHY Configuration delay */
+#define PHY_CONFIG_DELAY                ((uint32_t)0x00000FFFU)
+
+#define PHY_READ_TO                     ((uint32_t)0x0000FFFFU)
+#define PHY_WRITE_TO                    ((uint32_t)0x0000FFFFU)
+
+/* Section 3: Common PHY Registers */
+
+#define PHY_BCR                         ((uint16_t)0x00U)    /*!< Transceiver Basic Control Register   */
+#define PHY_BSR                         ((uint16_t)0x01U)    /*!< Transceiver Basic Status Register    */
+ 
+#define PHY_RESET                       ((uint16_t)0x8000U)  /*!< PHY Reset */
+#define PHY_LOOPBACK                    ((uint16_t)0x4000U)  /*!< Select loop-back mode */
+#define PHY_FULLDUPLEX_100M             ((uint16_t)0x2100U)  /*!< Set the full-duplex mode at 100 Mb/s */
+#define PHY_HALFDUPLEX_100M             ((uint16_t)0x2000U)  /*!< Set the half-duplex mode at 100 Mb/s */
+#define PHY_FULLDUPLEX_10M              ((uint16_t)0x0100U)  /*!< Set the full-duplex mode at 10 Mb/s  */
+#define PHY_HALFDUPLEX_10M              ((uint16_t)0x0000U)  /*!< Set the half-duplex mode at 10 Mb/s  */
+#define PHY_AUTONEGOTIATION             ((uint16_t)0x1000U)  /*!< Enable auto-negotiation function     */
+#define PHY_RESTART_AUTONEGOTIATION     ((uint16_t)0x0200U)  /*!< Restart auto-negotiation function    */
+#define PHY_POWERDOWN                   ((uint16_t)0x0800U)  /*!< Select the power down mode           */
+#define PHY_ISOLATE                     ((uint16_t)0x0400U)  /*!< Isolate PHY from MII                 */
+
+#define PHY_AUTONEGO_COMPLETE           ((uint16_t)0x0020U)  /*!< Auto-Negotiation process completed   */
+#define PHY_LINKED_STATUS               ((uint16_t)0x0004U)  /*!< Valid link established               */
+#define PHY_JABBER_DETECTION            ((uint16_t)0x0002U)  /*!< Jabber condition detected            */
+  
+/* Section 4: Extended PHY Registers */
+
+#define PHY_SR                          ((uint16_t)0x1FU)    /*!< PHY special control/ status register Offset     */
+
+#define PHY_SPEED_STATUS                ((uint16_t)0x0004U)  /*!< PHY Speed mask                                  */
+#define PHY_DUPLEX_STATUS               ((uint16_t)0x0010U)  /*!< PHY Duplex mask                                 */
+
+
+#define PHY_ISFR                        ((uint16_t)0x1DU)    /*!< PHY Interrupt Source Flag register Offset       */
+#define PHY_ISFR_INT4                   ((uint16_t)0x0010U)  /*!< PHY Link down inturrupt                         */   
+
+/* ################## SPI peripheral configuration ########################## */
+
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+* Activated: CRC code is present inside driver
+* Deactivated: CRC code cleaned from driver
+*/
+
+#define USE_SPI_CRC                     1U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32f7xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32f7xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32f7xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+   
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32f7xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32f7xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CAN_MODULE_ENABLED
+  #include "stm32f7xx_hal_can.h"
+#endif /* HAL_CAN_MODULE_ENABLED */
+
+#ifdef HAL_CEC_MODULE_ENABLED
+  #include "stm32f7xx_hal_cec.h"
+#endif /* HAL_CEC_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32f7xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32f7xx_hal_cryp.h" 
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DMA2D_MODULE_ENABLED
+  #include "stm32f7xx_hal_dma2d.h"
+#endif /* HAL_DMA2D_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+  #include "stm32f7xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_DCMI_MODULE_ENABLED
+  #include "stm32f7xx_hal_dcmi.h"
+#endif /* HAL_DCMI_MODULE_ENABLED */
+
+#ifdef HAL_ETH_MODULE_ENABLED
+  #include "stm32f7xx_hal_eth.h"
+#endif /* HAL_ETH_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32f7xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+ 
+#ifdef HAL_SRAM_MODULE_ENABLED
+  #include "stm32f7xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+  #include "stm32f7xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+  #include "stm32f7xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+
+#ifdef HAL_SDRAM_MODULE_ENABLED
+  #include "stm32f7xx_hal_sdram.h"
+#endif /* HAL_SDRAM_MODULE_ENABLED */      
+
+#ifdef HAL_HASH_MODULE_ENABLED
+ #include "stm32f7xx_hal_hash.h"
+#endif /* HAL_HASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32f7xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32f7xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32f7xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+ #include "stm32f7xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_LTDC_MODULE_ENABLED
+ #include "stm32f7xx_hal_ltdc.h"
+#endif /* HAL_LTDC_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32f7xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_QSPI_MODULE_ENABLED
+ #include "stm32f7xx_hal_qspi.h"
+#endif /* HAL_QSPI_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+ #include "stm32f7xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32f7xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+ #include "stm32f7xx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SD_MODULE_ENABLED
+ #include "stm32f7xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */
+
+#ifdef HAL_SPDIFRX_MODULE_ENABLED
+ #include "stm32f7xx_hal_spdifrx.h"
+#endif /* HAL_SPDIFRX_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32f7xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32f7xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32f7xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32f7xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32f7xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32f7xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32f7xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+ #include "stm32f7xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+ #include "stm32f7xx_hal_hcd.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+   
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F7xx_HAL_CONF_H */
+ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Porting pjsip on stm32f4-discovery to STM32F4 Cube. The porting process incudes:

* Improvement of ethernet driver to xmit skbuff immediately without extra buffers allocation
* Add new ipl_impl_prio.h, which implements ipl_save and ipl_restore basing on the following logic. Let's change the prio of faults (mem fault, bus fault and usage fault) to 0. And all other interrupts and exceptions to 1. So we can allow generating of fault even inside ipl_lock/unlock without hard fault excalation.
* Add new stm32f4_pa_cube.c, which is a port of stm32f4_pa.c portaudio layer to Cube.