### PR TITLE
Third party mirrors

### DIFF
--- a/mk/extbld/lib.mk
+++ b/mk/extbld/lib.mk
@@ -1,10 +1,6 @@
 ##
 # This file should be included by extbld Makefiles.
 #
-# This also could generate md5sums for specified extbld Makefile:
-# Assuming you are in ROOT_DIR, and you are going to generate md5sums of third_party/smth/, run
-# make EXTBLD_LIB=$PWD/mk/extbld/lib.mk ROOT_DIR=$PWD -C third-party/smth BUILD_DIR=$PWD/build/extbld/third_party/smth md5_gen
-#
 
 ifeq ($(strip $(ROOT_DIR)),)
 $(error ROOT_DIR is not set)
@@ -18,12 +14,11 @@ include $(ROOT_DIR)/mk/core/common.mk
 include $(ROOT_DIR)/mk/core/string.mk
 
 .PHONY : all download extract patch configure build install
-.PHONY : md5_gen
 
 all : download extract patch configure build install
 
-PKG_SOURCE_DIR   ?= $(BUILD_DIR)/$(PKG_NAME)-$(PKG_VER)
 PKG_INSTALL_DIR  := $(BUILD_DIR)/install
+PKG_SOURCE_DIR   = $(filter-out %/install,$(wildcard $(BUILD_DIR)/*))
 DOWNLOAD_BASEDIR := $(ROOT_DIR)/download
 ifeq ($(value PKG_DOWNLOADS_SEPARATE),)
 DOWNLOAD_DIR     := $(DOWNLOAD_BASEDIR)
@@ -34,23 +29,35 @@ endif
 $(DOWNLOAD_DIR) $(BUILD_DIR) $(PKG_INSTALL_DIR):
 	mkdir -p $@
 
+PKG_NAME    ?=
+PKG_VER     ?=
 PKG_SOURCES ?=
-# Name of an archive where package will be saved to.
-PKG_ARCHIVE_NAME ?=""
-sources_git      := $(filter %.git,$(PKG_SOURCES))
-targets_git	  = $(basename $(notdir $1))
-sources_download := $(filter-out %.git,$(PKG_SOURCES))
-# Return PKG_ARCHIVE_NAME of the specified package in case if
-# the url does not contain package name
-pkg_archive_name  = $(if $(call eq,$(PKG_ARCHIVE_NAME),""),$(call notdir,$1),$(PKG_ARCHIVE_NAME))
-sources_extract  := $(filter %.tar.gz %.tar.bz2 %.tar.xz %tgz %tbz %zip,$(call pkg_archive_name,$(sources_download)))
+
+sources_git := $(filter %.git,$(PKG_SOURCES))
+targets_git = $(basename $(notdir $1))
+sources_archive_mirrors := $(filter-out %.git,$(PKG_SOURCES))
+
+pkg_ext ?=
+first_url := $(word 1,$(sources_archive_mirrors))
+ifneq ($(filter %.tar.gz %.tar.bz %.tar.xz,$(first_url)),)
+	pkg_ext := .tar$(suffix $(first_url))
+else ifneq ($(filter %.tgz %.tbz %.zip,$(first_url)),)
+	pkg_ext := $(suffix $(first_url))
+endif
+
+ifneq ($(PKG_VER),)
+	pkg_archive_name := $(PKG_NAME)-$(PKG_VER)$(pkg_ext)
+else
+	pkg_archive_name := $(PKG_NAME)$(pkg_ext)
+endif
 
 DOWNLOAD  := $(BUILD_DIR)/.downloaded
 $(DOWNLOAD): | $(DOWNLOAD_DIR) $(BUILD_DIR)
-	$(foreach d,$(sources_download), \
-		if [ ! -f $(DOWNLOAD_DIR)/$(call pkg_archive_name,$d) ]; then \
-			cd $(DOWNLOAD_DIR) && (curl -o $(call pkg_archive_name,$d) -k -L '$d'); \
-		fi;)
+	$(foreach d,$(sources_archive_mirrors), \
+		if [ ! -f $(DOWNLOAD_DIR)/$(pkg_archive_name) ] ; then \
+			cd $(DOWNLOAD_DIR); \
+			curl -o $(pkg_archive_name) -f -k -L '$d'; \
+		fi;) \
 	$(foreach g,$(sources_git), \
 		if [ ! -d $(DOWNLOAD_DIR)/$(call targets_git,$g) ]; then \
 			cd $(DOWNLOAD_DIR); \
@@ -60,29 +67,21 @@ $(DOWNLOAD): | $(DOWNLOAD_DIR) $(BUILD_DIR)
 
 DOWNLOAD_CHECK  := $(BUILD_DIR)/.download_checked
 $(DOWNLOAD_CHECK) : $(DOWNLOAD)
-	$(if $(call eq,$(words $(PKG_SOURCES)),$(words $(PKG_MD5))),, \
-		echo "different number of sources and MD5"; false)
-	( cd $(DOWNLOAD_DIR); \
-		$(foreach c,$(filter-out %.-,$(join $(PKG_SOURCES),$(addprefix .,$(PKG_MD5)))), \
-			$(MD5) $(call pkg_archive_name,$(basename $c)) | grep $(subst .,,$(suffix $c)) 2>&1 >/dev/null ; ) \
+	cd $(DOWNLOAD_DIR) && ( \
+		$(MD5) $(pkg_archive_name) | $(AWK) '{print $$1}' | grep $(PKG_MD5) 2>&1 >/dev/null; \
 	)
 	touch $@
 
 download : $(DOWNLOAD) $(DOWNLOAD_CHECK)
-md5_gen : $(DOWNLOAD)
-	@echo PKG_MD5 := \\
-	@$(foreach s,$(PKG_SOURCES),md5=$$(md5sum $(DOWNLOAD_DIR)/$(call pkg_archive_name,$s) 2>/dev/null) && echo -e "\\t$${md5%%  *} \\" || echo -- "-";)
-	@echo
 
 EXTRACT  := $(BUILD_DIR)/.extracted
 extract : $(EXTRACT)
 $(EXTRACT): | $(DOWNLOAD_DIR) $(BUILD_DIR)
-	$(foreach i,$(sources_extract),\
-		$(if $(filter %zip,$i),unzip -q $(DOWNLOAD_DIR)/$i -d $(BUILD_DIR),\
-			mkdir -p $(BUILD_DIR) && ( cd $(BUILD_DIR); tar -xf $(DOWNLOAD_DIR)/$i) );)
+	$(if $(filter %zip,$(pkg_ext)), \
+		unzip -q $(DOWNLOAD_DIR)/$(pkg_archive_name) -d $(BUILD_DIR), \
+		tar -xf $(DOWNLOAD_DIR)/$(pkg_archive_name) -C $(BUILD_DIR))
 	COPY_FILES="$(addprefix $(DOWNLOAD_DIR)/, \
-			$(call targets_git,$(sources_git)) \
-			$(filter-out $(sources_extract),$(call pkg_archive_name,$(sources_download))))"; \
+			$(call targets_git,$(sources_git)))"; \
 		if [ "$$COPY_FILES" ]; then \
 			cp -R $$COPY_FILES $(BUILD_DIR); \
 		fi

--- a/mk/extbld/lib.mk
+++ b/mk/extbld/lib.mk
@@ -56,7 +56,7 @@ $(DOWNLOAD): | $(DOWNLOAD_DIR) $(BUILD_DIR)
 	$(foreach d,$(sources_archive_mirrors), \
 		if [ ! -f $(DOWNLOAD_DIR)/$(pkg_archive_name) ] ; then \
 			cd $(DOWNLOAD_DIR); \
-			curl -o $(pkg_archive_name) -f -k -L '$d'; \
+			curl -o $(pkg_archive_name) -f -k -L '$d' || $(RM) $(pkg_archive_name); \
 		fi;) \
 	$(foreach g,$(sources_git), \
 		if [ ! -d $(DOWNLOAD_DIR)/$(call targets_git,$g) ]; then \

--- a/third-party/bsp/st_discovery_vl/Makefile
+++ b/third-party/bsp/st_discovery_vl/Makefile
@@ -1,8 +1,8 @@
 
 PKG_NAME := stsw-stm32078
 
-PKG_SOURCES := https://www.dropbox.com/s/jobnwywszl0kkg6/stsw-stm32078.zip?dl=0
-PKG_ARCHIVE_NAME :=stsw-stm32078.zip
+PKG_SOURCES := https://www.dropbox.com/s/jobnwywszl0kkg6/stsw-stm32078.zip
+
 PKG_MD5     := c16271bdba349cdc03ae5bc3746a2e24
 
 PKG_PATCHES := cmsis_strex_output_fix.patch

--- a/third-party/bsp/st_f3/Makefile
+++ b/third-party/bsp/st_f3/Makefile
@@ -2,7 +2,6 @@
 PKG_NAME := stm32f3
 
 PKG_SOURCES := https://www.dropbox.com/s/3oe6e10fbi3pcci/stm32f3discovery.zip
-PKG_ARCHIVE_NAME :=stm32f3discovery.zip
 PKG_MD5     := e7eddb371433c2dd8ab101a0fb337827
 
 PKG_PATCHES := buildfix.patch

--- a/third-party/bsp/st_f4/Makefile
+++ b/third-party/bsp/st_f4/Makefile
@@ -2,7 +2,6 @@
 PKG_NAME := stsw-stm32070
 
 PKG_SOURCES := https://www.dropbox.com/s/uc887rs81w0y86n/STM32F4xx_Ethernet_Example.zip
-PKG_ARCHIVE_NAME :=STM32F4xx_Ethernet_Example.zip
 PKG_MD5     := 7f1a0e638e1b944be66cd335f69507cd
 
 PKG_PATCHES := stmf4_audio_codec.patch stmf4_eth_buildfix.patch

--- a/third-party/bsp/stmf3cube/Makefile
+++ b/third-party/bsp/stmf3cube/Makefile
@@ -1,8 +1,7 @@
 
-PKG_NAME := stm32f3
+PKG_NAME := stm32cubef3
 
-PKG_SOURCES := https://www.dropbox.com/s/c154pmnrmkhop7b/stm32cubef3.zip?dl=0
-PKG_ARCHIVE_NAME :=stm32cubef3.zip
+PKG_SOURCES := https://www.dropbox.com/s/c154pmnrmkhop7b/stm32cubef3.zip
 PKG_MD5     := 0b6817c0da649bd4c15d2b141713dcec
 
 include $(EXTBLD_LIB)

--- a/third-party/bsp/stmf4cube/Makefile
+++ b/third-party/bsp/stmf4cube/Makefile
@@ -1,8 +1,8 @@
 
-PKG_NAME := stm32f4
+PKG_NAME := stm32cubef4
 PKG_PATCHES := patch.txt
 
-PKG_SOURCES := https://www.dropbox.com/s/kglgqpgw186ho6r/stm32cubef4.zip?dl=0
-PKG_ARCHIVE_NAME :=stm32cubef4.zip
+PKG_SOURCES := https://www.dropbox.com/s/kglgqpgw186ho6r/stm32cubef4.zip
+
 PKG_MD5     := fb93309ca8acdc6bfe9fc089cc6441fe
 include $(EXTBLD_LIB)

--- a/third-party/bsp/stmf7cube/Makefile
+++ b/third-party/bsp/stmf7cube/Makefile
@@ -1,10 +1,9 @@
 
-PKG_NAME := stm32f7
+PKG_NAME := stm32cubef7
 PKG_PATCHES := patch.txt \
 	audio.patch
 
-PKG_SOURCES := https://www.dropbox.com/s/2u5cuh3gmrv375m/stm32cubef7.zip?dl=0
-PKG_ARCHIVE_NAME :=stm32cubef7.zip
+PKG_SOURCES := https://www.dropbox.com/s/2u5cuh3gmrv375m/stm32cubef7.zip
 PKG_MD5     := 15f04dadded7602d1406cc0623ba0e22
 
 include $(EXTBLD_LIB)

--- a/third-party/chibi-scheme/Makefile
+++ b/third-party/chibi-scheme/Makefile
@@ -2,8 +2,6 @@
 PKG_NAME := chibi-scheme
 PKG_VER  := 0.6.1
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
-
 PKG_SOURCES := https://github.com/ashinn/$(PKG_NAME)/archive/$(PKG_VER).tar.gz
 PKG_MD5     := 16b69c3497b46dfb65af8d98549b037b
 

--- a/third-party/dropbear/Makefile
+++ b/third-party/dropbear/Makefile
@@ -2,7 +2,9 @@
 PKG_NAME := dropbear
 PKG_VER  := 2018.76
 
-PKG_SOURCES := https://matt.ucc.asn.au/dropbear/releases/$(PKG_NAME)-$(PKG_VER).tar.bz2
+PKG_SOURCES := https://matt.ucc.asn.au/dropbear/releases/$(PKG_NAME)-$(PKG_VER).tar.bz2 \
+	https://dropbear.nl/mirror/releases/$(PKG_NAME)-$(PKG_VER).tar.bz2
+
 PKG_MD5     := c3912f7fcdcc57c99937e4a79480d2c2
 
 PKG_PATCHES := dropbear.patch

--- a/third-party/freedesktop/mesa/glu/libglu_imx6/Makefile
+++ b/third-party/freedesktop/mesa/glu/libglu_imx6/Makefile
@@ -2,10 +2,7 @@
 PKG_NAME := glu
 PKG_VER  := 9.0.0
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.bz2
-
-
-PKG_SOURCES := ftp://ftp.freedesktop.org/pub/mesa/glu/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := ftp://ftp.freedesktop.org/pub/mesa/glu/$(PKG_NAME)-$(PKG_VER).tar.bz2
 
 PKG_MD5     := be9249132ff49275461cf92039083030
 

--- a/third-party/freedesktop/mesa/glu/libglu_osmesa/Makefile
+++ b/third-party/freedesktop/mesa/glu/libglu_osmesa/Makefile
@@ -2,10 +2,7 @@
 PKG_NAME := glu
 PKG_VER  := 9.0.0
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.bz2
-
-
-PKG_SOURCES := ftp://ftp.freedesktop.org/pub/mesa/glu/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := ftp://ftp.freedesktop.org/pub/mesa/glu/$(PKG_NAME)-$(PKG_VER).tar.bz2
 
 PKG_MD5     := be9249132ff49275461cf92039083030
 

--- a/third-party/freedesktop/mesa/libdrm/etnaviv/Makefile
+++ b/third-party/freedesktop/mesa/libdrm/etnaviv/Makefile
@@ -2,10 +2,7 @@
 PKG_NAME := libdrm
 PKG_VER  := 2.4.96
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
-
-
-PKG_SOURCES := https://dri.freedesktop.org/libdrm/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := https://dri.freedesktop.org/libdrm/$(PKG_NAME)-$(PKG_VER).tar.gz
 
 PKG_MD5     := dd0a89154ee3d60c37ee5b8099979875
 

--- a/third-party/freedesktop/mesa/libdrm/sw/Makefile
+++ b/third-party/freedesktop/mesa/libdrm/sw/Makefile
@@ -2,10 +2,7 @@
 PKG_NAME := libdrm
 PKG_VER  := 2.4.96
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
-
-
-PKG_SOURCES := https://dri.freedesktop.org/libdrm/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := https://dri.freedesktop.org/libdrm/$(PKG_NAME)-$(PKG_VER).tar.gz
 
 PKG_MD5     := dd0a89154ee3d60c37ee5b8099979875
 

--- a/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Makefile
+++ b/third-party/freedesktop/mesa/mesa/mesa_etnaviv/Makefile
@@ -3,9 +3,7 @@
 PKG_NAME := mesa
 PKG_VER  := 18.2.5
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.xz
-
-PKG_SOURCES := https://mesa.freedesktop.org/archive/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := https://mesa.freedesktop.org/archive/$(PKG_NAME)-$(PKG_VER).tar.xz
 
 PKG_MD5     := b31a43ebb8b37fb704a9a75c90bbd71b
 

--- a/third-party/freedesktop/mesa/mesa/mesa_sw/Makefile
+++ b/third-party/freedesktop/mesa/mesa/mesa_sw/Makefile
@@ -3,9 +3,7 @@
 PKG_NAME := mesa
 PKG_VER  := 18.2.5
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.xz
-
-PKG_SOURCES := https://mesa.freedesktop.org/archive/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := https://mesa.freedesktop.org/archive/$(PKG_NAME)-$(PKG_VER).tar.xz
 
 PKG_MD5     := b31a43ebb8b37fb704a9a75c90bbd71b
 

--- a/third-party/freedesktop/mesa/mesa_demos/Makefile
+++ b/third-party/freedesktop/mesa/mesa_demos/Makefile
@@ -2,10 +2,7 @@
 PKG_NAME := mesa-demos
 PKG_VER  := 8.3.0
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.bz2
-
-
-PKG_SOURCES := https://mesa.freedesktop.org/archive/demos/$(PKG_VER)/$(PKG_ARCHIVE_NAME)
+PKG_SOURCES := https://mesa.freedesktop.org/archive/demos/$(PKG_NAME)-$(PKG_VER).tar.bz2
 
 PKG_MD5     := 628e75c23c17394f11a316c36f8e4164
 

--- a/third-party/lib/coap/Makefile
+++ b/third-party/lib/coap/Makefile
@@ -1,8 +1,6 @@
 PKG_NAME := libcoap
 PKG_VER  := 4.1.1
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
-
 PKG_SOURCES := https://github.com/obgm/$(PKG_NAME)/archive/v$(PKG_VER).tar.gz
 PKG_MD5     := ff1af4bd9893c1728e765aa08a816e41
 

--- a/third-party/lib/nuklear/Makefile
+++ b/third-party/lib/nuklear/Makefile
@@ -1,7 +1,6 @@
 PKG_NAME := nuklear
 PKG_VER := ef2dcd3b779647e0140bb78863cb8439774e277b
 
-PKG_ARCHIVE_NAME :=$(PKG_NAME)-$(PKG_VER).zip
 PKG_SOURCES := https://github.com/vurtun/nuklear/archive/$(PKG_VER).zip
 PKG_MD5     := 318736d16bc0f7f1808aba365826d6c0
 

--- a/third-party/lib/openlibm/Makefile
+++ b/third-party/lib/openlibm/Makefile
@@ -7,7 +7,7 @@ PKG_VER := 2252cbd02c176a31f74fa10f8fcdf926c3124987
 PKG_ARCHIVE_NAME := openlibm-$(PKG_VER).tar.gz
 
 PKG_SOURCES := https://github.com/embox/openlibm/archive/$(PKG_VER).tar.gz
-PKG_MD5 := 2252cbd02c176a31f74fa10f8fcdf926c3124987
+PKG_MD5 := f5bec5f9f47d11067820497858334673
 
 PKG_PATCHES := patch.txt
 

--- a/third-party/lib/openlibm/Makefile
+++ b/third-party/lib/openlibm/Makefile
@@ -4,8 +4,6 @@ PKG_NAME := openlibm
 PKG_VER := 2252cbd02c176a31f74fa10f8fcdf926c3124987
 
 # PKG_DOWNLOADS_SEPARATE := true
-PKG_ARCHIVE_NAME := openlibm-$(PKG_VER).tar.gz
-
 PKG_SOURCES := https://github.com/embox/openlibm/archive/$(PKG_VER).tar.gz
 PKG_MD5 := f5bec5f9f47d11067820497858334673
 

--- a/third-party/lib/stb/Makefile
+++ b/third-party/lib/stb/Makefile
@@ -1,7 +1,6 @@
 PKG_NAME := stb
 PKG_VER := 423298e07169bced18a82c2d0e6a6341a19db65c
 
-PKG_ARCHIVE_NAME :=$(PKG_NAME)-$(PKG_VER).zip
 PKG_SOURCES := https://github.com/nothings/stb/archive/$(PKG_VER).zip
 PKG_MD5     := f4a555402efab6d3808aab43018d4c4b
 

--- a/third-party/lua/lib/luasocket/Makefile
+++ b/third-party/lua/lib/luasocket/Makefile
@@ -2,7 +2,6 @@
 PKG_NAME := luasocket
 PKG_VER  := 321c0c9b1f7b6b83cd83b58e7e259f53eca69373
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
 PKG_SOURCES := https://github.com/diegonehab/luasocket/archive/$(PKG_VER).tar.gz
 PKG_MD5     := e2d6845e1f75d2e24df5563f643598af
 

--- a/third-party/mruby/Makefile
+++ b/third-party/mruby/Makefile
@@ -2,8 +2,6 @@
 PKG_NAME := mruby
 PKG_VER  := 1.1.0
 
-PKG_ARCHIVE_NAME := $(PKG_NAME)-$(PKG_VER).tar.gz
-
 PKG_SOURCES := https://github.com/mruby/mruby/archive/$(PKG_VER).tar.gz
 PKG_MD5     := 60d75ea704c9285f3c80b3ad1d2b68de
 

--- a/third-party/packetdrill/Makefile
+++ b/third-party/packetdrill/Makefile
@@ -4,15 +4,15 @@ PKG_VER  := d799c219acfa
 
 PKG_SOURCES := https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/packetdrill/source-archive.zip
 PKG_MD5     := 1c203d1474022b0aad2364f3ab92494e
-PKG_SOURCE_DIR := $(BUILD_DIR)/$(PKG_NAME)/gtests/net/$(PKG_NAME)
 
 PKG_PATCHES := packetdrill.patch
 
 include $(EXTBLD_LIB)
 
+PACKETDRILL_SOURCE_DIR := $(BUILD_DIR)/$(PKG_NAME)/gtests/net/$(PKG_NAME)
 
 $(BUILD) :
-	cd $(PKG_SOURCE_DIR) && ( \
+	cd $(PACKETDRILL_SOURCE_DIR) && ( \
 		$(MAKE) -f Makefile.common \
 			MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)' \
 			CC=$(EMBOX_GCC) \
@@ -21,5 +21,5 @@ $(BUILD) :
 	touch $@
 
 $(INSTALL) :
-	cp $(PKG_SOURCE_DIR)/packetdrill $(PKG_INSTALL_DIR)/packetdrill.o
+	cp $(PACKETDRILL_SOURCE_DIR)/packetdrill $(PKG_INSTALL_DIR)/packetdrill.o
 	touch $@

--- a/third-party/phoneme/Makefile
+++ b/third-party/phoneme/Makefile
@@ -3,7 +3,6 @@ PKG_NAME := phoneme
 PKG_VER  := trunk
 
 PKG_SOURCES := https://www.dropbox.com/s/13ihqov40oud914/phoneme-trunk.tar.gz
-PKG_ARCHIVE_NAME :=phoneme-trunk.tar.gz
 PKG_MD5     := b552aa86b2832d00563636330ec64299
 
 PKG_PATCHES := pkg_patch.txt


### PR DESCRIPTION
* Remove multiple PKG_SOURCES/PKG_MD5. Now PKG_SOURCES is just a list of mirrors for a single package
* Get rid of PKG_ARCHIVE_NAME. Now each downloaded package will be saved to download/ folder with name combined of $(PKG_NAME)-$(PKG_VER).extension. Extension will be derived from url.
* When package downloading is failed for some reason remove partially downloaded package.
