### PR TITLE
cortexm_nvic: Fix initialization

### DIFF
--- a/src/drivers/interrupt/cortexm/cortexm_nvic.c
+++ b/src/drivers/interrupt/cortexm/cortexm_nvic.c
@@ -90,7 +90,10 @@ static int nvic_init(void) {
 	int i;
 	void *ptr;
 
+	ipl = ipl_save();
+
 	for (i = 0; i < EXCEPTION_TABLE_SZ; i++) {
+		irqctrl_disable(i);
 		exception_table[i] = ((int) interrupt_handle_enter) | 1;
 	}
 
@@ -101,8 +104,6 @@ static int nvic_init(void) {
 
 	assert(EXCEPTION_TABLE_SZ >= 14);
 	exception_table[14] = ((int) __pendsv_handle) | 1;
-
-	ipl = ipl_save();
 
 	REG_STORE(SCB_VTOR, 1 << 29 /* indicate, table in SRAM */ |
 			(int) exception_table);

--- a/third-party/bsp/stmf7cube/arch.c
+++ b/third-party/bsp/stmf7cube/arch.c
@@ -11,6 +11,7 @@
 
 #include <hal/arch.h>
 #include <hal/clock.h>
+#include <hal/ipl.h>
 
 #include <system_stm32f7xx.h>
 #include <stm32f7xx_hal.h>
@@ -63,6 +64,8 @@ static void SystemClock_Config(void)
 extern void nvic_table_fill_stubs(void);
 
 void arch_init(void) {
+	ipl_t ipl = ipl_save();
+
 	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 216000000);
 
 	SystemInit();
@@ -71,6 +74,8 @@ void arch_init(void) {
 	nvic_table_fill_stubs();
 
 	SystemClock_Config();
+
+	ipl_restore(ipl);
 }
 
 void arch_idle(void) {


### PR DESCRIPTION
Problems could occur if kernel was not started by regular reboot, but
just with a jump to start symbol