### PR TITLE
posix: Add missing getgrXXX functions

### DIFF
--- a/src/compat/posix/include/grp.h
+++ b/src/compat/posix/include/grp.h
@@ -18,19 +18,17 @@ struct group {
 	char  **gr_mem; /* Pointer to a null-terminated array of character pointers to member names.*/
 };
 
-static inline struct group *getgrnam(const char *name) {
-	(void)name;
-	return NULL;
-}
-
 __BEGIN_DECLS
 
 extern int fgetgrent_r(FILE *fp, struct group *gbuf, char *tbuf,
 		size_t buflen, struct group **gbufp);
 
 extern struct group * getgrgid(gid_t gid);
-extern int getgrgid_r(gid_t, struct group *, char *, size_t, struct group **);
-extern int getgrnam_r(const char *, struct group *, char *, size_t , struct group **);
+extern struct group *getgrnam(const char *name);
+extern int getgrgid_r(gid_t gid, struct group *gbuf, char *buf,
+		size_t buflen, struct group **gbufp);
+extern int getgrnam_r(const char *name, struct group *gbuf, char *buf,
+		size_t buflen, struct group **gbufp);
 
 __END_DECLS
 

--- a/src/compat/posix/include/grp.h
+++ b/src/compat/posix/include/grp.h
@@ -22,6 +22,7 @@ __BEGIN_DECLS
 
 extern int fgetgrent_r(FILE *fp, struct group *gbuf, char *tbuf,
 		size_t buflen, struct group **gbufp);
+extern struct group *fgetgrent(FILE *stream);
 
 extern struct group * getgrgid(gid_t gid);
 extern struct group *getgrnam(const char *name);

--- a/src/compat/posix/include/grp.h
+++ b/src/compat/posix/include/grp.h
@@ -25,6 +25,9 @@ static inline struct group *getgrnam(const char *name) {
 
 __BEGIN_DECLS
 
+extern int fgetgrent_r(FILE *fp, struct group *gbuf, char *tbuf,
+		size_t buflen, struct group **gbufp);
+
 extern struct group * getgrgid(gid_t gid);
 extern int getgrgid_r(gid_t, struct group *, char *, size_t, struct group **);
 extern int getgrnam_r(const char *, struct group *, char *, size_t , struct group **);

--- a/src/compat/posix/include/grp.h
+++ b/src/compat/posix/include/grp.h
@@ -31,6 +31,12 @@ extern int getgrgid_r(gid_t gid, struct group *gbuf, char *buf,
 extern int getgrnam_r(const char *name, struct group *gbuf, char *buf,
 		size_t buflen, struct group **gbufp);
 
+extern int getgrent_r(struct group *gbuf, char *buf,
+		size_t buflen, struct group **gbufp);
+extern struct group *getgrent(void);
+extern void setgrent(void);
+extern void endgrent(void);
+
 __END_DECLS
 
 #endif /* GRP_H_ */

--- a/src/compat/posix/pwd_grp/pwd_grp.c
+++ b/src/compat/posix/pwd_grp/pwd_grp.c
@@ -291,6 +291,20 @@ int fgetgrent_r(FILE *fp, struct group *gbuf, char *tbuf,
 	return 0;
 }
 
+struct group *fgetgrent(FILE *stream) {
+	static struct group grp_buf;
+	static char buf[64];
+	struct group *res;
+	int ret;
+
+	if (0 != (ret = fgetgrent_r(stream, &grp_buf, buf, sizeof(buf), &res))) {
+		SET_ERRNO(ret);
+		return NULL;
+	}
+
+	return res;
+}
+
 int getgrnam_r(const char *name, struct group *grp,
 	char *buf, size_t buflen, struct group **result) {
 	int res;

--- a/src/compat/posix/pwd_grp/pwd_grp.c
+++ b/src/compat/posix/pwd_grp/pwd_grp.c
@@ -327,6 +327,21 @@ struct group * getgrgid(gid_t gid) {
 	return result;
 }
 
+struct group *getgrnam(const char *name) {
+	static struct group grp_buf;
+	static char buf[64];
+	struct group *res;
+	int ret;
+
+	ret = getgrnam_r(name, &grp_buf, buf, sizeof(buf), &res);
+	if (0 != ret) {
+		SET_ERRNO(ret);
+		return NULL;
+	}
+
+	return res;
+}
+
 int getgrgid_r(gid_t gid, struct group *grp,
 	char *buf, size_t buflen, struct group **result) {
 	int res;

--- a/src/compat/posix/pwd_grp/pwd_grp.c
+++ b/src/compat/posix/pwd_grp/pwd_grp.c
@@ -179,7 +179,7 @@ struct passwd *getpwnam(const char *name) {
 	struct passwd *res;
 	int ret;
 
-	if (0 != (ret = getpwnam_r(name, &getpwnam_buffer, buff, 0x80,  &res))) {
+	if (0 != (ret = getpwnam_r(name, &getpwnam_buffer, buff, sizeof(buff),  &res))) {
 		SET_ERRNO(-ret);
 		return NULL;
 	}
@@ -219,7 +219,7 @@ struct passwd *getpwuid(uid_t uid) {
 	struct passwd *res;
 	int ret;
 
-	if (0 != (ret = getpwuid_r(uid, &getpwuid_buffer, buff, 80, &res))) {
+	if (0 != (ret = getpwuid_r(uid, &getpwuid_buffer, buff, sizeof(buff), &res))) {
 		SET_ERRNO(-ret);
 		return NULL;
 	}
@@ -307,9 +307,9 @@ int getgrnam_r(const char *name, struct group *grp,
 }
 
 struct group * getgrgid(gid_t gid) {
-	static struct group *result;
-	struct group grp;
-	char buf[64];
+	static struct group grp;
+	static char buf[64];
+	struct group *result;
 	int ret;
 
 	ret = getgrgid_r(gid, &grp, buf, sizeof buf, &result);
@@ -356,7 +356,7 @@ int getmaxuid() {
 		return res;
 	}
 
-	while (0 == (res = fgetpwent_r(file, &pwd, buff, 80, &result))) {
+	while (0 == (res = fgetpwent_r(file, &pwd, buff, sizeof(buff), &result))) {
 		if (pwd.pw_uid > curmax) {
 			curmax = pwd.pw_uid;
 		}

--- a/third-party/samba/samba_embox_compat.h
+++ b/third-party/samba/samba_embox_compat.h
@@ -108,23 +108,6 @@ int initgroups(const char *user, gid_t group) {
 }
 
 static inline
-void setgrent(void) {
-	DPRINT();
-}
-
-static inline
-struct group *getgrent(void) {
-	DPRINT();
-	errno = EPERM;
-	return 0;
-}
-
-static inline
-void endgrent(void) {
-	DPRINT();
-}
-
-static inline
 unsigned int alarm(unsigned int seconds) {
 	DPRINT();
 	return 0;


### PR DESCRIPTION
Also:
* Fix typos with incorrect buffer size passed to reentrant functions in getpwuid and getmaxuid
* getgrgid now returns pointer to correct internal data structure
* All getgrXXX functions return (or set errno to) ENOENT if no entry is found and corresponding errno value on other errors