### PR TITLE
arm: Fix mmu_pte_value()

### DIFF
--- a/src/arch/arm/mmu/mmu_small_page.c
+++ b/src/arch/arm/mmu/mmu_small_page.c
@@ -21,7 +21,7 @@ mmu_pte_t *mmu_pmd_value(mmu_pmd_t *pmd) {
 }
 
 mmu_paddr_t mmu_pte_value(mmu_pte_t *pte) {
-	return 0;
+	return ((uint32_t) *pte) & ~MMU_PAGE_MASK;
 }
 
 void mmu_pgd_set(mmu_pgd_t *pgd, mmu_pmd_t *pmd) {


### PR DESCRIPTION
This function is supposed to return physical address to which virtual
page points.

Fixing this function will fix some memory leaks