### PR TITLE
Fix etna-related examples

### DIFF
--- a/platform/etnaviv/cmds/Mybuild
+++ b/platform/etnaviv/cmds/Mybuild
@@ -1,5 +1,6 @@
 package platform.etnaviv.cmd
 
+@App
 @AutoCmd
 @Cmd(name = "etnaviv_2d_test",
 	help = "Draw simple 2D scene with Etnaviv GPU")
@@ -17,8 +18,10 @@ module etnaviv_2d_test {
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
 	depends platform.etnaviv.xml_headers
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 }
 
+@App
 @AutoCmd
 @Cmd(name = "cube",
 	help = "Draw simple cube")
@@ -33,8 +36,10 @@ module cube {
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
 	depends third_party.lib.estransform
 	depends platform.etnaviv.xml_headers
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 }
 
+@App
 @AutoCmd
 @Cmd(name = "hardcode_cube",
 	help = "Draw cube from pre-compiled buffer")
@@ -47,8 +52,10 @@ module hardcode_cube {
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
 	depends platform.etnaviv.xml_headers
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 }
 
+@App
 @AutoCmd
 @Cmd(name = "tri",
 	help = "Draw triangle with purple background using gallium")
@@ -64,8 +71,10 @@ module tri {
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
 	depends third_party.lib.estransform
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 }
 
+@App
 @AutoCmd
 @Cmd(name = "etnaviv_compiler",
 	help = "Draw triangle with purple background using gallium")
@@ -84,8 +93,10 @@ module etnaviv_compiler {
 	source "etnaviv_compiler_cmdline.c"
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 }
 
+@App
 @AutoCmd
 @Cmd(name = "quad_tex",
 	help = "Draw quad-texangle with purple background using gallium")
@@ -100,6 +111,7 @@ module quad_tex {
 	source "quad_tex.c"
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 	depends third_party.lib.estransform
 }
 

--- a/platform/etnaviv/cmds/quad_tex_animated/Mybuild
+++ b/platform/etnaviv/cmds/quad_tex_animated/Mybuild
@@ -1,5 +1,6 @@
 package platform.etnaviv.cmd
 
+@App
 @AutoCmd
 @Cmd(name = "quad_tex_animated",
 	help = "Draw quad-texangle with purple background using gallium")
@@ -14,6 +15,7 @@ module quad_tex_animated {
 	source "quad_tex_animated.c"
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
+	depends third_party.freedesktop.mesa.mesa_etnaviv
 	depends third_party.lib.estransform
 
 	@InitFS

--- a/platform/mesa/cmds/osdemo_fb/Mybuild
+++ b/platform/mesa/cmds/osdemo_fb/Mybuild
@@ -1,5 +1,6 @@
 package embox.cmd
 
+@App
 @AutoCmd
 @Cmd(name = "osdemo_fb",
 	help = "Adopted osdemo application from mesa_demo",
@@ -27,6 +28,7 @@ module osdemo_fb {
 	depends third_party.freedesktop.mesa.libglu_osmesa
 }
 
+@App
 @AutoCmd
 @Cmd(name = "osdemo_imx6",
 	help = "Adopted osdemo application from mesa_demo",
@@ -40,7 +42,6 @@ module osdemo_fb {
 		AUTHORS
 			Anton Bondarev
 	''')
-
 @BuildDepends(third_party.freedesktop.mesa.mesa_etnaviv)
 @BuildDepends(third_party.freedesktop.mesa.libglu_etnaviv)
 @Build(stage=2,script="true")

--- a/src/arch/arm/armlib/exceptions/Mybuild
+++ b/src/arch/arm/armlib/exceptions/Mybuild
@@ -2,6 +2,7 @@ package embox.arch.arm.armlib
 
 module exceptions {
 	option number log_level=0
+	option boolean keep_going=true /* Don't stall on undefined exception */
 
 	source "entry.S"
 	source "exception_table.S"

--- a/src/arch/arm/armlib/exceptions/arm_undefined_exception_handler.c
+++ b/src/arch/arm/armlib/exceptions/arm_undefined_exception_handler.c
@@ -5,14 +5,15 @@
  * @author  Anton Kozlov
  * @date    23.10.2013
  */
-#include <util/log.h>
 
 #include <stdint.h>
 
-#include <kernel/printk.h>
-
 #include <arm/fpu.h>
+#include <framework/mod/options.h>
+#include <kernel/printk.h>
+#include <util/log.h>
 
+#define KEEP_GOING OPTION_GET(BOOLEAN,keep_going)
 struct pt_regs_exception {
 #ifdef ARM_FPU_VFP
 	struct pt_regs_fpu vfp;
@@ -45,4 +46,7 @@ void arm_undefined_exception(struct pt_regs_exception *pt_regs) {
 			pt_regs->regs[6], pt_regs->regs[7],	pt_regs->regs[8],
 			pt_regs->regs[9], pt_regs->regs[10], pt_regs->regs[11],
 			pt_regs->regs[12], pt_regs->prev_lr, pt_regs->spsr);
+#if !KEEP_GOING
+	while(1);
+#endif
 }

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Mybuild
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Mybuild
@@ -1,5 +1,6 @@
 package third_party.freedesktop.mesa
 
+@App
 @BuildDepends(third_party.freedesktop.mesa.libdrm_etnaviv)
 @Build(script="$(EXTERNAL_MAKE)")
 module  mesa_etnaviv {


### PR DESCRIPTION
Use `@App` signature to reset MESA .bss and .data sections.