### PR TITLE
Work on lib/tftp

### DIFF
--- a/src/cmds/bootloader/Qspi_loader.my
+++ b/src/cmds/bootloader/Qspi_loader.my
@@ -1,0 +1,21 @@
+package embox.cmd
+
+@AutoCmd
+@Cmd(	name = "qspi_loader",
+	help = "Load data to stm32f7discovery QSPI memory",
+	man  = '''
+     	NAME
+		qspi_loader - load data to stm32f7discovery QSPI memory via tftp
+	SYNOPSIS
+		qspi_loader FILE_NAME SERVER_ADDERSS
+	AUTHORS
+		Denis Deryugin <deryugin.denis@gmail.com>
+	''')
+@BuildDepends(third_party.bsp.stmf7cube.core)
+module qspi_loader {
+	source "qspi_loader.c"
+
+	depends embox.lib.tftp
+	depends embox.driver.flash.stm32f7_qspi
+	depends third_party.bsp.stmf7cube.stm32f7_discovery_bsp
+}

--- a/src/cmds/bootloader/qspi_loader.c
+++ b/src/cmds/bootloader/qspi_loader.c
@@ -1,0 +1,74 @@
+/**
+ * @file qspi_loader.c
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 18.06.2019
+ */
+
+#include <assert.h>
+
+#include <lib/tftp.h>
+
+#include "stm32746g_discovery.h"
+#include "stm32746g_discovery_qspi.h"
+
+static int qspi_recv_file(char *filename, char *hostname) {
+	struct tftp_stream *s = tftp_new_stream(hostname, filename, TFTP_DIR_GET, true);
+	int addr = 0;
+	int last_block = -1;
+	int bytes;
+	uint8_t buf[TFTP_SEGSIZE];
+	QSPI_Info info;
+
+	BSP_QSPI_Init();
+
+	BSP_QSPI_GetInfo(&info);
+
+	while (1) {
+		bytes = tftp_stream_read(s, buf);
+
+		if (bytes < 0) {
+			fprintf(stderr, "%s: error: code=%d, msg='%s`\n",
+					hostname, -bytes, tftp_error(s));
+			tftp_delete_stream(s);
+			return bytes;
+		}
+
+		if (bytes == 0) {
+			/* End of file */
+			break;
+		}
+
+		if (last_block != (addr + bytes) / info.EraseSectorSize) {
+			do {
+				last_block++;
+				assert(last_block <= info.EraseSectorsNumber);
+				BSP_QSPI_Erase_Block(last_block * info.EraseSectorSize);
+			} while (last_block < (addr + bytes) / info.EraseSectorSize);
+		}
+
+		BSP_QSPI_Write(buf, addr, bytes);
+
+		addr += bytes;
+	}
+
+	tftp_delete_stream(s);
+
+	BSP_QSPI_EnableMemoryMappedMode();
+	return 0;
+}
+
+int main(int argc, char **argv) {
+
+	if (argc != 3) {
+		printf("Usage: %s file_name tftp_srv_addr\n", argv[0]);
+	}
+
+	if (qspi_recv_file(argv[argc - 2], argv[argc - 1])) {
+		fprintf(stderr, "Error\n");
+		return 0;
+	}
+
+	return 0;
+}

