### PR TITLE
Fix Mesa

### DIFF
--- a/platform/etnaviv/cmds/cube.c
+++ b/platform/etnaviv/cmds/cube.c
@@ -7,6 +7,7 @@
  */
 
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -715,7 +716,7 @@ int main(int argc, char *argv[]) {
 	height = fb->var.yres;
 	frame_size = width * height * fb->var.bits_per_pixel / 8;
 
-	printf("Screen: %dx%d (%dbpp)\n", width, height,
+	printf("Screen: %dx%d (%"PRIu32"bpp)\n", width, height,
 			fb->var.bits_per_pixel);
 
 	if ((version = drmGetVersion(fd))) {

--- a/platform/mesa/cmds/osdemo_fb/osdemo_fb.c
+++ b/platform/mesa/cmds/osdemo_fb/osdemo_fb.c
@@ -39,7 +39,7 @@ static int animated_scene;
 void init_buffers(void) {
 	mesa_fbi = fb_lookup(0);
 
-	printf("%dx%d, %dbpp\n", mesa_fbi->var.xres, mesa_fbi->var.yres,
+	printf("%"PRIu32"x%"PRIu32", %"PRIu32"bpp\n", mesa_fbi->var.xres, mesa_fbi->var.yres,
 			mesa_fbi->var.bits_per_pixel);
 
 	Width = mesa_fbi->var.xres;

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_buffer.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_buffer.c
@@ -15,6 +15,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <inttypes.h>
+
 #include <../arch/arm/armlib/mem_barriers.h>
 
 #include "etnaviv_compat.h"
@@ -118,7 +120,7 @@ void etnaviv_buffer_dump(struct etnaviv_gpu *gpu,
 	uint32_t *ptr = buf->vaddr + off;
 	int i;
 
-	log_debug("virt %p phys 0x%08x free 0x%08x\n", ptr,
+	log_debug("virt %p phys 0x%08"PRIu32" free 0x%08"PRIu32"\n", ptr,
 			etnaviv_cmdbuf_get_va(buf) + off, size - len * 4 - off);
 
 	if (mod_logger.logging.level == 0) {
@@ -130,7 +132,7 @@ void etnaviv_buffer_dump(struct etnaviv_gpu *gpu,
 			printk("\n");
 		if (i % 8 == 0)
 			printk("\t%p: ", ptr + i);
-		printk("%08x ", *(ptr + i));
+		printk("%08"PRIu32" ", *(ptr + i));
 	}
 
 	printk("\n");

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
@@ -86,7 +86,7 @@ int etnaviv_ioctl_gem_new(struct drm_device *dev, void *data, struct drm_file *f
 	}
 
 	return etnaviv_gem_new_handle(dev, file, args->size,
-			args->flags, &args->handle);
+			args->flags, (void *) &args->handle);
 }
 
 int etnaviv_ioctl_gem_info(struct drm_device *dev, void *data, struct drm_file *file)

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.c
@@ -3,6 +3,7 @@
  * @author Anton Bondarev
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -319,7 +320,7 @@ static void etnaviv_hw_identify(struct etnaviv_gpu *gpu) {
 		}
 	}
 
-	log_info("model: GC%x, revision: %x", gpu->identity.model, gpu->identity.revision);
+	log_info("model: GC%"PRIu32", revision: %"PRIu32, gpu->identity.model, gpu->identity.revision);
 
 	gpu->identity.features = gpu_read(gpu, VIVS_HI_CHIP_FEATURE);
 
@@ -747,45 +748,45 @@ int etnaviv_gpu_debugfs(struct etnaviv_gpu *gpu, char *s) {
 	verify_dma(gpu, &debug);
 
 	seq_puts(m, "\tfeatures\n");
-	seq_printf(m, "\t minor_features0: 0x%08x\n",
+	seq_printf(m, "\t minor_features0: 0x%08"PRIu32"\n",
 		   gpu->identity.minor_features0);
-	seq_printf(m, "\t minor_features1: 0x%08x\n",
+	seq_printf(m, "\t minor_features1: 0x%08"PRIu32"\n",
 		   gpu->identity.minor_features1);
-	seq_printf(m, "\t minor_features2: 0x%08x\n",
+	seq_printf(m, "\t minor_features2: 0x%08"PRIu32"\n",
 		   gpu->identity.minor_features2);
-	seq_printf(m, "\t minor_features3: 0x%08x\n",
+	seq_printf(m, "\t minor_features3: 0x%08"PRIu32"\n",
 		   gpu->identity.minor_features3);
-	seq_printf(m, "\t minor_features4: 0x%08x\n",
+	seq_printf(m, "\t minor_features4: 0x%08"PRIu32"\n",
 		   gpu->identity.minor_features4);
-	seq_printf(m, "\t minor_features5: 0x%08x\n",
+	seq_printf(m, "\t minor_features5: 0x%08"PRIu32"\n",
 		   gpu->identity.minor_features5);
 
 	seq_puts(m, "\tspecs\n");
-	seq_printf(m, "\t stream_count:  %d\n",
+	seq_printf(m, "\t stream_count:  %"PRIu32"\n",
 			gpu->identity.stream_count);
-	seq_printf(m, "\t register_max: %d\n",
+	seq_printf(m, "\t register_max: %"PRIu32"\n",
 			gpu->identity.register_max);
-	seq_printf(m, "\t thread_count: %d\n",
+	seq_printf(m, "\t thread_count: %"PRIu32"\n",
 			gpu->identity.thread_count);
-	seq_printf(m, "\t vertex_cache_size: %d\n",
+	seq_printf(m, "\t vertex_cache_size: %"PRIu32"\n",
 			gpu->identity.vertex_cache_size);
-	seq_printf(m, "\t shader_core_count: %d\n",
+	seq_printf(m, "\t shader_core_count: %"PRIu32"\n",
 			gpu->identity.shader_core_count);
-	seq_printf(m, "\t pixel_pipes: %d\n",
+	seq_printf(m, "\t pixel_pipes: %"PRIu32"\n",
 			gpu->identity.pixel_pipes);
-	seq_printf(m, "\t vertex_output_buffer_size: %d\n",
+	seq_printf(m, "\t vertex_output_buffer_size: %"PRIu32"\n",
 			gpu->identity.vertex_output_buffer_size);
-	seq_printf(m, "\t buffer_size: %d\n",
+	seq_printf(m, "\t buffer_size: %"PRIu32"\n",
 			gpu->identity.buffer_size);
-	seq_printf(m, "\t instruction_count: %d\n",
+	seq_printf(m, "\t instruction_count: %"PRIu32"\n",
 			gpu->identity.instruction_count);
-	seq_printf(m, "\t num_constants: %d\n",
+	seq_printf(m, "\t num_constants: %"PRIu32"\n",
 			gpu->identity.num_constants);
-	seq_printf(m, "\t varyings_count: %d\n",
+	seq_printf(m, "\t varyings_count: %"PRIu8"\n",
 			gpu->identity.varyings_count);
 
-	seq_printf(m, "\taxi: 0x%08x\n", axi);
-	seq_printf(m, "\tidle: 0x%08x\n", idle);
+	seq_printf(m, "\taxi: 0x%08"PRIu32"\n", axi);
+	seq_printf(m, "\tidle: 0x%08"PRIu32"\n", idle);
 	idle |= ~gpu->idle_mask & ~VIVS_HI_IDLE_STATE_AXI_LP;
 	if ((idle & VIVS_HI_IDLE_STATE_FE) == 0)
 		seq_puts(m, "\t FE is not idle\n");
@@ -820,9 +821,9 @@ int etnaviv_gpu_debugfs(struct etnaviv_gpu *gpu, char *s) {
 		uint32_t write = gpu_read(gpu, VIVS_MC_DEBUG_WRITE);
 
 		seq_puts(m, "\tMC\n");
-		seq_printf(m, "\t read0: 0x%08x\n", read0);
-		seq_printf(m, "\t read1: 0x%08x\n", read1);
-		seq_printf(m, "\t write: 0x%08x\n", write);
+		seq_printf(m, "\t read0: 0x%08"PRIu32"\n", read0);
+		seq_printf(m, "\t read1: 0x%08"PRIu32"\n", read1);
+		seq_printf(m, "\t write: 0x%08"PRIu32"\n", write);
 	}
 
 	seq_puts(m, "\tDMA ");
@@ -846,17 +847,17 @@ int etnaviv_gpu_debugfs(struct etnaviv_gpu *gpu, char *s) {
 
 
 
-	seq_printf(m, "\t address 0: 0x%08x\n", debug.address[0]);
-	seq_printf(m, "\t address 1: 0x%08x\n", debug.address[1]);
-	seq_printf(m, "\t state 0: 0x%08x\n", debug.state[0]);
-	seq_printf(m, "\t state 1: 0x%08x\n", debug.state[1]);
+	seq_printf(m, "\t address 0: 0x%08"PRIu32"\n", debug.address[0]);
+	seq_printf(m, "\t address 1: 0x%08"PRIu32"\n", debug.address[1]);
+	seq_printf(m, "\t state 0: 0x%08"PRIu32"\n", debug.state[0]);
+	seq_printf(m, "\t state 1: 0x%08"PRIu32"\n", debug.state[1]);
 	seq_printf(m, "\t    command state       = %d (%s)\n", cmdState, _cmdState   [cmdState]);
 	seq_printf(m, "\t    command DMA state   = %d (%s)\n", cmdDmaState, _cmdDmaState[cmdDmaState]);
 	seq_printf(m, "\t    command fetch state = %d (%s)\n", cmdFetState, _cmdFetState[cmdFetState]);
 	seq_printf(m, "\t    DMA request state   = %d (%s)\n", dmaReqState, _reqDmaState[dmaReqState]);
 	seq_printf(m, "\t    cal state           = %d (%s)\n", calState, _calState   [calState]);
 	seq_printf(m, "\t    VE request state    = %d (%s)\n", veReqState, _veReqState [veReqState]);
-	seq_printf(m, "\t last fetch 64 bit word: 0x%08x 0x%08x\n",
+	seq_printf(m, "\t last fetch 64 bit word: 0x%08"PRIu32" 0x%08"PRIu32"\n",
 		   dma_lo, dma_hi);
 
 	ret = 0;

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/patch.txt
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/patch.txt
@@ -688,6 +688,14 @@ diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/tests/Makefile.in mesa-18.2.5/
 diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi.cpp mesa-18.2.5/src/mesa/state_tracker/st_glsl_to_tgsi.cpp
 --- mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi.cpp	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/mesa/state_tracker/st_glsl_to_tgsi.cpp	2018-11-27 13:44:25.490152782 +0300
+@@ -29,6 +29,7 @@
+  *
+  * Translate GLSL IR to TGSI.
+  */
++#include <GL/gl.h>
+ 
+ #include "st_glsl_to_tgsi.h"
+ 
 @@ -58,7 +58,7 @@
  #include "st_glsl_to_tgsi_temprename.h"
  
@@ -818,18 +826,6 @@ diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi_temprename.cpp
     conditionality_in_loop_id(conditionality_untouched),
     if_scope_write_flags(0),
     next_ifelse_nesting_depth(0),
-diff -aur mesa-18.2.5-orig/include/drm-uapi/drm.h .mesa-18.2.5/include/drm-uapi/drm.h
---- mesa-18.2.5-orig/include/drm-uapi/drm.h	2018-11-15 15:32:30.000000000 +0300
-+++ mesa-18.2.5/include/drm-uapi/drm.h	2018-11-27 14:33:18.038728314 +0300
-@@ -44,7 +44,7 @@
- 
- #else /* One of the BSDs */
- 
--#include <sys/ioccom.h>
-+//#include <sys/ioccom.h>
- #include <sys/types.h>
- typedef int8_t   __s8;
- typedef uint8_t  __u8;
 diff -aur mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_ureg.h mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_ureg.h
 --- mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_ureg.h	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_ureg.h	2018-11-27 15:14:22.242543610 +0300
@@ -1209,3 +1205,122 @@ diff -aur -x configure mesa-18.2.5-orig/include/c99_math.h mesa-18.2.5/include/c
 +#endif /* #ifdef __cplusplus */
  
  #endif /* #define _C99_MATH_H_ */
+--- mesa-18.2.5-orig/include/GL/gl.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/GL/gl.h	2019-05-13 15:58:00.273171450 +0300
+@@ -27,6 +27,45 @@
+ #ifndef __gl_h_
+ #define __gl_h_
+ 
++#ifndef STDINT_H_
++#define STDINT_H_
++#include <asm-generic/types32.h>
++typedef __s8 int8_t;
++typedef __u8 uint8_t;
++typedef __s16 int16_t;
++typedef __u16 uint16_t;
++typedef __s32 int32_t;
++typedef __u32 uint32_t;
++typedef __s64 int64_t;
++typedef __u64 uint64_t;
++typedef __intptr_t intptr_t;
++typedef __uintptr_t uintptr_t;
++typedef int64_t intmax_t;
++typedef uint64_t uintmax_t;
++
++#define UINT64_C(c) __UINT64_C(c)
++#define UINT8_MAX __UINT8_MAX__
++#define INT8_MAX __UINT8_MAX__
++#define UINT16_MAX __UINT16_MAX__
++#define INT16_MAX __UINT16_MAX__
++#define UINT32_MAX __UINT32_MAX__
++#define INT32_MAX __UINT32_MAX__
++#define UINT64_MAX __UINT64_MAX__
++#define INT64_MAX __UINT64_MAX__
++
++#define UINT8_MIN 0
++#define INT8_MIN -__UINT8_MAX__
++#define UINT16_MIN 0
++#define INT16_MIN -__UINT16_MAX__
++#define UINT32_MIN 0
++#define INT32_MIN -__UINT32_MAX__
++#define UINT64_MIN 0
++#define INT64_MIN -__UINT64_MAX__
++
++#define UINTPTR_MAX __UINTPTR_MAX__
++
++#endif
++
+ #if defined(USE_MGL_NAMESPACE)
+ #include "gl_mangle.h"
+ #endif
+diff -aur mesa-18.2.5-orig/include/drm-uapi/drm.h mesa-18.2.5/include/drm-uapi/drm.h
+--- mesa-18.2.5-orig/include/drm-uapi/drm.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/drm-uapi/drm.h	2019-05-13 15:59:42.046502371 +0300
+@@ -44,16 +44,10 @@
+ 
+ #else /* One of the BSDs */
+ 
+-#include <sys/ioccom.h>
++//#include <sys/ioccom.h>
+ #include <sys/types.h>
+-typedef int8_t   __s8;
+-typedef uint8_t  __u8;
+-typedef int16_t  __s16;
+-typedef uint16_t __u16;
+-typedef int32_t  __s32;
+-typedef uint32_t __u32;
+-typedef int64_t  __s64;
+-typedef uint64_t __u64;
++#include <asm-generic/types32.h>
++
+ typedef size_t   __kernel_size_t;
+ typedef unsigned long drm_handle_t;
+ 
+diff -aur mesa-18.2.5-orig/src/util/set.h mesa-18.2.5/src/util/set.h
+--- mesa-18.2.5-orig/src/util/set.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/util/set.h	2019-05-13 16:08:26.513156659 +0300
+@@ -31,6 +31,8 @@
+ #include <inttypes.h>
+ #include <stdbool.h>
+ 
++#define uint32_t unsigned
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff -aur mesa-18.2.5-orig/src/compiler/glsl/ir.h mesa-18.2.5/src/compiler/glsl/ir.h
+--- mesa-18.2.5-orig/src/compiler/glsl/ir.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/compiler/glsl/ir.h	2019-05-13 16:09:51.389821322 +0300
+@@ -34,6 +34,8 @@
+ #include "ir_visitor.h"
+ #include "ir_hierarchical_visitor.h"
+ 
++#define uint32_t unsigned
++
+ #ifdef __cplusplus
+ 
+ /**
+diff -aur mesa-18.2.5-orig/src/util/hash_table.h mesa-18.2.5/src/util/hash_table.h
+--- mesa-18.2.5-orig/src/util/hash_table.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/util/hash_table.h	2019-05-13 16:06:46.233159024 +0300
+@@ -34,6 +34,8 @@
+ #include "c99_compat.h"
+ #include "macros.h"
+ 
++#define uint32_t unsigned
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff -aur mesa-18.2.5-orig/src/mesa/main/mtypes.h .mesa-18.2.5/src/mesa/main/mtypes.h
+--- mesa-18.2.5-orig/src/mesa/main/mtypes.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/mesa/main/mtypes.h	2019-05-13 16:30:08.303125934 +0300
+@@ -34,7 +34,7 @@
+ #define MTYPES_H
+ 
+ 
+-#include <stdint.h>             /* uint32_t */
++#include <GL/gl.h>             /* uint32_t */
+ #include <stdbool.h>
+ #include "c11/threads.h"
+ 

--- a/third-party/freedesktop/mesa/mesa/mesa_sw/patch.txt
+++ b/third-party/freedesktop/mesa/mesa/mesa_sw/patch.txt
@@ -695,6 +695,14 @@ diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/tests/Makefile.in mesa-18.2.5/
 diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi.cpp mesa-18.2.5/src/mesa/state_tracker/st_glsl_to_tgsi.cpp
 --- mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi.cpp	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/mesa/state_tracker/st_glsl_to_tgsi.cpp	2018-11-27 13:44:25.490152782 +0300
+@@ -29,6 +29,7 @@
+  *
+  * Translate GLSL IR to TGSI.
+  */
++#include <GL/gl.h>
+ 
+ #include "st_glsl_to_tgsi.h"
+ 
 @@ -58,7 +58,7 @@
  #include "st_glsl_to_tgsi_temprename.h"
  
@@ -819,18 +827,6 @@ diff -aur mesa-18.2.5-orig/src/mesa/state_tracker/st_glsl_to_tgsi_temprename.cpp
     if_scope_write_flags(0),
     next_ifelse_nesting_depth(0),
     current_unpaired_if_write_scope(nullptr),
-diff -aur mesa-18.2.5-orig/include/drm-uapi/drm.h .mesa-18.2.5/include/drm-uapi/drm.h
---- mesa-18.2.5-orig/include/drm-uapi/drm.h	2018-11-15 15:32:30.000000000 +0300
-+++ mesa-18.2.5/include/drm-uapi/drm.h	2018-11-27 14:33:18.038728314 +0300
-@@ -44,7 +44,7 @@
- 
- #else /* One of the BSDs */
- 
--#include <sys/ioccom.h>
-+//#include <sys/ioccom.h>
- #include <sys/types.h>
- typedef int8_t   __s8;
- typedef uint8_t  __u8;
 diff -aur mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_info.h mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_info.h
 --- mesa-18.2.5-orig/src/gallium/auxiliary/tgsi/tgsi_info.h	2018-11-15 15:32:30.000000000 +0300
 +++ mesa-18.2.5/src/gallium/auxiliary/tgsi/tgsi_info.h	2018-11-27 15:06:25.497385062 +0300
@@ -874,3 +870,123 @@ diff -aur mesa-18.2.5-orig/include/c99_alloca.h mesa-18.2.5/include/c99_alloca.h
  #  include <stdlib.h>
  
  #endif /* !defined(_MSC_VER) */
+diff -aur mesa-18.2.5-orig/include/GL/gl.h mesa-18.2.5/include/GL/gl.h
+--- mesa-18.2.5-orig/include/GL/gl.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/GL/gl.h	2019-05-13 15:58:00.273171450 +0300
+@@ -27,6 +27,45 @@
+ #ifndef __gl_h_
+ #define __gl_h_
+ 
++#ifndef STDINT_H_
++#define STDINT_H_
++#include <asm-generic/types32.h>
++typedef __s8 int8_t;
++typedef __u8 uint8_t;
++typedef __s16 int16_t;
++typedef __u16 uint16_t;
++typedef __s32 int32_t;
++typedef __u32 uint32_t;
++typedef __s64 int64_t;
++typedef __u64 uint64_t;
++typedef __intptr_t intptr_t;
++typedef __uintptr_t uintptr_t;
++typedef int64_t intmax_t;
++typedef uint64_t uintmax_t;
++
++#define UINT64_C(c) __UINT64_C(c)
++#define UINT8_MAX __UINT8_MAX__
++#define INT8_MAX __UINT8_MAX__
++#define UINT16_MAX __UINT16_MAX__
++#define INT16_MAX __UINT16_MAX__
++#define UINT32_MAX __UINT32_MAX__
++#define INT32_MAX __UINT32_MAX__
++#define UINT64_MAX __UINT64_MAX__
++#define INT64_MAX __UINT64_MAX__
++
++#define UINT8_MIN 0
++#define INT8_MIN -__UINT8_MAX__
++#define UINT16_MIN 0
++#define INT16_MIN -__UINT16_MAX__
++#define UINT32_MIN 0
++#define INT32_MIN -__UINT32_MAX__
++#define UINT64_MIN 0
++#define INT64_MIN -__UINT64_MAX__
++
++#define UINTPTR_MAX __UINTPTR_MAX__
++
++#endif
++
+ #if defined(USE_MGL_NAMESPACE)
+ #include "gl_mangle.h"
+ #endif
+diff -aur mesa-18.2.5-orig/include/drm-uapi/drm.h mesa-18.2.5/include/drm-uapi/drm.h
+--- mesa-18.2.5-orig/include/drm-uapi/drm.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/include/drm-uapi/drm.h	2019-05-13 15:59:42.046502371 +0300
+@@ -44,16 +44,10 @@
+ 
+ #else /* One of the BSDs */
+ 
+-#include <sys/ioccom.h>
++//#include <sys/ioccom.h>
+ #include <sys/types.h>
+-typedef int8_t   __s8;
+-typedef uint8_t  __u8;
+-typedef int16_t  __s16;
+-typedef uint16_t __u16;
+-typedef int32_t  __s32;
+-typedef uint32_t __u32;
+-typedef int64_t  __s64;
+-typedef uint64_t __u64;
++#include <asm-generic/types32.h>
++
+ typedef size_t   __kernel_size_t;
+ typedef unsigned long drm_handle_t;
+ 
+diff -aur mesa-18.2.5-orig/src/util/set.h mesa-18.2.5/src/util/set.h
+--- mesa-18.2.5-orig/src/util/set.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/util/set.h	2019-05-13 16:08:26.513156659 +0300
+@@ -31,6 +31,8 @@
+ #include <inttypes.h>
+ #include <stdbool.h>
+ 
++#define uint32_t unsigned
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff -aur mesa-18.2.5-orig/src/compiler/glsl/ir.h mesa-18.2.5/src/compiler/glsl/ir.h
+--- mesa-18.2.5-orig/src/compiler/glsl/ir.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/compiler/glsl/ir.h	2019-05-13 16:09:51.389821322 +0300
+@@ -34,6 +34,8 @@
+ #include "ir_visitor.h"
+ #include "ir_hierarchical_visitor.h"
+ 
++#define uint32_t unsigned
++
+ #ifdef __cplusplus
+ 
+ /**
+diff -aur mesa-18.2.5-orig/src/util/hash_table.h mesa-18.2.5/src/util/hash_table.h
+--- mesa-18.2.5-orig/src/util/hash_table.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/util/hash_table.h	2019-05-13 16:06:46.233159024 +0300
+@@ -34,6 +34,8 @@
+ #include "c99_compat.h"
+ #include "macros.h"
+ 
++#define uint32_t unsigned
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff -aur mesa-18.2.5-orig/src/mesa/main/mtypes.h mesa-18.2.5/src/mesa/main/mtypes.h
+--- mesa-18.2.5-orig/src/mesa/main/mtypes.h	2018-11-15 15:32:30.000000000 +0300
++++ mesa-18.2.5/src/mesa/main/mtypes.h	2019-05-13 16:30:08.303125934 +0300
+@@ -34,7 +34,7 @@
+ #define MTYPES_H
+ 
+ 
+-#include <stdint.h>             /* uint32_t */
++#include <GL/gl.h>             /* uint32_t */
+ #include <stdbool.h>
+ #include "c11/threads.h"
+ 


### PR DESCRIPTION
Extend patches to fit new uint32_t defines

Just use old typedefs in mesa instead of including stdint.h