### PR TITLE
autotest: expect: Disable fs tests temporarily

### DIFF
--- a/scripts/continuous/fs/run.sh
+++ b/scripts/continuous/fs/run.sh
@@ -127,8 +127,6 @@ interactive_tests() {
 	rm $PID_FILE
 }
 
-interactive_tests $EXPECT_TESTS_BASE/x86_fs_shell_commands.config
-
 for f in $FS_TEST_RO; do
 	img=$BASE_DIR/$f.img
 


### PR DESCRIPTION
Something going wrong with our expect fs tests, random errors at the random tests and random places (probably due to embox telnet/shell/very fast tests execution or something else). So temporarily disable expect fs tests and starting figure out what's going on.

By the way, net tests are pretty OK. Also, these errors with fs depend on -no-kvm flag I guess.