### PR TITLE
Stm32 fix static irq

### DIFF
--- a/platform/efm32zg_sk3200/templates/debug/mods.config
+++ b/platform/efm32zg_sk3200/templates/debug/mods.config
@@ -53,7 +53,7 @@ configuration conf {
 	include embox.kernel.cpu.bkl_api
 	include embox.kernel.cpu.cpudata_api
 	include embox.kernel.critical
-	include embox.kernel.irq_static
+	include embox.kernel.irq_static_light
 	include embox.profiler.trace
 
 	include efm32zg_sk3200.bsp

--- a/platform/stellaris/templates/lm3s811evb/mods.config
+++ b/platform/stellaris/templates/lm3s811evb/mods.config
@@ -17,7 +17,7 @@ configuration conf {
 	include embox.driver.serial.core_notty
 
 	include embox.kernel.critical
-	include embox.kernel.irq_static
+	include embox.kernel.irq_static_light
 	include embox.kernel.spinlock(spin_debug=false)
 	include embox.kernel.task.single
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=12)

--- a/src/drivers/audio/stm32/stm32_audio_f7.c
+++ b/src/drivers/audio/stm32/stm32_audio_f7.c
@@ -233,7 +233,7 @@ static irq_return_t stm32_audio_in_dma_interrupt(unsigned int irq_num,
 }
 
 static_assert(86 == STM32_AUDIO_IN_DMA_IRQ);
-STATIC_IRQ_ATTACH(STM32_AUDIO_IN_DMA_IRQ, stm32_audio_in_dma_interrupt, NULL);
+STATIC_IRQ_ATTACH(86, stm32_audio_in_dma_interrupt, NULL);
 
 /******** Functions for OUTPUT audio device ********/
 static void stm32_audio_out_start(struct audio_dev *dev) {
@@ -299,4 +299,4 @@ static irq_return_t stm32_audio_out_dma_interrupt(unsigned int irq_num,
 }
 
 static_assert(76 == STM32_AUDIO_OUT_DMA_IRQ);
-STATIC_IRQ_ATTACH(STM32_AUDIO_OUT_DMA_IRQ, stm32_audio_out_dma_interrupt, NULL);
+STATIC_IRQ_ATTACH(76, stm32_audio_out_dma_interrupt, NULL);

--- a/src/drivers/interrupt/cortexm_irq_handle.S
+++ b/src/drivers/interrupt/cortexm_irq_handle.S
@@ -9,6 +9,8 @@
 .text
 .thumb
 .syntax unified
+
+.thumb_func
 .global interrupt_handle_enter
 interrupt_handle_enter:
     mov    r0, sp
@@ -30,6 +32,7 @@ interrupt_handle_enter:
 
     bl     interrupt_handle
 
+.thumb_func
 .global __irq_trampoline
 __irq_trampoline:
 
@@ -38,6 +41,7 @@ __irq_trampoline:
     # http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Babefdjc.html
     bx     r1
 
+.thumb_func
 .global __pendsv_handle
 __pendsv_handle:
 
@@ -59,6 +63,7 @@ out:
     mov    sp, r0
     bx     r14
 
+.thumb_func
 .global __pending_handle
 __pending_handle:
     add    r1, r1, #52

--- a/src/kernel/Irq.my
+++ b/src/kernel/Irq.my
@@ -6,18 +6,29 @@ abstract module irq_api {
 abstract module static_irq_table_impl {
 
 }
-module irq_static extends irq_api {
+
+module irq_static_common {
 	source "irq_static.c"
-	source "irq_static.h"
 	source "arm_m_irq.S"
 	depends irq_lock
 	depends irq_stack
 	depends static_irq_table_impl
 }
 
+module irq_static extends irq_api {
+	source "irq_static.h"
+	depends irq_static_common
+}
+
+module irq_static_light extends irq_api {
+	source "irq_static_light.h"
+	depends irq_static_common
+}
+
 module no_irq extends irq_api {
 	source "no_irq.c"
 
+	depends irq_static_common
 }
 
 module irq extends irq_api {

--- a/src/kernel/irq_static.h
+++ b/src/kernel/irq_static.h
@@ -22,6 +22,10 @@
 #define STATIC_IRQ_ATTACH(_irq_nr, _hnd, _data) \
 	__STATIC_IRQ_ATTACH(_irq_nr, __static_irq__ ## _irq_nr, _hnd, _data)
 
+/* First, handle irq with _hnd(). After irq is handled we need
+ * to exit irq and call critical_dispatch_pending() in a right place
+ * with interrupts enabled. To do this, let's call interrupt_handle_enter()
+ * like in the case with non-static interrupts. */
 #define __STATIC_IRQ_ATTACH(_irq_nr, _static_hnd, _hnd, _data) \
 	__attribute__((naked)) static void _static_hnd(void) { \
 		asm("stmdb sp!, {r0-r12, lr}"); \

--- a/src/kernel/irq_static_light.h
+++ b/src/kernel/irq_static_light.h
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date Mar 13, 2014
+ * @author: Anton Bondarev
+ */
+
+#ifndef IRQ_STATIC_LIGHT_H_
+#define IRQ_STATIC_LIGHT_H_
+
+#define STATIC_IRQ_EXTENTION
+
+#include <asm-generic/static_irq.h>
+#include <asm/regs.h>
+
+#ifndef __ASSEMBLER__
+#include <assert.h>
+#include <kernel/irq_stack.h>
+#endif
+
+#define STATIC_IRQ_ATTACH(_irq_nr, _hnd, _data) \
+	__STATIC_IRQ_ATTACH(_irq_nr, __static_irq__ ## _irq_nr, _hnd, _data)
+
+#define __STATIC_IRQ_ATTACH(_irq_nr, _static_hnd, _hnd, _data) \
+	static void _static_hnd(void) { \
+		assertf(irq_stack_protection() == 0, \
+			"Stack overflow detected on irq handler %s\n", __func__); \
+		_hnd(_irq_nr, _data); \
+	} \
+	ARM_M_IRQ_HANDLER_DEF(_irq_nr, _static_hnd);
+
+#endif /* IRQ_STATIC_LIGHT_H_ */

--- a/templates/arm/stm32_vl/mods.config
+++ b/templates/arm/stm32_vl/mods.config
@@ -43,7 +43,7 @@ configuration conf {
 	include embox.cmd.sys.version
 
 	include embox.kernel.critical
-	include embox.kernel.irq_static
+	include embox.kernel.irq_static_light
 	include embox.mem.pool_adapter
 
 	include embox.util.LibUtil

--- a/templates/arm/stm32_vl_light/mods.config
+++ b/templates/arm/stm32_vl_light/mods.config
@@ -18,7 +18,7 @@ configuration conf {
 	include embox.driver.gpio.stm32
 
 	include embox.kernel.critical
-	include embox.kernel.irq_static
+	include embox.kernel.irq_static_light
 	include embox.kernel.spinlock(spin_debug=false)
 	include embox.kernel.task.single
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=1)


### PR DESCRIPTION
Fix `irq_static` to make test `embox.test.kernel.thread.thread_systimer_irq_test` work for both static and non-static vector table. Nevertheless, the old version of irq_static remained, since it is useful when we do not use threads, but only light threads. Now, this module is renamed to `irq_static_light`.