### PR TITLE
Fix fs autotests

### DIFF
--- a/scripts/continuous/fs/run.sh
+++ b/scripts/continuous/fs/run.sh
@@ -127,6 +127,7 @@ interactive_tests() {
 	rm $PID_FILE
 }
 
+interactive_tests $EXPECT_TESTS_BASE/x86_fs_unit_tests.config
 interactive_tests $EXPECT_TESTS_BASE/x86_fs_shell_commands.config
 
 for f in $FS_TEST_RO; do

--- a/scripts/continuous/fs/run.sh
+++ b/scripts/continuous/fs/run.sh
@@ -127,6 +127,8 @@ interactive_tests() {
 	rm $PID_FILE
 }
 
+interactive_tests $EXPECT_TESTS_BASE/x86_fs_shell_commands.config
+
 for f in $FS_TEST_RO; do
 	img=$BASE_DIR/$f.img
 

--- a/scripts/expect/framework/test_exec.exp
+++ b/scripts/expect/framework/test_exec.exp
@@ -15,13 +15,20 @@ proc ::autotest::telnet_connect {} {
 }
 
 proc ::autotest::telnet_disconnect {} {
+	global spawn_id
 	send "exit\r"
 	expect "Connection closed by foreign host"
 	return 0
 }
 
+proc ::autotest::eval_test_body {test_body} {
+	global spawn_id
+	eval $test_body
+}
+
 proc ::autotest::test_exec {mode test_name test_body} {
 	# https://stackoverflow.com/questions/30532532/expect-fails-when-running-proc-inside-proc
+	variable res
 	global spawn_id
 
 	if {$test_body == ""} {
@@ -30,13 +37,9 @@ proc ::autotest::test_exec {mode test_name test_body} {
 
 	if {$mode == "target"} { telnet_connect }
 
-	set res [eval $test_body]
-	if {$res != 0} {
-		if {$mode == "target"} { telnet_disconnect }
-		return -1
-	}
+	set res [eval_test_body $test_body]
 
 	if {$mode == "target"} { telnet_disconnect }
 
-	return 0
+	return $res
 }

--- a/scripts/expect/fs_shell_commands_test.exp
+++ b/scripts/expect/fs_shell_commands_test.exp
@@ -33,7 +33,6 @@ TEST_CASE_TARGET {pwd should show correct directory} {
 	return 0
 }
 
-TEST_CASE_DECLARE_FIXME {
 TEST_CASE_TARGET {Echo to regular file} {
 	set TELNET_PROMPT ":/#"
 
@@ -46,7 +45,6 @@ TEST_CASE_TARGET {Echo to regular file} {
 	test_exec_embox_cmd "rm 1.txt\r"
 
 	return 0
-}
 }
 
 # I don't know why, but sometimes this test is also failed.

--- a/scripts/expect/fs_unit_tests.exp
+++ b/scripts/expect/fs_unit_tests.exp
@@ -6,13 +6,11 @@ namespace import autotest::*
 
 TEST_SUITE_SETUP
 
-TEST_CASE_DECLARE_FIXME {
 TEST_CASE_TARGET {Run fs concurrency tests multiple times} {
 	for {set i 0} {$i < 4} {incr i} {
 		test_exec_embox_cmd_timeout 30 "test -t concurrency_test\r"
 	}
 	return 0
-}
 }
 
 TEST_CASE_TARGET {Run select_test several times} {

--- a/templates/x86/test/fs/mods.config
+++ b/templates/x86/test/fs/mods.config
@@ -67,7 +67,7 @@ configuration conf {
 	include embox.cmd.net.ntpdate
 	include embox.cmd.net.bootpc
 	include embox.cmd.net.httpd
-	include embox.cmd.net.telnetd
+	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail


### PR DESCRIPTION
Previously, we disabled fs interactive tests, enable them back.

Several fixes that helped to enable tests back:

* Fix telnetd options handling. There can be intermixed cleint data and telnet options, so do smarter hadnling instead of dropping such intermixed packets.
* Fix tty raise condition
* Use telnetd_use_pthread=0 for x86/test/fs