### PR TITLE
IntegratorCP interrupt/net drivers refactor

### DIFF
--- a/src/drivers/interrupt/integrator_pic/Mybuild
+++ b/src/drivers/interrupt/integrator_pic/Mybuild
@@ -7,4 +7,6 @@ module integrator_pic extends irqctrl_api {
 
 	source "integrator_pic.c"
 	source "integrator_pic.h"
+
+	depends embox.driver.periph_memory
 }

--- a/src/drivers/interrupt/integrator_pic/integrator_pic.c
+++ b/src/drivers/interrupt/integrator_pic/integrator_pic.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <sys/mman.h>
 
+#include <drivers/common/memory.h>
 #include <kernel/critical.h>
 #include <hal/reg.h>
 #include <hal/ipl.h>
@@ -29,15 +30,6 @@ EMBOX_UNIT_INIT(integrator_pic_init);
  * Initialize the PIC
  */
 static int integrator_pic_init(void) {
-	if (NULL == mmap_device_memory(
-		(void*) ICU_BASE,
-		0x10,
-		PROT_READ | PROT_WRITE | PROT_NOCACHE,
-		MAP_FIXED,
-		(unsigned long) ICU_BASE)) {
-		return -1;
-	}
-
 	REG_STORE(ICU_IRQENCLR, ((1 << IRQCTRL_IRQS_TOTAL) - 1));
 	return 0;
 }
@@ -93,3 +85,10 @@ void interrupt_handle(void) {
 void swi_handle(void) {
 	printk("swi!\n");
 }
+
+static struct periph_memory_desc icu_mem = {
+	.start = ICU_BASE,
+	.len   = 0x10,
+};
+
+PERIPH_MEMORY_DEFINE(icu_mem);

--- a/src/drivers/net/lan91c111/Mybuild
+++ b/src/drivers/net/lan91c111/Mybuild
@@ -13,4 +13,5 @@ module lan91c111 {
 	depends embox.net.core
 	depends embox.net.entry_api
 	depends embox.net.util.show_packet
+	depends embox.driver.periph_memory
 }

--- a/src/drivers/net/lan91c111/lan91c111.c
+++ b/src/drivers/net/lan91c111/lan91c111.c
@@ -8,6 +8,7 @@
 #include <sys/mman.h>
 
 #include <util/log.h>
+#include <drivers/common/memory.h>
 
 #include <kernel/printk.h>
 #include <kernel/irq.h>
@@ -299,15 +300,6 @@ EMBOX_UNIT_INIT(lan91c111_init);
 static int lan91c111_init(void) {
         struct net_device *nic;
 
-	if (NULL == mmap_device_memory(
-		(void*) BANK_BASE_ADDR,
-		0x10,
-		PROT_READ | PROT_WRITE | PROT_NOCACHE,
-		MAP_FIXED,
-		(unsigned long) BANK_BASE_ADDR)) {
-		return -1;
-	}
-
         if (NULL == (nic = etherdev_alloc(0))) {
                 return -ENOMEM;
         }
@@ -321,3 +313,10 @@ static int lan91c111_init(void) {
 
 	return inetdev_register_dev(nic);
 }
+
+static struct periph_memory_desc lan91c111_mem = {
+	.start = BANK_BASE_ADDR,
+	.len   = 0x10,
+};
+
+PERIPH_MEMORY_DEFINE(lan91c111_mem);


### PR DESCRIPTION
Use static `periph_memory_desc` instead of runtime `mmap_device_memory` to map device registers.