### PR TITLE
Fixes due to new qemu 3.1.0

### DIFF
--- a/scripts/continuous/net/forwarding/test_ping_forwarding.sh
+++ b/scripts/continuous/net/forwarding/test_ping_forwarding.sh
@@ -43,14 +43,14 @@ test_suite_setup() {
 
 	export CONTINIOUS_RUN_TIMEOUT=120
 	AUTOQEMU_NICS="" AUTOQEMU_NICS_CONFIG="" KERNEL=$EMBOX1_KERNEL $CONT_RUN generic/qemu_bg \
-		 "-net nic,vlan=0,model=virtio,macaddr=AA:BB:CC:DD:EE:12
-			-net tap,vlan=0,script=./scripts/qemu/start_script,downscript=./scripts/qemu/stop_script
-			-net nic,model=virtio,vlan=1,macaddr=AA:BB:CC:DD:EE:22 -net socket,vlan=1,listen=:12345" \
+		 "-net nic,model=virtio,netdev=n0,macaddr=AA:BB:CC:DD:EE:12
+			-netdev tap,script=./scripts/qemu/start_script,downscript=./scripts/qemu/stop_script,vnet_hdr=no,id=n0
+			-net nic,model=virtio,netdev=n1,macaddr=AA:BB:CC:DD:EE:22 -netdev socket,id=n1,listen=:12345" \
 		 $QEMU1_PID_FILE
 
 	AUTOQEMU_NICS="" AUTOQEMU_NICS_CONFIG="" KERNEL=$EMBOX2_KERNEL $CONT_RUN generic/qemu_bg \
-		 "-net nic,model=virtio,vlan=3,macaddr=AA:BB:CC:DD:EE:23
-			-net socket,vlan=3,connect=:12345" \
+		 "-net nic,model=virtio,netdev=n2,macaddr=AA:BB:CC:DD:EE:23
+			-netdev socket,id=n2,connect=:12345" \
 		 $QEMU2_PID_FILE
 
 	sudo route add default gw $QEMU1_ETH0 dev $TAP_DEV

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -125,7 +125,7 @@ make >/dev/null 2>/dev/null
 
 tap_up
 
-export AUTOQEMU_NICS_CONFIG="tap,ifname=tap0,script=no,downscript=no"
+export AUTOQEMU_NICS_CONFIG="tap,ifname=tap0,script=no,downscript=no,vnet_hdr=no"
 export CONTINIOUS_RUN_TIMEOUT=60
 $CONT_RUN generic/qemu_bg "" $PID_FILE
 if [ 0 -ne $? ]; then

--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -211,21 +211,31 @@ if [ $nic_n -gt 0 ]; then
 	sudo='sudo -E'
 	for ni in "${!qemu_nics[@]}"; do
 
-		if [ ${qemu_nics_config[$ni]} ] && [ ${qemu_nics_config[$ni]} != "-" ]; then
-			host_nic_config=${qemu_nics_config[$ni]}
-		else
-			host_nic_config="tap,script=$DATADIR/start_script,downscript=$DATADIR/stop_script"
-		fi
-
 		nic_model=${NIC2QEMU[${qemu_nics[$ni]}]}
 		echo
 		if [ ! $nic_model ]; then
 			error "nic model ${qemu_nics[$ni]} is not supported"
 		fi
+
+		if [ ${qemu_nics_config[$ni]} ] && [ ${qemu_nics_config[$ni]} != "-" ]; then
+			host_nic_config=${qemu_nics_config[$ni]}
+		else
+			if [ $nic_model = "virtio" ]; then
+				vnet_hdr="vnet_hdr=no"
+			else
+				vnet_hdr=""
+			fi
+			host_nic_config="tap,script=$DATADIR/start_script,downscript=$DATADIR/stop_script,$vnet_hdr"
+		fi
+
 		nic_macaddr="AA:BB:CC:DD:EE:0$(($ni + 2))"
+
+		# For new version of QEMU it should be in future:
+		# -nic $host_nic_config,model=$nic_model,mac=$nic_macaddr
+		#
 		nic_lines="$nic_lines \
-			-net nic,vlan=$ni,model=$nic_model,macaddr=$nic_macaddr \
-			-net $host_nic_config,vlan=$ni"
+			-net nic,netdev=n$ni,model=$nic_model,macaddr=$nic_macaddr \
+			-netdev $host_nic_config,id=n$ni"
 	done
 fi
 

--- a/src/net/socket/sock_hash.c
+++ b/src/net/socket/sock_hash.c
@@ -6,18 +6,28 @@
  */
 #include <net/sock.h>
 #include <util/dlist.h>
+#include <hal/ipl.h>
 
 void sock_hash(struct sock *sk) {
+	ipl_t ipl;
+
 	assert(sk != NULL);
 	assert(sk->p_ops != NULL);
 	assert(dlist_empty_entry(sk, lnk));
 
+	/* TODO Probably, it's better to use spinlock here */
+	ipl = ipl_save();
 	dlist_add_prev_entry(sk, sk->p_ops->sock_list, lnk);
+	ipl_restore(ipl);
 }
 
 void sock_unhash(struct sock *sk) {
+	ipl_t ipl;
+
 	assert(sk != NULL);
 	assert(!dlist_empty_entry(sk, lnk));
 
+	ipl = ipl_save();
 	dlist_del_init_entry(sk, lnk);
+	ipl_restore(ipl);
 }


### PR DESCRIPTION
In newer QEMU versions (>= 2.9.0, I guess) there is no more `vlan=0` option for `-net nic`. So migrating to new options.

[Qemu](https://wiki.qemu.org/Documentation/Networking#The_legacy_-net_option) proposes to use `-netdev tap` instead of  `-net tap`, and `-device` instead of `-net nic`. But the problem here that we are using embedded (on-board) network cards while `-device` works only with user creatable. A newer version of QEMU [proposes](https://qemu.weilnetz.de/doc/qemu-doc.html#Network-options) to use `-nic tap,model=virtio...` to get on-board network card, but QEMU 2.5.0 (old, but not too old version) doesn't have this option. In this PR I propose to use `-netdev` together with legacy `-net nic` for backward compatibilities with older QEMU versions. In the future, it could be changed to just `-nic tap,model=virtio...`

Also:
* Fix raise condition in sock_hash
* Fix virtio QEMU options to run with `-netdev` well