### PR TITLE
Fix x86 exceptions

### DIFF
--- a/mk/image.lds.S
+++ b/mk/image.lds.S
@@ -54,11 +54,11 @@ SECTIONS {
 		_dtors_end   = .;
 
 		ALIGNMENT();
-		/*_eh_frame_start = .;*/
-		__EH_FRAME_BEGIN__ = .;
+		_eh_frame_begin = .;
 		KEEP(*(.eh_frame))
 		KEEP(*(.eh_frame.*))
-		/*KEEP(*(.gcc_except_table))*/
+		KEEP(*(.eh_frame_end))
+		/* KEEP(*(.gcc_except_table*)) */
 
 		ALIGNMENT();
 		*(.checksum)

--- a/src/compat/cxx/core/cxx_invoke_constructors.c
+++ b/src/compat/cxx/core/cxx_invoke_constructors.c
@@ -5,13 +5,26 @@
  * @author: Anton Bondarev
  */
 
+#include <stdint.h>
 
 typedef void (*ctor_func_t)(void);
+
+const uint32_t __attribute__ ((section(".eh_frame_end"))) eh_frame_end = 0;
+
+__attribute__((weak)) void __register_frame(void *begin) {
+}
+
+void register_eh_frame(void) {
+	extern const char _eh_frame_begin;
+	__register_frame((void *)&_eh_frame_begin);
+}
 
 void cxx_invoke_constructors(void) {
 	extern const char _ctors_start, _ctors_end;
 	ctor_func_t *func;
 	int n_entries;
+
+	register_eh_frame();
 
 	for (func = (ctor_func_t *) &_ctors_start, n_entries = 0;
 			*func && (func != (ctor_func_t *) &_ctors_end);

--- a/src/tests/c++/Mybuild
+++ b/src/tests/c++/Mybuild
@@ -4,6 +4,8 @@ package embox.test.cxx
 module memory_test {
 	source "memory.cpp"
 
+	depends embox.lib.cxx.ConstructionPolicy
+	depends embox.lib.cxx.DestructionPolicy
 	@NoRuntime depends embox.lib.libsupcxx
 }
 
@@ -11,6 +13,8 @@ module memory_test {
 module exception_test {
 	source "exceptions.cpp"
 
+	depends embox.lib.cxx.ConstructionPolicy
+	depends embox.lib.cxx.DestructionPolicy
 	@NoRuntime depends embox.lib.libsupcxx
 }
 
@@ -18,5 +22,7 @@ module exception_test {
 module inheritance_test {
 	source "inheritance.cpp"
 
+	depends embox.lib.cxx.ConstructionPolicy
+	depends embox.lib.cxx.DestructionPolicy
 	@NoRuntime depends embox.lib.libsupcxx
 }

--- a/src/tests/c++/exceptions.cpp
+++ b/src/tests/c++/exceptions.cpp
@@ -31,4 +31,41 @@ TEST_CASE("Throw/catch exception") {
 	}
 	test_assert_emitted("ab");
 }
+
+/* This function calls itself 100 times expanding call stack,
+ * and then throws exception */
+static void test_func_throw(void) {
+	static int i = 0;
+
+	if (++i < 100) {
+		test_func_throw();
+	} else {
+		throw MyException();
+	}
+}
+
+static void test_func_catch2(void) {
+	try {
+		test_emit('a');
+		test_func_throw();
+	}
+	catch (std::exception& e) {
+		test_emit('b');
+	}
+}
+
+static void test_func_catch1(void) {
+	try {
+		test_func_catch2();
+	}
+	catch (std::exception& e) {
+		test_emit('c');
+	}
+}
+
+TEST_CASE("Catch exception in outer function") {
+	/* Throws exception in the inner funtion, catch in outer function */
+	test_func_catch1();
+	test_assert_emitted("ab");
+}
 } /* namespace */


### PR DESCRIPTION
Previously .eh_frame was only included in lds script, but not used.