### PR TITLE
Fix ttys_dvfs dev_open assignment

### DIFF
--- a/src/drivers/tty/serial/ttys_dvfs.c
+++ b/src/drivers/tty/serial/ttys_dvfs.c
@@ -18,7 +18,7 @@
 #include "idesc_serial.h"
 #include <fs/dvfs.h>
 
-static struct idesc *uart_cdev_open(struct dev_module *cdev, void *priv) {
+struct idesc *uart_cdev_open(struct dev_module *cdev, void *priv) {
 	struct idesc *idesc;
 	struct file *f;
 	int res;

--- a/src/drivers/tty/serial/ttys_dvfs.h
+++ b/src/drivers/tty/serial/ttys_dvfs.h
@@ -19,7 +19,9 @@ struct tty_uart {
 	struct uart *uart;
 };
 
+extern struct idesc *uart_cdev_open(struct dev_module *cdev, void *priv);
+
 #define TTYS_DEF(name, uart) \
-		CHAR_DEV_DEF(name, NULL, NULL, NULL, uart)
+		CHAR_DEV_DEF(name, uart_cdev_open, NULL, NULL, uart)
 
 #endif /* TTYS_H_ */


### PR DESCRIPTION
arm/stm32f7cube


```
ASSERTION FAILED on CPU 0
at src/fs/driver/devfs/devfs_dvfs.c:225
in function devfs_open_idesc

dev->dev_open
```