### PR TITLE
ARM GCC 8.3.0 build fixes

### DIFF
--- a/platform/nuklear/templates/stm32f7/build.conf
+++ b/platform/nuklear/templates/stm32f7/build.conf
@@ -9,9 +9,6 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 
-// We do not pass -march=armv7e-m because it does not working together with -mcpu=cortex-m7
-// See https://bugs.launchpad.net/gcc-arm-embedded/+bug/1592635
-// Moreover, as it stated in the bug, "We advise against the use of both -mcpu and -march switches"
-CFLAGS += -mthumb -mlittle-endian -mcpu=cortex-m7 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -mtune=cortex-m7 -march=armv7e-m -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/pjsip/templates/stm32f4cube/build.conf
+++ b/platform/pjsip/templates/stm32f4cube/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -Os -g -Wno-maybe-uninitialized
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/pjsip/templates/stm32f4discovery/build.conf
+++ b/platform/pjsip/templates/stm32f4discovery/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -Os -g -Wno-maybe-uninitialized
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/pjsip/templates/stm32f7cube/build.conf
+++ b/platform/pjsip/templates/stm32f7cube/build.conf
@@ -9,10 +9,7 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -Os -g -Wno-maybe-uninitialized
 CFLAGS += -mthumb -mlittle-endian
 CFLAGS += -ffreestanding
-// We do not pass -march=armv7e-m because it does not working together with -mcpu=cortex-m7
-// See https://bugs.launchpad.net/gcc-arm-embedded/+bug/1592635
-// Moreover, as it stated in the bug, "We advise against the use of both -mcpu and -march switches"
-CFLAGS += -mcpu=cortex-m7
+CFLAGS += -mtune=cortex-m7 -march=armv7e-m
 
 /* Switch between FPU and non-FPU modes */
 #CFLAGS += -msoft-float

--- a/platform/stm32f3_agents/templates/feather/build.conf
+++ b/platform/stm32f3_agents/templates/feather/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/stm32f3_sensors/templates/car/build.conf
+++ b/platform/stm32f3_sensors/templates/car/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/stm32f4_cnc/templates/debug/build.conf
+++ b/platform/stm32f4_cnc/templates/debug/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/stm32f4_cnc/templates/windows/build.conf
+++ b/platform/stm32f4_cnc/templates/windows/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/platform/stm32f4_multibots/templates/nrf24/build.conf
+++ b/platform/stm32f4_multibots/templates/nrf24/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/src/arch/arm/armlib/boot/Mybuild
+++ b/src/arch/arm/armlib/boot/Mybuild
@@ -1,5 +1,6 @@
 package embox.arch.arm.armlib
 
