### PR TITLE
Linux compat

### DIFF
--- a/src/compat/linux/include/asm-generic/dma-mapping.h
+++ b/src/compat/linux/include/asm-generic/dma-mapping.h
@@ -1,0 +1,40 @@
+/**
+ * @file dma-mapping.h
+ * @brief Allocate/free DMA memory
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 05.02.2018
+ */
+
+#ifndef LINUX_DMA_MAPPING_H_
+#define LINUX_DMA_MAPPING_H_
+
+#include <linux/types.h>
+#include <sys/types.h>
+
+#include <assert.h>
+#include <mem/sysmalloc.h>
+#include <mem/vmem.h>
+
+struct device;
+
+/**
+ * Allocate strong-ordered memory
+ */
+static inline void *dma_alloc_coherent(struct device *dev, size_t size,
+		dma_addr_t *handle, gfp_t flag) {
+	void *mem = sysmalloc(size);
+	mmu_ctx_t ctx = vmem_current_context();
+	vmem_page_flags_t flags = VMEM_PAGE_WRITABLE;
+
+	vmem_page_set_flags(ctx, (mmu_vaddr_t) mem, flags);
+
+	return mem;
+}
+
+static inline void dma_free_coherent(struct device *dev, size_t size,
+		void *cpu_addr, dma_addr_t handle) {
+	sysfree(cpu_addr);
+}
+
+#endif /* LINUX_DMA_MAPPING_H_ */

--- a/src/compat/linux/include/err.h
+++ b/src/compat/linux/include/err.h
@@ -1,0 +1,28 @@
+/**
+ * @file err.h
+ * @brief Linux-compatible formatted error messages
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 29.11.2017
+ */
+
+#ifndef LINUX_ERR_H_
+#define LINUX_ERR_H_
+
+#include <stdlib.h>
+
+/* TODO output format is not the same as "man err" requiers */
+
+static inline void err(int eval, const char *fmt, ...) {
+}
+
+static inline void errx(int eval, const char *fmt, ...) {
+}
+
+static inline void warn(const char *fmt, ...) {
+}
+
+static inline void warnx(const char *fmt, ...) {
+}
+
+#endif /* LINUX_ERR_H_ */

--- a/src/compat/linux/include/linux/idr.h
+++ b/src/compat/linux/include/linux/idr.h
@@ -1,0 +1,117 @@
+/**
+ * @file
+ *
+ * @date Jan 22, 2018
+ * @author Anton Bondarev
+ */
+
+#ifndef SRC_COMPAT_LINUX_INCLUDE_IDR_H_
+#define SRC_COMPAT_LINUX_INCLUDE_IDR_H_
+
+#include <assert.h>
+#include <stddef.h>
+#include <limits.h>
+
+#include <util/bitmap.h>
+
+#include <linux/types.h>
+
+struct idr {
+	int inited;
+	unsigned long id_pool;
+	void *object_handlers[sizeof(unsigned long) * LONG_BIT];
+};
+
+/**
+ * idr_preload - preload for idr_alloc()
+ * @gfp_mask: allocation mask to use for preloading
+ *
+ * Preload per-cpu layer buffer for idr_alloc().  Can only be used from
+ * process context and each idr_preload() invocation should be matched with
+ * idr_preload_end().  Note that preemption is disabled while preloaded.
+ *
+ * The first idr_alloc() in the preloaded section can be treated as if it
+ * were invoked with @gfp_mask used for preloading.  This allows using more
+ * permissive allocation masks for idrs protected by spinlocks.
+ *
+ * For example, if idr_alloc() below fails, the failure can be treated as
+ * if idr_alloc() were called with GFP_KERNEL rather than GFP_NOWAIT.
+ *
+ *	idr_preload(GFP_KERNEL);
+ *	spin_lock(lock);
+ *
+ *	id = idr_alloc(idr, ptr, start, end, GFP_NOWAIT);
+ *
+ *	spin_unlock(lock);
+ *	idr_preload_end();
+ *	if (id < 0)
+ *		error;
+ */
+static inline void idr_preload(gfp_t gfp_mask) { }
+
+/**
+ * idr_alloc - allocate new idr entry
+ * @idr: the (initialized) idr
+ * @ptr: pointer to be associated with the new id
+ * @start: the minimum id (inclusive)
+ * @end: the maximum id (exclusive, <= 0 for max)
+ * @gfp_mask: memory allocation flags
+ *
+ * Allocate an id in [start, end) and associate it with @ptr.  If no ID is
+ * available in the specified range, returns -ENOSPC.  On memory allocation
+ * failure, returns -ENOMEM.
+ *
+ * Note that @end is treated as max when <= 0.  This is to always allow
+ * using @start + N as @end as long as N is inside integer range.
+ *
+ * The user is responsible for exclusively synchronizing all operations
+ * which may modify @idr.  However, read-only accesses such as idr_find()
+ * or iteration can be performed under RCU read lock provided the user
+ * destroys @ptr in RCU-safe way after removal from idr.
+ */
+static inline int idr_alloc(struct idr *idp, void *ptr, int start, int end, gfp_t gfp_mask) {
+	int id;
+	assert(idp);
+
+	if (!idp->inited) {
+		idp->id_pool = 0;
+		idp->inited = 1;
+		memset(idp->object_handlers, 0, sizeof(idp->object_handlers));
+	}
+
+	if (start > sizeof(unsigned long) * CHAR_BIT) {
+		return -ENOSPC;
+	}
+
+	id = bitmap_find_zero_bit(&idp->id_pool, 1, start);
+	idp->object_handlers[id] = ptr;
+	bitmap_set_bit(&idp->id_pool, id);
+
+	return id;
+}
+
+/**
+ * idr_preload_end - end preload section started with idr_preload()
+ *
+ * Each idr_preload() should be matched with an invocation of this
+ * function.  See idr_preload() for details.
+ */
+static inline void idr_preload_end(void) { }
+
+/**
+ * idr_find - return pointer for given id
+ * @idr: idr handle
+ * @id: lookup key
+ *
+ * Return the pointer given the id it has been registered with.  A %NULL
+ * return indicates that @id is not valid or you passed %NULL in
+ * idr_get_new().
+ *
+ */
+static inline void *idr_find(struct idr *idr, int id)
+{
+	return idr->object_handlers[id];
+}
+
+
+#endif /* SRC_COMPAT_LINUX_INCLUDE_IDR_H_ */

