### PR TITLE
Work on etnaviv driver

### DIFF
--- a/platform/etnaviv/cmds/Mybuild
+++ b/platform/etnaviv/cmds/Mybuild
@@ -85,3 +85,21 @@ module etnaviv_compiler {
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
 }
+
+@AutoCmd
+@Cmd(name = "quad_tex",
+	help = "Draw quad-texangle with purple background using gallium")
+
+@BuildDepends(third_party.freedesktop.mesa.libdrm_etnaviv)
+@Build(stage=2,script="true")
+module quad_tex {
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/include")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src/gallium/include")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src/gallium/auxiliary")
+	source "quad_tex.c"
+
+	depends third_party.freedesktop.mesa.libdrm_etnaviv
+	depends third_party.lib.estransform
+}
+

--- a/platform/etnaviv/cmds/Mybuild
+++ b/platform/etnaviv/cmds/Mybuild
@@ -65,3 +65,23 @@ module tri {
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
 	depends third_party.lib.estransform
 }
+
+@AutoCmd
+@Cmd(name = "etnaviv_compiler",
+	help = "Draw triangle with purple background using gallium")
+@BuildDepends(third_party.freedesktop.mesa.libdrm_etnaviv)
+@Build(stage=2,script="true")
+module etnaviv_compiler {
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/include")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src/gallium/include")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src/gallium/auxiliary")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/mesa_etnaviv/mesa-18.2.5/src/gallium/drivers/etnaviv")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96/include/drm/")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96/etnaviv/")
+	@IncludePath("$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96/")
+
+	source "etnaviv_compiler_cmdline.c"
+
+	depends third_party.freedesktop.mesa.libdrm_etnaviv
+}

--- a/platform/etnaviv/cmds/etnaviv_compiler_cmdline.c
+++ b/platform/etnaviv/cmds/etnaviv_compiler_cmdline.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2015 Etnaviv Project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sub license,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Rob Clark <robclark@freedesktop.org>
+ *    Christian Gmeiner <christian.gmeiner@gmail.com>
+ */
+
+#include <err.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "tgsi/tgsi_dump.h"
+#include "tgsi/tgsi_parse.h"
+#include "tgsi/tgsi_text.h"
+
+#include "etnaviv_compiler.h"
+#include "etnaviv_debug.h"
+#include "etnaviv_internal.h"
+#include "etnaviv_shader.h"
+
+#include "util/u_memory.h"
+
+static const struct etna_specs specs_gc2000 = {
+   .vs_need_z_div = 0,
+   .has_sin_cos_sqrt = 1,
+   .has_sign_floor_ceil = 1,
+   .vertex_sampler_offset = 8,
+   .vertex_output_buffer_size = 512,
+   .vertex_cache_size = 16,
+   .shader_core_count = 4,
+   .max_instructions = 512,
+   .max_varyings = 12,
+   .max_registers = 64,
+   .max_vs_uniforms = 168,
+   .max_ps_uniforms = 128,
+   .num_constants = 168,
+};
+
+static int
+read_file(const char *file_name, void **ptr, size_t *rsize)
+{
+    char *text = NULL;
+    size_t size;
+    size_t total_read = 0;
+    FILE *fp = fopen(file_name, "rb");
+
+    if (!fp) {
+        return 0;
+    }
+
+    fseek(fp, 0L, SEEK_END);
+    size = ftell(fp);
+    fseek(fp, 0L, SEEK_SET);
+
+    text = (char *) malloc(size + 1);
+    if (text != NULL) {
+        do {
+            size_t bytes = fread(text + total_read,
+                         1, size - total_read, fp);
+            if (bytes < size - total_read) {
+                free(text);
+                text = NULL;
+                break;
+            }
+
+            if (bytes == 0) {
+                break;
+            }
+
+            total_read += bytes;
+        } while (total_read < size);
+
+        text[total_read] = '\0';
+    }
+
+    fclose(fp);
+
+    *ptr = text;
+
+    *rsize = size;
+
+    return 0;
+}
+
+static void
+print_usage(void)
+{
+   printf("Usage: etnaviv_compiler [OPTIONS]... FILE\n");
+   printf("    --verbose         - verbose compiler/debug messages\n");
+   printf("    --frag-rb-swap    - swap rb in color output (FRAG)\n");
+   printf("    --help            - show this message\n");
+}
+
+int
+main(int argc, char **argv)
+{
+   int ret = 0, n = 1;
+   const char *filename;
+   struct tgsi_token toks[65536];
+   struct tgsi_parse_context parse;
+   struct etna_shader s = {};
+   struct etna_shader_key key = {};
+   void *ptr;
+   size_t size;
+
+   struct etna_shader_variant *v = CALLOC_STRUCT(etna_shader_variant);
+   if (!v) {
+      fprintf(stderr, "malloc failed!\n");
+      return 1;
+   }
+
+   etna_mesa_debug = ETNA_DBG_MSGS;
+
+   while (n < argc) {
+      if (!strcmp(argv[n], "--verbose")) {
+         etna_mesa_debug |= ETNA_DBG_COMPILER_MSGS;
+         n++;
+         continue;
+      }
+
+      if (!strcmp(argv[n], "--frag-rb-swap")) {
+         debug_printf(" %s", argv[n]);
+         key.frag_rb_swap = true;
+         n++;
+         continue;
+      }
+
+      if (!strcmp(argv[n], "--help")) {
+         print_usage();
+         return 0;
+      }
+
+      break;
+   }
+
+   filename = argv[n];
+
+   if (n >= argc) {
+	   printf("No fname given\n");
+	   return 0;
+   }
+
+   ret = read_file(filename, &ptr, &size);
+   if (ret) {
+      print_usage();
+      return ret;
+   }
+
+   debug_printf("%s\n", (char *)ptr);
+
+   if (!tgsi_text_translate(ptr, toks, ARRAY_SIZE(toks)))
+      errx(1, "could not parse `%s'", filename);
+
+   tgsi_parse_init(&parse, toks);
+
+   s.specs = &specs_gc2000;
+   s.tokens = toks;
+
+   v->shader = &s;
+   v->key = key;
+
+   if (!etna_compile_shader(v)) {
+      fprintf(stderr, "compiler failed!\n");
+      return 1;
+   }
+
+   etna_dump_shader(v);
+   etna_destroy_shader(v);
+}

