### PR TITLE
x86/test/net: (template) change dropbear startup

### DIFF
--- a/templates/x86/test/net/start_script.inc
+++ b/templates/x86/test/net/start_script.inc
@@ -19,5 +19,5 @@
 "ping google.com",
 "httpd &",
 "telnetd &",
-"service dropbear -Fsg",
+"service dropbear -F",
 "snmpd &",


### PR DESCRIPTION
Little change to be able to connect via ssh with only root password (though connection with authorized_keys still possible).