### PR TITLE
stm32f4-discovery telnet fix

### DIFF
--- a/src/cmds/Service.my
+++ b/src/cmds/Service.my
@@ -17,6 +17,9 @@ package embox.cmd
 			Alex Kalmuk
 	''')
 module service {
+	option number service_name_len=32
+	option number services_count=16
+
 	source "service.c"
 
 	depends embox.compat.libc.stdio.printf

--- a/src/cmds/service.c
+++ b/src/cmds/service.c
@@ -15,9 +15,10 @@
 #include <util/dlist.h>
 #include <sys/types.h>
 #include <signal.h>
+#include <framework/mod/options.h>
 
-#define SERVICE_NAME_LEN 32
-#define OBJECTS_QUANTITY 0x10
+#define SERVICE_NAME_LEN OPTION_GET(NUMBER,service_name_len)
+#define SERVICES_COUNT OPTION_GET(NUMBER,services_count)
 
 struct service_list {
 	struct dlist_head dlist_item;
@@ -25,7 +26,7 @@ struct service_list {
 	pid_t pid;
 };
 
-POOL_DEF(pool, struct service_list, OBJECTS_QUANTITY);
+POOL_DEF(pool, struct service_list, SERVICES_COUNT);
 
 static DLIST_DEFINE(head);
 

--- a/src/compat/posix/include/signal.h
+++ b/src/compat/posix/include/signal.h
@@ -15,6 +15,9 @@
 #include <util/bitmap.h>
 #include <sys/cdefs.h>
 
+#include <framework/mod/options.h>
+#include <module/embox/kernel/task/resource/sig_table.h>
+
 #define SIG_DFL ((sighandler_t) 0x1)
 #define SIG_IGN ((sighandler_t) 0x3)
 #define SIG_ERR ((sighandler_t) 0x5)
@@ -59,7 +62,9 @@
 #define SIGRTMIN    32
 #define SIGRTMAX    63
 
-#define _SIG_TOTAL  64
+#define _SIG_TOTAL \
+	OPTION_MODULE_GET(embox__kernel__task__resource__sig_table, \
+		NUMBER, sig_table_size)
 
 #define SA_NOCLDSTOP  (0x1ul << 0)
 #define SA_NOCLDWAIT  (0x1ul << 1)

--- a/src/drivers/i2c/adapters/stm32/Mybuild
+++ b/src/drivers/i2c/adapters/stm32/Mybuild
@@ -12,6 +12,7 @@ module stm32_i2c_f4 extends stm32_i2c {
 	source "stm32_i2c.c"
 
 	depends embox.driver.i2c
+	depends embox.driver.gpio.api
 	depends third_party.bsp.stmf4cube.stm32f4_discovery_bsp
 }
 

--- a/src/kernel/task/resource/Mybuild
+++ b/src/kernel/task/resource/Mybuild
@@ -56,6 +56,8 @@ module security {
 }
 
 module sig_table {
+	option number sig_table_size=64
+
 	source "sig_table.c"
 
 	depends embox.kernel.task.task_resource

--- a/templates/arm/stm32f4cube/mods.config
+++ b/templates/arm/stm32f4cube/mods.config
@@ -35,6 +35,8 @@ configuration conf {
 
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=16)
+	include embox.kernel.task.resource.sig_table(sig_table_size=10)
+	include embox.kernel.task.resource.env(env_per_task=2,env_str_len=16)
 
 	include embox.kernel.thread.thread_local_none
 	include embox.kernel.thread.thread_cancel_disable
@@ -56,10 +58,13 @@ configuration conf {
 	include embox.driver.tty.tty(rx_buff_sz=16, io_buff_sz=16)
 	include embox.driver.tty.task_breaking_disable
 
-	@Runlevel(2) include embox.cmd.sh.tish(builtin_commands = "cd export exit logout httpd")
+	@Runlevel(2) include embox.cmd.sh.tish(
+		builtin_commands = "cd export exit logout httpd pin ls help version"
+	)
 	include embox.init.setup_tty_diag
 	@Runlevel(3) include embox.init.start_script(shell_name="tish")
 
+	include embox.cmd.service(services_count=2)
 	include embox.cmd.help
 	include embox.cmd.fs.ls
 	include embox.cmd.msleep
@@ -82,6 +87,8 @@ configuration conf {
 	include embox.util.log
 	include embox.kernel.critical
 	include embox.kernel.irq
+	include embox.kernel.irq_stack_protection
+
 	include embox.mem.pool_adapter
 
 	include embox.util.LibUtil


### PR DESCRIPTION
Telnetd and httpd were crashed with asserts. The problem was the tasks allocates resource about 2Kb , because of the signal table size about 1Kb. I add an option to set signal table size.

So now you can run "service telnetd" and "service httpd" well again.

Also additional small fixes:

* Services count as options
* I2c missing dependance