--- a/platform/etnaviv/cmds/quad_tex.c
+++ b/platform/etnaviv/cmds/quad_tex.c
@@ -1,0 +1,352 @@
+/**************************************************************************
+ *
+ * Copyright © 2010 Jakob Bornecrantz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ **************************************************************************/
+
+
+#define USE_TRACE 0
+#define WIDTH 300
+#define HEIGHT 300
+#define NEAR 0
+#define FAR 1
+#define FLIP 0
+
+/* pipe_*_state structs */
+#include "pipe/p_state.h"
+/* pipe_context */
+#include "pipe/p_context.h"
+/* pipe_screen */
+#include "pipe/p_screen.h"
+/* PIPE_* */
+#include "pipe/p_defines.h"
+/* TGSI_SEMANTIC_{POSITION|GENERIC} */
+#include "pipe/p_shader_tokens.h"
+/* pipe_buffer_* helpers */
+#include "util/u_inlines.h"
+
+/* constant state object helper */
+#include "cso_cache/cso_context.h"
+
+/* u_sampler_view_default_template */
+#include "util/u_sampler.h"
+/* debug_dump_surface_bmp */
+#include "util/u_debug_image.h"
+/* util_draw_vertex_buffer helper */
+#include "util/u_draw_quad.h"
+/* FREE & CALLOC_STRUCT */
+#include "util/u_memory.h"
+/* util_make_[fragment|vertex]_passthrough_shader */
+#include "util/u_simple_shaders.h"
+/* to get a hardware pipe driver */
+#include "pipe-loader/pipe_loader.h"
+
+struct program
+{
+	struct pipe_loader_device *dev;
+	struct pipe_screen *screen;
+	struct pipe_context *pipe;
+	struct cso_context *cso;
+
+	struct pipe_blend_state blend;
+	struct pipe_depth_stencil_alpha_state depthstencil;
+	struct pipe_rasterizer_state rasterizer;
+	struct pipe_sampler_state sampler;
+	struct pipe_viewport_state viewport;
+	struct pipe_framebuffer_state framebuffer;
+	struct pipe_vertex_element velem[2];
+
+	void *vs;
+	void *fs;
+
+	union pipe_color_union clear_color;
+
+	struct pipe_resource *vbuf;
+	struct pipe_resource *target;
+	struct pipe_resource *tex;
+	struct pipe_sampler_view *view;
+};
+
+static void init_prog(struct program *p)
+{
+	struct pipe_surface surf_tmpl;
+	int ret;
+
+	/* find a hardware device */
+	ret = pipe_loader_probe(&p->dev, 1);
+	assert(ret);
+
+	/* init a pipe screen */
+	p->screen = pipe_loader_create_screen(p->dev);
+	assert(p->screen);
+
+	/* create the pipe driver context and cso context */
+	p->pipe = p->screen->context_create(p->screen, NULL, 0);
+	p->cso = cso_create_context(p->pipe, 0);
+
+	/* set clear color */
+	p->clear_color.f[0] = 0.3;
+	p->clear_color.f[1] = 0.1;
+	p->clear_color.f[2] = 0.3;
+	p->clear_color.f[3] = 1.0;
+
+	/* vertex buffer */
+	{
+		float vertices[4][2][4] = {
+			{
+				{ 0.9f, 0.9f, 0.0f, 1.0f },
+				{ 1.0f, 1.0f, 0.0f, 1.0f }
+			},
+			{
+				{ -0.9f, 0.9f, 0.0f, 1.0f },
+				{  0.0f, 1.0f, 0.0f, 1.0f }
+			},
+			{
+				{ -0.9f, -0.9f, 0.0f, 1.0f },
+				{  0.0f,  0.0f, 1.0f, 1.0f }
+			},
+			{
+				{ 0.9f, -0.9f, 0.0f, 1.0f },
+				{ 1.0f,  0.0f, 1.0f, 1.0f }
+			}
+		};
+
+		p->vbuf = pipe_buffer_create(p->screen, PIPE_BIND_VERTEX_BUFFER,
+					     PIPE_USAGE_DEFAULT, sizeof(vertices));
+		pipe_buffer_write(p->pipe, p->vbuf, 0, sizeof(vertices), vertices);
+	}
+
+	/* render target texture */
+	{
+		struct pipe_resource tmplt;
+		memset(&tmplt, 0, sizeof(tmplt));
+		tmplt.target = PIPE_TEXTURE_2D;
+		tmplt.format = PIPE_FORMAT_B8G8R8A8_UNORM; /* All drivers support this */
+		tmplt.width0 = WIDTH;
+		tmplt.height0 = HEIGHT;
+		tmplt.depth0 = 1;
+		tmplt.array_size = 1;
+		tmplt.last_level = 0;
+		tmplt.bind = PIPE_BIND_RENDER_TARGET;
+
+		p->target = p->screen->resource_create(p->screen, &tmplt);
+	}
+
+	/* sampler texture */
+	{
+		uint32_t *ptr;
+		struct pipe_transfer *t;
+		struct pipe_resource t_tmplt;
+		struct pipe_sampler_view v_tmplt;
+		struct pipe_box box;
+
+		memset(&t_tmplt, 0, sizeof(t_tmplt));
+		t_tmplt.target = PIPE_TEXTURE_2D;
+		t_tmplt.format = PIPE_FORMAT_B8G8R8A8_UNORM; /* All drivers support this */
+		t_tmplt.width0 = 2;
+		t_tmplt.height0 = 2;
+		t_tmplt.depth0 = 1;
+		t_tmplt.array_size = 1;
+		t_tmplt.last_level = 0;
+		t_tmplt.bind = PIPE_BIND_RENDER_TARGET;
+
+		p->tex = p->screen->resource_create(p->screen, &t_tmplt);
+
+		memset(&box, 0, sizeof(box));
+		box.width = 2;
+		box.height = 2;
+		box.depth = 1;
+
+		ptr = p->pipe->transfer_map(p->pipe, p->tex, 0, PIPE_TRANSFER_WRITE, &box, &t);
+                for (int i = 0; i < 128; i++) {
+                   ptr[i * 4 + 0] = 0xffff0000;
+                   ptr[i * 4 + 1] = 0xff0000ff;
+                   ptr[i * 4 + 2] = 0xff00ff00;
+                   ptr[i * 4 + 3] = 0xffffff00;
+                }
+		p->pipe->transfer_unmap(p->pipe, t);
+
+		u_sampler_view_default_template(&v_tmplt, p->tex, p->tex->format);
+
+		p->view = p->pipe->create_sampler_view(p->pipe, p->tex, &v_tmplt);
+	}
+
+	/* disabled blending/masking */
+	memset(&p->blend, 0, sizeof(p->blend));
+	p->blend.rt[0].colormask = PIPE_MASK_RGBA;
+
+	/* no-op depth/stencil/alpha */
+	memset(&p->depthstencil, 0, sizeof(p->depthstencil));
+
+	/* rasterizer */
+	memset(&p->rasterizer, 0, sizeof(p->rasterizer));
+	p->rasterizer.cull_face = PIPE_FACE_NONE;
+	p->rasterizer.half_pixel_center = 1;
+	p->rasterizer.bottom_edge_rule = 1;
+	p->rasterizer.depth_clip = 1;
+
+	/* sampler */
+	memset(&p->sampler, 0, sizeof(p->sampler));
+	p->sampler.wrap_s = PIPE_TEX_WRAP_CLAMP_TO_EDGE;
+	p->sampler.wrap_t = PIPE_TEX_WRAP_CLAMP_TO_EDGE;
+	p->sampler.wrap_r = PIPE_TEX_WRAP_CLAMP_TO_EDGE;
+	p->sampler.min_mip_filter = PIPE_TEX_MIPFILTER_NONE;
+	p->sampler.min_img_filter = PIPE_TEX_MIPFILTER_LINEAR;
+	p->sampler.mag_img_filter = PIPE_TEX_MIPFILTER_LINEAR;
+	p->sampler.normalized_coords = 1;
+
+	surf_tmpl.format = PIPE_FORMAT_B8G8R8A8_UNORM; /* All drivers support this */
+	surf_tmpl.u.tex.level = 0;
+	surf_tmpl.u.tex.first_layer = 0;
+	surf_tmpl.u.tex.last_layer = 0;
+	/* drawing destination */
+	memset(&p->framebuffer, 0, sizeof(p->framebuffer));
+	p->framebuffer.width = WIDTH;
+	p->framebuffer.height = HEIGHT;
+	p->framebuffer.nr_cbufs = 1;
+	p->framebuffer.cbufs[0] = p->pipe->create_surface(p->pipe, p->target, &surf_tmpl);
+
+	/* viewport, depth isn't really needed */
+	{
+		float x = 0;
+		float y = 0;
+		float z = NEAR;
+		float half_width = (float)WIDTH / 2.0f;
+		float half_height = (float)HEIGHT / 2.0f;
+		float half_depth = ((float)FAR - (float)NEAR) / 2.0f;
+		float scale, bias;
+
+		if (FLIP) {
+			scale = -1.0f;
+			bias = (float)HEIGHT;
+		} else {
+			scale = 1.0f;
+			bias = 0.0f;
+		}
+
+		p->viewport.scale[0] = half_width;
+		p->viewport.scale[1] = half_height * scale;
+		p->viewport.scale[2] = half_depth;
+
+		p->viewport.translate[0] = half_width + x;
+		p->viewport.translate[1] = (half_height + y) * scale + bias;
+		p->viewport.translate[2] = half_depth + z;
+	}
+
+	/* vertex elements state */
+	memset(p->velem, 0, sizeof(p->velem));
+	p->velem[0].src_offset = 0 * 4 * sizeof(float); /* offset 0, first element */
+	p->velem[0].instance_divisor = 0;
+	p->velem[0].vertex_buffer_index = 0;
+	p->velem[0].src_format = PIPE_FORMAT_R32G32B32A32_FLOAT;
+
+	p->velem[1].src_offset = 1 * 4 * sizeof(float); /* offset 16, second element */
+	p->velem[1].instance_divisor = 0;
+	p->velem[1].vertex_buffer_index = 0;
+	p->velem[1].src_format = PIPE_FORMAT_R32G32B32A32_FLOAT;
+
+	/* vertex shader */
+	{
+		const enum tgsi_semantic semantic_names[] =
+                   { TGSI_SEMANTIC_POSITION, TGSI_SEMANTIC_GENERIC };
+		const uint semantic_indexes[] = { 0, 0 };
+		p->vs = util_make_vertex_passthrough_shader(p->pipe, 2, semantic_names, semantic_indexes, FALSE);
+	}
+
+	/* fragment shader */
+	p->fs = util_make_fragment_tex_shader(p->pipe, TGSI_TEXTURE_2D,
+	                                      TGSI_INTERPOLATE_LINEAR,
+	                                      TGSI_RETURN_TYPE_FLOAT,
+	                                      TGSI_RETURN_TYPE_FLOAT, false,
+                                              false);
+}
+
+static void close_prog(struct program *p)
+{
+	cso_destroy_context(p->cso);
+
+	p->pipe->delete_vs_state(p->pipe, p->vs);
+	p->pipe->delete_fs_state(p->pipe, p->fs);
+
+	pipe_surface_reference(&p->framebuffer.cbufs[0], NULL);
+	pipe_sampler_view_reference(&p->view, NULL);
+	pipe_resource_reference(&p->target, NULL);
+	pipe_resource_reference(&p->tex, NULL);
+	pipe_resource_reference(&p->vbuf, NULL);
+
+	p->pipe->destroy(p->pipe);
+	p->screen->destroy(p->screen);
+	pipe_loader_release(&p->dev, 1);
+
+	FREE(p);
+}
+
+static void draw(struct program *p)
+{
+	const struct pipe_sampler_state *samplers[] = {&p->sampler};
+
+	/* set the render target */
+	cso_set_framebuffer(p->cso, &p->framebuffer);
+
+	/* clear the render target */
+	p->pipe->clear(p->pipe, PIPE_CLEAR_COLOR, &p->clear_color, 0, 0);
+
+	/* set misc state we care about */
+	cso_set_blend(p->cso, &p->blend);
+	cso_set_depth_stencil_alpha(p->cso, &p->depthstencil);
+	cso_set_rasterizer(p->cso, &p->rasterizer);
+	cso_set_viewport(p->cso, &p->viewport);
+
+	/* sampler */
+	cso_set_samplers(p->cso, PIPE_SHADER_FRAGMENT, 1, samplers);
+
+	/* texture sampler view */
+	cso_set_sampler_views(p->cso, PIPE_SHADER_FRAGMENT, 1, &p->view);
+
+	/* shaders */
+	cso_set_fragment_shader_handle(p->cso, p->fs);
+	cso_set_vertex_shader_handle(p->cso, p->vs);
+
+	/* vertex element data */
+	cso_set_vertex_elements(p->cso, 2, p->velem);
+
+	util_draw_vertex_buffer(p->pipe, p->cso,
+	                        p->vbuf, 0, 0,
+	                        PIPE_PRIM_QUADS,
+	                        4,  /* verts */
+	                        2); /* attribs/vert */
+
+        p->pipe->flush(p->pipe, NULL, 0);
+
+	debug_dump_surface_bmp(p->pipe, "result.bmp", p->framebuffer.cbufs[0]);
+}
+
+int main(int argc, char** argv)
+{
+	struct program *p = CALLOC_STRUCT(program);
+
+	init_prog(p);
+	draw(p);
+	close_prog(p);
+
+	return 0;
+}