+@DefaultImpl(static_excpt_table)
 abstract module setup_exception_table { }
 
 module low_excpt_table extends setup_exception_table {

--- a/src/arch/arm/armlib/boot/Mybuild
+++ b/src/arch/arm/armlib/boot/Mybuild
@@ -20,4 +20,6 @@ module reset_handler {
 /*	option number irq_stack_size = 0x100 */
 
 	source "reset_handler.S"
+
+	depends setup_exception_table
 }

--- a/src/arch/arm/armlib/exceptions/Mybuild
+++ b/src/arch/arm/armlib/exceptions/Mybuild
@@ -9,4 +9,7 @@ module exceptions {
 	source "exceptions.S"
 	source "arm_undefined_exception_handler.c"
 	source "abort_exception_handler.c"
+
+	depends embox.arch.arm.fpu.fpu
+	depends embox.arch.arm.armlib.mem_barriers
 }

--- a/src/drivers/gpio/pins_old/omap3_gpio.h
+++ b/src/drivers/gpio/pins_old/omap3_gpio.h
@@ -1,0 +1,64 @@
+/**
+ * @file
+ * @brief OMAP3 GPIO driver definitions
+ *
+ * @date 1.11.13
+ * @author Alexander Kalmuk
+ */
+
+#ifndef OMAP3_GPIO_H_
+#define OMAP3_GPIO_H_
+
+#include <stdint.h>
+#include <hal/reg.h>
+#include <kernel/irq.h>
+
+#define GPIO_REG_SIZE 0x2000
+
+#define GPIO_BASE_ADDRESS(i)      ((i) == 1 ? 0x48310000 : (0x49050000 + ((i) - 2) * GPIO_REG_SIZE))
+#define GPIO_IRQ(i)               (28 + (i))
+#define GPIO_NUM_BY_IRQ(i)        ((i) - 28)
+#define GPIO_MODULE_CNT           6
+
+/* Register offsets from base address */
+#define GPIO_REVISION             0x00
+#define GPIO_SYSCONFIG            0x10
+#define GPIO_SYSSTATUS            0x14
+#define GPIO_IRQSTATUS1           0x18
+#define GPIO_IRQENABLE1           0x1C
+#define GPIO_WAKEUPENABLE         0x20
+#define GPIO_IRQSTATUS2           0x28
+#define GPIO_IRQENABLE2           0x2C
+#define GPIO_CTRL                 0x30
+#define GPIO_OE                   0x34
+#define GPIO_DATAIN               0x38
+#define GPIO_DATAOUT              0x3C
+#define GPIO_LEVELDETECT0         0x40
+#define GPIO_LEVELDETECT1         0x44
+#define GPIO_RISINGDETECT         0x48
+#define GPIO_FALLINGDETECT        0x4C
+#define GPIO_DEBOUNCENABLE        0x50
+#define GPIO_DEBOUNCINGTIME       0x54
+#define GPIO_CLEARIRQENABLE1      0x60
+#define GPIO_SETIRQENABLE1        0x64
+#define GPIO_CLEARIRQENABLE2      0x70
+#define GPIO_SETIRQENABLE2        0x74
+#define GPIO_CLEARWKUENA          0x80
+#define GPIO_SETWKUENA            0x84
+#define GPIO_CLEARDATAOUT         0x90
+#define GPIO_SETDATAOUT           0x94
+
+#define GPIO_REVISION_MAJOR(l)    ((l >> 4) & 0xF)
+#define GPIO_REVISION_MINOR(l)    (l & 0xF)
+
+static inline uint32_t gpio_reg_read(unsigned long base, int offset) {
+	unsigned long reg_addr =  (base + (unsigned long) offset);
+	return REG_LOAD(reg_addr);
+}
+
+static inline void gpio_reg_write(unsigned long base, int offset, uint32_t val) {
+	unsigned long reg_addr = (base + (unsigned long) offset);
+	REG_STORE(reg_addr, val);
+}
+
+#endif /* OMAP3_GPIO_H_ */

--- a/src/drivers/tty/serial/ttys_oldfs.c
+++ b/src/drivers/tty/serial/ttys_oldfs.c
@@ -12,6 +12,7 @@
 #include <util/err.h>
 #include <util/indexator.h>
 
+#include <drivers/device.h>
 #include <mem/misc/pool.h>
 #include <drivers/char_dev.h>
 #include <drivers/serial/uart_device.h>

--- a/src/fs/syslib/Mybuild
+++ b/src/fs/syslib/Mybuild
@@ -61,9 +61,9 @@ module perm_full extends perm {
 
 	depends embox.compat.posix.util.environ
 	depends embox.compat.posix.proc.uid
+	depends embox.security.api
 	/* TODO tsort loop
 	depends embox.fs.core
-	depends embox.security.api
 	*/
 }
 

--- a/src/fs/syslib/nokfile.c
+++ b/src/fs/syslib/nokfile.c
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 #include <fs/kfile.h>
 
-struct file_desc *kopen(struct node *node, int flag) {
+struct idesc *kopen(struct node *node, int flag) {
 	return NULL;
 }
 

--- a/src/net/lib/dns/dns.c
+++ b/src/net/lib/dns/dns.c
@@ -169,7 +169,7 @@ static int dns_q_format(struct dns_q *query, char *buff, size_t buff_sz) {
 		return -ENOMEM;
 	}
 	field_val = htons(query->qtype);
-	memcpy(buff, &field_val, sizeof field_sz);
+	memcpy(buff, &field_val, sizeof field_val);
 	bytes_left -= field_sz;
 	buff += field_sz;
 
@@ -178,7 +178,7 @@ static int dns_q_format(struct dns_q *query, char *buff, size_t buff_sz) {
 		return -ENOMEM;
 	}
 	field_val = htons(query->qclass);
-	memcpy(buff, &field_val, sizeof field_sz);
+	memcpy(buff, &field_val, sizeof field_val);
 
 	return 0;
 }

--- a/templates/arm/am3505/build.conf
+++ b/templates/arm/am3505/build.conf
@@ -8,13 +8,11 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g -mno-unaligned-access
-CFLAGS += -march=armv7-a -mcpu=cortex-a8 -mtune=cortex-a8
+CFLAGS += -march=armv7-a -mtune=cortex-a8
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
-//CFLAGS += -msoft-float
 
 CFLAGS += -fno-stack-protector -fno-omit-frame-pointer -fno-optimize-sibling-calls
 CFLAGS += -mno-thumb-interwork -Uarm -mno-unaligned-access
-//-march=armv7-a -mtune=cortex-a8 -mfpu=neon -ftree-vectorize -ffast-math -mfloat-abi=softfp
 
 
 LDFLAGS += -N -g

--- a/templates/arm/arria_v/build.conf
+++ b/templates/arm/arria_v/build.conf
@@ -9,7 +9,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g

--- a/templates/arm/el24d2/build.conf
+++ b/templates/arm/el24d2/build.conf
@@ -9,7 +9,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp
 
 LDFLAGS += -N -g

--- a/templates/arm/iwave_imx6/build.conf
+++ b/templates/arm/iwave_imx6/build.conf
@@ -7,7 +7,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g -mno-unaligned-access
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g

--- a/templates/arm/iwave_imx6_etnaviv/build.conf
+++ b/templates/arm/iwave_imx6_etnaviv/build.conf
@@ -7,11 +7,11 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=soft -mno-unaligned-access
 
 CXXFLAGS += -fno-rtti -O0 -g -Wno-error=c++14-compat -mno-unaligned-access
 CXXFLAGS += -fno-exceptions -mfloat-abi=soft
-CXXFLAGS += -fno-threadsafe-statics -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CXXFLAGS += -fno-threadsafe-statics -march=armv7-a -mtune=cortex-a9
 
 LDFLAGS += -N -g

--- a/templates/arm/minimal/build.conf
+++ b/templates/arm/minimal/build.conf
@@ -6,7 +6,7 @@ PLATFORM = integratorcp
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mcpu=arm926ej-s -march=armv5te
+CFLAGS += -march=armv5te -mtune=arm926ej-s
 
 CFLAGS += -mfpu=vfp -mfloat-abi=hard
 

--- a/templates/arm/qemu/build.conf
+++ b/templates/arm/qemu/build.conf
@@ -6,7 +6,7 @@ PLATFORM = integratorcp
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mcpu=arm926ej-s -march=armv5te
+CFLAGS += -march=armv5te -mtune=arm926ej-s
 
 CFLAGS += -mfpu=vfp -mfloat-abi=hard
 

--- a/templates/arm/qt-app/build.conf
+++ b/templates/arm/qt-app/build.conf
@@ -6,7 +6,7 @@ PLATFORM = integratorcp
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mcpu=arm926ej-s -march=armv5te
+CFLAGS += -march=armv5te -mtune=arm926ej-s
 
 LDFLAGS += -N -g
 

--- a/templates/arm/raspi/build.conf
+++ b/templates/arm/raspi/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv6zk -mcpu=arm1176jzf-s -mtune=arm1176jzf-s
+CFLAGS += -march=armv6zk -mtune=arm1176jzf-s
 
 LDFLAGS += -N -g

--- a/templates/arm/sabrelite/build.conf
+++ b/templates/arm/sabrelite/build.conf
@@ -6,7 +6,7 @@ PLATFORM = sabrelite
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp
 
 LDFLAGS += -N -g

--- a/templates/arm/sk_imx6q/build.conf
+++ b/templates/arm/sk_imx6q/build.conf
@@ -7,7 +7,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g -mno-unaligned-access
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32_dvfs/build.conf
+++ b/templates/arm/stm32_dvfs/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -msoft-float -ffreestanding -mtune=cortex-m4
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32_dvfs/mods.config
+++ b/templates/arm/stm32_dvfs/mods.config
@@ -88,6 +88,7 @@ configuration conf {
 
 	include embox.fs.driver.dfs
 	include embox.fs.driver.dvfs_driver
+	include embox.fs.driver.devfs_dvfs
 	@Runlevel(2) include embox.fs.rootfs_dvfs(fstype="DumbFS")
 
 	include embox.driver.char_dev_dvfs

--- a/templates/arm/stm32_f4/build.conf
+++ b/templates/arm/stm32_f4/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -msoft-float -ffreestanding -mtune=cortex-m4
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32_modbus/build.conf
+++ b/templates/arm/stm32_modbus/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32_vl/build.conf
+++ b/templates/arm/stm32_vl/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7-m -mcpu=cortex-m3 -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7-m -mtune=cortex-m3 -ffreestanding
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32_vl_light/build.conf
+++ b/templates/arm/stm32_vl_light/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7-m -mcpu=cortex-m3 -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7-m -mtune=cortex-m3 -ffreestanding
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32f3cube/build.conf
+++ b/templates/arm/stm32f3cube/build.conf
@@ -8,6 +8,6 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32f4cube/build.conf
+++ b/templates/arm/stm32f4cube/build.conf
@@ -8,7 +8,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -ffreestanding
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -ffreestanding
 
 /* Switch between FPU and non-FPU modes */
 #CFLAGS += -msoft-float

--- a/templates/arm/stm32f4cube_clang/build.conf
+++ b/templates/arm/stm32f4cube_clang/build.conf
@@ -14,12 +14,12 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 ifeq ($(COMPILER),clang)
-CFLAGS += -target armv7e-m---  -mlittle-endian -mcpu=cortex-m4 -msoft-float \
+CFLAGS += -target armv7e-m---  -mlittle-endian -mtune=cortex-m4 -msoft-float \
 	-ffreestanding
 OLIBM_ARCH = armv7e-m
 LIBGCC_FINDER=arm-none-eabi-gcc -mthumb -march=armv7e-m
 else
-CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mcpu=cortex-m4 -msoft-float \
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float \
 	-ffreestanding
 endif
 

--- a/templates/arm/stm32f7cube/build.conf
+++ b/templates/arm/stm32f7cube/build.conf
@@ -9,10 +9,7 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -mthumb -mlittle-endian
 CFLAGS += -ffreestanding
-// We do not pass -march=armv7e-m because it does not working together with -mcpu=cortex-m7
-// See https://bugs.launchpad.net/gcc-arm-embedded/+bug/1592635
-// Moreover, as it stated in the bug, "We advise against the use of both -mcpu and -march switches"
-CFLAGS += -mcpu=cortex-m7
+CFLAGS += -mtune=cortex-m7 -march=armv7e-m
 
 /* Switch between FPU and non-FPU modes */
 #CFLAGS += -msoft-float

--- a/templates/arm/var_som_mx6/build.conf
+++ b/templates/arm/var_som_mx6/build.conf
@@ -7,7 +7,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g -mno-unaligned-access
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g

--- a/templates/arm/vexpress-a9/build.conf
+++ b/templates/arm/vexpress-a9/build.conf
@@ -9,7 +9,7 @@ ARCH = arm
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
-CFLAGS += -march=armv7-a -mcpu=cortex-a9 -mtune=cortex-a9
+CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 LDFLAGS += -N -g


### PR DESCRIPTION
New version of `arm-none-eabi-gcc` produces errors on mixing `-mcpu` and `-mtune/-march`, for example:

```switch -mcpu=cortex-a9 conflicts with -march=armv7-a switch```

According to [GCC docs](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html), `-mcpu` is equal to some `-mtune` and `-march`.

>  -mcpu=name[+extension…] <...> GCC uses this name to derive the name of the target ARM architecture (as if specified by -march) and the ARM processor type for which to tune for performance (as if specified by -mtune).

So I replaced all `-mcpu` with corresponding `-mtune` options.

Also added minor fixes for some ARM templates.