### PR TITLE
FB back buffer

### DIFF
--- a/platform/etnaviv/cmds/quad_tex_animated/quad_tex_animated.c
+++ b/platform/etnaviv/cmds/quad_tex_animated/quad_tex_animated.c
@@ -7,7 +7,7 @@
 #include <lib/fps.h>
 
 #define USE_TRACE 0
-#define WIDTH 480
+#define WIDTH 800
 #define HEIGHT 480
 #define NEAR 0
 #define FAR 1
@@ -301,13 +301,17 @@ static void draw(struct program *p) {
 
 	struct fb_info *mesa_fbi;
 	mesa_fbi = fb_lookup(0);
-	void *sw_base = fps_enable_swap(mesa_fbi);
+
+	void *sw_base;
 
 	struct pipe_transfer *transfer;
 	struct pipe_surface *surface = p->framebuffer.cbufs[0];
 	struct pipe_context *pipe = p->pipe;
 	struct pipe_resource *texture = surface->texture;
 	void *ptr = 0;
+
+	fps_enable_swap(mesa_fbi);
+
 	cso_set_blend(p->cso, &p->blend);
 	cso_set_depth_stencil_alpha(p->cso, &p->depthstencil);
 	cso_set_rasterizer(p->cso, &p->rasterizer);
@@ -361,6 +365,7 @@ static void draw(struct program *p) {
 				0, 0, surface->width, surface->height, &transfer);
 
 		uint16_t *p16;
+		sw_base = fps_current_frame(mesa_fbi);
 		for (int i = 0; i < HEIGHT; i++) {
 			p16 = ((void *)ptr) + (i * WIDTH * 2);
 			memcpy(sw_base + mesa_fbi->var.xres * i * 2, p16, WIDTH * 2);

--- a/src/drivers/gpu/ipu_v3/ipu_param_mem.h
+++ b/src/drivers/gpu/ipu_v3/ipu_param_mem.h
@@ -18,11 +18,11 @@
 
 #include <hal/reg.h>
 #include "ipu_priv.h"
-#include <kernel/printk.h>
+#include <util/log.h>
 
-#define dev_dbg(x, ...) printk(__VA_ARGS__)
-#define dev_warn(x, ...) printk(__VA_ARGS__)
-#define dev_err(x, ...) printk(__VA_ARGS__)
+#define dev_dbg(x, ...) log_debug(__VA_ARGS__)
+#define dev_warn(x, ...) log_warning(__VA_ARGS__)
+#define dev_err(x, ...) log_error(__VA_ARGS__)
 
 extern uint32_t *ipu_cpmem_base;
 

--- a/src/drivers/gpu/ipu_v3/ipuv3_fb.c
+++ b/src/drivers/gpu/ipu_v3/ipuv3_fb.c
@@ -83,8 +83,19 @@ static int mxcfb_set_par(struct fb_info *fbi, const struct fb_var_screeninfo *va
 	return 0;
 }
 
+static int mxcfb_set_base(struct fb_info *fbi, void *new_base) {
+	ipu_init_channel_buffer(mxc_fbi.ipu,
+					 mxc_fbi.ipu_ch, IPU_INPUT_BUFFER,
+					 IPU_PIX_FMT_RGB565,
+					 fbi->var.xres, fbi->var.yres,
+					 fbi->var.xres * fbi->var.bits_per_pixel / 8,
+					 (uint32_t) new_base);
+	return 0;
+}
+
 static struct fb_ops mxcfb_ops = {
-	.fb_set_var = mxcfb_set_par,
+	.fb_set_var  = mxcfb_set_par,
+	.fb_set_base = mxcfb_set_base,
 };
 
 extern void dcache_flush(const void *p, size_t size);

--- a/src/drivers/video/fb.h
+++ b/src/drivers/video/fb.h
@@ -163,6 +163,7 @@ struct fb_ops {
 	void (*fb_fillrect)(struct fb_info *info, const struct fb_fillrect *rect);
 	void (*fb_imageblit)(struct fb_info *info, const struct fb_image *image);
 	void (*fb_cursor)(struct fb_info *info, const struct fb_cursor *cursor);
+	int (*fb_set_base)(struct fb_info *info, void *new_base);
 };
 
 struct fb_info {

--- a/src/lib/fps/fps.h
+++ b/src/lib/fps/fps.h
@@ -16,5 +16,6 @@ extern void fps_print(struct fb_info *fb);
 extern void fps_set_base(struct fb_info *fb, void *base);
 extern void *fps_enable_swap(struct fb_info *fb);
 extern int fps_swap(struct fb_info *fb);
+extern void *fps_current_frame(struct fb_info *fb);
 
 #endif /* LIB_FPS_H_ */


### PR DESCRIPTION
Add handler for changing current buffer in fb_ops. It helps to increase performance by using additional buffers and reducing copying operation.