### PR TITLE
Extbld minor improvements

### DIFF
--- a/mk/extbld/arch-embox-gcc
+++ b/mk/extbld/arch-embox-gcc
@@ -9,8 +9,8 @@ fi
 
 cmd=$(basename $0)
 case $cmd in
-	*-gcc|*-clang) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CFLAGS";;
-	*-g++)         C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_IMPORTED_CXXFLAGS";;
+	*-gcc|*-clang) C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_DEPS_CPPFLAGS $EMBOX_IMPORTED_CFLAGS";;
+	*-g++)         C_CXX_FLAGS="$EMBOX_IMPORTED_CPPFLAGS $EMBOX_DEPS_CPPFLAGS $EMBOX_IMPORTED_CXXFLAGS";;
 	*)             echo "Unknown flags for $cmd"; exit 1;;
 esac
 

--- a/mk/extbld/toolchain.mk
+++ b/mk/extbld/toolchain.mk
@@ -48,19 +48,15 @@ else
 root2dist = $1
 endif
 
-# TODO: Probably it is more correct to impove Embox's cxx includes, rather than
-# use gcc includes. In any case, it is an issue we need to think about.
-EMBOX_CPPFLAGS_WITHOUT_LIBSTDCXX = $(filter-out %cxx/include, $(EMBOX_IMPORTED_CPPFLAGS))
-
 $(EMBOX_GCC_ENV): $(MKGEN_DIR)/build.mk $(MKGEN_DIR)/image.rule.mk
 $(EMBOX_GCC_ENV): mk/flags.mk mk/extbld/toolchain.mk
 $(EMBOX_GCC_ENV): | $(dir $(EMBOX_GCC_ENV))
 	@echo EMBOX_CROSS_COMPILE='"$(CROSS_COMPILE)"'                       > $@
-	@echo EMBOX_IMPORTED_CPPFLAGS='"$(call root2dist,$(EMBOX_CPPFLAGS_WITHOUT_LIBSTDCXX))"' >> $@
-	@echo EMBOX_IMPORTED_CFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_CFLAGS))"'              >> $@
-	@echo EMBOX_IMPORTED_CXXFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_CXXFLAGS))"'          >> $@
-	@echo EMBOX_IMPORTED_LDFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_LDFLAGS))"'            >> $@
-	@echo EMBOX_IMPORTED_LDFLAGS_FULL='"$(call root2dist,$(EMBOX_IMPORTED_LDFLAGS_FULL))"'  >> $@
+	@echo EMBOX_IMPORTED_CPPFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_CPPFLAGS))"'         >> $@
+	@echo EMBOX_IMPORTED_CFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_CFLAGS))"'             >> $@
+	@echo EMBOX_IMPORTED_CXXFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_CXXFLAGS))"'         >> $@
+	@echo EMBOX_IMPORTED_LDFLAGS='"$(call root2dist,$(EMBOX_IMPORTED_LDFLAGS))"'           >> $@
+	@echo EMBOX_IMPORTED_LDFLAGS_FULL='"$(call root2dist,$(EMBOX_IMPORTED_LDFLAGS_FULL))"' >> $@
 
 TOOLCHAIN_TEST_SRC := $(ROOT_DIR)/mk/extbld/toolchain_test.c
 TOOLCHAIN_TEST_OUT := $(OBJ_DIR)/toolchain_test

--- a/src/compat/libc/include/stdlib.h
+++ b/src/compat/libc/include/stdlib.h
@@ -202,10 +202,7 @@ extern int unsetenv(const char *name);
 extern int clearenv(void);
 extern int system(const char *command);
 
-static inline int mkstemp(char *path_template) {
-	(void)path_template;
-	return -1;
-}
+extern int mkstemp(char *path_template);
 
 extern int mbtowc(wchar_t *out, const char *in, size_t n);
 extern int wctomb(char *out, const wchar_t *in );

--- a/src/compat/libc/stdlib/Mybuild
+++ b/src/compat/libc/stdlib/Mybuild
@@ -42,10 +42,17 @@ static module multibyte {
 	source "wctomb.c"
 }
 
+static module mktemp {
+	option number log_level=4
+
+	source "mkstemp.c"
+}
+
 static module all {
 	depends core,
 		config,
 		rand,
 		system,
-		multibyte
+		multibyte,
+		mktemp
 }

