### PR TITLE
arm: Fix warnings

### DIFF
--- a/platform/mesa/templates/integratorcp/mods.config
+++ b/platform/mesa/templates/integratorcp/mods.config
@@ -169,7 +169,7 @@ configuration conf {
 	include embox.compat.posix.proc.atexit_stub
 	include embox.compat.posix.fs.rewinddir_stub
 
-	include embox.driver.video.fb_devfs_old
+	include embox.driver.video.fb_devfs
 	include embox.fs.syslib.idesc_mmap
 	include embox.cmd.testing.fb_devfs_access
 	include embox.cmd.testing.fb_direct_access

--- a/platform/nuklear/templates/arm_qemu/mods.config
+++ b/platform/nuklear/templates/arm_qemu/mods.config
@@ -169,7 +169,7 @@ configuration conf {
 	include embox.compat.posix.proc.atexit_stub
 	include embox.compat.posix.fs.rewinddir_stub
 
-	include embox.driver.video.fb_devfs_old
+	include embox.driver.video.fb_devfs
 	include embox.fs.syslib.idesc_mmap
 	include embox.cmd.testing.fb_devfs_access
 	include embox.cmd.testing.fb_direct_access

--- a/src/arch/arm/imx/cpuinfo.c
+++ b/src/arch/arm/imx/cpuinfo.c
@@ -6,6 +6,7 @@
  * @date 22.05.2017
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 
 #include <arch/arm/imx/cpuinfo.h>
@@ -68,7 +69,7 @@ void print_imx_cpuinfo() {
 	uint32_t rev = _imx_revision();
 	printk("\t\tCPU identification:\n");
 	printk("\t\t    i.MX%s\n", _imx_type((rev >> 16) & 0xFF));
-	printk("\t\t    Revision: %d.%d\n", (rev >> 8) & 0xFF, rev & 0xFF);
+	printk("\t\t    Revision: %"PRIu32".%"PRIu32"\n", (rev >> 8) & 0xFF, rev & 0xFF);
 }
 
 static int imx_cpuinfo_init(void) {

--- a/src/compat/posix/sys/mman/Mybuild
+++ b/src/compat/posix/sys/mman/Mybuild
@@ -28,4 +28,7 @@ module mmap extends mmap_api {
 }
 
 module mmap_stub extends mmap_api {
+	option number log_level = 0
+
+	source "mmap_stub.c"
 }

--- a/src/compat/posix/sys/mman/mmap_stub.c
+++ b/src/compat/posix/sys/mman/mmap_stub.c
@@ -1,0 +1,21 @@
+/**
+ * @file mmap.c
+ * @brief Various memory mapping
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 28.02.2018
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <sys/mman.h>
+
+#include <util/log.h>
+
+void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
+	return addr;
+}
+
+int munmap(void *addr, size_t size) {
+	return 0;
+}

--- a/src/drivers/char/char_dev_stub.h
+++ b/src/drivers/char/char_dev_stub.h
@@ -10,6 +10,7 @@
 #define DEVICE_H_
 
 #include <stddef.h>
+#include <fs/idesc.h>
 
 struct idesc;
 struct dev_module;
@@ -25,6 +26,11 @@ struct dev_module;
 #else
 	#define CHAR_DEV_DEF(chname, open_fn, close_fn, idesc_op, priv)
 #endif /* __GNUC__ */
+
+struct idesc_dev {
+	struct idesc idesc;
+	void *dev;
+};
 
 extern int char_dev_init_all(void);
 extern int char_dev_register(const struct dev_module *cdev);

--- a/src/drivers/interrupt/cortex_a9_gic/cortex_a9_gic.c
+++ b/src/drivers/interrupt/cortex_a9_gic/cortex_a9_gic.c
@@ -6,6 +6,7 @@
  */
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <sys/mman.h>
 
@@ -88,14 +89,14 @@ static int gic_init(void) {
 
 	tmp = REG_LOAD(GICD_TYPER);
 	printk("\n"
-			"\t\tNumber of SPI: %d\n"
-			"\t\tNumber of supported CPU interfaces: %d\n"
+			"\t\tNumber of SPI: %"PRIu32"\n"
+			"\t\tNumber of supported CPU interfaces: %"PRIu32"\n"
 			"\t\tSecutity Extension %s implemented\n",
 			GICD_TYPER_ITLINES(tmp) * 32,
 			1 + GICD_TYPER_CPUNR(tmp),
 			GICD_TYPER_SECEXT(tmp) ? "" : "not ");
 	if (tmp & (1 << 10)) {
-		printk("\t\tNumber of LSPI: %d", GICD_TYPER_LSPI(tmp));
+		printk("\t\tNumber of LSPI: %"PRIu32, GICD_TYPER_LSPI(tmp));
 	} else {
 		printk("\t\tLSPI not implemented");
 	}

--- a/src/drivers/video/Mybuild
+++ b/src/drivers/video/Mybuild
@@ -40,6 +40,7 @@ module bochs {
 	depends embox.driver.pci
 	@NoRuntime depends fb
 	@NoRuntime depends embox.compat.libc.all
+	depends embox.compat.posix.sys.mman.mmap_api
 }
 
 module raspi_video {
@@ -58,6 +59,7 @@ module cirrus_logic {
 
 	depends fb
 	depends embox.driver.pci
+	depends embox.compat.posix.sys.mman.mmap_api
 }
 
 module generic {

--- a/src/drivers/video/fb_devfs/fb_devfs.c
+++ b/src/drivers/video/fb_devfs/fb_devfs.c
@@ -14,6 +14,7 @@
 #include <drivers/video/fb.h>
 #include <linux/fb.h>
 #include <drivers/char_dev.h>
+#include <drivers/device.h>
 #include <mem/misc/pool.h>
 
 static void *

--- a/src/mem/vmem/Mybuild
+++ b/src/mem/vmem/Mybuild
@@ -14,6 +14,10 @@ module vmem_nommu extends vmem_api {
 	@IncludeExport(path="mem", target_name="vmem.h")
 	source "vmem_nommu.h"
 
+	source "vmem_device_memory.c"
+
+	depends embox.mem.mmap_nommu
+	depends embox.kernel.task.resource.mmap
 	depends embox.fs.syslib.idesc_mmap_api
 }
 

--- a/src/mem/vmem/Mybuild
+++ b/src/mem/vmem/Mybuild
@@ -30,7 +30,6 @@ module vmem extends vmem_api {
 
 	depends embox.arch.mmu
 	depends vmem_alloc
-	depends embox.mem.phymem
 	depends embox.mem.mmap_mmu
 	depends embox.fs.syslib.idesc_mmap_api
 	depends vmem_header

--- a/src/mem/vmem/vmem_device_memory.c
+++ b/src/mem/vmem/vmem_device_memory.c
@@ -14,7 +14,6 @@
 #include <kernel/task/resource/mmap.h>
 #include <mem/mapping/marea.h>
 #include <mem/mmap.h>
-#include <mem/phymem.h>
 
 static struct emmap *self_mmap(void) {
 	if (0 == mmap_kernel_inited()) {

--- a/src/mem/vmem/vmem_nommu.h
+++ b/src/mem/vmem/vmem_nommu.h
@@ -8,44 +8,4 @@
 #ifndef VMEM_NOMMU_H_
 #define VMEM_NOMMU_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
-static inline void *mmap_device_memory(void *addr,
-                           size_t len,
-                           int prot,
-                           int flags,
-                           uint64_t physical){
-	(void) addr;
-	(void) len;
-	(void) prot;
-	(void) flags;
-	(void) physical;
-
-	return addr;
-}
-
-static inline int munmap(void *addr, size_t size) {
-	(void) addr;
-	(void) size;
-
-	return 0;
-}
-
-#include <module/embox/fs/syslib/idesc_mmap_api.h>
-
-static inline void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
-	(void) addr;
-	(void) len;
-	(void) prot;
-	(void) flags;
-	(void) fd;
-	(void) off;
-
-	if(fd) {
-		return idesc_mmap(addr, len, prot, flags, fd, off);
-	}
-	return NULL;
-}
-
 #endif /* VMEM_NOMMU_H_ */

--- a/third-party/qt/Mybuild
+++ b/third-party/qt/Mybuild
@@ -24,6 +24,7 @@ static module core {
 	@NoRuntime depends embox.compat.posix.proc.waitpid
 	@NoRuntime depends embox.lib.LibExecStub
 	@NoRuntime depends embox.compat.posix.pthread_key
+	@NoRuntime depends embox.compat.posix.sys.mman.mmap_api
 	@NoRuntime depends embox.lib.libsupcxx
 	@NoRuntime depends embox.lib.libgcc
 }


### PR DESCRIPTION
uint32_t was misused in printf. It's interpreted as long unsigned int,
so %d is unusable here