### PR TITLE
travis: Get correct build status after travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   - set -e # make this script fail as soon as any individual command fail
   - . ./scripts/docker/docker_rc.sh
   - dr make confload-"$TEMPLATE"
-  - travis_wait run dr 'make &> build.log; tail -c 3M build.log'
+  - run dr ./scripts/continuous/build.sh
   - run dr ./scripts/continuous/run.sh "$TEMPLATE"
 
 addons:

--- a/scripts/continuous/build.sh
+++ b/scripts/continuous/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Since travis_wait doesn't work with docker well somewhy,
+# just use bell which prints something to stdout every 5 minutes.
+function bell() {
+	i=0
+	while true :
+	do
+		sleep 5m
+		i=$(($i+5))
+		echo "CI: Still building (minutes=$i)"
+	done
+}
+
+bell &
+bell_pid=$!
+
+make &> build.log
+RETVAL=$?
+tail -c 3M build.log
+
+# https://github.com/travis-ci/travis-ci/issues/6018 -- Prevert log truncation
+# on error. There are also many issues which refer to this one.
+sleep 5
+
+kill $bell_pid
+exit $RETVAL


### PR DESCRIPTION
Fix the problem with `travis_wait`: it used status of the last executed command, that is of `tail`, not make.