### PR TITLE
e2k context switch

### DIFF
--- a/src/arch/e2k/Mybuild
+++ b/src/arch/e2k/Mybuild
@@ -16,6 +16,12 @@ module arch {
 
 module interrupt extends embox.arch.interrupt {
 	source "ipl_impl.h"
+	source "ipl_impl.c"
+}
+
+module context extends embox.arch.context {
+	option number log_level = 0
+	source "context.c", "context_switch.S", "context.h"
 }
 
 module x86_boot {

--- a/src/arch/e2k/context.c
+++ b/src/arch/e2k/context.c
@@ -1,0 +1,96 @@
+/**
+ * @file
+ * @brief Context init for E2K
+ *
+ * @date 18.03.2019
+ * @author Alexander Kalmuk
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <hal/context.h>
+#include <util/binalign.h>
+#include <util/log.h>
+
+#include <e2k_api.h>
+
+/* This value is used for both stack base and size align. */
+#define E2K_STACK_ALIGN (1UL << 12)
+
+#define round_down(x, bound) ((x) & ~((bound) - 1))
+
+/* Reserve 1/4 for PSP stack, 1/4 for PCSP stack, and 1/2 for USD stack */
+#define PSP_CALC_STACK_BASE(sp, size) binalign_bound(sp - size, E2K_STACK_ALIGN)
+#define PSP_CALC_STACK_SIZE(sp, size) binalign_bound((size) / 4, E2K_STACK_ALIGN)
+
+#define PCSP_CALC_STACK_BASE(sp, size) \
+	(PSP_CALC_STACK_BASE(sp, size) + PSP_CALC_STACK_SIZE(sp, size))
+#define PCSP_CALC_STACK_SIZE(sp, size) binalign_bound((size) / 4, E2K_STACK_ALIGN)
+
+#define USD_CALC_STACK_BASE(sp, size) round_down(sp, E2K_STACK_ALIGN)
+#define USD_CALC_STACK_SIZE(sp, size) \
+	round_down(USD_CALC_STACK_BASE(sp, size) - PCSP_CALC_STACK_BASE(sp, size),\
+		E2K_STACK_ALIGN)
+
+static void e2k_calculate_stacks(struct context *ctx, uint64_t sp,
+	uint64_t size) {
+	uint64_t psp_size, pcsp_size, usd_size;
+
+	log_debug("Stacks:\n");
+
+	ctx->psp_lo |= PSP_CALC_STACK_BASE(sp, size) << PSP_BASE;
+	ctx->psp_lo |= E2_RWAR_RW_ENABLE << PSP_RW;
+	psp_size = PSP_CALC_STACK_SIZE(sp, size);
+	assert(psp_size);
+	ctx->psp_hi |= psp_size << PSP_SIZE;
+	log_debug("  PSP.base=0x%lx, PSP.size=0x%lx\n",
+		PSP_CALC_STACK_BASE(sp, size), psp_size);
+
+	ctx->pcsp_lo |= PCSP_CALC_STACK_BASE(sp, size) << PCSP_BASE;
+	ctx->pcsp_lo |= E2_RWAR_RW_ENABLE << PCSP_RW;
+	pcsp_size = PCSP_CALC_STACK_SIZE(sp, size);
+	assert(pcsp_size);
+	ctx->pcsp_hi |= pcsp_size << PCSP_SIZE;
+	log_debug("  PCSP.base=0x%lx, PCSP.size=0x%lx\n",
+		PCSP_CALC_STACK_BASE(sp, size), pcsp_size);
+
+	ctx->sbr = USD_CALC_STACK_BASE(sp, size);
+
+	ctx->usd_lo |= ctx->sbr << USD_BASE;
+	usd_size = USD_CALC_STACK_SIZE(sp, size);
+	assert(usd_size);
+	ctx->usd_hi |= usd_size << USD_SIZE;
+	log_debug("  USD.base=0x%lx, USD.size=0x%lx\n",
+		USD_CALC_STACK_BASE(sp, size), usd_size);
+}
+
+static void e2k_calculate_crs(struct context *ctx, uint64_t routine_addr) {
+	uint64_t usd_size = (ctx->usd_hi >> USD_SIZE) & USD_SIZE_MASK;
+
+	/* Reserve space in hardware stacks for @routine_addr */
+	/* Remark: We do not update psp.hi to reserve space for arguments,
+	 * since routine do not accepts any arguments. */
+	ctx->pcsp_hi |= SZ_OF_CR0_CR1 << PCSP_IND;
+
+	ctx->cr0_hi |= (routine_addr >> CR0_IP) << CR0_IP;
+
+	ctx->cr1_lo |= PSR_ALL_IRQ_ENABLED << CR1_PSR;
+
+	/* Divide on 16 because it field contains size in terms
+	 * of 128 bit values. */
+	ctx->cr1_hi |= (usd_size >> 4) << CR1_USSZ;
+}
+
+void context_init(struct context *ctx, unsigned int flags,
+		void (*routine_fn)(void), void *sp, unsigned int stack_size) {
+	memset(ctx, 0, sizeof(*ctx));
+
+	e2k_calculate_stacks(ctx, sp, stack_size);
+
+	e2k_calculate_crs(ctx, (uint64_t) routine_fn);
+
+	if (!(flags & CONTEXT_IRQDISABLE)) {
+		ctx->upsr |= (UPSR_IE | UPSR_NMIE);
+	}
+}

--- a/src/arch/e2k/context.h
+++ b/src/arch/e2k/context.h
@@ -1,0 +1,55 @@
+/**
+ * @file
+ *
+ * @date 18.03.2019
+ * @author Alexander Kalmuk
+ */
+
+#ifndef ARCH_E2K_CONTEXT_H_
+#define ARCH_E2K_CONTEXT_H_
+
+/* Specify that context_init() requires the stack size to be passed
+ * as an argument. Used in src/include/hal/context.h */
+#define CONTEXT_USE_STACK_SIZE 1
+
+#ifndef __ASSEMBLER__
+
+#include <stdint.h>
+
+struct context {
+	/* CRs */
+	uint64_t cr0_lo;
+	uint64_t cr0_hi;
+	uint64_t cr1_lo;
+	uint64_t cr1_hi;
+
+	/* Stacks */
+	uint64_t sbr;
+	uint64_t usd_lo;
+	uint64_t usd_hi;
+	uint64_t psp_lo;
+	uint64_t psp_hi;
+	uint64_t pcsp_lo;
+	uint64_t pcsp_hi;
+
+	/* IPL control */
+	uint64_t upsr;
+};
+
+#endif /* __ASSEMBLER__ */
+
+/* Offset within struct context */
+#define E2K_CTX_CR0_LO  0x00
+#define E2K_CTX_CR0_HI  0x08
+#define E2K_CTX_CR1_LO  0x10
+#define E2K_CTX_CR1_HI  0x18
+#define E2K_CTX_SBR     0x20
+#define E2K_CTX_USD_LO  0x28
+#define E2K_CTX_USD_HI  0x30
+#define E2K_CTX_PSP_LO  0x38
+#define E2K_CTX_PSP_HI  0x40
+#define E2K_CTX_PCSP_LO 0x48
+#define E2K_CTX_PCSP_HI 0x50
+#define E2K_CTX_UPSR    0x58
+
+#endif /* ARCH_E2K_CONTEXT_H_ */

--- a/src/arch/e2k/context_switch.S
+++ b/src/arch/e2k/context_switch.S
@@ -1,0 +1,89 @@
+/**
+ * @file
+ * @brief Context switch for E2K
+ *
+ * @date 18.03.2019
+ * @author Alexander Kalmuk
+ */
+
+#include <hal/context.h>
+#include <e2k_api.h>
+
+.section ".text", "ax"
+
+/* TODO Save and restore Global Registers. */
+
+.global $context_switch
+.type context_switch,@function
+$context_switch:
+	setwd wsz = 0x14, nfx = 0x0
+	setbn rsz = 0x3, rbs = 0x10, rcur = 0x0
+
+	/* Save current IPL */
+	rrd %upsr, %dr2
+	std %dr2, [%dr0 + E2K_CTX_UPSR]
+
+	/* Disable interrupts before saving/restoring context */
+	rrd   %upsr, %dr2
+	andnd %dr2, (UPSR_IE | UPSR_NMIE), %dr2
+	rwd   %dr2, %upsr
+
+	E2K_ASM_FLUSH_CPU
+
+	/* Save prev CRs */
+	rrd %cr0.lo, %dr2
+	rrd %cr0.hi, %dr3
+	rrd %cr1.lo, %dr4
+	rrd %cr1.hi, %dr5
+	std %dr2, [%dr0 + E2K_CTX_CR0_LO]
+	std %dr3, [%dr0 + E2K_CTX_CR0_HI]
+	std %dr4, [%dr0 + E2K_CTX_CR1_LO]
+	std %dr5, [%dr0 + E2K_CTX_CR1_HI]
+
+	/* Save prev stacks */
+	rrd %sbr,     %dr2
+	rrd %usd.lo,  %dr3
+	rrd %usd.hi,  %dr4
+	rrd %psp.lo,  %dr5
+	rrd %psp.hi,  %dr6
+	rrd %pcsp.lo, %dr7
+	rrd %pcsp.hi, %dr8
+	std %dr2, [%dr0 + E2K_CTX_SBR]
+	std %dr3, [%dr0 + E2K_CTX_USD_LO]
+	std %dr4, [%dr0 + E2K_CTX_USD_HI]
+	std %dr5, [%dr0 + E2K_CTX_PSP_LO]
+	std %dr6, [%dr0 + E2K_CTX_PSP_HI]
+	std %dr7, [%dr0 + E2K_CTX_PCSP_LO]
+	std %dr8, [%dr0 + E2K_CTX_PCSP_HI]
+
+	/* Load next CRs */
+	ldd [%dr1 + E2K_CTX_CR0_LO], %dr2
+	ldd [%dr1 + E2K_CTX_CR0_HI], %dr3
+	ldd [%dr1 + E2K_CTX_CR1_LO], %dr4
+	ldd [%dr1 + E2K_CTX_CR1_HI], %dr5
+	rwd %dr2, %cr0.lo
+	rwd %dr3, %cr0.hi
+	rwd %dr4, %cr1.lo
+	rwd %dr5, %cr1.hi
+
+	/* Load next stacks */
+	ldd [%dr1 + E2K_CTX_SBR],     %dr2
+	ldd [%dr1 + E2K_CTX_USD_LO],  %dr3
+	ldd [%dr1 + E2K_CTX_USD_HI],  %dr4
+	ldd [%dr1 + E2K_CTX_PSP_LO],  %dr5
+	ldd [%dr1 + E2K_CTX_PSP_HI],  %dr6
+	ldd [%dr1 + E2K_CTX_PCSP_LO], %dr7
+	ldd [%dr1 + E2K_CTX_PCSP_HI], %dr8
+	rwd %dr2, %sbr
+	rwd %dr3, %usd.lo
+	rwd %dr4, %usd.hi
+	rwd %dr5, %psp.lo
+	rwd %dr6, %psp.hi
+	rwd %dr7, %pcsp.lo
+	rwd %dr8, %pcsp.hi
+
+	/* Restore UPSR */
+	ldd [%dr1 + E2K_CTX_UPSR],    %dr9
+	rwd %dr9, %upsr
+
+	E2K_ASM_RETURN

--- a/src/arch/e2k/context_switch.S
+++ b/src/arch/e2k/context_switch.S
@@ -7,19 +7,17 @@
  */
 
 #include <hal/context.h>
+#include <asm/linkage.h>
 #include <e2k_api.h>
 
 .section ".text", "ax"
 
 /* TODO Save and restore Global Registers. */
 
-.global $context_switch
-.type context_switch,@function
-$context_switch:
-	setwd wsz = 0x14, nfx = 0x0
-	setbn rsz = 0x3, rbs = 0x10, rcur = 0x0
+C_ENTRY(context_switch):
+	setwd wsz = 0x10, nfx = 0x0
 
-	/* Save current IPL */
+	/* Save prev UPSR */
 	rrd %upsr, %dr2
 	std %dr2, [%dr0 + E2K_CTX_UPSR]
 
@@ -82,8 +80,8 @@ $context_switch:
 	rwd %dr7, %pcsp.lo
 	rwd %dr8, %pcsp.hi
 
-	/* Restore UPSR */
-	ldd [%dr1 + E2K_CTX_UPSR],    %dr9
-	rwd %dr9, %upsr
+	/* Restore next UPSR */
+	ldd [%dr1 + E2K_CTX_UPSR],    %dr2
+	rwd %dr2, %upsr
 
 	E2K_ASM_RETURN

--- a/src/arch/e2k/entry.c
+++ b/src/arch/e2k/entry.c
@@ -31,6 +31,9 @@ static void e2k_kernel_start(void) {
 	psr |= (PSR_IE | PSR_NMIE | PSR_UIE);
 	asm volatile ("rws %0, %%psr" : : "ri"(psr));
 
+	/* XXX Disable FPU. Should be enabled later. */
+	e2k_upsr_write(e2k_upsr_read() & ~UPSR_FE);
+
 	/* XXX We have to init UPSR too rigth here to guarantee consistent
 	 * behaviour. When we do use ipl_init here, CPU just hangs. */
 	ipl_init();

--- a/src/arch/e2k/entry.c
+++ b/src/arch/e2k/entry.c
@@ -34,10 +34,6 @@ static void e2k_kernel_start(void) {
 	/* XXX Disable FPU. Should be enabled later. */
 	e2k_upsr_write(e2k_upsr_read() & ~UPSR_FE);
 
-	/* XXX We have to init UPSR too rigth here to guarantee consistent
-	 * behaviour. When we do use ipl_init here, CPU just hangs. */
-	ipl_init();
-
 	kernel_start();
 }
 

--- a/src/arch/e2k/include/asm/linkage.h
+++ b/src/arch/e2k/include/asm/linkage.h
@@ -1,0 +1,20 @@
+/**
+ * @file
+ *
+ * @date 21.03.2019
+ * @author Alexander Kalmuk
+ */
+
+#ifndef ARCH_E2K_ASM_LINKAGE_H_
+#define ARCH_E2K_ASM_LINKAGE_H_
+
+#ifdef __ASSEMBLER__
+
+#define C_ENTRY(name) \
+	.global name; \
+	.type name,@function; \
+	name
+
+#endif
+
+#endif /* ARCH_E2K_ASM_LINKAGE_H_ */

--- a/src/arch/e2k/include/e2k_api.h
+++ b/src/arch/e2k/include/e2k_api.h
@@ -4293,4 +4293,16 @@ do { \
 #define E2_RWAR_W_ENABLE    0x2UL
 #define E2_RWAR_RW_ENABLE   (E2_RWAR_R_ENABLE | E2_RWAR_W_ENABLE)
 
+#ifndef	__ASSEMBLER__
+static inline uint32_t e2k_upsr_read(void) {
+	unsigned int upsr;
+	asm volatile ("rrs %%upsr, %0" : "=r"(upsr) :);
+	return upsr;
+}
+
+static inline void e2k_upsr_write(uint32_t val) {
+	asm volatile ("rws %0, %%upsr" : : "ri"(val));
+}
+#endif /* !__ASSEMBLER__ */
+
 #endif /* _E2K_API_H_ */

--- a/src/arch/e2k/include/e2k_api.h
+++ b/src/arch/e2k/include/e2k_api.h
@@ -4236,15 +4236,60 @@ do { \
 	return %ctpr3; \
 	ct %ctpr3; \
 	ipd 3;
+
+#define E2K_ASM_FLUSH_CPU \
+	flushr; \
+	nop 2;  \
+	flushc; \
+	nop 3;
+
 #endif /* __ASSEMBLER__ */
 
 /* UPSR register bits */
-#define UPSR_IE   (1 << 5) /* Enable interrutps */
-#define UPSR_NMIE (1 << 7) /* Enable non-maskable interrupts */
+#define UPSR_IE   (1UL << 5) /* Enable interrutps */
+#define UPSR_NMIE (1UL << 7) /* Enable non-maskable interrupts */
 
 /* PSR register bits */
-#define PSR_IE   (1 << 1) /* Enable interrutps */
-#define PSR_NMIE (1 << 4) /* Enable non-maskable interrupts */
-#define PSR_UIE  (1 << 5) /* Allow user to control interrupts */
+#define PSR_PM   (1UL << 0) /* Privileged mode */
+#define PSR_IE   (1UL << 1) /* Enable interrutps */
+#define PSR_NMIE (1UL << 4) /* Enable non-maskable interrupts */
+#define PSR_UIE  (1UL << 5) /* Allow user to control interrupts */
+
+/* We use this macro for Embox as default, and control IPL with UPSR */
+#define PSR_ALL_IRQ_ENABLED (PSR_IE | PSR_NMIE | PSR_UIE | PSR_PM)
+
+/* PSP.lo offsets */
+#define PSP_BASE  0
+#define PSP_SIZE  32
+#define PSP_RW    59
+/* PSP.hi offsets */
+#define PSP_IND   0
+
+/* PCSP.lo offsets */
+#define PCSP_BASE 0
+#define PCSP_SIZE 32
+#define PCSP_RW   59
+/* PCSP.hi offsets */
+#define PCSP_IND  0
+
+/* USD.lo offsets */
+#define USD_BASE  0
+/* USD.hi offsets */
+#define USD_SIZE  32
+#define USD_SIZE_MASK  0xFFFFFFFFUL
+
+/* CR0 offsets */
+#define CR0_IP 3
+/* CR1 offsets */
+#define CR1_WBS  33
+#define CR1_USSZ 36
+#define CR1_PSR  57
+
+/* Summary size of both CR0 and CR1 */
+#define SZ_OF_CR0_CR1 32
+
+#define E2_RWAR_R_ENABLE    0x1UL
+#define E2_RWAR_W_ENABLE    0x2UL
+#define E2_RWAR_RW_ENABLE   (E2_RWAR_R_ENABLE | E2_RWAR_W_ENABLE)
 
 #endif /* _E2K_API_H_ */

--- a/src/arch/e2k/include/e2k_api.h
+++ b/src/arch/e2k/include/e2k_api.h
@@ -4246,6 +4246,7 @@ do { \
 #endif /* __ASSEMBLER__ */
 
 /* UPSR register bits */
+#define UPSR_FE   (1UL << 0) /* Enable floating operations */
 #define UPSR_IE   (1UL << 5) /* Enable interrutps */
 #define UPSR_NMIE (1UL << 7) /* Enable non-maskable interrupts */
 

--- a/src/arch/e2k/ipl_impl.c
+++ b/src/arch/e2k/ipl_impl.c
@@ -1,0 +1,24 @@
+/**
+ * @file
+ *
+ * @date 18.03.2019
+ * @author Alexander Kalmuk
+ */
+
+#include <hal/ipl.h>
+#include <e2k_api.h>
+
+void ipl_init(void) {
+	e2k_upsr_write(e2k_upsr_read() | (UPSR_IE | UPSR_NMIE));
+}
+
+unsigned int ipl_save(void) {
+	unsigned int upsr;
+	upsr = e2k_upsr_read();
+	e2k_upsr_write(upsr & ~(UPSR_IE | UPSR_NMIE));
+	return upsr;
+}
+
+void ipl_restore(unsigned int ipl) {
+	e2k_upsr_write(ipl);
+}

--- a/src/arch/e2k/ipl_impl.h
+++ b/src/arch/e2k/ipl_impl.h
@@ -4,36 +4,8 @@
 #ifndef __ASSEMBLER__
 
 #include <stdint.h>
-#include <e2k_api.h>
 
 typedef uint32_t __ipl_t;
-
-static inline void e2k_clear_upsr(uint32_t mask) {
-	uint32_t upsr;
-	asm volatile ("rrs %%upsr, %0" : "=r"(upsr) :);
-	upsr &= ~mask;
-	asm volatile ("rws %0, %%upsr" : : "ri"(upsr));
-}
-
-static inline void e2k_set_upsr(uint32_t mask) {
-	uint32_t upsr;
-	asm volatile ("rrs %%upsr, %0" : "=r"(upsr) :);
-	upsr |= mask;
-	asm volatile ("rws %0, %%upsr" : : "ri"(upsr));
-}
-
-static inline void ipl_init(void) {
-	e2k_set_upsr(UPSR_IE | UPSR_NMIE);
-}
-
-static inline unsigned int ipl_save(void) {
-	e2k_clear_upsr(UPSR_IE | UPSR_NMIE);
-	return 0;
-}
-
-static inline void ipl_restore(unsigned int ipl) {
-	e2k_set_upsr(UPSR_IE | UPSR_NMIE);
-}
 
 #endif /* __ASSEMBLER__ */
 

--- a/src/arch/e2k/libarch/e2k_setjmp.S
+++ b/src/arch/e2k/libarch/e2k_setjmp.S
@@ -48,15 +48,16 @@ $update_pcsp_ind:
 .global $setjmp
 .type setjmp,@function
 $setjmp:
-	setwd wsz = 0xE, nfx = 0x0
+	setwd wsz = 0x14, nfx = 0x0
 	/* It's for db[N] registers */
-	setbn rsz = 0x3, rbs = 0xA, rcur = 0x0
+	setbn rsz = 0x3, rbs = 0x10, rcur = 0x0
 
-	/* We must disable interrupts here.
-	 */
-	rrd   %upsr, %dr1
-	andnd %dr1, (UPSR_IE | UPSR_NMIE), %dr1
-	rwd   %dr1, %upsr
+	/* We must disable interrupts here */
+	disp %ctpr1, ipl_save
+	ipd  3
+	call %ctpr1, wbs = 0x10
+	/* Store current IPL to dr9 */
+	addd 0, %db[0], %dr9
 
 	/* Store some registers to jmp_buf */
 	rrd %cr0.hi, %dr1
@@ -72,7 +73,7 @@ $setjmp:
 	addd 0, %dr7, %db[1]
 	disp %ctpr1, update_psp_ind
 	ipd  3
-	call %ctpr1, wbs = 0xA
+	call %ctpr1, wbs = 0x10
 	addd 0, %db[0], %dr6
 
 	/* Prepare CF stack to flush in longjmp */
@@ -82,7 +83,7 @@ $setjmp:
 	addd 0, %dr8, %db[1]
 	disp %ctpr1, update_pcsp_ind
 	ipd  3
-	call %ctpr1, wbs = 0xA
+	call %ctpr1, wbs = 0x10
 	addd 0, %db[0], %dr7
 
 	std %dr1, [%dr0 + E2K_JMBBUFF_CR0_HI]
@@ -94,9 +95,10 @@ $setjmp:
 	std %dr7, [%dr0 + E2K_JMBBUFF_PCSP_HI]
 
 	/* Enable interrupts */
-	rrd %upsr, %dr1
-	ord %dr1, (UPSR_IE | UPSR_NMIE), %dr1
-	rwd %dr1, %upsr
+	addd 0, %dr9, %db[0]
+	disp %ctpr1, ipl_restore
+	ipd  3
+	call %ctpr1, wbs = 0x10
 
 	/* return 0 */
 	adds 0, 0, %r0
@@ -107,19 +109,19 @@ $setjmp:
 .global $longjmp
 .type longjmp,@function
 $longjmp:
-	setwd wsz = 0x9, nfx = 0x0
+	setwd wsz = 0x14, nfx = 0x0
+	setbn rsz = 0x3, rbs = 0x10, rcur = 0x0
+
+	/* We must disable interrupts here */
+	disp %ctpr1, ipl_save
+	ipd  3
+	call %ctpr1, wbs = 0x10
+	/* Store current IPL to dr9 */
+	addd 0, %db[0], %dr9
 
 	/* We have to flush both RF and CF to memory because saved values
 	 * of P[C]SHTP can be not valid here. */
-	flushr
-	nop 2
-	flushc
-	nop 3
-
-	/* Disable interrupts */
-	rrd   %upsr, %dr2
-	andnd %dr2, (UPSR_IE | UPSR_NMIE), %dr2
-	rwd   %dr2, %upsr
+	E2K_ASM_FLUSH_CPU
 
 	/* Load registers previously saved in setjmp. */
 	ldd [%dr0 + E2K_JMBBUFF_CR0_HI], %dr2
@@ -139,9 +141,10 @@ $longjmp:
 	rwd %dr8, %pcsp.hi
 
 	/* Enable interrupts */
-	rrd %upsr, %dr2
-	ord %dr2, (UPSR_IE | UPSR_NMIE), %dr2
-	rwd %dr2, %upsr
+	addd 0, %dr9, %db[0]
+	disp %ctpr1, ipl_restore
+	ipd  3
+	call %ctpr1, wbs = 0x10
 
 	/* Actually, we return to setjmp caller with second
 	* argument of longjmp stored on r1 register. */

--- a/src/arch/e2k/libarch/e2k_setjmp.S
+++ b/src/arch/e2k/libarch/e2k_setjmp.S
@@ -6,6 +6,7 @@
  * @author Anton Bondarev
  */
 #include <asm/setjmp.h>
+#include <asm/linkage.h>
 #include <e2k_api.h>
 
 .section ".text", "ax"
@@ -45,9 +46,7 @@ $update_pcsp_ind:
 
 	E2K_ASM_RETURN
 
-.global $setjmp
-.type setjmp,@function
-$setjmp:
+C_ENTRY(setjmp):
 	setwd wsz = 0x14, nfx = 0x0
 	/* It's for db[N] registers */
 	setbn rsz = 0x3, rbs = 0x10, rcur = 0x0
@@ -104,11 +103,7 @@ $setjmp:
 	adds 0, 0, %r0
 	E2K_ASM_RETURN
 
-.size $setjmp, . - $setjmp
-
-.global $longjmp
-.type longjmp,@function
-$longjmp:
+C_ENTRY(longjmp):
 	setwd wsz = 0x14, nfx = 0x0
 	setbn rsz = 0x3, rbs = 0x10, rcur = 0x0
 
@@ -150,5 +145,3 @@ $longjmp:
 	* argument of longjmp stored on r1 register. */
 	adds 0, %r1, %r0
 	E2K_ASM_RETURN
-
-.size $longjmp, . - $longjmp

--- a/src/arch/e2k/libarch/e2k_syscall.S
+++ b/src/arch/e2k/libarch/e2k_syscall.S
@@ -5,15 +5,15 @@
  * @author Anton Bondarev
  */
 
+#include <asm/linkage.h>
+
 #define SYSCALL_NUMBER 1
 /*
  * syscall.
  */
 .text
 .align 8
-.global $syscall
-.type $syscall,@function
-$syscall:
+C_ENTRY(syscall):
 {
 	setwd wsz = 0x8
 	setbn rsz = 0x3, rbs = 0x4, rcur = 0x0
@@ -41,4 +41,3 @@ $syscall:
 {
 	ct %ctpr3
 }
-.size $syscall, .-$syscall

--- a/src/include/hal/context.h
+++ b/src/include/hal/context.h
@@ -31,8 +31,14 @@ struct context;
  * @param routine_fn Context's IP (instruction pointer)
  * @param sp Context's SP (stack pointer)
  */
+#ifndef CONTEXT_USE_STACK_SIZE
 extern void context_init(struct context *ctx, unsigned int flags,
 		void (*routine_fn)(void), void *sp);
+#else
+/* Currently, this version required only by E2K (Elbrus). */
+extern void context_init(struct context *ctx, unsigned int flags,
+		void (*routine_fn)(void), void *sp, unsigned int stack_size);
+#endif
 
 /**
  * Changes current thread context. Save previous thread context and load

--- a/src/kernel/thread/core.c
+++ b/src/kernel/thread/core.c
@@ -222,8 +222,14 @@ void thread_init(struct thread *t, int priority,
 	 * the end
 	 * +++++++++++++++ bottom (t->stack - allocated memory for the stack)
 	 */
+#ifndef CONTEXT_USE_STACK_SIZE
 	context_init(&t->context, CONTEXT_PRIVELEGED | CONTEXT_IRQDISABLE,
 			thread_trampoline, thread_stack_get(t) + thread_stack_get_size(t));
+#else
+	context_init(&t->context, CONTEXT_PRIVELEGED | CONTEXT_IRQDISABLE,
+			thread_trampoline, thread_stack_get(t) + thread_stack_get_size(t),
+			thread_stack_get_size(t));
+#endif
 
 	sigstate_init(&t->sigstate);
 

--- a/src/tests/hal/context/Mybuild
+++ b/src/tests/hal/context/Mybuild
@@ -1,6 +1,7 @@
 package embox.test.hal
 
 module context_switch_test {
+	option number stack_sz = 0x400
 	source "context_switch_test.c"
 	depends embox.arch.context
 }

--- a/src/tests/hal/context/context_switch_test.c
+++ b/src/tests/hal/context/context_switch_test.c
@@ -44,11 +44,19 @@ static void infinite(void) {
 }
 
 TEST_CASE("context switch test") {
+#ifndef CONTEXT_USE_STACK_SIZE
 	context_init(&entry_context, CONTEXT_PRIVELEGED,
 			entry, entry_stack + STACK_SZ);
 
 	context_init(&infinite_context, CONTEXT_PRIVELEGED,
 			infinite, infinite_stack + STACK_SZ);
+#else
+	context_init(&entry_context, CONTEXT_PRIVELEGED,
+			entry, entry_stack + STACK_SZ, STACK_SZ);
+
+	context_init(&infinite_context, CONTEXT_PRIVELEGED,
+			infinite, infinite_stack + STACK_SZ, STACK_SZ);
+#endif
 
 	TRACE("test begin\n");
 	context_switch(&redundant_context, &entry_context);

--- a/src/tests/hal/context/context_switch_test.c
+++ b/src/tests/hal/context/context_switch_test.c
@@ -8,9 +8,9 @@
 
 #include <hal/context.h>
 #include <embox/test.h>
-#include <stdio.h>
+#include <framework/mod/options.h>
 
-#define STACK_SZ 0x400
+#define STACK_SZ OPTION_GET(NUMBER, stack_sz)
 
 EMBOX_TEST_SUITE("context switch");
 

--- a/templates/e2k/monocube/mods.config
+++ b/templates/e2k/monocube/mods.config
@@ -9,6 +9,8 @@ configuration conf {
 	@Runlevel(0) include embox.arch.e2k.interrupt
 	@Runlevel(0) include embox.arch.e2k.context
 
+	include embox.kernel.spinlock(spin_debug = false)
+
 	@Runlevel(1) include embox.driver.serial.am85c30
 
 	@Runlevel(1) include embox.driver.interrupt.ioapic

--- a/templates/e2k/monocube/mods.config
+++ b/templates/e2k/monocube/mods.config
@@ -7,6 +7,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.generic.arch
 	@Runlevel(0) include embox.arch.e2k.libarch
 	@Runlevel(0) include embox.arch.e2k.interrupt
+	@Runlevel(0) include embox.arch.e2k.context
 
 	@Runlevel(1) include embox.driver.serial.am85c30
 
@@ -19,6 +20,23 @@ configuration conf {
 	@Runlevel(1) include embox.test.util.tree_test
 	@Runlevel(1) include embox.test.stdlib.setjmp_test
 	@Runlevel(1) include embox.test.kernel.timer_test
+	@Runlevel(1) include embox.test.hal.context_switch_test(stack_sz = 0x4000)
+	@Runlevel(1) include embox.test.kernel.sched.running_threads_test
+	@Runlevel(1) include embox.test.kernel.thread.thread_priority_test(threads_quantity=10)
+	@Runlevel(1) include embox.test.kernel.thread.thread_systimer_irq_test
+	@Runlevel(1) include embox.test.kernel.thread.thread_test
+
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+
+	/* @Runlevel(2) include embox.kernel.task.multi */
+	@Runlevel(2) include embox.kernel.stack(stack_size=0x10000)
+	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x10000)
+	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
 
 	@Runlevel(1) include embox.driver.clock.e2k(irq_num=2, freq=2000)
 
@@ -68,10 +86,8 @@ configuration conf {
 	include embox.cmd.help
 	include embox.cmd.sys.version
 
-	include embox.kernel.timer.sleep_nosched
 	include embox.cmd.testing.ticker
 
 
 	//include embox.cmd.fs.ls
-
 }


### PR DESCRIPTION
Implement context_switch for e2k (elbrus).

The following tests on context_switch and threads passed (included in e2k/template):
```
@Runlevel(1) include embox.test.hal.context_switch_test(stack_sz = 0x4000)
@Runlevel(1) include embox.test.kernel.sched.running_threads_test
@Runlevel(1) include embox.test.kernel.thread.thread_priority_test(threads_quantity=10)
@Runlevel(1) include embox.test.kernel.thread.thread_systimer_irq_test
@Runlevel(1) include embox.test.kernel.thread.thread_test
```

