### PR TITLE
qt: Fix rootfs/fonts initialization

### DIFF
--- a/third-party/qt/Mybuild
+++ b/third-party/qt/Mybuild
@@ -1,8 +1,9 @@
 package third_party.qt
 
-@Build(script="$(EXTERNAL_MAKE)")
+@Build(stage=1,script="$(EXTERNAL_MAKE)")
 @BuildArtifactPath(cppflags="-I$(abspath $(EXTERNAL_BUILD_DIR))/third_party/qt/core/install/include -I$(abspath $(EXTERNAL_BUILD_DIR))/third_party/qt/core/install/include/QtCore")
 @BuildDepends(third_party.gcc.core)
+@BuildDepends(third_party.lib.OpenLibm)
 @BuildDepends(third_party.STLport.core)
 static module core {
 	option boolean stl_support=false


### PR DESCRIPTION
Fix #601 by changing build order. Previously, Qt was builded after the kernel (so fonts were not included in rootfs when built just after `make confload-...`), now it works properly.