--- a/src/compat/libc/stdlib/mkstemp.c
+++ b/src/compat/libc/stdlib/mkstemp.c
@@ -1,0 +1,15 @@
+/**
+ * @file
+ * @brief
+ * @date 19.05.19
+ * @author Alexander Kalmuk
+ */
+
+#include <stdlib.h>
+#include <util/log.h>
+
+int mkstemp(char *path_template) {
+	(void)path_template;
+	log_error("");
+	return -1;
+}

--- a/third-party/STLport/Makefile
+++ b/third-party/STLport/Makefile
@@ -9,57 +9,9 @@ PKG_PATCHES := patch.txt
 
 include $(EXTBLD_LIB)
 
-EMBOX_TARGET_CC =$(shell which $(EMBOX_CROSS_COMPILE)gcc)
-EMBOX_TARGET_CXX=$(shell which $(EMBOX_CROSS_COMPILE)g++)
-
-ifeq (,$(EMBOX_TARGET_CC))
-$(error Cannot find C compiler: $(EMBOX_CROSS_COMPILE)gcc)
-endif
-ifeq (,$(EMBOX_TARGET_CXX))
-$(error Cannot find C++ compiler: $(EMBOX_CROSS_COMPILE)g++)
-endif
-
-AT=
-
-STLPORT_DIR   = $(BUILD_DIR)
-STLPORT_FLAGS = $(STLPORT_DIR)/flags
-
-EMBOX_IMPORTED_CPPFLAGS += -I../../stlport
-EMBOX_IMPORTED_CPPFLAGS += -save-temps=obj
-
-EMBOX_IMPORTED_CPPFLAGS += -DUSE_SPRINTF_INSTEAD
-EMBOX_IMPORTED_CPPFLAGS += $(filter -I%,$(EMBOX_CPPFLAGS))
-EMBOX_IMPORTED_CPPFLAGS += $(filter -nostdinc,$(EMBOX_CPPFLAGS))
-EMBOX_IMPORTED_CPPFLAGS += $(filter -D%,$(EMBOX_CPPFLAGS))
-EMBOX_IMPORTED_CPPFLAGS += $(filter -U%,$(EMBOX_CPPFLAGS))
-
-EMBOX_IMPORTED_CFLAGS   += $(EMBOX_IMPORTED_CPPFLAGS)
-EMBOX_IMPORTED_CFLAGS   += $(filter -fno-common,$(EMBOX_CFLAGS))
-EMBOX_IMPORTED_CFLAGS   += $(filter -march%,$(EMBOX_CFLAGS))
-EMBOX_IMPORTED_CFLAGS   += $(filter -m%,$(EMBOX_CFLAGS))
-EMBOX_IMPORTED_CFLAGS   += $(filter -fno-stack-protector,$(EMBOX_CFLAGS))
-EMBOX_IMPORTED_CFLAGS   += $(filter -g,$(EMBOX_CFLAGS))
-EMBOX_IMPORTED_CFLAGS   += $(filter -mno-unaligned-access,$(EMBOX_CFLAGS))
-EMBOX_IMPORTED_CFLAGS   += -I$(abspath .)/include
-
-EMBOX_IMPORTED_CXXFLAGS += $(EMBOX_IMPORTED_CPPFLAGS)
-EMBOX_IMPORTED_CXXFLAGS += $(subst .,$(ROOT_DIR),$(filter -I%,$(EMBOX_CXXFLAGS)))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -fno-common,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -march%,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -m32,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -fno-stack-protector,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -g,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -fno-rtti,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -fno-exceptions,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -fno-threadsafe-statics,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -mno-unaligned-access,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += $(filter -std=%,$(EMBOX_CXXFLAGS))
-EMBOX_IMPORTED_CXXFLAGS += -I$(abspath .)/include
-
-EMBOX_IMPORTED_MAKEFLAGS += $(filter -j,$(EMBOX_MAKEFLAGS))
-ifneq ($(filter -j,$(EMBOX_MAKEFLAGS)),)
-EMBOX_IMPORTED_MAKEFLAGS += $(shell nproc)
-endif
+STLPORT_CPPFLAGS += -I../../stlport
+STLPORT_CPPFLAGS += -DUSE_SPRINTF_INSTEAD
+STLPORT_CPPFLAGS += -I$(abspath .)/include
 
 ifneq (,$(filter -fno-rtti,$(EMBOX_CXXFLAGS)))
 EMBOX_RTTI_FLAG          = --without-rtti
