### PR TITLE
Clean arch/qemu templates

### DIFF
--- a/src/compat/libc/math/Mybuild
+++ b/src/compat/libc/math/Mybuild
@@ -1,6 +1,6 @@
 package embox.compat.libc
 
-@DefaultImpl(math_openlibm)
+@DefaultImpl(math_builtins)
 abstract module math {
 }
 

--- a/templates/arm/qemu/mods.config
+++ b/templates/arm/qemu/mods.config
@@ -77,7 +77,7 @@ configuration conf {
 	@Runlevel(2) include embox.mem.bitmask
 	@Runlevel(2) include embox.mem.static_heap(heap_size=134217728)
 	@Runlevel(2) include embox.mem.heap_bm(heap_size=67108864)
-
+/******* TESTS *************/
 	@Runlevel(1) include embox.test.critical
 	@Runlevel(1) include embox.test.framework.mod.member.ops_test
 	@Runlevel(1) include embox.test.kernel.timer_test
@@ -105,6 +105,9 @@ configuration conf {
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.page_allocator
 	@Runlevel(1) include embox.test.util.hashtable_test
+	@Runlevel(2) include embox.test.posix.fcntl.open_test
+
+	@Runlevel(2) include embox.test.math.fpu_context_consistency_test
 
 	@Runlevel(2) include embox.cmd.sh.tish(
 				prompt="%u@%h:%w%$", rich_prompt_support=1,
@@ -207,8 +210,4 @@ configuration conf {
 	include embox.compat.libc.stdio.asprintf
 	include embox.compat.posix.proc.atexit_stub
 	include embox.compat.posix.fs.rewinddir_stub
-
-	@Runlevel(1) include embox.test.math.math_test
-	@Runlevel(2) include embox.test.math.fpu_context_consistency_test
-	@Runlevel(2) include embox.test.posix.fcntl.open_test
 }

--- a/templates/mips/qemu/mods.config
+++ b/templates/mips/qemu/mods.config
@@ -160,5 +160,6 @@ configuration conf {
 	@Runlevel(2) include embox.util.LibUtil
 	@Runlevel(2) include embox.framework.LibFramework
 	@Runlevel(2) include embox.compat.libc.all
-	include embox.compat.libc.math_openlibm
+	include embox.compat.libc.math_builtins
+
 }

--- a/templates/mips64/qemu/mods.config
+++ b/templates/mips64/qemu/mods.config
@@ -160,5 +160,5 @@ configuration conf {
 	@Runlevel(2) include embox.util.LibUtil
 	@Runlevel(2) include embox.framework.LibFramework
 	@Runlevel(2) include embox.compat.libc.all
-	include embox.compat.libc.math_openlibm
+	include embox.compat.libc.math_builtins
 }

--- a/templates/ppc/qemu/mods.config
+++ b/templates/ppc/qemu/mods.config
@@ -46,7 +46,7 @@ configuration conf {
 	include embox.framework.LibFramework
 	include embox.arch.ppc.libarch
 	include embox.compat.libc.all
-	include embox.compat.libc.math_openlibm
+	include embox.compat.libc.math_builtins
 	include embox.compat.posix.termios
 
 	@Runlevel(1) include embox.test.critical

--- a/templates/x86/qemu/mods.config
+++ b/templates/x86/qemu/mods.config
@@ -194,9 +194,11 @@ configuration conf {
 	@Runlevel(2) include embox.util.LibUtil
 	@Runlevel(2) include embox.framework.LibFramework
 	@Runlevel(2) include embox.compat.libc.all
-	include embox.compat.libc.math_openlibm
+	include embox.compat.libc.math_builtins
 
+/*
 	include third_party.dash
+*/
 	include embox.compat.posix.proc.fork_copy_everything
 	include embox.arch.x86.fork
 }


### PR DESCRIPTION
* Switch default implementation of libm to math_builtins
* Remove third-party modules from <arch>/qemu templates
   * Switch libm to 'math_builtins'
   * Remove dash from x86/qemu
