### PR TITLE
Add GCC8 compatibility

### DIFF
--- a/src/tests/mem/heap.c
+++ b/src/tests/mem/heap.c
@@ -142,5 +142,16 @@ TEST_CASE("Allocates many objects with different size") {
 
 TEST_CASE("malloc fails when trying to allocate a very large"
 		" chunk of memory") {
+#ifdef __GNUC__
+#if __GNUC__ > 6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+#endif
+#endif
 	test_assert_null(malloc(4294966160));
+#ifdef __GNUC__
+#if __GNUC__ > 6
+#pragma GCC diagnostic pop
+#endif
+#endif
 }

--- a/src/tests/stdio/printf_test.c
+++ b/src/tests/stdio/printf_test.c
@@ -118,11 +118,20 @@ TEST_CASE("Test of snprintf with truncated output") {
 
 	test_assert_equal(3, snprintf(&random_char, 0, "012"));
 	test_assert_equal(random_char, backup_char);
-
+#ifdef __GNUC__
+#if __GNUC__ > 6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+#endif
 	test_assert_equal(4, snprintf(dest, 4, "1234"));
 	test_assert_str_equal(dest, "123");
-
 	test_assert_equal(8, snprintf(dest, 2, "12345678"));
+#ifdef __GNUC__
+#if __GNUC__ > 6
+#pragma GCC diagnostic pop
+#endif
+#endif
 	test_assert_str_equal(dest, "1");
 }
 
@@ -134,7 +143,7 @@ TEST_CASE("Test of printing with mistake in format") {
 }
 
 #if 0
-/* FIXME this test should respect support_floating option of 
+/* FIXME this test should respect support_floating option of
  * embox.compat.libc.stdio.print. Until then, disabled
  */
 TEST_CASE("Test of specifier with type float") {


### PR DESCRIPTION
Fix build for x86 templates for GCC 8.2.0

Fix #1205 