@@ -74,8 +26,8 @@ $(CONFIGURE) :
 			--target=embox \
 			--with-cc=$(EMBOX_GCC) \
 			--with-cxx=$(EMBOX_GXX) \
-			--with-extra-cflags="$(EMBOX_IMPORTED_CFLAGS)" \
-			--with-extra-cxxflags="$(EMBOX_IMPORTED_CXXFLAGS)" \
+			--with-extra-cflags="$(STLPORT_CPPFLAGS)" \
+			--with-extra-cxxflags="$(STLPORT_CPPFLAGS)" \
 			--enable-static \
 			--disable-shared \
 			$(EMBOX_RTTI_FLAG) \

--- a/third-party/dropbear/Makefile
+++ b/third-party/dropbear/Makefile
@@ -9,10 +9,7 @@ PKG_PATCHES := dropbear.patch
 
 include $(EXTBLD_LIB)
 
-EMBOX_IMPORTED_CFLAGS += -DLTC_NO_BSWAP
-EMBOX_IMPORTED_CFLAGS += -nostdinc
-
-EMBOX_IMPORTED_CPPFLAGS += -nostdinc
+DROPBEAR_CPPFLAGS += -DLTC_NO_BSWAP
 
 $(CONFIGURE) :
 	cp stubs.h $(PKG_SOURCE_DIR)
