### PR TITLE
arm: Fix return PC in stacktrace

### DIFF
--- a/src/arch/arm/lib/debug/stack_iter.c
+++ b/src/arch/arm/lib/debug/stack_iter.c
@@ -19,7 +19,6 @@
 
 int stack_iter_next(stack_iter_t *f) {
 	f->fp = (void *) *((int *) (f->fp - 0xc));
-	f->pc = (void *) *((int *) f->fp);
 	f->lr = (void *) *((int *) (f->fp - 0x4));
 
 	return (void *) *((int *) (f->fp - 0xc)) != 0;
@@ -27,7 +26,6 @@ int stack_iter_next(stack_iter_t *f) {
 
 void stack_iter_context(stack_iter_t *f, struct context *ctx) {
 	f->fp = (void*) ctx->system_r[11];	/* R11 is frame pointer */
-	f->pc = (void*) ctx->lr;
 	f->lr = (void*) ctx->lr;		/* R14 is link register */
 }
 
@@ -35,10 +33,8 @@ void stack_iter_current(stack_iter_t *f) {
 	__asm__ __volatile__ (
 		"mov %[fp], FP\n\t"
 		"mov %[lr], LR\n\t"
-		"mov %[pc], PC\n\t"
 		: [fp]"=r"(f->fp),
-		  [lr]"=r"(f->lr),
-		  [pc]"=r"(f->pc) : :
+		  [lr]"=r"(f->lr) : :
 	);
 	
 	/* We can't just take those registers
@@ -51,5 +47,6 @@ void stack_iter_current(stack_iter_t *f) {
 }
 
 void *stack_iter_get_retpc(stack_iter_t *f) {
-	return f->pc;
+	/* LR stores the actual address we should return to. */
+	return f->lr;
 }

--- a/src/arch/arm/lib/debug/stack_iter.h
+++ b/src/arch/arm/lib/debug/stack_iter.h
@@ -9,10 +9,11 @@
 #ifndef ARM_STACK_ITER_H_
 #define ARM_STACK_ITER_H_
 
+/* Frame consist of 4 registers saved on the stack {fp, ip, lr, pc}.
+ * But currently fp and lr are enough for our backtrace */
 typedef struct stack_iter {
 	void *fp;	/* Frame pointer */
 	void *lr;	/* Link register */
-	void *pc;	/* Program counter */
 } stack_iter_t;
 
 #endif /* ARM_STACK_ITER_H_ */


### PR DESCRIPTION
`stack_iter_get_retpc` was returning wrong PC value, since the actual return address is located in LR register.

To test that I added panic() in telnetd.c:main and investigated the traces.

Previous stack trace (one can see `+0xc` everywhere along the trace, also thread_trampoline is missing):
```
  6 0x00000b9c <whereami+0xc>                      src/lib/debug/whereami.c:166
  5 0x00032270 <main_embox__cmd__net__telnetd+0xc> ...net/telnetd/telnetd.c:352
  4 0x0007f938 <cmd_exec+0xc>                       src/framework/cmd/core.c:23
  3 0x00099f00 <exec_call+0xc>                  src/compat/posix/proc/exec.c:36
  2 0x000a88bc <task_exec_callback+0xc> .../vfork_exchanged/exec_exchanged.c:17
  1 0x0000e4e4 <task_trampoline+0xc>                 src/kernel/task/multi.c:43
```
New stack trace:
```
  6 0x000322f0 <main_embox__cmd__net__telnetd+0xc4> ...et/telnetd/telnetd.c:352
  5 0x0007f970 <cmd_exec+0x74>                      src/framework/cmd/core.c:23
  4 0x00099f98 <exec_call+0xd4>                 src/compat/posix/proc/exec.c:36
  3 0x000a8898 <task_exec_callback+0x18> ...vfork_exchanged/exec_exchanged.c:17
  2 0x0000e4d4 <task_trampoline+0x34>                src/kernel/task/multi.c:43
  1 0x0000f988 <thread_trampoline+0xa4>             src/kernel/thread/core.c:68
```