### PR TITLE
stdint.h: Change 32-bit defines for compatibility

### DIFF
--- a/src/compat/libc/include/inttypes.h
+++ b/src/compat/libc/include/inttypes.h
@@ -128,14 +128,14 @@ __END_DECLS
 #define    PRIiLEAST16 "i"
 #define    PRIiFAST16  "i"
 
-#if defined(__arm__) || defined(__mips__) || defined(__sparc__) || defined(__microblaze__) || defined(__PPC__)
+#if defined(__mips__) || defined(__sparc__) || defined(__microblaze__) || defined(__PPC__)
 #define    PRId32      "ld"
 #define    PRIdLEAST32 "ld"
 #define    PRIdFAST32  "ld"
 #define    PRIi32      "li"
 #define    PRIiLEAST32 "li"
 #define    PRIiFAST32  "li"
-#elif defined (i386) || defined (__e2k__)
+#elif defined (i386) || defined (__e2k__) || defined(arm)
 #define    PRId32      "d"
 #define    PRIdLEAST32 "d"
 #define    PRIdFAST32  "d"
@@ -189,7 +189,7 @@ __END_DECLS
 #define    PRIXFAST16  "X"
 
 
-#if defined(__arm__) || defined (__e2k__) || (defined(__mips__) && !defined(__gnu_linux__)) || defined(__sparc__) || defined(__microblaze__) || defined(__PPC__)
+#if defined (__e2k__) || (defined(__mips__) && !defined(__gnu_linux__)) || defined(__sparc__) || defined(__microblaze__) || defined(__PPC__)
 #define    PRIo32      "lo"
 #define    PRIoLEAST32 "lo"
 #define    PRIoFAST32  "lo"
@@ -209,7 +209,7 @@ __END_DECLS
 #define    PRIX64      "llX"
 #define    PRId64      "lld"
 
-#elif defined (i386) || (defined(__mips__) && defined(__gnu_linux__))
+#elif defined(arm) || defined (i386) || (defined(__mips__) && defined(__gnu_linux__))
 
 #define    PRIo32      "o"
 #define    PRIoLEAST32 "o"

--- a/src/compat/libc/include/stdint.h
+++ b/src/compat/libc/include/stdint.h
@@ -29,11 +29,15 @@ typedef __s16  int16_t;
 typedef __INT16_TYPE__ int16_t;
 #endif
 
+#ifdef __ARM_32BIT_STATE
+typedef int int32_t; /* For compatibility with 3rd-party software */
+#else
 #ifndef __INT32_TYPE__
 typedef __s32  int32_t;
 #else
 typedef __INT32_TYPE__ int32_t;
 #endif
+#endif /* __ARM_32BIT_STATE */
 
 #ifndef __INT64_TYPE__
 typedef __s64  int64_t;
@@ -53,11 +57,15 @@ typedef __u16  uint16_t;
 typedef __UINT16_TYPE__ uint16_t;
 #endif
 
+#ifdef __ARM_32BIT_STATE
+typedef unsigned int uint32_t; /* For compatibility with 3rd-party software */
+#else
 #ifndef __UINT32_TYPE__
 typedef __u32  uint32_t;
 #else
 typedef __UINT32_TYPE__ uint32_t;
 #endif
+#endif /* __ARM_32BIT_STATE */
 
 #ifndef __UINT64_TYPE__
 typedef __u64 uint64_t;


### PR DESCRIPTION
A lot of software acts like `int32_t` is the same as `int` and it works
just fine for x86 platform, but for ARM it's not the case: it's `long`

We can either patch every 3rd-party library we use or just redefine
`uint32_t`/`int32_t` for 32-bit ARM systems. Second options seems to be
better solution