--- a/src/compat/linux/include/linux/pagemap.h
+++ b/src/compat/linux/include/linux/pagemap.h
@@ -17,6 +17,7 @@
 #define PAGE_CACHE_SIZE         PAGE_SIZE()
 
 #define GFP_KERNEL    0
+#define GFP_NOWAIT    1
 
 #define PageLocked(pg) 1
 #define Page_Uptodate(pg) 0

--- a/src/compat/linux/include/linux/types.h
+++ b/src/compat/linux/include/linux/types.h
@@ -45,4 +45,6 @@ typedef unsigned long int 	u32_t;
 
 #endif /* __ASSEMBLER__ */
 
+typedef uint32_t dma_addr_t;
+
 #endif /* COMPAT_LINUX_LINUX_TYPES_H_ */

--- a/src/compat/linux/include/linux/types.h
+++ b/src/compat/linux/include/linux/types.h
@@ -24,6 +24,8 @@ typedef __u32 __be32;
 typedef __u64 __le64;
 typedef __u64 __be64;
 
+typedef uint32_t u32;
+
 /* bsd */
 typedef unsigned char     u_char;
 typedef unsigned short    u_short;

--- a/src/compat/linux/include/linux/types.h
+++ b/src/compat/linux/include/linux/types.h
@@ -10,6 +10,8 @@
 #ifndef COMPAT_LINUX_LINUX_TYPES_H_
 #define COMPAT_LINUX_LINUX_TYPES_H_
 
+#include <stdint.h>
+
 #ifndef __ASSEMBLER__
 
 #include <asm/types.h>
@@ -43,8 +45,8 @@ typedef unsigned char 		u8_t;
 typedef unsigned short int 	u16_t;
 typedef unsigned long int 	u32_t;
 
-#endif /* __ASSEMBLER__ */
+typedef uint32_t          dma_addr_t;
 
-typedef uint32_t dma_addr_t;
+#endif /* __ASSEMBLER__ */
 
 #endif /* COMPAT_LINUX_LINUX_TYPES_H_ */

--- a/src/compat/linux/include/linux/wait.h
+++ b/src/compat/linux/include/linux/wait.h
@@ -10,6 +10,7 @@
 #define __LINUX_WAIT_H_
 
 #include <sys/wait.h>
+#include <kernel/thread/thread_sched_wait.h>
 
 typedef struct { } wait_queue_head_t;
 
@@ -20,5 +21,9 @@ typedef struct { } wait_queue_head_t;
 
 static inline void wake_up(wait_queue_head_t *erase_wait)
 { /* Only used for waking up threads blocks on erases. Not used in eCos */ }
+
+
+#define wait_event_interruptible_timeout(wq, condition, timeout)	\
+		SCHED_WAIT_TIMEOUT(condition, timeout)
 
 #endif /* WAIT_H_ */


### PR DESCRIPTION
Extend Linux compatibility. This is mostly needed by etnaviv DRM driver (currently not merged to master).

Implemented functions are mostly stubs.