### PR TITLE
pl310: Clean code

### DIFF
--- a/src/drivers/cache/pl310/pl310.c
+++ b/src/drivers/cache/pl310/pl310.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include <drivers/common/memory.h>
+#include <kernel/time/ktime.h>
 #include <hal/reg.h>
 #include <util/log.h>
 
@@ -81,14 +82,11 @@ static int pl310_init(void) {
 
 	REG_ORIN(L2X0_AUX_CTRL, L2X0_AUX_INSTR_PREFETCH);
 	REG_ORIN(L2X0_AUX_CTRL, L2X0_AUX_DATA_PREFETCH);
-	//REG_ORIN(L2X0_AUX_CTRL, (3 << 23));
-	//REG_ORIN(L2X0_INTR_MASK, 0xFFFFFFFF);
 
 	REG_STORE(L70_INVAL, 0xFFF);
 	REG_STORE(PL310_BASE + 0x730, 0);
 
-	int t = 0xffffff;
-	while(t--);
+	ksleep(50);
 
 	REG_STORE(L2X0_CTRL, 1);
 
@@ -96,23 +94,6 @@ static int pl310_init(void) {
 	asm volatile ("mcr p15, 0, %0, c8, c6, 0" : : "r" (0));
 	asm volatile ("mcr p15, 0, %0, c8, c5, 0" : : "r" (0));
 
-#if 0
-	t = 0xffffff;
-	while(t--);
-
-	log_debug("Start memory test\n");
-
-	int t1 = clock();
-	for (int j = 0; j < 1; j++) {
-		for (int i = 0; i < BUF_SZ; i++) {
-			_test_buf[i] ^= i ^ j;
-		}
-	}
-	int t2 = clock();
-	log_debug("Time elapsed: %d\n", t2 - t1);
-
-	log_debug("Finish memory test");
-#endif
 	_reg_dump("");
 
 	return 0;


### PR DESCRIPTION
Replace annoying `while(t--);` with `ksleep(50)`. Without MMU turned on it takes too much time.