### PR TITLE
drivers/qspi/stm32f7_qspi: Initial implementation

### DIFF
--- a/src/drivers/flash/qspi/Mybuild
+++ b/src/drivers/flash/qspi/Mybuild
@@ -1,0 +1,8 @@
+package embox.driver.flash
+
+@BuildDepends(third_party.bsp.stmf7cube.core)
+module stm32f7_qspi {
+	source "stm32f7_qspi.c"
+
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
+}

--- a/src/drivers/flash/qspi/stm32f7_qspi.c
+++ b/src/drivers/flash/qspi/stm32f7_qspi.c
@@ -1,0 +1,22 @@
+/**
+ * @file qspi.c
+ * @brief QSPI flash driver (currently just for STM32F7Discovery)
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 07.06.2019
+ */
+
+#include <embox/unit.h>
+
+#include "stm32746g_discovery.h"
+#include "stm32746g_discovery_qspi.h"
+
+EMBOX_UNIT_INIT(stm32f7_qspi_init);
+
+static int stm32f7_qspi_init(void) {
+	BSP_QSPI_Init();
+
+	BSP_QSPI_EnableMemoryMappedMode();
+
+	return 0;
+}

--- a/templates/arm/stm32f7cube/mods.config
+++ b/templates/arm/stm32f7cube/mods.config
@@ -22,6 +22,7 @@ configuration conf {
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
 	//@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=115200, usartx=6)
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
+	@Runlevel(1) include embox.driver.flash.stm32f7_qspi
 
 	@Runlevel(2) include embox.driver.net.stm32f7cube_eth
 	@Runlevel(2) include embox.driver.net.loopback


### PR DESCRIPTION
Initialize QSPI memory to access via system bus with stm32f7cube functions