### PR TITLE
heap_simple: Rework

### DIFF
--- a/src/cmds/testing/memtest/Mybuild
+++ b/src/cmds/testing/memtest/Mybuild
@@ -10,15 +10,22 @@ package embox.cmd.testing
 		memtest [-nh] [-l LENGTH]
 	DESCRIPTION
 		This command measures speed of memcpy() in RAM.
+
+		If called with -p flag, perform stress test for heap.
 	OPTIONS
 		-n Test non-cached memory
-		-l LENGTH Number of bytes to be copied (default 0x1000000)
-		-r REPEAT Number of repeats (default 64)
+		-l LENGTH Number of bytes to be operated (default 0x1000000 for memcpy() and 0x2000 for heap)
+		-r REPEAT Number of repeats (default 64 for memcpy() and 2048 for heap)
+		-p Run stress-test for heap (a.k.a. pyramid)
+		-q Maximum number of heap regions
+		-s Random seed
 	AUTHORS
 		Denis Deryugin <denis.deryugin@gmail.com>
 	''')
 
 module memtest {
+	option number max_heap_regions=4096
+
 	source "memtest.c"
 
 	depends embox.compat.libc.stdio.printf

--- a/src/cmds/testing/memtest/memtest.c
+++ b/src/cmds/testing/memtest/memtest.c
@@ -12,27 +12,143 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <time.h>
 
+#include <framework/mod/options.h>
 #include <mem/vmem.h>
-
-static const size_t default_region_len = 16 * 1024 * 1024;
 
 static void print_help(char **argv) {
 	assert(argv);
 	assert(argv[0]);
 	printf("Usage: %s [-nh] [-l LENGHT]\n", argv[0]);
 	printf("\tOptions: -n Test non-cached memory\n");
-	printf("\t         -l LENGTH Number of bytes to be copied (default 0x1000000)\n");
-	printf("\t         -r REPEAT Number of repeats (default 64)\n");
+	printf("\t         -l LENGTH Number of bytes to be operated "
+			"(default 0x1000000 for memcpy() and 0x2000 for heap)\n");
+	printf("\t         -r REPEAT Number of repeats (default 64 for memcpy() and 2048 for heap)\n");
+	printf("\t         -p Run test for heap (a.k.a. pyramid)\n");
+	printf("\t         -q Maximum number of heap regions\n");
+	printf("\t         -s Random seed\n");
+}
+
+/* Heap-related stuff */
+static int max_region_len;
+static int random_seed;
+static int heap_regions;
+
+#define SCREEN_WIDTH 80
+
+#define MAX_HEAP_REGIONS OPTION_GET(NUMBER,max_heap_regions)
+static struct {
+	size_t size;
+	void *ptr;
+	uint32_t hash;
+} regions[MAX_HEAP_REGIONS];
+
+static int region_hash(int k) {
+	uint32_t res = 0;
+
+	if (regions[k].ptr == 0) {
+		return 0;
+	}
+
+	for (int i = 0; i < regions[k].size; i++) {
+		res ^= ((uint8_t *) regions[k].ptr)[i] << (8 * (i % 4));
+	}
+
+	return res;
+}
+
+static int fill_region(int k) {
+	assert(regions[k].ptr == NULL);
+
+	regions[k].size = random() % max_region_len;
+
+	regions[k].ptr = malloc(1 + regions[k].size);
+
+	if (regions[k].ptr == NULL && regions[k].size > 0) {
+		printf("\nFailed to allocate memory\n");
+		return 0;
+	}
+
+	for (int i = 0; i < regions[k].size; i++) {
+		((uint8_t *) regions[k].ptr)[i] = random() % 256;
+	}
+
+	regions[k].hash = region_hash(k);
+
+	return 0;
+}
+
+static int free_region(int k) {
+	if (regions[k].hash != region_hash(k)) {
+		printf("%d\n", k);
+		printf("\nError! Data modified somewhere @ %p .. %p\n",
+				regions[k].ptr, regions[k].ptr + regions[k].size);
+	}
+
+	free(regions[k].ptr);
+
+	regions[k].ptr = 0;
+
+	return 0;
+}
+
+static int heap_test(int repeat_num, int len) {
+	int k = 0;
+	max_region_len = len;
+
+	if (random_seed == 0) {
+		random_seed = random();
+	}
+
+	srandom(random_seed);
+
+	if (heap_regions > MAX_HEAP_REGIONS || heap_regions < 0) {
+		heap_regions = MAX_HEAP_REGIONS;
+	}
+
+	printf("Call malloc()/free() %d times; using memory regions up to %d bytes\n",
+			repeat_num, len);
+	printf("Up to %d regions active at the same time\n", heap_regions);
+	printf("Random seed =0x%08x\n", random_seed);
+
+	memset(regions, 0, sizeof(regions));
+
+	for (int i = 0; i < repeat_num; i++) {
+		if (i % (repeat_num / SCREEN_WIDTH) == 0) {
+			printf(".");
+			fflush(stdout);
+		}
+
+		k = random() % heap_regions;
+
+		if (regions[k].ptr != 0) {
+			free_region(k);
+		} else {
+			fill_region(k);
+		}
+	}
+
+	/* Clean up */
+	for (int i = 0; i < heap_regions; i++) {
+		if (regions[i].ptr != 0) {
+			free_region(i);
+		}
+	}
+
+	printf("\nTest finished!\n");
+
+	return 0;
 }
 
 int main(int argc, char **argv) {
 	int opt, nocache = 0, err;
 	size_t len = 0;
 	int seconds;
-	int repeat = 64;
+	int repeat = 0;
+	bool do_heap_test = false;
 	vmem_page_flags_t flags;
 
 	struct timespec time_post;
@@ -41,25 +157,55 @@ int main(int argc, char **argv) {
 	void *r_addr1, *r_addr2;
 	size_t r_len1, r_len2;
 
-	while (-1 != (opt = getopt(argc, argv, "nhl:r:"))) {
+	random_seed = 0;
+	heap_regions = 128;
+
+	while (-1 != (opt = getopt(argc, argv, "pnhl:r:s:q:"))) {
 		switch (opt) {
-		case 'n':
-			nocache = 1;
-			break;
-		case 'l':
-			len = strtol(optarg, NULL, 0);
-			break;
-		case 'r':
-			repeat = strtol(optarg, NULL, 0);
-			break;
-		case 'h':
-			print_help(argv);
-			return 0;
+			case 'n':
+				nocache = 1;
+				break;
+			case 'l':
+				len = strtol(optarg, NULL, 0);
+				break;
+			case 'r':
+				repeat = strtol(optarg, NULL, 0);
+				break;
+			case 'p':
+				do_heap_test = true;
+				break;
+			case 'q':
+				heap_regions = strtol(optarg, NULL, 0);
+				break;
+			case 's':
+				random_seed = strtol(optarg, NULL, 0);
+				break;
+			case 'h':
+				print_help(argv);
+				return 0;
 		}
 	}
 
+	if (do_heap_test) {
+		/* Default values for heap test */
+		if (len == 0) {
+			len = 8192;
+		}
+
+		if (repeat == 0) {
+			repeat = 2048;
+		}
+
+		return heap_test(repeat, len);
+	}
+
+	/* Default values for memcpy test */
 	if (len == 0) {
-		len = default_region_len;
+		len = 16 * 1024 * 1024;
+	}
+
+	if (repeat == 0) {
+		repeat = 64;
 	}
 
 	r_len1 = r_len2 = len;

--- a/src/mem/heap/Mybuild
+++ b/src/mem/heap/Mybuild
@@ -3,6 +3,7 @@ package embox.mem
 @DefaultImpl(heap_bm)
 abstract module heap_api {
 	option number heap_size = 524288
+	option number align = 4
 	depends embox.kernel.task.resource.task_heap
 }
 
@@ -43,9 +44,11 @@ module heap_bm extends heap_api {
 }
 
 module heap_simple extends heap_api {
+	option number log_level=1
 	source "heap_simple.c"
 
 	depends embox.mem.heap_place
+	depends embox.util.log
 }
 
 module sysmalloc_task_based extends sysmalloc_api {
@@ -59,7 +62,7 @@ module sysmalloc_task_based extends sysmalloc_api {
 
 @DefaultImpl(static_heap)
 abstract module heap_place {
-	
+
 }
 
 module static_heap extends heap_place {


### PR DESCRIPTION
This feature fixes problems with heap_simple on ARM, where memory access should be 4-byte aligned.

Also extend `memtest` command for heap stress test.