### PR TITLE
idesc_mmap: Refactor

### DIFF
--- a/platform/mesa/templates/integratorcp/mods.config
+++ b/platform/mesa/templates/integratorcp/mods.config
@@ -170,7 +170,7 @@ configuration conf {
 	include embox.compat.posix.fs.rewinddir_stub
 
 	include embox.driver.video.fb_devfs_old
-	include embox.fs.syslib.idesc_mmap_oldfs
+	include embox.fs.syslib.idesc_mmap
 	include embox.cmd.fb_devfs_access
 	include embox.cmd.fb_direct_access
 /*

--- a/platform/nuklear/templates/arm_qemu/mods.config
+++ b/platform/nuklear/templates/arm_qemu/mods.config
@@ -170,7 +170,7 @@ configuration conf {
 	include embox.compat.posix.fs.rewinddir_stub
 
 	include embox.driver.video.fb_devfs_old
-	include embox.fs.syslib.idesc_mmap_oldfs
+	include embox.fs.syslib.idesc_mmap
 	include embox.cmd.fb_devfs_access
 	include embox.cmd.fb_direct_access
 

--- a/src/fs/syslib/idesc_mmap/Mybuild
+++ b/src/fs/syslib/idesc_mmap/Mybuild
@@ -1,14 +1,14 @@
 package embox.fs.syslib
 
 @DefaultImpl(idesc_mmap_stub)
-abstract module idesc_mmap {
+abstract module idesc_mmap_api {
 }
 
-module idesc_mmap_stub extends idesc_mmap {
+module idesc_mmap_stub extends idesc_mmap_api {
 	source "idesc_mmap_stub.h"
 }
 
-module idesc_mmap_oldfs extends idesc_mmap {
+module idesc_mmap extends idesc_mmap_api {
 	source "idesc_mmap_decl.h"
-	source "idesc_mmap_oldfs.c"
+	source "idesc_mmap.c"
 }

--- a/src/fs/syslib/idesc_mmap/idesc_mmap.c
+++ b/src/fs/syslib/idesc_mmap/idesc_mmap.c
@@ -14,7 +14,7 @@
 #include <fs/idesc.h>
 #include <kernel/task/resource/idesc_table.h>
 
-#include <module/embox/fs/syslib/idesc_mmap.h>
+#include <module/embox/fs/syslib/idesc_mmap_api.h>
 
 void *
 idesc_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {

--- a/src/mem/vmem/Mybuild
+++ b/src/mem/vmem/Mybuild
@@ -7,7 +7,7 @@ abstract module vmem_api {
 module vmem_nommu extends vmem_api {
 	source "vmem_nommu.h"
 
-	depends embox.fs.syslib.idesc_mmap
+	depends embox.fs.syslib.idesc_mmap_api
 }
 
 module vmem extends vmem_api {

--- a/src/mem/vmem/vmem_nommu.h
+++ b/src/mem/vmem/vmem_nommu.h
@@ -32,7 +32,7 @@ static inline int munmap(void *addr, size_t size) {
 	return 0;
 }
 
-#include <module/embox/fs/syslib/idesc_mmap.h>
+#include <module/embox/fs/syslib/idesc_mmap_api.h>
 
 static inline void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
 	(void) addr;


### PR DESCRIPTION
Current `idesc_mmap()' implementation is compatible with new FS (we have the same implementation for idescs), so module name `idesc_mmap_oldfs` is somewhat misleading.