@@ -20,8 +17,7 @@ $(CONFIGURE) :
 	cd $(PKG_SOURCE_DIR) && ( \
 		./configure \
 			CC=$(EMBOX_GCC) \
-			CFLAGS="$(EMBOX_IMPORTED_CFLAGS)" \
-			CPPFLAGS="$(EMBOX_IMPORTED_CPPFLAGS)" \
+			CFLAGS="$(DROPBEAR_CPPFLAGS)" \
 			--host=$(AUTOCONF_TARGET_TRIPLET) \
 			--target=$(AUTOCONF_TARGET_TRIPLET) \
 			--prefix=/ \

--- a/third-party/e2fsprogs/Makefile
+++ b/third-party/e2fsprogs/Makefile
@@ -10,8 +10,7 @@ PKG_PATCHES := patch.txt
 include $(EXTBLD_LIB)
 
 E2FSPROGS_CPPFLAGS = -include $(ROOT_DIR)/third-party/e2fsprogs/e2fsprogs_embox_compat.h \
-	-I$(ROOT_DIR)/third-party/e2fsprogs/include \
-	${EMBOX_IMPORTED_CPPFLAGS}
+	-I$(ROOT_DIR)/third-party/e2fsprogs/include
 
 $(CONFIGURE) :
 	cd $(PKG_SOURCE_DIR) && autoconf && ( \

--- a/third-party/lib/boost/Makefile
+++ b/third-party/lib/boost/Makefile
@@ -12,7 +12,6 @@ include $(EXTBLD_LIB)
 
 BOOST_ADDITIONAL_CPPFLAGS += -I$(abspath .)/include
 BOOST_ADDITIONAL_CPPFLAGS += -include $(abspath .)/boost_embox_compat.h
-BOOST_ADDITIONAL_CPPFLAGS += $(filter -I%,$(EMBOX_CPPFLAGS))
 
 USER_TOOLS_CONFIG=$(PKG_SOURCE_DIR)/tools/build/src/user-config.jam
 USER_BOOST_CONFIG=$(PKG_SOURCE_DIR)/boost/config/user.hpp
@@ -47,14 +46,12 @@ $(BUILD) :
 	echo "#define BOOST_HAS_THREADS" >> $(USER_BOOST_CONFIG)
 	echo "#define BOOST_HAS_PTHREADS" >> $(USER_BOOST_CONFIG)
 	echo "#define BOOST_STRICT_CONFIG" >> $(USER_BOOST_CONFIG)
-
 	# Build boost libraries
 	cd $(PKG_SOURCE_DIR) && ( \
 		./b2 \
 		$(B2_OPTIONS) \
 		install \
 	)
-	
 	# Build example
 	cd $(PKG_SOURCE_DIR) && ( \
 		./b2 \

--- a/third-party/qt/Makefile
+++ b/third-party/qt/Makefile
@@ -70,32 +70,21 @@ ifneq ($(words $(QMAKE_CONF_M4)),1)
 $(error need exactly one qmake.conf.m4)
 endif
 
-QT_CPPFLAGS := $(filter -I%,$(EMBOX_CPPFLAGS))
 QT_CPPFLAGS += -include qt_embox_compat.h
-ifeq (1,$(call option_get,stl_support))
-QT_CPPFLAGS += -I$(EXTERNAL_BUILD_DIR)/third_party/STLport/libstlportg/include/stlport
-endif
-
 QT_CFLAGS   := $(QT_CPPFLAGS) -Wno-error
-QT_CXXFLAGS := $(QT_CPPFLAGS) $(filter -I%,$(EMBOX_CXXFLAGS)) -fpermissive -Wno-error
-QT_CXXFLAGS := $(subst -I./,-I$(ROOT_DIR)/,$(QT_CXXFLAGS))
-
-QT_MAKEFLAGS=
-ifneq ($(filter -j, $(EMBOX_MAKEFLAGS)),)
-	QT_MAKEFLAGS += -j $(shell nproc)
-endif
+QT_CXXFLAGS := $(QT_CPPFLAGS) -fpermissive -Wno-error
 
 $(CONFIGURE) :
 	cd $(PKG_SOURCE_DIR) && ( \
 		CC='$(EMBOX_GCC)' CXX='$(EMBOX_GXX)' CFLAGS='$(QT_CFLAGS)' CXXFLAGS='$(QT_CXXFLAGS)' \
 			m4 --prefix-builtins $(QMAKE_CONF_M4) > $(QMAKE_CONF) && \
-		MAKEFLAGS='$(QT_MAKEFLAGS)' ./configure $(QT_CONF_FLAGS) \
+		MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)' ./configure $(QT_CONF_FLAGS) \
 	)
 	touch $@
 
 $(BUILD) :
 	cd $(PKG_SOURCE_DIR) && ( \
-		$(MAKE) MAKEFLAGS='$(QT_MAKEFLAGS)'; \
+		$(MAKE) MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)'; \
 	)
 	touch $@
 
@@ -103,7 +92,7 @@ $(ROOTFS_IMAGE) : $(INSTALL)
 
 $(INSTALL) :
 	cd $(PKG_SOURCE_DIR) && ( \
-		$(MAKE) install MAKEFLAGS='$(QT_MAKEFLAGS)' \
+		$(MAKE) install MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)' \
 	)
 	cp $(PKG_SOURCE_DIR)/mkspecs/qdevice.pri $(PKG_INSTALL_DIR)/mkspecs/
 	mkdir -p $(ROOT_DIR)/conf/rootfs/fonts

--- a/third-party/tcl/tclsh/Makefile
+++ b/third-party/tcl/tclsh/Makefile
@@ -9,9 +9,7 @@ PKG_PATCHES := patch.txt
 
 include $(EXTBLD_LIB)
 
-tcl_cppflags = -include $(ROOT_DIR)/third-party/tcl/tclsh/tcl_embox_compat.h \
-	-I$(ROOT_DIR)/third-party/tcl/tclsh/include \
-	${EMBOX_IMPORTED_CPPFLAGS}
+tcl_cppflags = -include $(ROOT_DIR)/third-party/tcl/tclsh/tcl_embox_compat.h
 
 $(CONFIGURE) :
 	cd $(BUILD_DIR)/$(PKG_NAME)$(PKG_VER)/unix && ( \

--- a/third-party/tcl/tcludp/Makefile
+++ b/third-party/tcl/tcludp/Makefile
@@ -9,9 +9,7 @@ PKG_PATCHES := pkg_patch.txt
 
 include $(EXTBLD_LIB)
 
-tcl_cppflags = -include $(ROOT_DIR)/third-party/tcl/tcludp/tcludp_embox_compat.h \
-	-I$(ROOT_DIR)/build/extbld/third_party/tcl/core/install/include \
-	${EMBOX_IMPORTED_CPPFLAGS}
+tcl_cppflags = -include $(ROOT_DIR)/third-party/tcl/tcludp/tcludp_embox_compat.h
 
 $(CONFIGURE) :
 	cd $(BUILD_DIR)/$(PKG_NAME)-$(PKG_VER) && ( \


### PR DESCRIPTION
Now arch-gcc contains all CPPFLAGS derived from module's BuildDependcies.