### PR TITLE
FPS: Work on double buffering

### DIFF
--- a/platform/etnaviv/cmds/quad_tex_animated/quad_tex_animated.c
+++ b/platform/etnaviv/cmds/quad_tex_animated/quad_tex_animated.c
@@ -7,8 +7,6 @@
 #include <lib/fps.h>
 
 #define USE_TRACE 0
-#define WIDTH 800
-#define HEIGHT 480
 #define NEAR 0
 #define FAR 1
 #define FLIP 0
@@ -74,6 +72,9 @@ struct program
 	struct pipe_resource *target;
 	struct pipe_resource *tex;
 	struct pipe_sampler_view *view;
+
+	int width;
+	int height;
 };
 
 static float vertices[4][2][4] = {
@@ -133,8 +134,8 @@ static void init_prog(struct program *p)
 		memset(&tmplt, 0, sizeof(tmplt));
 		tmplt.target = PIPE_TEXTURE_2D;
 		tmplt.format = PIPE_FORMAT_B5G6R5_UNORM; /* All drivers support this */
-		tmplt.width0 = WIDTH;
-		tmplt.height0 = HEIGHT;
+		tmplt.width0 = p->width;
+		tmplt.height0 = p->height;
 		tmplt.depth0 = 1;
 		tmplt.array_size = 1;
 		tmplt.last_level = 0;
@@ -213,8 +214,8 @@ static void init_prog(struct program *p)
 	surf_tmpl.u.tex.last_layer = 0;
 	/* drawing destination */
 	memset(&p->framebuffer, 0, sizeof(p->framebuffer));
-	p->framebuffer.width = WIDTH;
-	p->framebuffer.height = HEIGHT;
+	p->framebuffer.width = p->width;
+	p->framebuffer.height = p->height;
 	p->framebuffer.nr_cbufs = 1;
 	p->framebuffer.cbufs[0] = p->pipe->create_surface(p->pipe, p->target, &surf_tmpl);
 
@@ -223,14 +224,14 @@ static void init_prog(struct program *p)
 		float x = 0;
 		float y = 0;
 		float z = NEAR;
-		float half_width = (float)WIDTH / 2.0f;
-		float half_height = (float)HEIGHT / 2.0f;
+		float half_width = (float)p->width / 2.0f;
+		float half_height = (float)p->height / 2.0f;
 		float half_depth = ((float)FAR - (float)NEAR) / 2.0f;
 		float scale, bias;
 
 		if (FLIP) {
 			scale = -1.0f;
-			bias = (float)HEIGHT;
+			bias = (float)p->height;
 		} else {
 			scale = 1.0f;
 			bias = 0.0f;
@@ -302,9 +303,9 @@ static void draw(struct program *p) {
 	struct fb_info *mesa_fbi;
 	mesa_fbi = fb_lookup(0);
 
-	void *sw_base;
+	void *sw_base[2] = { NULL, NULL };
 
-	struct pipe_transfer *transfer;
+	struct pipe_transfer *transfer[2];
 	struct pipe_surface *surface = p->framebuffer.cbufs[0];
 	struct pipe_context *pipe = p->pipe;
 	struct pipe_resource *texture = surface->texture;
@@ -329,8 +330,11 @@ static void draw(struct program *p) {
 
 	/* vertex element data */
 	cso_set_vertex_elements(p->cso, 2, p->velem);
+	int current_id;
+
 	while (true) {
 		step++;
+		current_id = step % 2;
 		const float theta = 0.01;
 
 		for (int i = 0; i < 4; i++) {
@@ -359,21 +363,21 @@ static void draw(struct program *p) {
 				2); /* attribs/vert */
 
 		p->pipe->flush(p->pipe, NULL, 0);
-
 		ptr = pipe_transfer_map(pipe, texture, surface->u.tex.level,
 				surface->u.tex.first_layer, PIPE_TRANSFER_READ,
-				0, 0, surface->width, surface->height, &transfer);
+				0, 0, surface->width, surface->height, &transfer[current_id]);
 
-		uint16_t *p16;
-		sw_base = fps_current_frame(mesa_fbi);
-		for (int i = 0; i < HEIGHT; i++) {
-			p16 = ((void *)ptr) + (i * WIDTH * 2);
-			memcpy(sw_base + mesa_fbi->var.xres * i * 2, p16, WIDTH * 2);
+		sw_base[current_id] = ptr;
+
+		if (sw_base[0] && sw_base[1]) {
+			/* Make sure we have both bsae frame and back frame
+			 * filled. Actualy, it's the same as (steps > 1) */
+			fps_set_base_frame(mesa_fbi, sw_base[0]);
+			fps_set_back_frame(mesa_fbi, sw_base[1]);
+			fps_print(mesa_fbi);
+			fps_swap(mesa_fbi);
+			pipe->transfer_unmap(pipe, transfer[current_id ^ 1]);
 		}
-
-		fps_print(mesa_fbi);
-		fps_swap(mesa_fbi);
-		pipe->transfer_unmap(pipe, transfer);
 	}
 }
 

--- a/src/drivers/gpu/drm/etnaviv/Mybuild
+++ b/src/drivers/gpu/drm/etnaviv/Mybuild
@@ -12,6 +12,8 @@ module etnaviv_drm {
 
 	option number log_level=1
 
+	option boolean use_gpu2d=true /* Workaround to avoid stall for some boards */
+
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96/include/drm")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/freedesktop/mesa/libdrm_etnaviv/libdrm-2.4.96/etnaviv/")
 	source "etnaviv_dev.c", "etnaviv_gem.c", "etnaviv_gem_submit.c", "etnaviv_cmdbuf.c", "etnaviv_cmd_parser.c", "etnaviv_gpu.c", "etnaviv_buffer.c", "etnaviv_mmu.c", "etnaviv_iommu_v2.c", "etnaviv_iommu.c"

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
@@ -53,6 +53,8 @@
 #define R2D_GPU2D_IRQ	OPTION_GET(NUMBER,r2d_gpu2d_irq)
 #define V2D_GPU2D_IRQ	OPTION_GET(NUMBER,v2d_gpu2d_irq)
 
+#define USE_GPU2D	OPTION_GET(BOOLEAN,use_gpu2d)
+
 #define ETNA_UNCACHED_BUFFER_SZ	(16 * 1024 * 1024)
 
 static uint8_t etnaviv_uncached_buffer[ETNA_UNCACHED_BUFFER_SZ] __attribute__ ((aligned (0x1000)));
@@ -225,6 +227,7 @@ static struct idesc *etnaviv_dev_open(struct dev_module *cdev, void *priv) {
 			return NULL;
 		}
 
+#if USE_GPU2D
 		if (irq_attach(	R2D_GPU2D_IRQ,
 				etna_irq_handler,
 				0,
@@ -240,18 +243,21 @@ static struct idesc *etnaviv_dev_open(struct dev_module *cdev, void *priv) {
 				"i.MX6 GPU2D")) {
 			return NULL;
 		}
+#endif
 
 		imx_gpu_power_set(1);
 
 		clk_enable("gpu3d");
+#if USE_GPU2D
 		clk_enable("gpu2d");
+#endif
 		clk_enable("openvg");
 		clk_enable("vpu");
-
+#if USE_GPU2D
 		etnaviv_gpu_init(&etnaviv_gpus[PIPE_ID_PIPE_2D]);
-		etnaviv_gpu_init(&etnaviv_gpus[PIPE_ID_PIPE_3D]);
-
 		etnaviv_gpu_debugfs(&etnaviv_gpus[PIPE_ID_PIPE_2D], "GPU2D");
+#endif
+		etnaviv_gpu_init(&etnaviv_gpus[PIPE_ID_PIPE_3D]);
 		etnaviv_gpu_debugfs(&etnaviv_gpus[PIPE_ID_PIPE_2D], "GPU3D");
 	}
 

--- a/src/drivers/power/imx/imx.c
+++ b/src/drivers/power/imx/imx.c
@@ -96,19 +96,6 @@ static void imx_anatop_pu_enable(int enable) {
 
 extern int clk_enable(char *clk_name);
 extern int clk_disable(char *clk_name);
-static void imx_power_clk(int enable) {
-	if (enable) {
-		clk_enable("gpu3d");
-		clk_enable("gpu2d");
-		clk_enable("openvg");
-		clk_enable("vpu");
-	} else {
-		clk_disable("gpu3d");
-		clk_disable("gpu2d");
-		clk_disable("openvg");
-		clk_disable("vpu");
-	}
-}
 
 void imx_gpu_power_set(int up) {
 	int t = 0xfffff;
@@ -122,8 +109,6 @@ void imx_gpu_power_set(int up) {
 		REG32_ORIN(GPC_CNTR, GPU_VPU_PUP_REQ);
 
 		while (REG32_LOAD(GPC_CNTR) & GPU_VPU_PUP_REQ);
-
-		imx_power_clk(1);
 	} else {
 		/* Power-down */
 		REG32_STORE(PGC_GPU_CTRL, 1);

--- a/src/lib/fps/fps.h
+++ b/src/lib/fps/fps.h
@@ -11,9 +11,11 @@
 
 #include <drivers/video/fb.h>
 
+/* Refer to fps.c for docs */
 extern void fps_set_format(const char *format);
 extern void fps_print(struct fb_info *fb);
-extern void fps_set_base(struct fb_info *fb, void *base);
+extern void fps_set_base_frame(struct fb_info *fb, void *base);
+extern void fps_set_back_frame(struct fb_info *fb, void *base);
 extern void *fps_enable_swap(struct fb_info *fb);
 extern int fps_swap(struct fb_info *fb);
 extern void *fps_current_frame(struct fb_info *fb);

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Mybuild
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Mybuild
@@ -17,4 +17,5 @@ module  mesa_etnaviv {
 	depends embox.compat.posix.pthread_key
 
 	depends third_party.freedesktop.mesa.libdrm_etnaviv
+	depends embox.lib.cxx.libsupcxx_standalone
 }

--- a/third-party/freedesktop/mesa/mesa/mesa_sw/Mybuild
+++ b/third-party/freedesktop/mesa/mesa/mesa_sw/Mybuild
@@ -14,4 +14,6 @@ module  mesa_osmesa {
 	depends embox.compat.posix.fs.mknod_api
 	depends third_party.freedesktop.mesa.libdrm
 	@NoRuntime depends embox.compat.posix.pthread_key
+
+	depends embox.lib.cxx.libsupcxx_standalone
 }


### PR DESCRIPTION
* Add functions to setup first/back frame base manually
* Use this feature in gallium examples to avoid use `memcpy()` and achieve high fps rate