### PR TITLE
Fix whereami

### DIFF
--- a/src/arch/arm/lib/debug/stack_iter.c
+++ b/src/arch/arm/lib/debug/stack_iter.c
@@ -19,7 +19,6 @@
 
 int stack_iter_next(stack_iter_t *f) {
 	f->fp = (void *) *((int *) (f->fp - 0xc));
-	f->pc = (void *) *((int *) f->fp);
 	f->lr = (void *) *((int *) (f->fp - 0x4));
 
 	return (void *) *((int *) (f->fp - 0xc)) != 0;
@@ -27,7 +26,6 @@ int stack_iter_next(stack_iter_t *f) {
 
 void stack_iter_context(stack_iter_t *f, struct context *ctx) {
 	f->fp = (void*) ctx->system_r[11];	/* R11 is frame pointer */
-	f->pc = (void*) ctx->lr;
 	f->lr = (void*) ctx->lr;		/* R14 is link register */
 }
 
@@ -35,10 +33,8 @@ void stack_iter_current(stack_iter_t *f) {
 	__asm__ __volatile__ (
 		"mov %[fp], FP\n\t"
 		"mov %[lr], LR\n\t"
-		"mov %[pc], PC\n\t"
 		: [fp]"=r"(f->fp),
-		  [lr]"=r"(f->lr),
-		  [pc]"=r"(f->pc) : :
+		  [lr]"=r"(f->lr) : :
 	);
 	
 	/* We can't just take those registers
@@ -51,5 +47,6 @@ void stack_iter_current(stack_iter_t *f) {
 }
 
 void *stack_iter_get_retpc(stack_iter_t *f) {
-	return f->pc;
+	/* LR stores the actual address we should return to. */
+	return f->lr;
 }

--- a/src/arch/arm/lib/debug/stack_iter.h
+++ b/src/arch/arm/lib/debug/stack_iter.h
@@ -9,10 +9,11 @@
 #ifndef ARM_STACK_ITER_H_
 #define ARM_STACK_ITER_H_
 
+/* Frame consist of 4 registers saved on the stack {fp, ip, lr, pc}.
+ * But currently fp and lr are enough for our backtrace */
 typedef struct stack_iter {
 	void *fp;	/* Frame pointer */
 	void *lr;	/* Link register */
-	void *pc;	/* Program counter */
 } stack_iter_t;
 
 #endif /* ARM_STACK_ITER_H_ */

--- a/templates/sparc/qemu/mods.config
+++ b/templates/sparc/qemu/mods.config
@@ -8,6 +8,9 @@ configuration conf {
 	@Runlevel(2) include embox.arch.system(core_freq=50000000)
 	@Runlevel(2) include embox.arch.sparc.vfork
 
+	include embox.arch.sparc.stackframe
+	include embox.lib.debug.whereami
+
 	@Runlevel(2) include embox.driver.diag(impl="embox__driver__serial__apbuart")
 
 	@Runlevel(2) include embox.driver.ambapp_dumb


### PR DESCRIPTION
* Make whereami(), traceback_dump() and traceback_dump_thread()  work in a common way for x86 and arm. Stack trace on sparc works too, but with bugs (in the master branch too). Probably, we can fix it later.
* Fix arm stack trace.