--- a/src/cmds/net/Tftp.my
+++ b/src/cmds/net/Tftp.my
@@ -35,6 +35,7 @@ package embox.cmd.net
 module tftp {
 	source "tftp.c"
 
+	depends embox.lib.tftp
 	depends embox.compat.libc.all
 	depends embox.compat.posix.net.socket
 	depends embox.compat.posix.util.getopt

--- a/src/cmds/net/Tftp.my
+++ b/src/cmds/net/Tftp.my
@@ -7,7 +7,7 @@ package embox.cmd.net
 		NAME
 			tftp - IPv4 Trivial File Transfer Protocol client
 		SYNOPSIS
-			tftp [-hab] -[g|p] files destination
+			tftp [-hab] -[g [-m addr] | p] files destination
 		DESCRIPTION
 			tftp is a client for the IPv4 Trivial file Transfer
 			Protocol, which can be used to transfer files from
@@ -20,8 +20,13 @@ package embox.cmd.net
 			-b           use binary mode to transfer
 			-g           get files from remote machine
 			-p           put files to remote machine
+			-m           write to memory location instead of file
+			             (works only with -g)
 		EXAMPLES
-			tftp -g hello.html 10.0.2.10
+			Save 'hello.html' from 10.0.2.10 to current directory:
+				tftp -g hello.html 10.0.2.10
+			Write 'img.bin' from 10.0.2.11 to 0x9000000:
+				tftp -g -m 0x9000000 img.bin 10.0.2.11
 		SEE ALSO
 			ftp, telnet
 		AUTHORS

--- a/src/lib/tftp/Mybuild
+++ b/src/lib/tftp/Mybuild
@@ -1,0 +1,15 @@
+package embox.lib
+
+module tftp {
+	option number log_level=0
+
+	source "tftp.c"
+
+	@IncludeExport(path="lib")
+	source "tftp.h"
+
+	@NoRuntime depends embox.compat.libc.stdio.all
+	@NoRuntime depends embox.compat.libc.str
+	@NoRuntime depends embox.net.udp
+	@NoRuntime depends embox.net.udp_sock
+}

--- a/src/lib/tftp/tftp.c
+++ b/src/lib/tftp/tftp.c
@@ -1,0 +1,403 @@
+/*
+ * @brief Interface for TFTP operations. Based on old version of cmds/net/tftp.c
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @author Nikolay Korotky
+ * @author Ilia Vaprol
+ * @version
+ * @date 18.06.2019
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+#include <lib/tftp.h>
+#include <util/log.h>
+#include <kernel/printk.h>
+
+struct tftp_msg {
+	uint16_t opcode;
+	union {
+		struct {
+			char name_and_mode[2];
+		} cmd /*__attribute__ ((packed))*/;
+		struct {
+			uint16_t block_num;
+			char stuff[TFTP_SEGSIZE];
+		} data /*__attribute__ ((packed))*/;
+		struct {
+			uint16_t block_num;
+		} ack /*__attribute__ ((packed))*/;
+		struct {
+			uint16_t error_code;
+			char error_msg[1];
+		} err /*__attriibute__ ((packed))*/;
+	} op /*__attribute__ ((packed))*/;
+} __attribute__ ((packed));
+
+struct tftp_stream {
+	FILE *fp;
+	void *addr;
+
+	char filename[PATH_MAX];
+
+	int pkg_number;
+
+	struct tftp_msg snd, rcv;
+	size_t snd_len, rcv_len;
+
+	struct sockaddr_storage rem_addr;
+	socklen_t rem_addrlen;
+
+	int sock;
+
+	int dst_port;
+
+	bool transmission_end;
+};
+
+static char *get_transfer_mode(bool binary_on) {
+	return binary_on ? "octet" : "netascii";
+}
+
+static int tftp_build_msg_cmd(struct tftp_msg *msg, size_t *msg_len,
+		uint16_t type, const char *filename, char *mode) {
+	char *ptr;
+	size_t sz;
+
+	msg->opcode = htons(type);
+	*msg_len = sizeof msg->opcode;
+
+	ptr = &msg->op.cmd.name_and_mode[0];
+	sz = strlen(filename) + 1;
+	memcpy(ptr, filename, sz * sizeof(char));
+	*msg_len += sz * sizeof(char);
+
+	ptr += sz;
+	sz = strlen(mode) + 1;
+	memcpy(ptr, mode, sz * sizeof(char));
+	*msg_len += sz * sizeof(char);
+
+	return 0;
+}
+
+static int tftp_build_msg_data(struct tftp_msg *msg, size_t *msg_len,
+		uint8_t *data, uint16_t block_num) {
+	msg->opcode = htons(TFTP_DATA);
+	*msg_len = sizeof msg->opcode;
+
+	msg->op.data.block_num = htons(block_num);
+	*msg_len += sizeof msg->op.data.block_num;
+
+	memcpy(msg->op.data.stuff, data, *msg_len);
+
+	return 0;
+}
+
+static int tftp_build_msg_ack(struct tftp_msg *msg, size_t *msg_len, uint16_t block_num) {
+	msg->opcode = htons(TFTP_ACK);
+	*msg_len = sizeof msg->opcode;
+
+	msg->op.ack.block_num = htons(block_num);
+	*msg_len += sizeof msg->op.ack.block_num;
+
+	return 0;
+}
+
+static int msg_with_correct_len(struct tftp_msg *msg, size_t msg_len) {
+	size_t field_sz, left_sz;
+	char *tmp;
+
+	left_sz = msg_len;
+
+	field_sz = sizeof msg->opcode;
+	if (left_sz < field_sz) return 0;
+
+	left_sz -= field_sz;
+
+	switch (ntohs(msg->opcode)) {
+	case TFTP_RRQ:
+	case TFTP_WRQ:
+		tmp = &msg->op.cmd.name_and_mode[0];
+		/* filename */
+		do
+			if (left_sz-- == 0) return 0;
+		while (*tmp++ != '\0');
+		/* mode */
+		do
+			if (left_sz-- == 0) return 0;
+		while (*tmp++ != '\0');
+		break;
+	case TFTP_DATA:
+		/* block number */
+		field_sz = sizeof msg->op.data.block_num;
+		if (left_sz < field_sz) return 0;
+		left_sz -= field_sz;
+		/* data */
+		left_sz = 0;
+		break;
+	case TFTP_ACK:
+		/* block number */
+		field_sz = sizeof msg->op.ack.block_num;
+		if (left_sz < field_sz) return 0;
+		left_sz -= field_sz;
+		break;
+	case TFTP_ERROR:
+		/* error code */
+		field_sz = sizeof msg->op.err.error_code;
+		if (left_sz < field_sz) return 0;
+		left_sz -= field_sz;
+		/* error message */
+		tmp = &msg->op.err.error_msg[0];
+		do
+			if (left_sz-- == 0) return 0;
+		while (*tmp++ != '\0');
+		break;
+	default: /* unknown operation */
+		return 0;
+	}
+
+	return !left_sz;
+}
+
+static int tftp_msg_send(struct tftp_msg *msg, size_t msg_len, struct tftp_stream *s) {
+	assert(s);
+	assert(msg);
+	assert(msg_with_correct_len(msg, msg_len)); /* debug msg_with_correct_len */
+
+	if (-1 == sendto(s->sock,
+				(char *)msg,
+				msg_len,
+				0,
+				(struct sockaddr *) &s->rem_addr, s->rem_addrlen)) {
+		log_error("tftp: send() failure");
+		return -errno;
+	}
+
+
+
+	return 0;
+}
+
+static int tftp_msg_recv(struct tftp_msg *msg, size_t *msg_len, struct tftp_stream *s) {
+	ssize_t ret;
+
+	assert(s);
+	assert(msg);
+	assert(msg_len);
+
+	ret = recvfrom(s->sock,
+			(char *) msg,
+			sizeof *msg,
+			0,
+			(struct sockaddr *)&s->rem_addr,
+			&s->rem_addrlen);
+	if (ret == -1) {
+		log_error("tftp: recv() failure");
+		return -errno;
+	}
+
+	*msg_len = ret;
+
+	return 0;
+}
+
+static struct tftp_stream stream;
+
+static int make_remote_addr(const char *hostname,
+		struct sockaddr_storage *out_raddr, socklen_t *out_raddr_len) {
+	int ret;
+	struct sockaddr_in *raddr_in;
+
+	raddr_in = (struct sockaddr_in *)out_raddr;
+	memset(out_raddr, 0, sizeof *out_raddr);
+	raddr_in->sin_family = AF_INET;
+	raddr_in->sin_port = htons(TFTP_TRANSFER_PORT);
+	ret = inet_aton(hostname, &raddr_in->sin_addr);
+	if (!ret) {
+		fprintf(stderr, "Can't parse remote address '%s`\n", hostname);
+		return -EINVAL;
+	}
+
+	*out_raddr_len = sizeof *raddr_in;
+
+	return 0;
+}
+
+int tftp_resend_cmd(struct tftp_stream *s) {
+	if (0 != tftp_msg_send(&s->snd, s->snd_len, s)) {
+		return -1;
+	}
+
+	if (0 != tftp_msg_recv(&s->rcv, &s->rcv_len, s)) {
+		return -2;
+	}
+
+	return 0;
+}
+
+struct tftp_stream *tftp_new_stream(const char *host, const char *file, int dir, bool binary_mode) {
+	struct tftp_stream *s = &stream;
+
+	memset(s, 0, sizeof(*s));
+
+	if (0 != make_remote_addr(host,
+				&s->rem_addr,
+				&s->rem_addrlen)) {
+		goto fail;
+	}
+	if (-1 == (s->sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))) {
+		goto fail;
+	}
+
+	if (dir == TFTP_DIR_PUT) {
+		if (-1 == connect(s->sock,
+				(struct sockaddr *) &s->rem_addr,
+				s->rem_addrlen)) {
+			goto fail;
+		}
+
+
+		if (0 != tftp_build_msg_cmd(&s->snd,
+				&s->snd_len,
+				TFTP_WRQ,
+				file,
+				get_transfer_mode(binary_mode))) {
+			goto fail;
+		}
+
+	} else {
+		if (0 != tftp_build_msg_cmd(&s->snd,
+					&s->snd_len,
+					TFTP_RRQ,
+					file,
+					get_transfer_mode(binary_mode))) {
+			goto fail;
+		}
+	}
+
+	do {
+		if (tftp_resend_cmd(s)) {
+			log_error("ERROR\n");
+			break;
+		}
+	} while (!msg_with_correct_len(&s->rcv, s->rcv_len));
+
+	strncpy(s->filename, file, sizeof(s->filename));
+
+	return s;
+
+fail:
+	if (s->sock >= 0) {
+		close(s->sock);
+	}
+
+	memset(s, 0, sizeof(*s));
+
+	return NULL;
+}
+
+int tftp_delete_stream(struct tftp_stream *s) {
+	if (s == NULL) {
+		return -EINVAL;
+	}
+
+	if (s->sock >= 0) {
+		close(s->sock);
+	}
+
+	memset(s, 0, sizeof(*s));
+
+	return 0;
+}
+
+int tftp_stream_write(struct tftp_stream *s, uint8_t *buf, size_t len) {
+	if (s == NULL) {
+		log_warning("stream is NULL, do nothing");
+		return 0;
+	}
+
+	switch (ntohs(s->rcv.opcode)) {
+		case TFTP_ACK:
+			while (ntohs(s->rcv.op.ack.block_num) != s->pkg_number) {
+				tftp_resend_cmd(s); /* invalid acknowledgement, send again */
+			}
+			break;
+		case TFTP_ERROR:
+			return -s->rcv.op.err.error_code;
+		default:
+			/* error */
+			return 0;
+	}
+
+	/* whether we have more data to transfer? */
+	if ((s->pkg_number != 0) && (s->snd_len != sizeof s->snd)) {
+		/* end of transmission */
+	}
+
+	/* get next stuff of data */
+	if (0 != tftp_build_msg_data(&s->snd, &s->snd_len, buf, ++s->pkg_number)) {
+		goto fail;
+	}
+
+	/* send request / data */
+	if (0 != tftp_msg_send(&s->snd, s->snd_len, s)) {
+		goto fail;
+	}
+
+	return s->snd_len;
+fail:
+	return 0;
+}
+
+int tftp_stream_read(struct tftp_stream *s, uint8_t *buf) {
+	int data_len;
+
+	if (s->transmission_end) {
+		return 0;
+	}
+
+	switch (ntohs(s->rcv.opcode)) {
+		case TFTP_DATA:
+			while (ntohs(s->rcv.op.ack.block_num) != s->pkg_number + 1) {
+				tftp_resend_cmd(s);
+			}
+
+			data_len = s->rcv_len - (sizeof s->rcv - sizeof s->rcv.op.data.stuff);
+			memcpy(buf, s->rcv.op.data.stuff, data_len);
+
+			if (s->rcv_len != sizeof(s->rcv)) {
+				s->transmission_end = true;
+			}
+			break;
+		case TFTP_ERROR:
+			return -s->rcv.op.err.error_code;
+			goto fail;
+		default:
+			goto fail;
+	}
+
+	if (0 != tftp_build_msg_ack(&s->snd, &s->snd_len, ++s->pkg_number)) {
+		goto fail;
+	}
+
+	if (0 != tftp_msg_send(&s->snd, s->snd_len, s)) {
+		goto fail;
+	}
+
+	return data_len;
+fail:
+	return 0;
+}
+
+const char *tftp_error(struct tftp_stream *s) {
+	assert(s);
+
+	return s->rcv.op.err.error_msg;
+}

