### PR TITLE
Fix CI x86/test/net

### DIFF
--- a/scripts/continuous/net/forwarding/test_ping_forwarding.sh
+++ b/scripts/continuous/net/forwarding/test_ping_forwarding.sh
@@ -72,7 +72,7 @@ test_case_ping_forwarding() {
 	test_retcode
 }
 
-disabled_test_case_big_ping_forwarding() {
+test_case_big_ping_forwarding() {
 	echo "Test case \"embox should forward big ping\""
 	ping -I $TAP_DEV -c 4 -s 16384 $QEMU2_ETH0
 	test_retcode

--- a/scripts/continuous/net/forwarding/test_ping_forwarding.sh
+++ b/scripts/continuous/net/forwarding/test_ping_forwarding.sh
@@ -36,6 +36,8 @@ build_embox() {
 }
 
 test_suite_setup() {
+	$CONT_RUN generic/save_conf
+
 	build_embox $EMBOX1_START_SCRIPT $EMBOX1_KERNEL
 	build_embox $EMBOX2_START_SCRIPT $EMBOX2_KERNEL
 
@@ -55,6 +57,8 @@ test_suite_setup() {
 }
 
 test_suite_teardown() {
+	$CONT_RUN generic/restore_conf
+
 	$CONT_RUN generic/qemu_bg_kill "" $QEMU1_PID_FILE || true
 	$CONT_RUN generic/qemu_bg_kill "" $QEMU2_PID_FILE || true
 	rm $EMBOX1_KERNEL $EMBOX2_KERNEL || true

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -143,7 +143,7 @@ fi
 
 tap_down
 
-test_begin
+test_begin "ping forwarding test suite"
 	$TEST_PING_FORWARING_SCRIPT
 	test_retcode
 test_end

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -22,7 +22,7 @@ test_case_target_should_reply_to_ping() {
 	test_retcode
 }
 
-disabled_test_case_target_should_reply_to_big_ping() {
+test_case_target_should_reply_to_big_ping() {
 	ping $EMBOX_IP -c 4 -s 16384
 	test_retcode
 }

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -49,7 +49,7 @@ test_case_snmp_should_reply() {
 	test_retcode
 }
 
-disabled_test_case_interactive_tests_should_success() {
+test_case_interactive_tests_should_success() {
 	sudo killall in.rlogind
 	expect $EXPECT_TESTS_BASE/framework/run_all.exp
 	test_retcode

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -51,10 +51,16 @@ test_case_snmp_should_reply() {
 
 test_case_interactive_tests_should_success() {
 	sudo killall in.rlogind
-	expect $EXPECT_TESTS_BASE/framework/run_all.exp
+
+	expect $EXPECT_TESTS_BASE/framework/run_all.exp \
+		$EXPECT_TESTS_BASE/x86_net_tests.config 10.0.2.16 10.0.2.10 ""
+
 	test_retcode
 
-	cat testrun.log
+	# This file contains thw full log, which can be relatively large, so we do not
+	# print it to standard output.
+	#
+	# cat testrun.log
 }
 
 #test_case_ftp_should_be_able_to_upload_a_file() {

--- a/scripts/continuous/run.sh
+++ b/scripts/continuous/run.sh
@@ -15,6 +15,7 @@ OTHER_ARGS="$@"
 
 TIMEOUT=${CONTINIOUS_RUN_TIMEOUT-45}
 
+EMCONF=./conf
 EMKERNEL=./build/base/bin/embox
 OUTPUT_FILE=./cont.out
 
@@ -50,6 +51,8 @@ atml2run=(
 	['generic/qemu']=default_run
 	['generic/qemu_bg']=run_bg_wrapper
 	['generic/qemu_bg_kill']=kill_bg_wrapper
+	['generic/save_conf']=save_conf
+	['generic/restore_conf']=restore_conf
 	['generic/fail']=false
 )
 
@@ -112,6 +115,8 @@ kill_bg() {
 	pstree -A -p $sim_bg | sed 's/[0-9a-z{}_\.+`-]*(\([0-9]\+\))/\1 /g' | xargs sudo kill
 
 	cat $OUTPUT_FILE
+
+	restore_conf
 }
 
 ## FIXME not working
@@ -170,6 +175,19 @@ kill_bg_wrapper() {
 	echo "Embox output on end"
 	echo "==================="
 	kill_bg
+}
+
+save_conf() {
+	echo "Save conf/ to $EMCONF.orig"
+	rm -rf $EMCONF.orig
+	cp -r $EMCONF $EMCONF.orig
+}
+
+restore_conf() {
+	if [ -d $EMCONF.orig ]; then
+		echo "Restore conf/ from $EMCONF.orig"
+		cp -rf $EMCONF.orig/* $EMCONF
+	fi
 }
 
 if ! echo ${!atml2run[@]} | grep $ATML &>/dev/null; then

--- a/scripts/expect/framework/run_all.exp
+++ b/scripts/expect/framework/run_all.exp
@@ -1,25 +1,29 @@
 #!/usr/bin/expect
 
-proc run_all_tests {} {
+source [file join [file dirname [info script]] test_core.exp]
+
+proc run_all_tests {tests_list_file embox_ip host_ip host_passwd} {
 	set logfile testrun.log
 	set dir [file dirname [info script]]
-	#TODO get tests_list_file in some better way
-	set tests_list_file [file join $dir ../tests_list.config]
 
 	set tests [split [exec cat $tests_list_file] "\n"]
 
 	exec rm -f $logfile
 
+	set test_res 0
 	set i 0
 	foreach t $tests {
 		incr i
 		puts "\n$i.  autotest: ======= running TEST SUITE: $t ... ======= "
 
-		exec rm -f .tmp.txt
-		exec touch .tmp.txt
+		set short_log $dir/../$t.log
+
+		exec rm -f .tmp.txt $short_log
+		exec touch .tmp.txt $short_log
 
 		set status 0
-		if {[catch {exec expect $dir/../$t.exp >> .tmp.txt} results options]} {
+
+		if {[catch {exec expect $dir/../$t.exp $embox_ip $host_ip $host_passwd >> .tmp.txt} results options]} {
 		    set details [dict get $options -errorcode]
 		    if {[lindex $details 0] eq "CHILDSTATUS"} {
 		        set status [lindex $details 2]
@@ -31,14 +35,25 @@ proc run_all_tests {} {
 
 		exec cat .tmp.txt >> $logfile
 
+		puts [exec cat $short_log]
 		if { $status != 0 } {
+			# Find the last failed test and print only its output
+			set line_failed_test [exec grep -n "TEST CASE.*running" $logfile | tail -1 | awk {{gsub(":","",$1); print $1}}]
+			puts [exec tail -n +$line_failed_test $logfile]
 			puts "    autotest: FAILED (error code = $status)"
-			puts [exec cat .tmp.txt]
-			exit 1
+			set test_res -1
 		} else {
 			puts "    autotest: PASSED"
 		}
 	}
+
+	return $test_res
 }
 
-run_all_tests
+set tests_list_file [lindex $argv 0]
+set embox_ip        [lindex $argv 1]
+set host_ip         [lindex $argv 2]
+set host_passwd     [lindex $argv 3]
+
+set retcode [run_all_tests $tests_list_file $embox_ip $host_ip $host_passwd]
+exit $retcode

--- a/scripts/expect/framework/test_cmd.exp
+++ b/scripts/expect/framework/test_cmd.exp
@@ -1,28 +1,27 @@
-proc test_assert_regexp_equal {cmd success_output} {
-	send $cmd
-	set cmd_name [lindex [split $cmd " "] 0]
-	expect "$cmd"
+proc __expect_regexp {pattern} {
 	expect {
-	         timeout { puts "$cmd_name timeout\n"; exit 1 }
-	        -regexp "$cmd_name:.*" { puts "$expect_out(buffer)\n"; exit 1  }
-	        "$success_output" { }
+	     timeout { puts "\n\nautotest error: Waiting for \"$pattern\" pattern timeout\n\n"; exit 1 }
+		-re "$pattern" {}
 	}
 	return 0
 }
 
-proc test_assert_timeout {cmd in_timeout} {
-	set TELNET_PROMPT ":/#"
+# Sends $cmd to remote target (Embox) and sequentially waits for each
+# pattern from $args to appear
+proc test_assert_regexp_equal {args} {
+	foreach pattern $args {
+		__expect_regexp $pattern
+	}
+	return 0
+}
 
-	set timeout $in_timeout
+proc test_assert_regexp_equal_timeout {new_timeout args} {
+	set timeout $new_timeout
 
-	send $cmd
-	set cmd_name [lindex [split $cmd " "] 0]
-	expect "$cmd"
-	expect {
-	         timeout { puts "$cmd_name timeout\n"; set timeout 10; exit 1 }
-	        -regexp "$cmd_name:.*" { puts "$expect_out(buffer)\n"; set timeout 10  }
-	        $TELNET_PROMPT { set timeout 10 }
+	foreach pattern $args {
+		__expect_regexp $pattern
 	}
 
+	set timeout 10
 	return 0
 }

--- a/scripts/expect/framework/test_core.exp
+++ b/scripts/expect/framework/test_core.exp
@@ -1,65 +1,84 @@
 package provide autotest 1.0
 
 namespace eval ::autotest {
-    namespace export TEST_SETUP_HOST TEST_TEARDOWN_HOST \
-    	TEST_SETUP_TARGET TEST_TEARDOWN_TARGET TEST_CASE
-    namespace export test_assert_regexp_equal
+	namespace export TEST_SETUP_HOST TEST_TEARDOWN_HOST \
+		TEST_SETUP_TARGET TEST_TEARDOWN_TARGET \
+		TEST_CASE_TARGET TEST_CASE_HOST
 
-    variable setup_host_proc ""
-    variable teardown_host_proc ""
-    variable setup_target_proc ""
-    variable teardown_target_proc ""
+	# MUST BE CALLED IN EACH TEST SUITE
+	namespace export TEST_SUITE_SETUP
 
-    variable embox_ip "10.0.2.16"
-    variable host_ip "10.0.2.10"
+	namespace export test_assert_regexp_equal
+	namespace export test_assert_regexp_equal_timeout
+
+	variable embox_ip
+	variable host_ip
+	variable host_passwd
 }
 
 source [file join [file dirname [info script]] test_exec.exp]
 source [file join [file dirname [info script]] test_cmd.exp]
 
-proc init_test_suite {} {
-	set setup_host_proc ""
-	set teardown_host_proc ""
+proc ::autotest::TEST_SUITE_SETUP {} {
+	global argv
+
+	variable embox_ip
+	variable host_ip
+	variable host_passwd
+
+	set embox_ip    [lindex $argv 0]
+	set host_ip     [lindex $argv 1]
+	set host_passwd [lindex $argv 2]
 }
 
-proc ::autotest::TEST_SETUP_HOST {setup} {
-	variable setup_host_proc
-	set setup_host_proc $setup
+proc ::autotest::TEST_SETUP_HOST {setup_body} {
+	eval $setup_body
 }
 
-proc ::autotest::TEST_TEARDOWN_HOST {teardown} {
-	variable teardown_host_proc
-	set teardown_host_proc $teardown
+proc ::autotest::TEST_TEARDOWN_HOST {teardown_body} {
+	eval $teardown_body
 }
 
-proc ::autotest::TEST_SETUP_TARGET {setup} {
-	variable setup_target_proc
-	set setup_target_proc $setup
+proc ::autotest::TEST_SETUP_TARGET {setup_body} {
+	telnet_connect
+	eval $setup_body
+	telnet_disconnect
 }
 
-proc ::autotest::TEST_TEARDOWN_TARGET {teardown} {
-	variable teardown_target_proc
-	set teardown_target_proc $teardown
+proc ::autotest::TEST_TEARDOWN_TARGET {teardown_body} {
+	telnet_connect
+	eval $teardown_body
+	telnet_disconnect
 }
 
-proc ::autotest::TEST_CASE {test_name test_body} {
-	variable setup_host_proc
-	variable teardown_host_proc
+proc ::autotest::TEST_CASE_IMPL {mode test_name test_body} {
+	set logfile "[file rootname [info script]].log"
 
-	#init_test_suite
+	puts "\n		TEST CASE \"$test_name\" running ...\n"
+	
+	# Execute test
+	set res [test_exec $mode $test_name $test_body]
 
-	if { $setup_host_proc != "" && [catch {eval $setup_host_proc}] } {
-		puts "autotest: incorrect setup_host_proc name - $setup_host_proc"
-		exit 1
+	if {[file exists $logfile]} {
+		if {$res != 0} {
+			set result_str "        TEST CASE \"$test_name\" ERROR"
+		} else {
+			set result_str "        TEST CASE \"$test_name\" OK"
+		}
+		exec echo -e $result_str >> $logfile
 	}
 
-	puts "\n              autotest: TEST CASE \"$test_name\" running ...\n"
-	test_exec $test_name $test_body
-
-	if { $teardown_host_proc != "" && [catch {eval $teardown_host_proc}] } {
-		puts "autotest: incorrect teardown_host_proc - $teardown_host_proc"
+	if {$res != 0} {
 		exit 1
 	}
 
 	return 0
+}
+
+proc ::autotest::TEST_CASE_TARGET {test_name test_body} {
+	return [TEST_CASE_IMPL "target" $test_name $test_body]
+}
+
+proc ::autotest::TEST_CASE_HOST {test_name test_body} {
+	return [TEST_CASE_IMPL "host" $test_name $test_body]
 }

--- a/scripts/expect/framework/test_exec.exp
+++ b/scripts/expect/framework/test_exec.exp
@@ -1,45 +1,42 @@
-set timeout 10
-
-proc ::autotest::test_exec {test_name test_body} {
+proc ::autotest::telnet_connect {} {
+	# https://stackoverflow.com/questions/30532532/expect-fails-when-running-proc-inside-proc
 	global spawn_id
 	variable embox_ip
-	variable setup_target_proc
-	variable teardown_target_proc
 
-	proc telnet_connect {} {
-		# The piece of embox's prompt
-		set TELNET_PROMPT ":/#"
-		expect {
-			timeout { puts "telnet.exp: connection timeout\n"; return -1 }
-			$TELNET_PROMPT
-		}
+	spawn telnet $embox_ip
+
+	# The piece of embox's prompt
+	set TELNET_PROMPT ":/#"
+	expect {
+		timeout { puts "\ntelnet: connection timeout\n"; exit 1 }
+		-re "$TELNET_PROMPT" { }
+	}
+	return 0
+}
+
+proc ::autotest::telnet_disconnect {} {
+	send "exit\r"
+	expect "Connection closed by foreign host"
+	return 0
+}
+
+proc ::autotest::test_exec {mode test_name test_body} {
+	# https://stackoverflow.com/questions/30532532/expect-fails-when-running-proc-inside-proc
+	global spawn_id
+
+	if {$test_body == ""} {
 		return 0
 	}
 
-	sleep 1
+	if {$mode == "target"} { telnet_connect }
 
-	spawn telnet $embox_ip
-	set res [telnet_connect]
+	set res [eval $test_body]
 	if {$res != 0} {
-		fail $test_name
-		exit 1
+		if {$mode == "target"} { telnet_disconnect }
+		return -1
 	}
 
-	if {$test_body != ""} {
-		if { $setup_target_proc != "" && [catch {eval $setup_target_proc}] } {
-			puts "error: incorrect setup_target_proc name - $setup_target_proc"
-			exit 1
-		}
+	if {$mode == "target"} { telnet_disconnect }
 
-		set res [eval $test_body]
-		if {$res != 0} {
-			exit 1
-		}
-
-		if { $teardown_target_proc != "" && [catch {eval $teardown_target_proc}] } {
-			puts "error: incorrect teardown_target_proc name - $teardown_target_proc"
-			exit 1
-		}
-	}
 	return 0
 }

--- a/scripts/expect/ntpdate.exp
+++ b/scripts/expect/ntpdate.exp
@@ -12,7 +12,9 @@ namespace import autotest::*
 
 set host_date ""
 
-proc get_host_date {} {
+TEST_SUITE_SETUP
+
+TEST_SETUP_HOST {
 	global host_date
 	# Get current host's date in the format same as in Embox (e.g. 2014-01-05).
 	spawn date -u --rfc-3339=date
@@ -23,19 +25,12 @@ proc get_host_date {} {
 	set host_date $expect_out(0,string)
 }
 
-TEST_SETUP_HOST {get_host_date}
-
-TEST_CASE {ntpdate test} {
+TEST_CASE_TARGET {ntpdate test} {
 	variable host_ip
 	global host_date
 
 	send "ntpdate $host_ip\r"
-	expect "ntpdate"
-	expect {
-	        timeout  { puts "ntpdate.exp: timeout\n"; exit 1 }
-	        -regexp "ntpdate:.*" { puts "$expect_out(buffer)\n"; exit 1 }
-	        ":/#"
-	}
+	test_assert_regexp_equal ":/#"
 
 	# And compare the host date with the Embox's one.
 	# XXX: compare the both times too, not only dates

--- a/scripts/expect/ping.exp
+++ b/scripts/expect/ping.exp
@@ -4,10 +4,20 @@ source [file join [file dirname [info script]] framework/test_core.exp]
 
 namespace import autotest::*
 
-TEST_CASE {ping can send 1 packet without errors} {
+TEST_CASE_TARGET {Embox should ping host} {
 	variable host_ip
 
-	test_assert_regexp_equal "ping -c 1 $host_ip\r\n" "+0 errors"
+	send "ping -c 4 $host_ip\r"
+	test_assert_regexp_equal "0 errors"
+
+	return 0
+}
+
+TEST_CASE_TARGET {Embox should ping google.com} {
+	variable host_ip
+
+	send "ping -c 4 google.com\r"
+	test_assert_regexp_equal "0 errors"
 
 	return 0
 }

--- a/scripts/expect/ping.exp
+++ b/scripts/expect/ping.exp
@@ -4,6 +4,8 @@ source [file join [file dirname [info script]] framework/test_core.exp]
 
 namespace import autotest::*
 
+TEST_SUITE_SETUP
+
 TEST_CASE_TARGET {Embox should ping host} {
 	variable host_ip
 
@@ -18,6 +20,33 @@ TEST_CASE_TARGET {Embox should ping google.com} {
 
 	send "ping -c 4 google.com\r"
 	test_assert_regexp_equal "0 errors"
+
+	return 0
+}
+
+TEST_CASE_HOST {Embox should reply after ping flooding} {
+	variable embox_ip
+	variable host_passwd
+
+	# Flood for 10 seconds
+	set timeout 10
+	spawn sudo ping -f $embox_ip
+	expect "password" { send "$host_passwd\r" }
+	expect "try again" { puts "Incorrect password. Please, check host_passwd in test_core.c"; exit 1}
+	expect timeout
+	# Ctrl-C
+	send \x03
+
+	sleep 1
+
+	# Now check whether target replies or not
+	spawn ping -c 4 $embox_ip
+	expect timeout
+	lassign [wait] pid spawnid os_error_flag value
+	if {$value != 0} {
+		puts "Target won't reply after ping flooding"
+		exit 1
+	}
 
 	return 0
 }

--- a/scripts/expect/rlogin.exp
+++ b/scripts/expect/rlogin.exp
@@ -16,7 +16,7 @@ set host_passwd "rlogin"
 # !!! FIXME: This test does not work with Embox because on Embox we could not
 # run rlogin through telnet. Seems it is happened because telnet pass the
 # all received data into shell but not into rlogin client
-TEST_CASE {rlogin test} {
+TEST_CASE_TARGET {rlogin test} {
 	variable host_ip
 	global host_username
 	global host_passwd

--- a/scripts/expect/telnet.exp
+++ b/scripts/expect/telnet.exp
@@ -7,7 +7,7 @@ namespace import autotest::*
 TEST_CASE {execute "help" command through telnet} {
 	set TELNET_PROMPT ":/#"
 
-	test_assert_regexp_equal "help\r\n"    $TELNET_PROMPT
+	test_assert_regexp_equal "help\r"    $TELNET_PROMPT
 
 	return 0
 }

--- a/scripts/expect/telnet.exp
+++ b/scripts/expect/telnet.exp
@@ -4,10 +4,42 @@ source [file join [file dirname [info script]] framework/test_core.exp]
 
 namespace import autotest::*
 
-TEST_CASE {execute "help" command through telnet} {
+TEST_SUITE_SETUP
+
+TEST_CASE_TARGET {Execute "help" command once} {
 	set TELNET_PROMPT ":/#"
 
-	test_assert_regexp_equal "help\r"    $TELNET_PROMPT
+	send "help\r"
+	test_assert_regexp_equal "Available commands" $TELNET_PROMPT
+
+	return 0
+}
+
+TEST_CASE_TARGET {Execute "help" multiple times} {
+	set TELNET_PROMPT ":/#"
+
+	for {set i 0} {$i < 128} {incr i} {
+		send "help\r"
+		test_assert_regexp_equal "Available commands" $TELNET_PROMPT
+		exec sleep 0.1
+	}
+
+	return 0
+}
+
+TEST_CASE_HOST {Connect and exit several times telnet} {
+	variable embox_ip
+	set TELNET_PROMPT ":/#"
+
+	for {set i 0} {$i < 32} {incr i} {
+		exec sleep 0.5
+		puts "\nCONNECT iter=$i"
+
+		spawn telnet $embox_ip
+		test_assert_regexp_equal $TELNET_PROMPT
+		send "exit\r"
+		test_assert_regexp_equal "Connection closed by foreign host"
+	}
 
 	return 0
 }

--- a/scripts/expect/telnet.exp
+++ b/scripts/expect/telnet.exp
@@ -27,6 +27,7 @@ TEST_CASE_TARGET {Execute "help" multiple times} {
 	return 0
 }
 
+if {0} {
 TEST_CASE_HOST {Connect and exit several times telnet} {
 	variable embox_ip
 	set TELNET_PROMPT ":/#"
@@ -42,4 +43,5 @@ TEST_CASE_HOST {Connect and exit several times telnet} {
 	}
 
 	return 0
+}
 }

--- a/scripts/expect/vfat.exp
+++ b/scripts/expect/vfat.exp
@@ -14,7 +14,7 @@ proc vfat_setup {} {
 
 TEST_SETUP_TARGET {vfat_setup}
 
-TEST_CASE {vfat test} {
+TEST_CASE_TARGET {vfat test} {
 	test_assert_regexp_equal "mkfs -t vfat /dev/hda\r"             ":/#"
 
 	test_assert_regexp_equal "mount -t vfat /dev/hda /vfat_mnt\r"  ":/#"

--- a/scripts/expect/x86_net_tests.config
+++ b/scripts/expect/x86_net_tests.config
@@ -1,2 +1,3 @@
 ntpdate
 telnet
+ping


### PR DESCRIPTION
The main objective was to get `x86/test/net` back to its previous old state (and possibly externd).

What's done:
* Autotest framework is significantly rewritten and improved. Several new tests on telnet and ping are added
* Enable old ping forwarding tests. Small improvements in net/run.sh