### PR TITLE
Fix etnaviv

### DIFF
--- a/platform/etnaviv/cmds/quad_tex/quad_tex.c
+++ b/platform/etnaviv/cmds/quad_tex/quad_tex.c
@@ -413,8 +413,6 @@ static void draw(struct program *p) {
 
 		sw_base[current_id] = ptr;
 
-		ksleep(5);
-
 		if (sw_base[0] && sw_base[1]) {
 			if (first_run) {
 				vmem_set_flags(vmem_current_context(),

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_buffer.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_buffer.c
@@ -35,11 +35,9 @@
  * Command Buffer helper:
  */
 
-extern void dcache_flush(const void *p, size_t size);
 static inline void OUT(struct etnaviv_cmdbuf *buffer, uint32_t data) {
 	uint32_t *vaddr = (uint32_t *)buffer->vaddr;
 	vaddr[buffer->user_size / 4] = data;
-	dcache_flush(&vaddr[buffer->user_size / 4], 4);
 	buffer->user_size += 4;
 }
 
@@ -152,8 +150,6 @@ static void etnaviv_buffer_replace_wait(struct etnaviv_cmdbuf *buffer,
 	data_mem_barrier();
 	lw[0] = cmd;
 	data_mem_barrier();
-
-	dcache_flush(lw, 8);
 }
 /*
  * Ensure that there is space in the command buffer to contiguously write
@@ -220,9 +216,6 @@ void etnaviv_buffer_queue(struct etnaviv_gpu *gpu, unsigned int event,
 	unsigned int waitlink_offset = buffer->user_size - 16;
 	uint32_t return_target, return_dwords;
 	uint32_t link_target, link_dwords;
-
-	dcache_flush(buffer->vaddr, buffer->size * 4);
-	dcache_flush(cmdbuf->vaddr, cmdbuf->size * 4);
 
 	log_debug("exec_state=%d", gpu->exec_state);
 	link_target = etnaviv_cmdbuf_get_va(cmdbuf);

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_cmd_parser.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_cmd_parser.c
@@ -59,7 +59,7 @@ bool etnaviv_cmd_validate_one(struct etnaviv_gpu *gpu, uint32_t *stream,
 			stream, size, relocs, reloc_size);
 	while (buf < end) {
 		uint32_t cmd = *buf;
-		unsigned int len, n, off;
+		unsigned int len, n = 0, off;
 		unsigned int op = cmd >> 27;
 		log_debug("buf(%p) cmd(%x) op(%x)", buf, cmd, op);
 

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gem_submit.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gem_submit.c
@@ -32,8 +32,6 @@
 #define BO_LOCKED   0x4000
 #define BO_PINNED   0x2000
 
-extern void dcache_flush(const void *p, size_t size);
-
 static struct etnaviv_gem_submit *submit_create(struct drm_device *dev,
 		struct etnaviv_gpu *gpu, size_t nr) {
 	/* In current implementation we process single gem_submit
@@ -239,9 +237,6 @@ int etnaviv_ioctl_gem_submit(struct drm_device *dev, void *data, struct drm_file
 
 	etnaviv_buffer_dump(gpu, cmdbuf, 0, cmdbuf->user_size);
 
-	dcache_flush(cmdbuf->vaddr, args->stream_size * 4);
-	dcache_flush(stream, args->stream_size * 4);
-
 	if (!etnaviv_cmd_validate_one(gpu, stream, args->stream_size / 4,
 				relocs, args->nr_relocs)) {
 		return -EINVAL;
@@ -261,9 +256,7 @@ int etnaviv_ioctl_gem_submit(struct drm_device *dev, void *data, struct drm_file
 		}
 	}
 
-	dcache_flush(stream, args->stream_size * 4);
 	memcpy(cmdbuf->vaddr, stream, args->stream_size);
-	dcache_flush(cmdbuf->vaddr, args->stream_size * 4);
 	cmdbuf->user_size = ALIGN(args->stream_size, 8);
 
 	return etnaviv_gpu_submit(gpu, submit, cmdbuf);

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.h
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_gpu.h
@@ -108,6 +108,8 @@ struct etnaviv_gpu {
 	uint32_t active_fence;
 	uint32_t completed_fence;
 	uint32_t retired_fence;
+
+	int busy;
 };
 
 extern int etnaviv_gpu_get_param(struct etnaviv_gpu *gpu, uint32_t param,


### PR DESCRIPTION
Mark command buffer memory as non-cacheable, so some cases of blank screen are fixed