--- a/src/lib/tftp/tftp.h
+++ b/src/lib/tftp/tftp.h
@@ -1,0 +1,67 @@
+/**
+ * @file tftp.h
+ * @brief Interface for TFTP operations. Based on old version of cmds/net/tftp.c
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @author Nikolay Korotky
+ * @author Ilia Vaprol
+ * @version
+ * @date 18.06.2019
+ */
+
+#ifndef LIB_TFTP_H_
+#define LIB_TFTP_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*
+ * Trivial File Transfer Protocol (IEN-133)
+ */
+#define TFTP_SEGSIZE 512                /* data segment size */
+
+#define TFTP_TRANSFER_PORT 69 /* default well known port */
+
+/*
+ * Packet types.
+ */
+#define TFTP_RRQ     1	/* read request */
+#define TFTP_WRQ     2	/* write request */
+#define TFTP_DATA    3	/* data packet */
+#define TFTP_ACK     4	/* acknowledgement */
+#define TFTP_ERROR   5	/* error code */
+#define TFTP_OACK    6	/* options acknowledgment */
+
+/*
+ * Errors
+ */
+
+/* These initial 7 are passed across the net in "ERROR" packets. */
+#define	TFTP_EUNDEF      0	/* not defined */
+#define	TFTP_ENOTFOUND   1	/* file not found */
+#define	TFTP_EACCESS     2	/* access violation */
+#define	TFTP_ENOSPACE    3	/* disk full or allocation exceeded */
+#define	TFTP_EBADOP      4	/* illegal TFTP operation */
+#define	TFTP_EBADID      5	/* unknown transfer ID */
+#define	TFTP_EEXISTS     6	/* file already exists */
+#define	TFTP_ENOUSER     7	/* no such user */
+/* These extensions are return codes in our API, *never* passed on the net. */
+#define TFTP_TIMEOUT     8	/* operation timed out */
+#define TFTP_NETERR      9	/* some sort of network error */
+#define TFTP_INVALID    10	/* invalid parameter */
+#define TFTP_PROTOCOL   11	/* protocol violation */
+#define TFTP_TOOLARGE   12	/* file is larger than buffer */
+
+#define TFTP_DIR_PUT 0x1
+#define TFTP_DIR_GET 0x2
+
+struct tftp_stream;
+
+extern struct tftp_stream *tftp_new_stream(const char *host, const char *file, int dir, bool binary_mode);
+extern int tftp_delete_stream(struct tftp_stream *s);
+
+extern int tftp_stream_write(struct tftp_stream *s, uint8_t *buf, size_t len);
+extern int tftp_stream_read(struct tftp_stream *s, uint8_t *buf);
+
+extern const char *tftp_error(struct tftp_stream *s);
+
+#endif /* LIB_TFTP_H_ */

--- a/templates/arm/stm32f7cube/mods.config
+++ b/templates/arm/stm32f7cube/mods.config
@@ -45,6 +45,8 @@ configuration conf {
 	include embox.net.sock_noxattr
 	include embox.net.tcp
 	include embox.net.tcp_sock
+	include embox.net.udp
+	include embox.net.udp_sock
 	include embox.kernel.sched.sched
 	include embox.kernel.sched.idle_light
 	//include embox.kernel.thread.signal_stub
@@ -62,6 +64,10 @@ configuration conf {
 	//include embox.init.setup_tty_diag
 	@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
 
+	include embox.cmd.mem
+	include embox.cmd.goto
+	include embox.cmd.net.tftp
+	include embox.cmd.qspi_loader
 	include embox.cmd.service
 	include embox.cmd.fs.ls
 	include embox.cmd.net.ifconfig


### PR DESCRIPTION
* Move tftp protocol stuff to lib/tftp
* Rework `tftp` command:
  * Add flag for saving files directly to memory
  * Fix bug with getting files: now don't wait data from port 69
  * Add more examples
  * Minor refactor
* Add `qspi_loader` to write data to stm32f7qspi via tftp protocol