### PR TITLE
Fix of pgd_allocator frees more than available space.

### DIFF
--- a/src/mem/pagealloc/bitmask.c
+++ b/src/mem/pagealloc/bitmask.c
@@ -61,14 +61,18 @@ static void mark_n_busy(struct page_allocator *allocator,
 static void mark_n_free(struct page_allocator *allocator,
 		unsigned int start_page, unsigned int page_q) {
 	unsigned int page_i;
+	int count_free = 0;
 
 	assert(allocator);
 	assert(start_page + page_q <= allocator->pages_n);
 	for (page_i = start_page; page_i < start_page + page_q; page_i++) {
-		bitmap_clear_bit(allocator->bitmap, page_i);
+		if (bitmap_test_bit(allocator->bitmap, page_i)) {
+			bitmap_clear_bit(allocator->bitmap, page_i);
+			++count_free;
+		}
 	}
 
-	allocator->free += page_q * allocator->page_size;
+	allocator->free += count_free * allocator->page_size;
 }
 
 static void *search_multi_page(struct page_allocator *allocator, size_t page_q) {


### PR DESCRIPTION
The problem was that in the `src/mem/mmap/mmap_mmu.c:132` called `mmap_clear(mmap);` and `vmem_free_context(mmap->ctx);`. 
This functions leads to the call of `src/mem/vmem/vmem_alloc.c:vmem_free_pgd_table` 2 times, which causes to free 2 pages instead of 1.
Fix was to check if current page already freed or not.