--- a/platform/etnaviv/cmds/tri.c
+++ b/platform/etnaviv/cmds/tri.c
@@ -26,8 +26,8 @@
 #define USE_TRACE 0
 #define WIDTH 300
 #define HEIGHT 300
-#define NEAR 30
-#define FAR 1000
+#define NEAR 0
+#define FAR 1
 #define FLIP 0
 
 #include "pipe/p_state.h"
@@ -110,6 +110,7 @@ static void init_prog(struct program *p)
 
 		p->vbuf = pipe_buffer_create(p->screen, PIPE_BIND_VERTEX_BUFFER,
 					     PIPE_USAGE_DEFAULT, sizeof(vertices));
+
 		pipe_buffer_write(p->pipe, p->vbuf, 0, sizeof(vertices), vertices);
 	}
 
@@ -127,8 +128,6 @@ static void init_prog(struct program *p)
 		tmplt.bind = PIPE_BIND_RENDER_TARGET;
 
 		p->target = p->screen->resource_create(p->screen, &tmplt);
-
-		printf("p target %p\n", p->target);
 	}
 
 	/* disabled blending/masking */
@@ -140,19 +139,19 @@ static void init_prog(struct program *p)
 
 	/* rasterizer */
 	memset(&p->rasterizer, 0, sizeof(p->rasterizer));
-	p->rasterizer.cull_face = PIPE_FACE_NONE;
+	p->rasterizer.cull_face         = PIPE_FACE_NONE;
 	p->rasterizer.half_pixel_center = 1;
-	p->rasterizer.bottom_edge_rule = 1;
-	p->rasterizer.depth_clip = 1;
+	p->rasterizer.bottom_edge_rule  = 1;
+	p->rasterizer.depth_clip        = 1;
 
 	surf_tmpl.format = PIPE_FORMAT_B8G8R8A8_UNORM;
-	surf_tmpl.u.tex.level = 0;
+	surf_tmpl.u.tex.level       = 0;
 	surf_tmpl.u.tex.first_layer = 0;
-	surf_tmpl.u.tex.last_layer = 0;
+	surf_tmpl.u.tex.last_layer  = 0;
 	/* drawing destination */
 	memset(&p->framebuffer, 0, sizeof(p->framebuffer));
-	p->framebuffer.width = WIDTH;
-	p->framebuffer.height = HEIGHT;
+	p->framebuffer.width    = WIDTH;
+	p->framebuffer.height   = HEIGHT;
 	p->framebuffer.nr_cbufs = 1;
 	p->framebuffer.cbufs[0] = p->pipe->create_surface(p->pipe, p->target, &surf_tmpl);
 
@@ -160,7 +159,7 @@ static void init_prog(struct program *p)
 	{
 		float x = 0;
 		float y = 0;
-		float z = FAR;
+		float z = NEAR;
 		float half_width = (float)WIDTH / 2.0f;
 		float half_height = (float)HEIGHT / 2.0f;
 		float half_depth = ((float)FAR - (float)NEAR) / 2.0f;
@@ -185,19 +184,19 @@ static void init_prog(struct program *p)
 
 	/* vertex elements state */
 	memset(p->velem, 0, sizeof(p->velem));
-	p->velem[0].src_offset = 0 * 4 * sizeof(float); /* offset 0, first element */
-	p->velem[0].instance_divisor = 0;
+	p->velem[0].src_offset          = 0 * 4 * sizeof(float); /* offset 0, first element */
+	p->velem[0].instance_divisor    = 0;
 	p->velem[0].vertex_buffer_index = 0;
-	p->velem[0].src_format = PIPE_FORMAT_R32G32B32A32_FLOAT;
+	p->velem[0].src_format          = PIPE_FORMAT_R32G32B32A32_FLOAT;
 
-	p->velem[1].src_offset = 1 * 4 * sizeof(float); /* offset 16, second element */
-	p->velem[1].instance_divisor = 0;
+	p->velem[1].src_offset          = 1 * 4 * sizeof(float); /* offset 16, second element */
+	p->velem[1].instance_divisor    = 0;
 	p->velem[1].vertex_buffer_index = 0;
-	p->velem[1].src_format = PIPE_FORMAT_R32G32B32A32_FLOAT;
+	p->velem[1].src_format          = PIPE_FORMAT_R32G32B32A32_FLOAT;
 
 	/* vertex shader */
 	{
-			const uint semantic_names[] = { TGSI_SEMANTIC_POSITION,
+			const enum tgsi_semantic semantic_names[] = { TGSI_SEMANTIC_POSITION,
 							TGSI_SEMANTIC_COLOR };
 			const uint semantic_indexes[] = { 0, 0 };
 			p->vs = util_make_vertex_passthrough_shader(
@@ -256,10 +255,9 @@ static void draw(struct program *p) {
 	debug_dump_surface_bmp(p->pipe, "result.bmp", p->framebuffer.cbufs[0]);
 }
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
 	struct program *p = CALLOC_STRUCT(program);
-	printf("p = %p\n", p);
+
 	init_prog(p);
 	draw(p);
 	close_prog(p);

--- a/platform/etnaviv/templates/imx6/mods.config
+++ b/platform/etnaviv/templates/imx6/mods.config
@@ -45,6 +45,7 @@ configuration conf {
 	include embox.driver.tty.serial_dvfs
 	include embox.driver.serial.uart_dev_dvfs
 
+	include embox.fs.driver.devfs_dvfs
 	include embox.fs.driver.dvfs_driver
 	include embox.fs.driver.initfs_dvfs
 	@Runlevel(2) include embox.fs.rootfs_dvfs
@@ -67,7 +68,8 @@ configuration conf {
 	include platform.etnaviv.cmd.hardcode_cube
 	include platform.etnaviv.cmd.cube
 	include platform.etnaviv.cmd.tri
-	include platform.etnaviv.cmd.drmdevice
+	include platform.etnaviv.cmd.quad_tex
+	include platform.etnaviv.cmd.etnaviv_compiler
 	include platform.etnaviv.cmd.etnaviv_2d_test
 
 	@Runlevel(2) include embox.mem.static_heap(heap_size=167108864)
@@ -95,7 +97,6 @@ configuration conf {
 
 	include embox.driver.gpu.etnaviv_drm(log_level=0)
 	include third_party.freedesktop.mesa.mesa_etnaviv
-	//include third_party.freedesktop.mesa.libglu_osmesa
 	include embox.cmd.osdemo_imx6
 
 	include embox.lib.cxx.standalone

--- a/platform/etnaviv/templates/imx6/start_script.inc
+++ b/platform/etnaviv/templates/imx6/start_script.inc
@@ -1,4 +1,1 @@
 "export LIBGL_DEBUG=verbose",
-"osdemo_imx6"
-//"tri"
-//"cube"

--- a/src/compat/libc/assert/assert_impl.h
+++ b/src/compat/libc/assert/assert_impl.h
@@ -16,6 +16,12 @@
 
 #ifdef NDEBUG
 
+#if defined __cplusplus
+# define __ASSERT_VOID_CAST static_cast<void>
+#else
+# define __ASSERT_VOID_CAST (void)
+#endif
+
 /* Do nothing.
  *
  * Implementation note: casting zero to typeof(condition) in the 'while' clause
@@ -26,7 +32,7 @@
  *      unused.
  */
 # define __assert(condition, expr_str, ...) \
-	do { } while ((__typeof__(condition)) 0)
+	(__ASSERT_VOID_CAST (0))
 
 #else
 

--- a/src/compat/linux/include/linux/sizes.h
+++ b/src/compat/linux/include/linux/sizes.h
@@ -1,0 +1,50 @@
+/**
+ * @file sizes.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 11.01.2019
+ */
+
+#ifndef COMPAT_LINUX_SIZES_H_
+#define COMPAT_LINUX_SIZES_H_
+
+#define SZ_1		0x00000001
+#define SZ_2		0x00000002
+#define SZ_4		0x00000004
+#define SZ_8		0x00000008
+#define SZ_16		0x00000010
+#define SZ_32		0x00000020
+#define SZ_64		0x00000040
+#define SZ_128		0x00000080
+#define SZ_256		0x00000100
+#define SZ_512		0x00000200
+
+#define SZ_1K		0x00000400
+#define SZ_2K		0x00000800
+#define SZ_4K		0x00001000
+#define SZ_8K		0x00002000
+#define SZ_16K		0x00004000
+#define SZ_32K		0x00008000
+#define SZ_64K		0x00010000
+#define SZ_128K		0x00020000
+#define SZ_256K		0x00040000
+#define SZ_512K		0x00080000
+
+#define SZ_1M		0x00100000
+#define SZ_2M		0x00200000
+#define SZ_4M		0x00400000
+#define SZ_8M		0x00800000
+#define SZ_16M		0x01000000
+#define SZ_32M		0x02000000
+#define SZ_64M		0x04000000
+#define SZ_128M		0x08000000
+#define SZ_256M		0x10000000
+#define SZ_512M		0x20000000
+
+#define SZ_1G		0x40000000
+#define SZ_2G		0x80000000
+
+#define SZ_4G	((unsigned long long) 4 * SZ_1G)
+
+#endif /* COMPAT_LINUX_SIZES_H_ */

--- a/src/compat/linux/include/linux/types.h
+++ b/src/compat/linux/include/linux/types.h
@@ -45,7 +45,8 @@ typedef unsigned char 		u8_t;
 typedef unsigned short int 	u16_t;
 typedef unsigned long int 	u32_t;
 
-typedef uint32_t          dma_addr_t;
+typedef uint32_t dma_addr_t;
+typedef uint32_t phys_addr_t;
 
 #endif /* __ASSEMBLER__ */
 

--- a/src/compat/posix/include/sys/select.h
+++ b/src/compat/posix/include/sys/select.h
@@ -10,7 +10,7 @@
 #define SYS_SELECT_H_
 
 #include <sys/types.h>
-
+#include <limits.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/src/drivers/char/char_dev_dvfs/char_dev.h
+++ b/src/drivers/char/char_dev_dvfs/char_dev.h
@@ -14,8 +14,8 @@
 #include <util/array.h>
 
 #define CHAR_DEV_DEF(chname, open_fn, close_fn, idesc_op, priv) \
-	ARRAY_SPREAD_DECLARE(const struct dev_module, __device_registry); \
-	ARRAY_SPREAD_ADD(__device_registry, { \
+	ARRAY_SPREAD_DECLARE(const struct dev_module, __char_device_registry); \
+	ARRAY_SPREAD_ADD(__char_device_registry, { \
 			.name = chname, \
 			.dev_priv = priv, \
 			.dev_iops = idesc_op, \

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_buffer.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_buffer.c
@@ -129,7 +129,7 @@ void etnaviv_buffer_dump(struct etnaviv_gpu *gpu,
 		if (i && !(i % 8))
 			printk("\n");
 		if (i % 8 == 0)
-			printk("\t0x%p: ", ptr + i);
+			printk("\t%p: ", ptr + i);
 		printk("%08x ", *(ptr + i));
 	}
 

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_cmd_parser.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_cmd_parser.c
@@ -14,8 +14,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//#include <linux/kernel.h>
-
 #include <util/log.h>
 
 #include "etnaviv_compat.h"
@@ -31,60 +29,6 @@ struct etna_validation_state {
 	const struct drm_etnaviv_gem_submit_reloc *relocs;
 	unsigned int num_relocs;
 	uint32_t *start;
-};
-
-static const struct {
-	uint16_t offset;
-	uint16_t size;
-} etnaviv_sensitive_states[] __initconst = {
-#define ST(start, num) { (start) >> 2, (num) }
-	/* 2D */
-	ST(0x1200, 1),
-	ST(0x1228, 1),
-	ST(0x1238, 1),
-	ST(0x1284, 1),
-	ST(0x128c, 1),
-	ST(0x1304, 1),
-	ST(0x1310, 1),
-	ST(0x1318, 1),
-	ST(0x12800, 4),
-	ST(0x128a0, 4),
-	ST(0x128c0, 4),
-	ST(0x12970, 4),
-	ST(0x12a00, 8),
-	ST(0x12b40, 8),
-	ST(0x12b80, 8),
-	ST(0x12ce0, 8),
-	/* 3D */
-	ST(0x0644, 1),
-	ST(0x064c, 1),
-	ST(0x0680, 8),
-	ST(0x086c, 1),
-	ST(0x1028, 1),
-	ST(0x1410, 1),
-	ST(0x1430, 1),
-	ST(0x1458, 1),
-	ST(0x1460, 8),
-	ST(0x1480, 8),
-	ST(0x1500, 8),
-	ST(0x1520, 8),
-	ST(0x1608, 1),
-	ST(0x1610, 1),
-	ST(0x1658, 1),
-	ST(0x165c, 1),
-	ST(0x1664, 1),
-	ST(0x1668, 1),
-	ST(0x16a4, 1),
-	ST(0x16c0, 8),
-	ST(0x16e0, 8),
-	ST(0x1740, 8),
-	ST(0x17c0, 8),
-	ST(0x17e0, 8),
-	ST(0x2400, 14 * 16),
-	ST(0x10800, 32 * 16),
-	ST(0x14600, 16),
-	ST(0x14800, 8 * 8),
-#undef ST
 };
 
 #define ETNAVIV_STATES_SIZE (VIV_FE_LOAD_STATE_HEADER_OFFSET__MASK + 1u)

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_cmdbuf.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_cmdbuf.h
@@ -27,19 +27,16 @@ struct etnaviv_cmdbuf_suballoc;
 struct etnaviv_cmdbuf {
 	/* suballocator this cmdbuf is allocated from */
 	struct etnaviv_cmdbuf_suballoc *suballoc;
-	/* user context key, must be unique between all active users */
-	struct etnaviv_file_private *ctx;
 	/* cmdbuf properties */
 	int suballoc_offset;
 	void *vaddr;
+	void *ctx;
 	uint32_t size;
 	uint32_t user_size;
 	/* fence after which this buffer is to be disposed */
 	struct dma_fence *fence;
 	/* target exec state */
 	uint32_t exec_state;
-	/* per GPU in-flight list */
-	struct list_head node;
 	/* BOs attached to this command buffer */
 	unsigned int nr_bos;
 	struct etnaviv_vram_mapping *bo_map[0];

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_compat.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_compat.h
@@ -11,6 +11,8 @@
 
 #include <errno.h>
 #include <linux/list.h>
+#include <linux/sizes.h>
+#include <linux/types.h>
 #include <linux/kernel.h>
 #include <mem/sysmalloc.h>
 #include <string.h>
@@ -38,8 +40,6 @@ static inline void *kzalloc(int a, int b) {
 
 #define DRM_ERROR log_error
 
-#define atomic_t int
-
 struct reservation_object {
 	int stub;
 };
@@ -62,27 +62,14 @@ static inline int order_base_2(int q) {
 	return res;
 };
 
-#define SZ_4K 4096
-#define SZ_2M (2 * 1024 * 1024)
-#define SZ_2G ((long long) 2 * 1024 * 1024 * 1024)
-
-#define __initconst
-#define __init
-#define __iomem
-
 #define BIT(n) (1 << (n))
 
-struct work_struct;
-struct dma_buf_attachment;
-struct vm_fault;
 struct platform_device;
 struct drm_device;
 struct drm_file;
 struct file;
 struct drm_gem_object;
 struct timespec;
-
-typedef int phys_addr_t;
 
 #define PHYS_OFFSET 0x10000000 /* Start of RAM */
 

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
@@ -190,7 +190,7 @@ static irq_return_t etna_irq_handler(unsigned int irq, void *data)
 }
 
 static int etnaviv_ref = 0;
-static struct idesc *etnaviv_dev_open(struct inode *node, struct idesc *idesc) {
+static struct idesc *etnaviv_dev_open(struct dev_module *cdev, void *priv) {
 	struct file *file;
 	int i;
 
@@ -378,10 +378,6 @@ static void *etnaviv_dev_idesc_mmap(struct idesc *idesc, void *addr, size_t len,
 	return res;
 }
 
-static struct file_operations etnaviv_dev_ops = {
-	.open = etnaviv_dev_open,
-};
-
 static struct idesc_ops etnaviv_dev_idesc_ops = {
 	.close = etnaviv_dev_close,
 	.id_readv = etnaviv_dev_read,
@@ -392,7 +388,7 @@ static struct idesc_ops etnaviv_dev_idesc_ops = {
 	.idesc_mmap = etnaviv_dev_idesc_mmap,
 };
 
-CHAR_DEV_DEF(ETNAVIV_DEV_NAME, NULL, NULL, &etnaviv_dev_idesc_ops, NULL);
+CHAR_DEV_DEF(ETNAVIV_DEV_NAME, etnaviv_dev_open, NULL, &etnaviv_dev_idesc_ops, NULL);
 
 static struct periph_memory_desc vivante3d_mem = {
 	.start = VIVANTE_3D_BASE,

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_drv.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_drv.h
@@ -26,10 +26,6 @@ struct etnaviv_mmu;
 struct etnaviv_gem_object;
 struct etnaviv_gem_submit;
 
-struct etnaviv_file_private {
-	int dummy;
-};
-
 struct etnaviv_drm_private {
 	int num_gpus;
 	struct etnaviv_gpu *gpu[ETNA_MAX_PIPES];
@@ -38,61 +34,25 @@ struct etnaviv_drm_private {
 int etnaviv_ioctl_gem_submit(struct drm_device *dev, void *data,
 		struct drm_file *file);
 
-int etnaviv_gem_mmap(struct file *filp, struct vm_area_struct *vma);
-int etnaviv_gem_fault(struct vm_fault *vmf);
 int etnaviv_gem_mmap_offset(struct drm_gem_object *obj, uint64_t *offset);
-struct sg_table *etnaviv_gem_prime_get_sg_table(struct drm_gem_object *obj);
-void *etnaviv_gem_prime_vmap(struct drm_gem_object *obj);
-void etnaviv_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
-int etnaviv_gem_prime_mmap(struct drm_gem_object *obj,
-			   struct vm_area_struct *vma);
-struct drm_gem_object *etnaviv_gem_prime_import_sg_table(struct drm_device *dev,
-	struct dma_buf_attachment *attach, struct sg_table *sg);
-int etnaviv_gem_prime_pin(struct drm_gem_object *obj);
-void etnaviv_gem_prime_unpin(struct drm_gem_object *obj);
-void *etnaviv_gem_vmap(struct drm_gem_object *obj);
-int etnaviv_gem_cpu_prep(struct drm_gem_object *obj, uint32_t op,
-		struct timespec *timeout);
-int etnaviv_gem_cpu_fini(struct drm_gem_object *obj);
-void etnaviv_gem_free_object(struct drm_gem_object *obj);
 int etnaviv_gem_new_handle(struct drm_device *dev, struct drm_file *file,
 		uint32_t size, uint32_t flags, uint32_t *handle);
-struct drm_gem_object *etnaviv_gem_new_locked(struct drm_device *dev,
-		uint32_t size, uint32_t flags);
 struct drm_gem_object *etnaviv_gem_new(struct drm_device *dev,
 		uint32_t size, uint32_t flags);
-int etnaviv_gem_new_userptr(struct drm_device *dev, struct drm_file *file,
-	uintptr_t ptr, uint32_t size, uint32_t flags, uint32_t *handle);
 uint16_t etnaviv_buffer_init(struct etnaviv_gpu *gpu);
 uint16_t etnaviv_buffer_config_mmuv2(struct etnaviv_gpu *gpu, uint32_t mtlb_addr, uint32_t safe_addr);
-void etnaviv_buffer_end(struct etnaviv_gpu *gpu);
 void etnaviv_buffer_queue(struct etnaviv_gpu *gpu, unsigned int event,
 	struct etnaviv_cmdbuf *cmdbuf);
-void etnaviv_validate_init(void);
 bool etnaviv_cmd_validate_one(struct etnaviv_gpu *gpu,
 	uint32_t *stream, unsigned int size,
 	struct drm_etnaviv_gem_submit_reloc *relocs, unsigned int reloc_size);
-
-#ifdef CONFIG_DEBUG_FS
-void etnaviv_gem_describe_objects(struct etnaviv_drm_private *priv,
-	struct seq_file *m);
-#endif
-
-void *etnaviv_ioremap(struct platform_device *pdev, const char *name,
-		const char *dbgname);
-void etnaviv_writel(uint32_t data, void __iomem *addr);
-uint32_t etnaviv_readl(const void __iomem *addr);
-
-#define DBG(fmt, ...) DRM_DEBUG(fmt"\n", ##__VA_ARGS__)
-#define VERB(fmt, ...) if (0) DRM_DEBUG(fmt"\n", ##__VA_ARGS__)
 
 /*
  * Return the storage size of a structure with a variable length array.
  * The array is nelem elements of elem_size, where the base structure
  * is defined by base.  If the size overflows size_t, return zero.
  */
-static inline size_t size_vstruct(size_t nelem, size_t elem_size, size_t base)
-{
+static inline size_t size_vstruct(size_t nelem, size_t elem_size, size_t base) {
 	if (elem_size && nelem > (SIZE_MAX - base) / elem_size)
 		return 0;
 	return base + nelem * elem_size;

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gem.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gem.c
@@ -20,14 +20,13 @@
 #include "etnaviv_gem.h"
 #include "etnaviv_drv.h"
 
-
 int etnaviv_gem_obj_add(struct drm_device *dev, struct drm_gem_object *obj) {
 	return 0;
 }
 
 static int etnaviv_gem_new_impl(struct drm_device *dev, uint32_t size,
 		uint32_t flags, struct reservation_object *robj,
-		const struct etnaviv_gem_ops *ops, struct drm_gem_object **obj) {
+		void *ops, struct drm_gem_object **obj) {
 	struct etnaviv_gem_object *etnaviv_obj;
 	unsigned sz = sizeof(*etnaviv_obj);
 	etnaviv_obj = sysmalloc(sz);
@@ -38,10 +37,8 @@ static int etnaviv_gem_new_impl(struct drm_device *dev, uint32_t size,
 	}
 
 	etnaviv_obj->flags = flags;
-	etnaviv_obj->ops = ops;
 
 	mutex_init(&etnaviv_obj->lock);
-	INIT_LIST_HEAD(&etnaviv_obj->gem_node);
 
 	*obj = &etnaviv_obj->base;
 
@@ -109,8 +106,7 @@ int etnaviv_gem_mmap_offset(struct drm_gem_object *obj, uint64_t *offset) {
 }
 
 struct etnaviv_vram_mapping *etnaviv_gem_mapping_get(
-	struct drm_gem_object *obj, struct etnaviv_gpu *gpu)
-{
+	struct drm_gem_object *obj, struct etnaviv_gpu *gpu) {
 	struct etnaviv_gem_object *etnaviv_obj = to_etnaviv_bo(obj);
 	struct etnaviv_vram_mapping *mapping;
 

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gem.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gem.h
@@ -27,20 +27,12 @@ struct etnaviv_gem_object {
 	const struct etnaviv_gem_ops *ops;
 	pthread_mutex_t lock;
 
-	struct list_head gem_node;
 	struct etnaviv_gpu *gpu;     /* non-null if active */
 
 	int flags;
 };
 
 struct vm_area_struct;
-struct etnaviv_gem_ops {
-	int (*get_pages)(struct etnaviv_gem_object *);
-	void (*release)(struct etnaviv_gem_object *);
-	void *(*vmap)(struct etnaviv_gem_object *);
-	int (*mmap)(struct etnaviv_gem_object *, struct vm_area_struct *);
-};
-
 
 extern int etnaviv_gem_mmap_offset(struct drm_gem_object *obj, uint64_t *offset);
 

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.c
@@ -117,8 +117,7 @@ int etnaviv_gpu_get_param(struct etnaviv_gpu *gpu, uint32_t param, uint64_t *val
 #define etnaviv_field(val, field) \
 	(((val) & field##__MASK) >> field##__SHIFT)
 
-static void etnaviv_hw_specs(struct etnaviv_gpu *gpu)
-{
+static void etnaviv_hw_specs(struct etnaviv_gpu *gpu) {
 	if (gpu->identity.minor_features0 &
 	    chipMinorFeatures0_MORE_MINOR_FEATURES) {
 		uint32_t specs[4];
@@ -267,8 +266,7 @@ static void etnaviv_hw_specs(struct etnaviv_gpu *gpu)
 		gpu->identity.varyings_count -= 1;
 }
 
-static void etnaviv_hw_identify(struct etnaviv_gpu *gpu)
-{
+static void etnaviv_hw_identify(struct etnaviv_gpu *gpu) {
 	uint32_t chipIdentity;
 
 	chipIdentity = gpu_read(gpu, VIVS_HI_CHIP_IDENTITY);
@@ -379,15 +377,13 @@ static void etnaviv_hw_identify(struct etnaviv_gpu *gpu)
 	etnaviv_hw_specs(gpu);
 }
 
-static void etnaviv_gpu_load_clock(struct etnaviv_gpu *gpu, uint32_t clock)
-{
+static void etnaviv_gpu_load_clock(struct etnaviv_gpu *gpu, uint32_t clock) {
 	gpu_write(gpu, VIVS_HI_CLOCK_CONTROL, clock |
 		  VIVS_HI_CLOCK_CONTROL_FSCALE_CMD_LOAD);
 	gpu_write(gpu, VIVS_HI_CLOCK_CONTROL, clock);
 }
 
-static void etnaviv_gpu_update_clock(struct etnaviv_gpu *gpu)
-{
+static void etnaviv_gpu_update_clock(struct etnaviv_gpu *gpu) {
 	unsigned int fscale = 1 << (6 - 1);//gpu->freq_scale);
 	uint32_t clock = VIVS_HI_CLOCK_CONTROL_DISABLE_DEBUG_REGISTERS |
 	                 VIVS_HI_CLOCK_CONTROL_FSCALE_VAL(fscale);
@@ -395,8 +391,7 @@ static void etnaviv_gpu_update_clock(struct etnaviv_gpu *gpu)
 	etnaviv_gpu_load_clock(gpu, clock);
 }
 
-static int etnaviv_hw_reset(struct etnaviv_gpu *gpu)
-{
+static int etnaviv_hw_reset(struct etnaviv_gpu *gpu) {
 	uint32_t control, idle;
 	bool failed = true;
 
@@ -895,9 +890,7 @@ int etnaviv_gpu_wait_fence_interruptible(struct etnaviv_gpu *gpu,
 				fence, gpu->retired_fence,
 				gpu->completed_fence);
 			ret = -ETIMEDOUT;
-		} /* else if (ret != -ERESTARTSYS) {
-			ret = 0;
-		} */
+		}
 	}
 
 	return ret;

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.h
@@ -100,7 +100,7 @@ struct etnaviv_gpu {
 
 	uint32_t memory_base;
 
-	struct etnaviv_file_private *lastctx;
+	void *lastctx;
 	int switch_context;
 
 	/* Fencing support */

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_mmu.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_mmu.c
@@ -39,8 +39,7 @@ int etnaviv_iommu_init(struct etnaviv_gpu *gpu) {
 	return 0;
 }
 
-void etnaviv_iommu_restore(struct etnaviv_gpu *gpu)
-{
+void etnaviv_iommu_restore(struct etnaviv_gpu *gpu) {
 	if (gpu->mmu.version == ETNAVIV_IOMMU_V1) {
 		etnaviv_iommuv1_restore(gpu);
 	} else {
@@ -51,8 +50,7 @@ void etnaviv_iommu_restore(struct etnaviv_gpu *gpu)
 extern struct etnaviv_iommu_ops etnaviv_iommu_ops;
 int etnaviv_iommu_get_suballoc_va(struct etnaviv_gpu *gpu, dma_addr_t paddr,
 				size_t size,
-				  uint32_t *iova)
-{
+				  uint32_t *iova) {
 	struct etnaviv_iommu *mmu = &gpu->mmu;
 
 	if (mmu->version == ETNAVIV_IOMMU_V1) {

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_mmu.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_mmu.h
@@ -27,8 +27,6 @@ enum etnaviv_iommu_version {
 struct etnaviv_gpu;
 struct etnaviv_vram_mapping;
 struct iommu_domain;
-struct sg_table;
-struct drm_mm_node;
 
 struct iommu_ops {
 	void (*domain_free)(struct iommu_domain *domain);
@@ -62,36 +60,15 @@ struct etnaviv_iommu {
 
 	enum etnaviv_iommu_version version;
 
-	/* memory manager for GPU address area */
-	//struct mutex lock;
 	struct list_head mappings;
-	//struct drm_mm mm;
 	uint32_t last_iova;
 	bool need_flush;
 };
 
 struct etnaviv_gem_object;
 
-int etnaviv_iommu_attach(struct etnaviv_iommu *iommu, const char **names,
-	int cnt);
-int etnaviv_iommu_map(struct etnaviv_iommu *iommu, uint32_t iova,
-	struct sg_table *sgt, unsigned len, int prot);
-int etnaviv_iommu_unmap(struct etnaviv_iommu *iommu, uint32_t iova,
-	struct sg_table *sgt, unsigned len);
-int etnaviv_iommu_map_gem(struct etnaviv_iommu *mmu,
-	struct etnaviv_gem_object *etnaviv_obj, uint32_t memory_base,
-	struct etnaviv_vram_mapping *mapping);
-void etnaviv_iommu_unmap_gem(struct etnaviv_iommu *mmu,
-	struct etnaviv_vram_mapping *mapping);
-void etnaviv_iommu_destroy(struct etnaviv_iommu *iommu);
-
-int etnaviv_iommu_get_suballoc_va(struct etnaviv_gpu *gpu, dma_addr_t paddr,  size_t size,
-				  uint32_t *iova);
-void etnaviv_iommu_put_suballoc_va(struct etnaviv_gpu *gpu, size_t size,
-				   uint32_t iova);
-
-size_t etnaviv_iommu_dump_size(struct etnaviv_iommu *iommu);
-void etnaviv_iommu_dump(struct etnaviv_iommu *iommu, void *buf);
+int etnaviv_iommu_get_suballoc_va(struct etnaviv_gpu *gpu, dma_addr_t paddr,
+		size_t size, uint32_t *iova);
 
 int etnaviv_iommu_init(struct etnaviv_gpu *gpu);
 void etnaviv_iommu_restore(struct etnaviv_gpu *gpu);

--- a/third-party/freedesktop/mesa/libdrm/etnaviv/Makefile
+++ b/third-party/freedesktop/mesa/libdrm/etnaviv/Makefile
@@ -19,6 +19,7 @@ $(CONFIGURE) :
 		./configure --host=$(AUTOCONF_TARGET_TRIPLET) \
 			--enable-etnaviv-experimental-api \
 			--enable-static \
+			--disable-dependency-tracking \
 			--disable-shared \
 			--disable-tegra-experimental-api \
 			--disable-vmwgfx \

--- a/third-party/freedesktop/mesa/libdrm/etnaviv/patch.txt
+++ b/third-party/freedesktop/mesa/libdrm/etnaviv/patch.txt
@@ -324,3 +324,53 @@ diff -aur libdrm-2.4.96-orig/xf86drm.c libdrm-2.4.96/xf86drm.c
      }
      node_count = i;
  
+--- libdrm-2.4.96-orig/build-aux/ltmain.sh	2018-10-16 17:49:10.000000000 +0300
++++ libdrm-2.4.96/build-aux/ltmain.sh	2018-12-26 13:38:36.446796112 +0300
+@@ -7008,47 +7008,6 @@
+ 	continue
+ 	;;
+ 
+-      -l*)
+-	if test X-lc = "X$arg" || test X-lm = "X$arg"; then
+-	  case $host in
+-	  *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-beos* | *-cegcc* | *-*-haiku*)
+-	    # These systems don't actually have a C or math library (as such)
+-	    continue
+-	    ;;
+-	  *-*-os2*)
+-	    # These systems don't actually have a C library (as such)
+-	    test X-lc = "X$arg" && continue
+-	    ;;
+-	  *-*-openbsd* | *-*-freebsd* | *-*-dragonfly* | *-*-bitrig*)
+-	    # Do not include libc due to us having libc/libc_r.
+-	    test X-lc = "X$arg" && continue
+-	    ;;
+-	  *-*-rhapsody* | *-*-darwin1.[012])
+-	    # Rhapsody C and math libraries are in the System framework
+-	    func_append deplibs " System.ltframework"
+-	    continue
+-	    ;;
+-	  *-*-sco3.2v5* | *-*-sco5v6*)
+-	    # Causes problems with __ctype
+-	    test X-lc = "X$arg" && continue
+-	    ;;
+-	  *-*-sysv4.2uw2* | *-*-sysv5* | *-*-unixware* | *-*-OpenUNIX*)
+-	    # Compiler inserts libc in the correct place for threads to work
+-	    test X-lc = "X$arg" && continue
+-	    ;;
+-	  esac
+-	elif test X-lc_r = "X$arg"; then
+-	 case $host in
+-	 *-*-openbsd* | *-*-freebsd* | *-*-dragonfly* | *-*-bitrig*)
+-	   # Do not include libc_r directly, use -pthread flag.
+-	   continue
+-	   ;;
+-	 esac
+-	fi
+-	func_append deplibs " $arg"
+-	continue
+-	;;
+-
+       -mllvm)
+ 	prev=mllvm
+ 	continue

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Makefile
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Makefile
@@ -25,7 +25,6 @@ $(CONFIGURE) :
 	export EMBOX_GCC_LINK=full; \
 	export PKG_CONFIG_PATH=$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96:$(ROOT_DIR)/build/extbld/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96/etnaviv;\
 	cd $(PKG_SOURCE_DIR) && aclocal && autoconf &&( \
-		patch configure -p0 < $(SRC_DIR)/../third-party/freedesktop/mesa/mesa/mesa_etnaviv/configure.patch;\
 		./configure --host=$(AUTOCONF_TARGET_TRIPLET) \
 			--target=$(AUTOCONF_TARGET_TRIPLET) \
 			--enable-static  --disable-shared \
@@ -49,7 +48,7 @@ $(CONFIGURE) :
 			HAVE_GALLIUM_SOFTWARE_PIPE=yes \
 			CC=$(EMBOX_GCC) \
 			CXX=$(EMBOX_GXX) \
-			CPPFLAGS='$(MESA_CPPFLAGS) -DGALLIUM_ETNAVIV' \
+			CPPFLAGS='$(MESA_CPPFLAGS) -DGALLIUM_ETNAVIV -DHAVE_PTHREADS' \
 	)
 	touch $@
 

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Mybuild
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Mybuild
@@ -1,6 +1,6 @@
 package third_party.freedesktop.mesa
 
-@BuildDepends(third_party.freedesktop.mesa.libdrm)
+@BuildDepends(third_party.freedesktop.mesa.libdrm_etnaviv)
 @Build(script="$(EXTERNAL_MAKE)")
 module  mesa_etnaviv {
 	source "^BUILD/extbld/^MOD_PATH/install/libglapi.a"

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/patch.txt
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/patch.txt
@@ -74,7 +74,7 @@ diff -aur -x configure -x Makefile.in -x aclocal.m4 mesa-18.2.5-orig/src/mesa/ma
     struct mem_block *heap;
     unsigned ofs;
     unsigned size;
-+#if !defined(__EMBOX__)
++#if 1
     unsigned free:1;
     unsigned reserved:1;
 +#else
@@ -92,7 +92,7 @@ diff -aur -x configure -x Makefile.in -x aclocal.m4 mesa-18.2.5-orig/src/mesa/pr
     struct prog_src_register SrcReg[3];
     struct prog_dst_register DstReg;
 -
-+#if !defined(__EMBOX__)
++#if 1
     /**
      * Saturate each value of the vectored result to the range [0,1].
      *
@@ -342,7 +342,7 @@ diff -aur mesa-18.2.5-orig/src/mesa/program/prog_parameter.h mesa-18.2.5/src/mes
  {
     const char *Name;        /**< Null-terminated string */
 -   gl_register_file Type:16;  /**< PROGRAM_CONSTANT or STATE_VAR */
-+   gl_register_file Type;  /**< PROGRAM_CONSTANT or STATE_VAR */
++   gl_register_file Type:16;  /**< PROGRAM_CONSTANT or STATE_VAR */
     GLenum16 DataType;         /**< GL_FLOAT, GL_FLOAT_VEC2, etc */
     /**
      * Number of components (1..4), or more.
@@ -368,17 +368,6 @@ diff -aur mesa-18.2.5-orig/src/util/disk_cache.c mesa-18.2.5/src/util/disk_cache
  
  #include <ctype.h>
  #include <ftw.h>
-diff -aur mesa-18.2.5-orig/src/util/macros.h mesa_osmesa/mesa-18.2.5/src/util/macros.h
---- mesa-18.2.5-orig/src/util/macros.h	2018-11-15 15:32:30.000000000 +0300
-+++ mesa-18.2.5/src/util/macros.h	2018-11-26 16:57:09.087062100 +0300
-@@ -63,7 +63,6 @@
-  */
- #define STATIC_ASSERT(COND) \
-    do { \
--      (void) sizeof(char [1 - 2*!(COND)]); \
-    } while (0)
- 
- 
 diff -aur mesa-18.2.5-orig/src/util/build_id.c mesa-18.2.5/src/util/build_id.c
 --- mesa-18.2.5-orig/src/util/build_id.c	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/util/build_id.c	2018-11-26 17:43:40.410165708 +0300
@@ -647,62 +636,6 @@ diff -aur mesa-18.2.5-orig/meson.build mesa-18.2.5/meson.build
  endif
  if dep_dl.found()
    gl_priv_libs += '-ldl'
-diff -aur mesa-18.2.5-orig/src/mesa/vbo/vbo.h mesa-18.2.5/src/mesa/vbo/vbo.h
---- mesa-18.2.5-orig/src/mesa/vbo/vbo.h	2018-11-15 15:32:30.000000000 +0300
-+++ mesa-18.2.5/src/mesa/vbo/vbo.h	2018-11-27 12:36:44.045238643 +0300
-@@ -42,14 +42,14 @@
- 
- struct _mesa_prim
- {
--   GLuint mode:8;    /**< GL_POINTS, GL_LINES, GL_QUAD_STRIP, etc */
--   GLuint indexed:1;
--   GLuint begin:1;
--   GLuint end:1;
--   GLuint weak:1;
--   GLuint no_current_update:1;
--   GLuint is_indirect:1;
--   GLuint pad:18;
-+   GLuint mode;    /**< GL_POINTS, GL_LINES, GL_QUAD_STRIP, etc */
-+   GLuint indexed;
-+   GLuint begin;
-+   GLuint end;
-+   GLuint weak;
-+   GLuint no_current_update;
-+   GLuint is_indirect;
-+   GLuint pad;
- 
-    GLuint start;
-    GLuint count;
-diff -aur mesa-18.2.5-orig/src/mesa/main/mtypes.h mesa-18.2.5/src/mesa/main/mtypes.h
---- mesa-18.2.5-orig/src/mesa/main/mtypes.h	2018-11-15 15:32:30.000000000 +0300
-+++ mesa-18.2.5/src/mesa/main/mtypes.h	2018-11-27 12:52:28.970719504 +0300
-@@ -1420,12 +1420,12 @@
-    GLenum16 Format;         /**< Default: GL_RGBA, but may be GL_BGRA */
-    GLboolean Enabled;       /**< Whether the array is enabled */
-    GLubyte Size;            /**< Components per element (1,2,3,4) */
--   unsigned Normalized:1;   /**< Fixed-point values are normalized when converted to floats */
--   unsigned Integer:1;      /**< Fixed-point values are not converted to floats */
--   unsigned Doubles:1;      /**< double precision values are not converted to floats */
--   unsigned _ElementSize:8; /**< Size of each element in bytes */
-+   unsigned Normalized;   /**< Fixed-point values are normalized when converted to floats */
-+   unsigned Integer;      /**< Fixed-point values are not converted to floats */
-+   unsigned Doubles;      /**< double precision values are not converted to floats */
-+   unsigned _ElementSize; /**< Size of each element in bytes */
-    /** Index into gl_vertex_array_object::BufferBinding[] array */
--   unsigned BufferBindingIndex:6;
-+   unsigned BufferBindingIndex;
- 
-    /**
-     * Derived effective buffer binding index
-@@ -1440,7 +1440,7 @@
-     * Note that _mesa_update_vao_derived_arrays is called when binding
-     * the VAO to Array._DrawVAO.
-     */
--   unsigned _EffBufferBindingIndex:6;
-+   unsigned _EffBufferBindingIndex;
-    /**
-     * Derived effective relative offset.
-     *
 diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/tests/Makefile.in mesa-18.2.5/src/mesa/state_tracker/tests/Makefile.in
 --- mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi_private.h	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/mesa/state_tracker/st_glsl_to_tgsi_private.h	2018-11-27 13:53:09.117870555 +0300
@@ -843,132 +776,48 @@ diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi_temprename.cpp
  
  /* Without c++11 define the nullptr for forward-compatibility
   * and better readibility */
-@@ -218,11 +218,14 @@
+@@ -196,9 +196,9 @@
+    /* Helper constants to make the tracking code more readable. */
+    static const int write_is_conditional = -1;
+    static const int conditionality_unresolved = 0;
+-   static const int conditionality_untouched;
+-   static const int write_is_unconditional;
++static const int conditionality_untouched = 0x3FFFFFFF;
+ 
++static const int write_is_unconditional = 0x3FFFFFFF - 1;
+    /* A bit field tracking the nexting levels of if-else clauses where the
+     * temporary has (so far) been written to in the if branch, but not in the
+     * else branch.
+@@ -218,11 +218,7 @@
     bool was_written_in_current_else_scope;
  };
  
 -const int
 -temp_comp_access::conditionality_untouched = numeric_limits<int>::max();
-+static const int write_is_conditional = 0xcafe;
-+static const int write_is_unconditional = 0xdead;
-+static const int conditionality_untouched = 0xbeef;
-+//const int
-+//temp_comp_access::conditionality_untouched = numeric_limits<int>::max();
  
 -const int
 -temp_comp_access::write_is_unconditional = numeric_limits<int>::max() - 1;
-+//const int
-+//temp_comp_access::write_is_unconditional = numeric_limits<int>::max() - 1;
  
  /* Class to track the access to all components of a temporary register. */
  class temp_access {
-@@ -266,7 +269,7 @@
+@@ -266,7 +262,7 @@
     scope_nesting_depth(depth),
     scope_begin(scope_begin),
     scope_end(-1),
 -   break_loop_line(numeric_limits<int>::max()),
-+//   break_loop_line(numeric_limits<int>::max()),
++   break_loop_line(0x3FFFFFFF),
     parent_scope(parent)
  {
  }
-@@ -355,12 +358,6 @@
- 
- const prog_scope *prog_scope::enclosing_conditional() const
- {
--   if (is_conditional())
--      return this;
--
--   if (parent_scope)
--      return parent_scope->enclosing_conditional();
--
-    return nullptr;
- }
- 
-@@ -551,8 +548,8 @@
+@@ -551,7 +547,7 @@
     first_write(-1),
     last_read(-1),
     last_write(-1),
 -   first_read(numeric_limits<int>::max()),
--   conditionality_in_loop_id(conditionality_untouched),
-+//   first_read(numeric_limits<int>::max()),
-+//   conditionality_in_loop_id(conditionality_untouched),
++   first_read(0x3FFFFFFF),
+    conditionality_in_loop_id(conditionality_untouched),
     if_scope_write_flags(0),
     next_ifelse_nesting_depth(0),
-    current_unpaired_if_write_scope(nullptr),
-@@ -573,8 +570,6 @@
-    /* If the conditionality of the first write is already resolved then
-     * no further checks are required.
-     */
--   if (conditionality_in_loop_id == write_is_unconditional ||
--       conditionality_in_loop_id == write_is_conditional)
-       return;
- 
-    /* Check whether we are in a condition within a loop */
-@@ -586,8 +581,6 @@
-        * resolved as unconditional in the enclosing loop then check whether
-        * we read before write in an IF/ELSE branch.
-        */
--      if ((conditionality_in_loop_id != write_is_conditional) &&
--          (conditionality_in_loop_id != enclosing_loop->id())) {
- 
-          if (current_unpaired_if_write_scope)  {
- 
-@@ -611,9 +604,7 @@
-           * it should survive a loop. This can be signaled like if it were
-           * conditionally written.
-           */
--         conditionality_in_loop_id = write_is_conditional;
-       }
--   }
- }
- 
- void temp_comp_access::record_write(int line, prog_scope *scope)
-@@ -630,22 +621,16 @@
-        */
-       const prog_scope *conditional = scope->enclosing_conditional();
-       if (!conditional || !conditional->innermost_loop()) {
--         conditionality_in_loop_id = write_is_unconditional;
-       }
-    }
- 
-    /* The conditionality of the first write is already resolved. */
--   if (conditionality_in_loop_id == write_is_unconditional ||
--       conditionality_in_loop_id == write_is_conditional)
-       return;
- 
-    /* If the nesting depth is larger than the supported level,
-     * then we assume conditional writes.
-     */
--   if (next_ifelse_nesting_depth >= supported_ifelse_nesting_depth) {
--      conditionality_in_loop_id = write_is_conditional;
-       return;
--   }
- 
-    /* If we are in an IF/ELSE scope within a loop and the loop has not
-     * been resolved already, then record this write.
-@@ -662,7 +647,6 @@
-       /* The first write in an IF branch within a loop implies unresolved
-        * conditionality (if it was untouched or unconditional before).
-        */
--      conditionality_in_loop_id = conditionality_unresolved;
-       was_written_in_current_else_scope = false;
-       record_if_write(scope);
-    } else {
-@@ -757,13 +741,12 @@
-      /* The temporary was not written in the IF branch corresponding
-       * to this ELSE branch, hence the write is conditional.
-       */
--      conditionality_in_loop_id = write_is_conditional;
-    }
- }
- 
- bool temp_comp_access::conditional_ifelse_write_in_loop() const
- {
--   return conditionality_in_loop_id <= conditionality_unresolved;
-+   return 0;
- }
- 
- void temp_comp_access::propagate_lifetime_to_dominant_write_scope()
 diff -aur mesa-18.2.5-orig/include/drm-uapi/drm.h .mesa-18.2.5/include/drm-uapi/drm.h
 --- mesa-18.2.5-orig/include/drm-uapi/drm.h	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/include/drm-uapi/drm.h	2018-11-27 14:33:18.038728314 +0300
@@ -981,18 +830,6 @@ diff -aur mesa-18.2.5-orig/include/drm-uapi/drm.h .mesa-18.2.5/include/drm-uapi/
  #include <sys/types.h>
  typedef int8_t   __s8;
  typedef uint8_t  __u8;
-diff -aur mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_info.h mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_info.h
---- mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_info.h	2018-11-15 15:32:30.000000000 +0300
-+++ mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_info.h	2018-11-27 15:06:25.497385062 +0300
-@@ -79,7 +79,7 @@
-    unsigned pre_dedent:1;
-    unsigned post_indent:1;
-    enum tgsi_output_mode output_mode:4;
--   enum tgsi_opcode opcode:10;
-+   enum tgsi_opcode opcode;
- };
- 
- const struct tgsi_opcode_info *
 diff -aur mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_ureg.h mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_ureg.h
 --- mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_ureg.h	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_ureg.h	2018-11-27 15:14:22.242543610 +0300
@@ -1062,6 +899,17 @@ diff -aur mesa-18.2.5-orig/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c m
  #include "target-helpers/drm_helper_public.h"
  #include "state_tracker/drm_driver.h"
  #include "pipe_loader_priv.h"
+@@ -45,7 +46,7 @@
+ #include "util/u_dl.h"
+ #include "util/u_debug.h"
+ 
+-#define DRM_RENDER_NODE_DEV_NAME_FORMAT "%s/renderD%d"
+-#define DRM_RENDER_NODE_MAX_NODES 63
+-#define DRM_RENDER_NODE_MIN_MINOR 128
++#define DRM_RENDER_NODE_DEV_NAME_FORMAT "/dev/card"
++#define DRM_RENDER_NODE_MAX_NODES 0
++#define DRM_RENDER_NODE_MIN_MINOR 0
+ #define DRM_RENDER_NODE_MAX_MINOR (DRM_RENDER_NODE_MIN_MINOR + DRM_RENDER_NODE_MAX_NODES)
 diff -aur mesa-18.2.5-orig/src/loader/meson.build .mesa-18.2.5/src/loader/meson.build
 --- mesa-18.2.5-orig/src/loader/meson.build	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/loader/meson.build	2018-11-28 13:37:12.429213122 +0300
@@ -1139,3 +987,225 @@ diff -aur mesa-18.2.5-orig/src/gallium/auxiliary/pipe-loader/pipe_loader_sw.c me
  #include "state_tracker/drisw_api.h"
  #include "state_tracker/sw_driver.h"
  #include "state_tracker/sw_winsys.h"
+diff -aur mesa-18.2.5-orig/src/util/macros.h mesa-18.2.5/src/util/macros.h
+--- mesa-18.2.5-orig/src/util/macros.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/util/macros.h	2018-11-30 19:56:38.935477971 +0300
+@@ -63,7 +63,6 @@
+  */
+ #define STATIC_ASSERT(COND) \
+    do { \
+-      (void) sizeof(char [1 - 2*!(COND)]); \
+    } while (0)
+ 
+ 
+@@ -292,7 +291,7 @@
+  * Macro for declaring an explicit conversion operator.  Defaults to an
+  * implicit conversion if C++11 is not supported.
+  */
+-#if __cplusplus >= 201103L
++#if 0
+ #define EXPLICIT_CONVERSION explicit
+ #elif defined(__cplusplus)
+ #define EXPLICIT_CONVERSION
+--- mesa-18.2.5-orig/src/gallium/auxiliary/util/u_debug_image.c	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/gallium/auxiliary/util/u_debug_image.c	2018-12-20 15:18:14.249309336 +0300
+@@ -34,9 +34,13 @@
+ 
+ #include <stdio.h>
+ 
++#include <drivers/video/fb.h>
++#include <drivers/video/fb_overlay.h>
+ 
+-#ifdef DEBUG
+ 
++#if 1
++
++static struct fb_info *mesa_fbi;
+ /**
+  * Dump an image to .ppm file.
+  * \param format  PIPE_FORMAT_x
+@@ -261,28 +273,30 @@
+    bmih.biYPelsPerMeter = 0;
+    bmih.biClrUsed = 0;
+    bmih.biClrImportant = 0;
++   mesa_fbi = fb_lookup(0);
+ 
+-   stream = fopen(filename, "wb");
+-   if (!stream)
+-      goto error1;
+-
+-   fwrite(&bmfh, 14, 1, stream);
+-   fwrite(&bmih, 40, 1, stream);
++   printf("%dx%d, %dbpp base %p\n", mesa_fbi->var.xres, mesa_fbi->var.yres,
++		   mesa_fbi->var.bits_per_pixel, mesa_fbi->screen_base);
+ 
+    y = height;
++
++   uint16_t *base = mesa_fbi->screen_base;
++
+    while (y--) {
+       float *ptr = rgba + (stride * y * 4);
+       for (x = 0; x < width; ++x) {
++      uint16_t *ptr_d = base + (y * mesa_fbi->var.xres + x);
+          struct bmp_rgb_quad pixel;
+          pixel.rgbRed   = float_to_ubyte(ptr[x*4 + 0]);
+          pixel.rgbGreen = float_to_ubyte(ptr[x*4 + 1]);
+          pixel.rgbBlue  = float_to_ubyte(ptr[x*4 + 2]);
+          pixel.rgbAlpha = float_to_ubyte(ptr[x*4 + 3]);
+-         fwrite(&pixel, 1, 4, stream);
++
++	 pix_fmt_convert(&pixel, ptr_d, 1, RGBA8888, RGB565);
++
+       }
+    }
+ 
+-   fclose(stream);
+ error1:
+    ;
+ }
+--- mesa-18.2.5-orig/src/gallium/auxiliary/util/u_debug_image.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/gallium/auxiliary/util/u_debug_image.h	2018-12-20 13:48:41.819002990 +0300
+@@ -32,7 +32,7 @@
+ #include "pipe/p_format.h"
+ 
+ 
+-#ifdef DEBUG
++#if 1
+ struct pipe_context;
+ struct pipe_surface;
+ struct pipe_transfer;
+--- mesa-18.2.5-orig/include/c11/threads.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/c11/threads.h	2018-12-19 17:06:36.701749715 +0300
+@@ -60,13 +60,7 @@
+ 
+ /*-------------------------- functions --------------------------*/
+ 
+-#if defined(_WIN32) && !defined(__CYGWIN__)
+-#include "threads_win32.h"
+-#elif defined(HAVE_PTHREAD)
+ #include "threads_posix.h"
+-#else
+-#error Not supported on this platform.
+-#endif
+ 
+ 
+ 
+--- mesa-18.2.5-orig/src/gallium/targets/osmesa/target.c	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/gallium/targets/osmesa/target.c	2018-12-19 17:00:49.457393698 +0300
+@@ -25,15 +25,27 @@
+ #include "target-helpers/inline_debug_helper.h"
+ 
+ #include "sw/null/null_sw_winsys.h"
+-
++#include <renderonly/renderonly.h>
+ 
+ struct pipe_screen *
+ osmesa_create_screen(void);
+ 
++static struct renderonly ro;
+ 
+ struct pipe_screen *
+ osmesa_create_screen(void)
+ {
++	struct etna_gpu *gpu;
++	int fd = open("/dev/card", 0);
++	struct etna_device *dev = etna_device_new(fd);
++	gpu = etna_gpu_new(dev, 0);
++	ro.gpu_fd = fd;
++	struct pipe_screen *ret = etna_screen_create(dev, gpu, &ro);
++
++	printf("\nCreated screen successfully!\n");
++
++	return ret;
++#if 0
+    struct sw_winsys *winsys;
+    struct pipe_screen *screen;
+ 
+@@ -53,4 +65,5 @@
+ 
+    /* Inject optional trace, debug, etc. wrappers */
+    return debug_screen_wrap(screen);
++#endif
+ }
+--- mesa-18.2.5-orig/src/gallium/auxiliary/util/u_debug.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/gallium/auxiliary/util/u_debug.h	2018-12-24 19:12:29.322450151 +0300
+@@ -193,10 +193,10 @@
+ 
+ 
+ /** Override standard assert macro */
+-#ifdef assert
+-#undef assert
+-#endif
+-#define assert(expr) debug_assert(expr)
++//#ifdef assert
++//#undef assert
++//#endif
++//#define assert(expr) debug_assert(expr)
+ 
+ 
+ /**
+--- mesa-18.2.5-orig/src/mesa/program/prog_parameter.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/mesa/program/prog_parameter.h	2018-12-25 12:19:34.877720656 +0300
+@@ -68,7 +68,8 @@
+    PROGRAM_MEMORY,      /**< for shared, global and local memory */
+    PROGRAM_IMAGE,       /**< for shader images, compile-time only */
+    PROGRAM_HW_ATOMIC,   /**< for hw atomic counters, compile-time only */
+-   PROGRAM_FILE_MAX
++   PROGRAM_FILE_MAX,
++   PROGRAM_STUB = (1 << 16) - 1,
+ } gl_register_file;
+ 
+ 
+--- mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_info.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_info.h	2018-12-25 12:28:49.120789700 +0300
+@@ -66,7 +66,8 @@
+    /**
+     * Example: TGSI_OPCODE_TEX
+     */
+-   TGSI_OUTPUT_OTHER           = 4
++   TGSI_OUTPUT_OTHER           = 4,
++   TGSI_BOUND                  = (1 << 10) - 1,
+ };
+ 
+ struct tgsi_opcode_info
+--- mesa-18.2.5-orig/src/gallium/include/pipe/p_shader_tokens.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/gallium/include/pipe/p_shader_tokens.h	2018-12-25 12:35:44.118699419 +0300
+@@ -613,6 +613,7 @@
+    TGSI_OPCODE_LOD                = 249,
+ 
+    TGSI_OPCODE_LAST               = 250,
++   TGSI_OPCODE_BOUND              = (1 << 10) - 1,
+ };
+ 
+ 
+diff -aur mesa-18.2.5-orig/include/EGL/eglplatform.h mesa-18.2.5/include/EGL/eglplatform.h
+--- mesa-18.2.5-orig/include/EGL/eglplatform.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/EGL/eglplatform.h	2019-02-18 12:36:19.358953030 +0300
+@@ -77,7 +77,7 @@
+ typedef HBITMAP EGLNativePixmapType;
+ typedef HWND    EGLNativeWindowType;
+ 
+-#elif defined(__WINSCW__) || defined(__SYMBIAN32__)  /* Symbian */
++#elif defined(__WINSCW__) || defined(__SYMBIAN32__)  /* Symbian */ || defined(__EMBOX__)
+ 
+ typedef int   EGLNativeDisplayType;
+ typedef void *EGLNativeWindowType;
+diff -aur -x configure mesa-18.2.5-orig/include/c99_math.h mesa-18.2.5/include/c99_math.h
+--- mesa-18.2.5-orig/include/c99_math.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/c99_math.h	2019-02-25 19:24:54.368694957 +0300
+@@ -184,7 +184,7 @@
+ #error "Need to include or define an fpclassify function"
+ #endif
+ 
+-
++#ifdef __cplusplus
+ /* Since C++11, the following functions are part of the std namespace. Their C
+  * counteparts should still exist in the global namespace, however cmath
+  * undefines those functions, which in glibc 2.23, are defined as macros rather
+@@ -207,5 +207,6 @@
+ using std::isunordered;
+ #endif
+ 
++#endif /* #ifdef __cplusplus */
+ 
+ #endif /* #define _C99_MATH_H_ */


### PR DESCRIPTION
This branch contains a bunch of etnaviv-related fixes/improvements:
* Add commands: `quad_tex` for simple texture test, `etnaviv_compiler` for compiling TGSI shaders to low-level instructions.
* Add fix for etnaviv driver so it's now can be used with new chardev interface (previously, it wasn't present in /dev/)
* Clean etnaviv driver source code
* Fix `assert()` for bit fields
* Update mesa/libdrm patches
* Minor `compat/linux` improvements