### PR TITLE
Simplify vmem & mmu subsystems

### DIFF
--- a/platform/etnaviv/cmds/quad_tex/quad_tex.c
+++ b/platform/etnaviv/cmds/quad_tex/quad_tex.c
@@ -1,13 +1,13 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/mman.h>
 
 #include <drivers/video/fb.h>
 #include <drivers/video/fb_overlay.h>
 #include <lib/fps.h>
 #include <kernel/time/ktime.h>
 #include <mem/vmem.h>
-#include <unistd.h>
 
 #define MAX_QUADS 1024
 #define EPS 0.001
@@ -418,12 +418,12 @@ static void draw(struct program *p) {
 				vmem_set_flags(vmem_current_context(),
 						(mmu_vaddr_t) sw_base[0],
 						p->frame_width * p->frame_height * 2,
-						VMEM_PAGE_WRITABLE);
+						PROT_WRITE | PROT_READ | PROT_NOCACHE);
 
 				vmem_set_flags(vmem_current_context(),
 						(mmu_vaddr_t) sw_base[1],
 						p->frame_width * p->frame_height * 2,
-						VMEM_PAGE_WRITABLE);
+						PROT_WRITE | PROT_READ | PROT_NOCACHE);
 
 				fps_set_base_frame(mesa_fbi, sw_base[0]);
 				fps_set_back_frame(mesa_fbi, sw_base[1]);

--- a/platform/etnaviv/templates/imx6/mods.config
+++ b/platform/etnaviv/templates/imx6/mods.config
@@ -17,7 +17,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.kernel.thread.core(thread_stack_size=0x300000)
 

--- a/platform/mesa/templates/integratorcp/mods.config
+++ b/platform/mesa/templates/integratorcp/mods.config
@@ -8,7 +8,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.libarch
 	@Runlevel(0) include embox.arch.arm.vfork
 
-	include embox.mem.vmem_nommu
+	//include embox.mem.vmem_nommu
 
 	include embox.lib.debug.whereami
 

--- a/platform/mesa/templates/mesa_imx6/mods.config
+++ b/platform/mesa/templates/mesa_imx6/mods.config
@@ -17,7 +17,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.kernel.thread.core(thread_stack_size=0x300000)
 

--- a/platform/nuklear/templates/arm_qemu/mods.config
+++ b/platform/nuklear/templates/arm_qemu/mods.config
@@ -8,7 +8,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.libarch
 	@Runlevel(0) include embox.arch.arm.vfork
 
-	include embox.mem.vmem_nommu
+	//include embox.mem.vmem_nommu
 
 	include embox.lib.debug.whereami
 

--- a/platform/pjsip/templates/arm-qemu/mods.config
+++ b/platform/pjsip/templates/arm-qemu/mods.config
@@ -13,7 +13,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(
 				domain_access=1,v5_format=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.mem.bitmask(page_size=0x1000)
 	@Runlevel(2) include embox.mem.static_heap(heap_size=0x1000000)

--- a/platform/pjsip/templates/x86-qemu/mods.config
+++ b/platform/pjsip/templates/x86-qemu/mods.config
@@ -6,7 +6,7 @@ configuration conf {
 	include embox.arch.x86.kernel.context
 	include embox.arch.x86.kernel.interrupt
 
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.mem.phymem
 
 	include embox.arch.x86.mmu

--- a/platform/quake3/templates/qemu/mods.config
+++ b/platform/quake3/templates/qemu/mods.config
@@ -1,7 +1,7 @@
 package genconfig
 
 configuration conf {
-	@Runlevel(1) include embox.mem.vmem
+	//@Runlevel(1) include embox.mem.vmem
 	@Runlevel(2) include embox.arch.x86.boot.multiboot(video_mode_set=1, video_width=800, video_height=600, video_depth=32)
 	@Runlevel(2) include embox.arch.x86.kernel.arch
 	@Runlevel(2) include embox.arch.x86.kernel.locore

--- a/src/arch/arm/mmu/Mybuild
+++ b/src/arch/arm/mmu/Mybuild
@@ -1,6 +1,6 @@
 package embox.arch.arm
 
-module mmu_section extends embox.arch.mmu {
+module mmu_section extends embox.mem.vmem {
 	option number page_size=0x100000
 	option number domain_access=3
 	option number log_level = 0
@@ -11,10 +11,13 @@ module mmu_section extends embox.arch.mmu {
 	source "mmu_common.c"
 
 	source "mmu_section.c"
+
+	depends embox.mem.vmem_header
 	depends embox.mem.vmem_alloc_pool
+	depends embox.mem.vmem_depends
 }
 
-module mmu_small_page extends embox.arch.mmu {
+module mmu_small_page extends embox.mem.vmem {
 	option number page_size=4096
 	option number domain_access=3
 	option number log_level = 0
@@ -29,6 +32,7 @@ module mmu_small_page extends embox.arch.mmu {
 
 	depends embox.mem.vmem_header
 	depends embox.mem.vmem_alloc_pool
+	depends embox.mem.vmem_depends
 }
 
 module mmuinfo extends embox.arch.mmuinfo {

--- a/src/arch/arm/mmu/mmu_common.c
+++ b/src/arch/arm/mmu/mmu_common.c
@@ -20,7 +20,7 @@
 #include <framework/mod/options.h>
 #include <kernel/printk.h>
 
-EMBOX_UNIT_INIT(mmu_init);
+//EMBOX_UNIT_INIT(mmu_init);
 
 #define DOMAIN_ACCESS OPTION_GET(NUMBER, domain_access)
 #define CTX_NUMBER    32 /* TODO: make it related to number of tasks */
@@ -71,6 +71,7 @@ void _print_mmu_regs(void);
 * @note Set flag CR_M at c1, the control register
 */
 void mmu_on(void) {
+	mmu_init();
 #ifndef NOMMU
 	__asm__ __volatile__ (
 		"mrc p15, 0, r0, c1, c0, 0\n\t"

--- a/src/arch/arm/mmu/mmu_section.c
+++ b/src/arch/arm/mmu/mmu_section.c
@@ -7,6 +7,8 @@
  */
 
 #include <string.h>
+#include <sys/mman.h>
+
 #include <asm/hal/mmu.h>
 #include <hal/mmu.h>
 #include <mem/vmem.h>
@@ -61,20 +63,26 @@ int mmu_pte_present(mmu_pte_t *pte) {
 
 void mmu_pte_set_writable(mmu_pte_t *pte, int value) {
 #if 0	
-	if (value & VMEM_PAGE_WRITABLE)
+	if (value & PROT_WRITE)
 		*pte |= ARM_MMU_SECTION_WRITE_ACC;
 #endif
 }
 
 void mmu_pte_set_cacheable(mmu_pte_t *pte, int value) {
-	if (value & VMEM_PAGE_CACHEABLE)
-		*pte |= 0x08; /* ARM_MMU_SECTION_C */
+	if (value & PROT_NOCACHE) {
+		*pte &= ~L1D_C; /* ARM_MMU_SECTION_C */
+	} else {
+		*pte |= L1D_C; /* ARM_MMU_SECTION_C */
+	}
 }
 
 void mmu_pte_set_usermode(mmu_pte_t *pte, int value) {
 }
 
 void mmu_pte_set_executable(mmu_pte_t *pte, int value) {
-	if (!(value & VMEM_PAGE_EXECUTABLE))
-		*pte |= 0x10; /* ARM_MMU_SECTION_XN */
+	if (value & PROT_EXEC) {
+		*pte &= ~L1D_XN; /* ARM_MMU_SECTION_XN */
+	} else {
+		*pte |= L1D_XN; /* ARM_MMU_SECTION_XN */
+	}
 }

--- a/src/arch/generic/Mybuild
+++ b/src/arch/generic/Mybuild
@@ -8,7 +8,7 @@ module syscall_stub extends embox.arch.syscall {
 	source "syscall_stub.h"
 }
 
-module nommu extends embox.arch.mmu {
+module nommu extends embox.mem.vmem_nommu {
 	option number page_size=4
 	source "nommu.h"
 }

--- a/src/arch/microblaze/mmu/Mybuild
+++ b/src/arch/microblaze/mmu/Mybuild
@@ -1,7 +1,9 @@
 package embox.arch.microblaze
 
-module mmu extends embox.arch.mmu {
+module mmu extends embox.mem.vmem {
 	source "mmu_core.c"
 	source "mmu.c"
 	source "mmu.h"
+
+	depends embox.mem.vmem_depends	
 }

--- a/src/arch/microblaze/mmu/mmu.c
+++ b/src/arch/microblaze/mmu/mmu.c
@@ -6,6 +6,7 @@
  * @author Anton Bulychev
  */
 #include <stdint.h>
+#include <sys/mman.h>
 
 #include <hal/mmu.h>
 
@@ -88,10 +89,10 @@ void mmu_pte_set_usermode(uintptr_t *pte, int val) {
 }
 
 void mmu_pte_set_cacheable(uintptr_t *pte, int val) {
-	if (val) {
-		mmu_set_val(pte, *pte | MMU_PAGE_CACHEABLE);
-	} else {
+	if (val & PROT_NOCACHE) {
 		mmu_set_val(pte, *pte & (~MMU_PAGE_CACHEABLE));
+	} else {
+		mmu_set_val(pte, *pte | MMU_PAGE_CACHEABLE);
 	}
 }
 

--- a/src/arch/ppc/mmu/Mybuild
+++ b/src/arch/ppc/mmu/Mybuild
@@ -1,6 +1,8 @@
 package embox.arch.ppc
 
-module mmu extends embox.arch.mmu {
+module mmu extends embox.mem.vmem {
 	option number page_size=4096
 	source "mmu.c", "mmu.h"
+
+	depends embox.mem.vmem_depends
 }

--- a/src/arch/sparc/mmu/Mybuild
+++ b/src/arch/sparc/mmu/Mybuild
@@ -1,6 +1,6 @@
 package embox.arch.sparc
 
-module mmu extends embox.arch.mmu {
+module mmu extends embox.mem.vmem {
 	option number log_level = 0
 
 	option number page_size=4096
@@ -8,5 +8,5 @@ module mmu extends embox.arch.mmu {
 
 	source "mmu.c", "mmu.h"
 
-	//depends embox.arch.sparc.testtrap // used to define page fault handler
+	depends embox.mem.vmem_depends
 }

--- a/src/arch/sparc/mmu/mmu.c
+++ b/src/arch/sparc/mmu/mmu.c
@@ -168,10 +168,10 @@ void mmu_pte_set_writable(uintptr_t *pte, int value){
 }
 
 void mmu_pte_set_cacheable(uintptr_t *pte, int value) {
-	if (value) {
-		*pte = *pte | MMU_PAGE_CACHEABLE;
-	} else {
+	if (value & PROT_NOCACHE) {
 		*pte = *pte & (~MMU_PAGE_CACHEABLE);
+	} else {
+		*pte = *pte | MMU_PAGE_CACHEABLE;
 	}
 }
 

--- a/src/arch/x86/mmu/Mybuild
+++ b/src/arch/x86/mmu/Mybuild
@@ -1,10 +1,12 @@
 package embox.arch.x86
 
-module mmu extends embox.arch.mmu {
+module mmu extends embox.mem.vmem {
 	option number log_level=0
 
 	option number page_size=4096
 
 	source "mmu.c", "mmu.h"
+
+	depends embox.mem.vmem_depends
 	depends embox.arch.x86.testtrap
 }

--- a/src/arch/x86/mmu/mmu.c
+++ b/src/arch/x86/mmu/mmu.c
@@ -179,10 +179,10 @@ void mmu_pte_set_usermode(uintptr_t *pte, int val) {
 }
 
 void mmu_pte_set_cacheable(uintptr_t *pte, int val) {
-	if (val) {
-		*pte = *pte & (~MMU_PAGE_DISABLE_CACHE);
-	} else {
+	if (val & PROT_NOCACHE) {
 		*pte = *pte | MMU_PAGE_DISABLE_CACHE;
+	} else {
+		*pte = *pte & (~MMU_PAGE_DISABLE_CACHE);
 	}
 }
 

--- a/src/cmds/hardware/memmap/Memmap.my
+++ b/src/cmds/hardware/memmap/Memmap.my
@@ -26,5 +26,5 @@ module memmap {
 
 	depends embox.mem.marea_header
 	depends embox.mem.mmap_header
-	depends embox.mem.vmem_api
+	depends embox.arch.mmu
 }

--- a/src/cmds/hardware/memmap/memmap.c
+++ b/src/cmds/hardware/memmap/memmap.c
@@ -47,7 +47,7 @@ static void show_vmem_translation(void) {
 
 	dlist_foreach_entry(marea, &emmap->marea_list, mmap_link) {
 		printf("map region (base 0x%" PRIxPTR " size %zu flags 0x%" PRIx32 ")\n",
-				marea->start, marea->size, prot_to_vmem_flags(marea->flags));
+				marea->start, marea->size, marea->flags);
 		for (voff = 0; voff < marea->size; voff += MMU_PAGE_SIZE) {
 			paddr = vmem_translate(emmap->ctx, marea->start + voff);
 			printf("0x%16x -> 0x%16x \n", marea->start + voff, paddr);

--- a/src/cmds/mem/Infomem.my
+++ b/src/cmds/mem/Infomem.my
@@ -33,7 +33,6 @@ module infomem {
 	@NoRuntime depends embox.compat.libc.stdio.printf
 	depends embox.compat.posix.util.getopt
 	depends embox.mem.phymem
-	depends embox.mem.vmem_alloc
-	depends embox.mem.vmem_api
+
 	depends embox.driver.periph_memory
 }

--- a/src/cmds/mem/infomem.c
+++ b/src/cmds/mem/infomem.c
@@ -18,23 +18,20 @@
 static void print_vmem(struct page_allocator *pgd_allocator,
 		struct page_allocator *pmd_allocator,
 		struct page_allocator *pte_allocator) {
-	int is_on_vmem = vmem_mmu_enabled();
 
 	printf("\nVIRTUAL MEMORY:\n");
-	printf("vmem is %s\n", is_on_vmem ? "ON" : "OFF");
 
-	if (is_on_vmem) {
-		printf("PGD tables count / free - %zu / %zu\n", pgd_allocator->pages_n,
-					pgd_allocator->free / pgd_allocator->page_size);
-		printf("PMD tables count / free - %zu / %zu\n", pmd_allocator->pages_n,
-					pmd_allocator->free / pmd_allocator->page_size);
-		if (pte_allocator) {
-			printf("PTE tables count / free - %zu / %zu\n", pte_allocator->pages_n,
-					pte_allocator->free / pte_allocator->page_size);
-		} else {
-			printf("PTE do not available in this configuration\n");
-		}
+	printf("PGD tables count / free - %zu / %zu\n", pgd_allocator->pages_n,
+				pgd_allocator->free / pgd_allocator->page_size);
+	printf("PMD tables count / free - %zu / %zu\n", pmd_allocator->pages_n,
+				pmd_allocator->free / pmd_allocator->page_size);
+	if (pte_allocator) {
+		printf("PTE tables count / free - %zu / %zu\n", pte_allocator->pages_n,
+				pte_allocator->free / pte_allocator->page_size);
+	} else {
+		printf("PTE do not available in this configuration\n");
 	}
+
 	printf("-----------------------------------------\n");
 }
 

--- a/src/cmds/testing/memtest/memtest.c
+++ b/src/cmds/testing/memtest/memtest.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
 	int seconds;
 	int repeat = 0;
 	bool do_heap_test = false;
-	vmem_page_flags_t flags;
+	int flags;
 
 	struct timespec time_post;
 	struct timespec time_pre;
@@ -218,10 +218,10 @@ int main(int argc, char **argv) {
 
 	if (nocache) {
 		printf("Mark memory as non-cacheable\n");
-		flags = VMEM_PAGE_WRITABLE;
+		flags = PROT_WRITE | PROT_READ | PROT_NOCACHE;
 	} else {
 		printf("Mark memory as cacheable\n");
-		flags = VMEM_PAGE_WRITABLE | VMEM_PAGE_CACHEABLE;
+		flags = PROT_WRITE | PROT_READ;
 	}
 
 	if ((err = vmem_set_flags(vmem_current_context(),

--- a/src/compat/linux/include/asm-generic/dma-mapping.h
+++ b/src/compat/linux/include/asm-generic/dma-mapping.h
@@ -11,8 +11,9 @@
 
 #include <linux/types.h>
 #include <sys/types.h>
-
+#include <sys/mman.h>
 #include <assert.h>
+
 #include <mem/sysmalloc.h>
 #include <mem/vmem.h>
 
@@ -25,7 +26,7 @@ static inline void *dma_alloc_coherent(struct device *dev, size_t size,
 		dma_addr_t *handle, gfp_t flag) {
 	void *mem = sysmalloc(size);
 	mmu_ctx_t ctx = vmem_current_context();
-	vmem_page_flags_t flags = VMEM_PAGE_WRITABLE;
+	int flags = PROT_WRITE | PROT_READ /*| PROT_NOCACHE */;
 
 	vmem_set_flags(ctx, (mmu_vaddr_t) mem, size, flags);
 

--- a/src/compat/posix/sys/mman/Mybuild
+++ b/src/compat/posix/sys/mman/Mybuild
@@ -25,7 +25,6 @@ module mmap extends mmap_api {
 	depends embox.mem.mmap
 	depends embox.mem.phymem
 	depends embox.kernel.task.resource.phymem
-	depends embox.mem.vmem_api
 }
 
 module mmap_stub extends mmap_api {

--- a/src/compat/posix/sys/mman/mmap.c
+++ b/src/compat/posix/sys/mman/mmap.c
@@ -58,7 +58,7 @@ void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
 					(mmu_paddr_t) phy,
 					(mmu_vaddr_t) virt,
 					len,
-					prot_to_vmem_flags(prot));
+					prot);
 		}
 	} else {
 		assert(fd > 0);
@@ -74,7 +74,7 @@ void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
 	if ((err = vmem_set_flags(emmap->ctx,
 					(mmu_vaddr_t) virt,
 					len,
-					prot_to_vmem_flags(prot)))) {
+					prot))) {
 		log_error("Failed to set memory attributes for mmap()");
 		return MAP_FAILED;
 	}

--- a/src/drivers/cache/pl310/pl310.c
+++ b/src/drivers/cache/pl310/pl310.c
@@ -67,15 +67,7 @@ static void _reg_dump(char *s) {
 	log_debug("=====================================\n");
 }
 
-#define BUF_SZ (16 * 1024 * 1024)
-
-uint8_t _test_buf[BUF_SZ];
-
-extern int32_t vmem_info(uint32_t vaddr);
-
 static int pl310_init(void) {
-	memset(_test_buf, 0, BUF_SZ);
-
 	REG_STORE(L2X0_CTRL, 0);
 
 	REG_ORIN(L2X0_AUX_CTRL, L2X0_AUX_INSTR_PREFETCH);

--- a/src/drivers/cache/pl310/pl310.c
+++ b/src/drivers/cache/pl310/pl310.c
@@ -72,8 +72,6 @@ static void _reg_dump(char *s) {
 uint8_t _test_buf[BUF_SZ];
 
 extern int32_t vmem_info(uint32_t vaddr);
-extern void vmem_on(void);
-extern void vmem_off(void);
 
 static int pl310_init(void) {
 	memset(_test_buf, 0, BUF_SZ);

--- a/src/drivers/console/vc/Mybuild
+++ b/src/drivers/console/vc/Mybuild
@@ -7,7 +7,7 @@ module vga extends embox.driver.diag.diag_api {
 	source "vc_vga.h"
 
 	depends embox.driver.tty.vterm_video
-	depends embox.mem.vmem_api
+	depends embox.compat.posix.sys.mman.mmap_api
 }
 
 module vc {

--- a/src/drivers/gpmc/omap_gpmc.c
+++ b/src/drivers/gpmc/omap_gpmc.c
@@ -9,6 +9,7 @@
 #include <util/log.h>
 
 #include <errno.h>
+#include <sys/mman.h>
 
 #include <drivers/common/memory.h>
 
@@ -67,7 +68,7 @@ static int gpmc_cs_enable_mem(int cs, uint32_t base, uint32_t size) {
 	gpmc_cs_reg_write(cs, GPMC_CS_CONFIG7, l);
 
 #ifndef NOMMU
-	vmem_map_region(vmem_current_context(), base, base, size, VMEM_PAGE_WRITABLE);
+	vmem_map_region(vmem_current_context(), base, base, size, PROT_WRITE | PROT_READ | PROT_NOCACHE);
 #endif
 
 	return 0;

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_cmdbuf.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_cmdbuf.c
@@ -15,6 +15,8 @@
  */
 
 #include <stdio.h>
+#include <sys/mman.h>
+
 #include <kernel/thread/sync/mutex.h>
 #include <util/binalign.h>
 #include <util/bitmap.h>
@@ -69,7 +71,7 @@ etnaviv_cmdbuf_suballoc_new(struct etnaviv_gpu * gpu) {
 	if (vmem_set_flags(vmem_current_context(),
 					(mmu_vaddr_t) suballoc->addr,
 					SUBALLOC_SIZE,
-					VMEM_PAGE_WRITABLE)) {
+					PROT_WRITE | PROT_READ | PROT_NOCACHE)) {
 		log_error("Failed to set vmem flags");
 		goto free_dma;
 	}

--- a/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
+++ b/src/drivers/gpu/drm/etnaviv/etnaviv_dev.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <sys/mman.h>
 
 #include <util/err.h>
 
@@ -257,7 +258,7 @@ static struct idesc *etnaviv_dev_open(struct dev_module *cdev, void *priv) {
 	if ((err = vmem_set_flags(vmem_current_context(),
 					(mmu_vaddr_t) etnaviv_uncached_buffer,
 					sizeof(etnaviv_uncached_buffer),
-					VMEM_PAGE_WRITABLE))) {
+					PROT_WRITE | PROT_READ | PROT_NOCACHE))) {
 		log_error("Failed to set page attributes! Error %d", err);
 
 		return NULL;

--- a/src/kernel/task/resource/mmap/Mybuild
+++ b/src/kernel/task/resource/mmap/Mybuild
@@ -7,7 +7,7 @@ module mmap_full extends mmap {
 	source "mmap.c"
 
 	depends embox.kernel.task.task_resource
-	@NoRuntime depends embox.mem.vmem_api
+	@NoRuntime depends embox.arch.mmu
 	@NoRuntime depends embox.mem.mmap
 	@NoRuntime depends embox.mem.marea
 	@NoRuntime depends embox.mem.marea_header
@@ -18,6 +18,6 @@ module mmap_trivial extends mmap {
 	source "mmap_trivial.c"
 
 	depends embox.mem.mmap_header
-	@NoRuntime depends embox.mem.vmem_api
+	@NoRuntime depends embox.arch.mmu
 	depends embox.kernel.task.task_resource
 }

--- a/src/kernel/task/resource/mmap/mmap.c
+++ b/src/kernel/task/resource/mmap/mmap.c
@@ -45,7 +45,7 @@ static int mmap_inherit(struct emmap *mmap, struct emmap *p_mmap) {
 				vmem_translate(p_mmap->ctx, marea->start),
 				marea->start,
 				marea->size,
-				prot_to_vmem_flags(marea->flags)))) {
+				marea->flags))) {
 				return err;
 		}
 	}

--- a/src/kernel/thread/stack_protect.c
+++ b/src/kernel/thread/stack_protect.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stddef.h>
+#include <sys/mman.h>
 
 #include <kernel/thread.h>
 #include <kernel/thread/stack_protect.h>
@@ -21,7 +22,7 @@ void stack_protect(struct thread *t, size_t size)
     mmu_set_context(ctx);
 
     vmem_unmap_region(ctx, (mmu_vaddr_t)t, size);
-    vmem_map_region(ctx, (mmu_vaddr_t)t, (mmu_vaddr_t)t, size, VMEM_PAGE_WRITABLE | VMEM_PAGE_USERMODE);
+    vmem_map_region(ctx, (mmu_vaddr_t)t, (mmu_vaddr_t)t, size, PROT_WRITE | PROT_READ | PROT_NOCACHE | VMEM_PAGE_USERMODE);
 
     vmem_set_flags(ctx, (mmu_vaddr_t)t + VMEM_PAGE_SIZE, size , 0);
     mmu_flush_tlb();
@@ -35,7 +36,7 @@ void stack_protect_release(struct thread *t)
 
     ctx = vmem_current_context();
     mmu_set_context(ctx);
-    vmem_set_flags(ctx, (mmu_vaddr_t)t + VMEM_PAGE_SIZE, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE | VMEM_PAGE_USERMODE);
+    vmem_set_flags(ctx, (mmu_vaddr_t)t + VMEM_PAGE_SIZE, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ | PROT_NOCACHE | VMEM_PAGE_USERMODE);
     mmu_flush_tlb();
 }
 

--- a/src/lib/exec/exec.c
+++ b/src/lib/exec/exec.c
@@ -176,7 +176,7 @@ static int load_interp(char *filename, exec_t *exec) {
 
 	mmap_place(task_self_resource_mmap(), base_addr, size, 0);
 	vmem_map_region(vmem_current_context(), base_addr, base_addr, size,
-				VMEM_PAGE_WRITABLE | VMEM_PAGE_EXECUTABLE | VMEM_PAGE_USERMODE);
+			PROT_WRITE | PROT_READ | PROT_EXEC | VMEM_PAGE_USERMODE);
 
 	for (int i = 0; i < header.e_phnum; i++) {
 		ph = &ph_table[i];
@@ -270,7 +270,7 @@ static int load_exec(const char *filename, exec_t *exec) {
 				(mmu_paddr_t) paddr,
 				ph->p_vaddr,
 				size,
-				VMEM_PAGE_WRITABLE | VMEM_PAGE_EXECUTABLE | VMEM_PAGE_USERMODE);
+				PROT_WRITE | PROT_READ | PROT_EXEC | VMEM_PAGE_USERMODE);
 
 		/* XXX brk is a max of ph's right sides. It unaligned now! */
 		mmap_set_brk(task_self_resource_mmap(),
@@ -305,7 +305,7 @@ uint32_t mmap_create_stack(struct emmap *mmap) {
 	uintptr_t base = mmap_alloc(mmap, size);
 	mmap_place(task_self_resource_mmap(), base, size, 0);
 	vmem_map_region(mmap->ctx, base, base, size,
-				VMEM_PAGE_WRITABLE | VMEM_PAGE_EXECUTABLE | VMEM_PAGE_USERMODE);
+			PROT_WRITE | PROT_READ | PROT_EXEC | VMEM_PAGE_USERMODE);
 	return base + size;
 }
 

--- a/src/mem/marea/marea.c
+++ b/src/mem/marea/marea.c
@@ -16,7 +16,7 @@
 
 POOL_DEF(marea_pool, struct marea, MAREA_NUM);
 
-struct marea *marea_alloc(uintptr_t start, size_t size, uint32_t flags) {
+struct marea *marea_alloc(uintptr_t start, size_t size, int flags) {
 	struct marea *marea;
 
 	if (!(marea = pool_alloc(&marea_pool))) {

--- a/src/mem/marea/marea.h
+++ b/src/mem/marea/marea.h
@@ -14,12 +14,12 @@
 struct marea {
 	uintptr_t start;
 	size_t size;
-	uint32_t flags;
+	int flags;
 
 	struct dlist_head mmap_link;
 };
 
-extern struct marea *marea_alloc(uintptr_t start, size_t size, uint32_t flags);
+extern struct marea *marea_alloc(uintptr_t start, size_t size, int flags);
 extern void marea_free(struct marea *marea);
 
 #endif /* MAREA_H_ */

--- a/src/mem/mmap/Mybuild
+++ b/src/mem/mmap/Mybuild
@@ -11,4 +11,5 @@ module mmap {
 	depends marea
 	depends mmap_header
 	depends embox.kernel.task.resource.mmap
+	depends embox.mem.vmem_depends
 }

--- a/src/mem/mmap/mmap.c
+++ b/src/mem/mmap/mmap.c
@@ -46,7 +46,7 @@ static int mmap_check_marea(struct emmap *mmap, struct marea *marea) {
 	return 0;
 }
 
-int mmap_place(struct emmap *mmap, uintptr_t start, size_t size, uint32_t flags) {
+int mmap_place(struct emmap *mmap, uintptr_t start, size_t size, int flags) {
 	struct marea *marea;
 
 	assert(mmap);

--- a/src/mem/mmap/mmap.h
+++ b/src/mem/mmap/mmap.h
@@ -29,7 +29,7 @@ struct emmap {
 	struct dlist_head page_list;
 };
 
-extern int mmap_place(struct emmap *mmap, uintptr_t start, size_t size, uint32_t flags);
+extern int mmap_place(struct emmap *mmap, uintptr_t start, size_t size, int flags);
 extern int mmap_release(struct emmap *mmap, uintptr_t addr);
 extern uintptr_t mmap_alloc(struct emmap *mmap, size_t size);
 extern int mmap_prot(struct emmap *mmap, uintptr_t addr);

--- a/src/mem/vmem/Mybuild
+++ b/src/mem/vmem/Mybuild
@@ -5,25 +5,22 @@ module vmem_header {
 	source "vmem.h"
 }
 
-@DefaultImpl(vmem_nommu)
-abstract module vmem_api {
-}
-
-module vmem_nommu extends vmem_api {
+module vmem_nommu extends embox.arch.mmu {
 	@IncludeExport(path="mem",target_name="vmem.h")
 	source "vmem_nommu.h"
 }
 
-module vmem extends vmem_api {
+module vmem extends embox.arch.mmu {
 	option number log_level = 1
 
 	source "vmem.c"
 	source "mapper.c"
 	source "vmem_context.c"
+}
 
+module vmem_depends {
 	depends embox.mem.vmem_alloc
 	depends embox.mem.page_api
-	depends embox.arch.mmu
 
 	depends embox.mem.mmap_header
 	depends embox.mem.mmap

--- a/src/mem/vmem/vmem.c
+++ b/src/mem/vmem/vmem.c
@@ -26,25 +26,9 @@
 #include <util/binalign.h>
 #include <util/math.h>
 
-static int mmu_enabled;
-
 /* Section pointers. */
 extern char _text_vma, _rodata_vma, _data_vma, _bss_vma;
 extern char _text_len, _rodata_len, _data_len, _bss_len_with_reserve;
-
-void vmem_on(void) {
-	mmu_on();
-	mmu_enabled = 1;
-}
-
-void vmem_off(void) {
-	mmu_off();
-	mmu_enabled = 0;
-}
-
-int vmem_mmu_enabled(void) {
-	return mmu_enabled;
-}
 
 int vmem_map_kernel(void) {
 	int err = 0;
@@ -107,7 +91,7 @@ static int vmem_init(void) {
 	emmap = task_resource_mmap(task_kernel_task());
 	mmu_set_context(emmap->ctx);
 
-	vmem_on();
+	mmu_on();
 
 	return 0;
 }

--- a/src/mem/vmem/vmem.c
+++ b/src/mem/vmem/vmem.c
@@ -93,12 +93,12 @@ static int vmem_init(void) {
 		emmap = task_resource_mmap(task);
 		dlist_foreach_entry(marea, &emmap->marea_list, mmap_link) {
 			log_debug("map region (base 0x%" PRIxPTR " size %zu flags 0x%" PRIx32 ")",
-					marea->start, marea->size, prot_to_vmem_flags(marea->flags));
+					marea->start, marea->size, marea->flags);
 			if (vmem_map_region(emmap->ctx,
 					marea->start,
 					marea->start,
 					marea->size,
-					prot_to_vmem_flags(marea->flags))) {
+					marea->flags)) {
 				panic("Failed to initialize kernel memory mapping");
 			}
 		}

--- a/src/mem/vmem/vmem.h
+++ b/src/mem/vmem/vmem.h
@@ -16,27 +16,7 @@
 #define VMEM_PAGE_SIZE        MMU_PAGE_SIZE
 #define VMEM_PAGE_MASK        MMU_PAGE_MASK
 
-#define VMEM_PAGE_WRITABLE    (1 << 0)
-#define VMEM_PAGE_CACHEABLE   (1 << 1)
-#define VMEM_PAGE_USERMODE    (1 << 2)
-/* Used on sparc LEON3 */
-#define VMEM_PAGE_EXECUTABLE  (1 << 3)
-
-typedef uint32_t vmem_page_flags_t;
-
-static inline vmem_page_flags_t prot_to_vmem_flags(uint32_t flags) {
-	vmem_page_flags_t vmem_page_flags = 0;
-	if (flags & PROT_WRITE) {
-		vmem_page_flags |= VMEM_PAGE_WRITABLE;
-	}
-	if (flags & PROT_EXEC) {
-		vmem_page_flags |= VMEM_PAGE_EXECUTABLE;
-	}
-	if (!(flags & PROT_NOCACHE)) {
-		vmem_page_flags |= VMEM_PAGE_CACHEABLE;
-	}
-	return vmem_page_flags;
-}
+#define VMEM_PAGE_USERMODE    (1 << 6)
 
 extern int vmem_create_context(mmu_ctx_t *ctx);
 extern mmu_ctx_t vmem_current_context(void);
@@ -45,11 +25,11 @@ extern void vmem_free_context(mmu_ctx_t ctx);
 extern mmu_paddr_t vmem_translate(mmu_ctx_t ctx, mmu_vaddr_t virt_addr);
 
 extern int vmem_map_region(mmu_ctx_t ctx, mmu_paddr_t phy_addr, mmu_vaddr_t virt_addr,
-		size_t reg_size, vmem_page_flags_t flags);
+		size_t reg_size, int flags);
 
 extern void vmem_unmap_region(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, size_t reg_size);
 
-extern int vmem_set_flags(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, ssize_t len, vmem_page_flags_t flags);
+extern int vmem_set_flags(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, ssize_t len, int flags);
 
 extern void vmem_on(void);
 extern void vmem_off(void);

--- a/src/mem/vmem/vmem.h
+++ b/src/mem/vmem/vmem.h
@@ -31,10 +31,6 @@ extern void vmem_unmap_region(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, size_t reg_s
 
 extern int vmem_set_flags(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, ssize_t len, int flags);
 
-extern void vmem_on(void);
-extern void vmem_off(void);
-extern int vmem_mmu_enabled(void);
-
 #define MMU_LAST_LEVEL (MMU_LEVELS - 1)
 
 #ifndef __MMU_SHIFT_1

--- a/src/mem/vmem/vmem_device_memory/vmem_device_memory.c
+++ b/src/mem/vmem/vmem_device_memory/vmem_device_memory.c
@@ -42,13 +42,11 @@ void *mmap_device_memory(void *addr,
 		return NULL;
 	}
 
-	if (vmem_mmu_enabled()) {
-		vmem_map_region(vmem_current_context(),
+	vmem_map_region(vmem_current_context(),
 				start,
 				start,
 				len,
 				prot);
-	}
 
 	return addr;
 }

--- a/src/mem/vmem/vmem_device_memory/vmem_device_memory.c
+++ b/src/mem/vmem/vmem_device_memory/vmem_device_memory.c
@@ -47,7 +47,7 @@ void *mmap_device_memory(void *addr,
 				start,
 				start,
 				len,
-				prot_to_vmem_flags(prot));
+				prot);
 	}
 
 	return addr;

--- a/src/mem/vmem/vmem_nommu.h
+++ b/src/mem/vmem/vmem_nommu.h
@@ -16,8 +16,6 @@
 
 #define VMEM_PAGE_USERMODE    (1 << 6)
 
-#define vmem_mmu_enabled() 0
-
 static inline int vmem_create_context(mmu_ctx_t *ctx) {
 	(void)ctx;
 	return 0;

--- a/src/mem/vmem/vmem_nommu.h
+++ b/src/mem/vmem/vmem_nommu.h
@@ -9,30 +9,12 @@
 #ifndef VMEM_NOMMU_H
 #define VMEM_NOMMU_H
 
+#include <stdint.h>
+
 #include <hal/mmu.h>
 #include <sys/mman.h>
 
-#define VMEM_PAGE_WRITABLE    (1 << 0)
-#define VMEM_PAGE_CACHEABLE   (1 << 1)
-#define VMEM_PAGE_USERMODE    (1 << 2)
-/* Used on sparc LEON3 */
-#define VMEM_PAGE_EXECUTABLE  (1 << 3)
-
-typedef uint32_t vmem_page_flags_t;
-
-static inline vmem_page_flags_t prot_to_vmem_flags(uint32_t flags) {
-	vmem_page_flags_t vmem_page_flags = 0;
-	if (flags & PROT_WRITE) {
-		vmem_page_flags |= VMEM_PAGE_WRITABLE;
-	}
-	if (flags & PROT_EXEC) {
-		vmem_page_flags |= VMEM_PAGE_EXECUTABLE;
-	}
-	if (!(flags & PROT_NOCACHE)) {
-		vmem_page_flags |= VMEM_PAGE_CACHEABLE;
-	}
-	return vmem_page_flags;
-}
+#define VMEM_PAGE_USERMODE    (1 << 6)
 
 #define vmem_mmu_enabled() 0
 

--- a/src/mem/vmem/vmem_nommu.h
+++ b/src/mem/vmem/vmem_nommu.h
@@ -9,21 +9,13 @@
 #ifndef VMEM_NOMMU_H
 #define VMEM_NOMMU_H
 
-#include <stdint.h>
-
 #include <hal/mmu.h>
-#include <sys/mman.h>
 
-#define VMEM_PAGE_USERMODE    (1 << 6)
-
-static inline int vmem_create_context(mmu_ctx_t *ctx) {
-	(void)ctx;
-	return 0;
-}
+#define vmem_create_context(ctx)
 
 #define vmem_current_context() 0
 
-#define vmem_free_context()
+#define vmem_free_context(ctx)
 
 #define vmem_translate(a,b) b
 

--- a/src/tests/kernel/thread/stack_protect_test.c
+++ b/src/tests/kernel/thread/stack_protect_test.c
@@ -13,7 +13,6 @@ EMBOX_TEST_SUITE("Stack protection test suite");
 TEST_SETUP(case_setup);
 TEST_TEARDOWN(case_teardown);
 
-static int mmu_was_enabled;
 static mmu_ctx_t ctx;
 static volatile int exception_flag;
 static volatile int first_check;
@@ -64,18 +63,11 @@ static int case_setup(void) {
     ctx = vmem_current_context();
     mmu_set_context(ctx);
 
-    mmu_was_enabled = vmem_mmu_enabled();
-    if (!mmu_was_enabled) {
-        vmem_on();
-    }
     stack_protect_enable();
     return 0;
 }
 
 static int case_teardown(void) {
-    if (vmem_mmu_enabled() && !mmu_was_enabled) {
-        vmem_off();
-    }
     stack_protect_disable();
     return 0;
 }

--- a/src/tests/kernel/thread/stack_protect_test.c
+++ b/src/tests/kernel/thread/stack_protect_test.c
@@ -25,7 +25,7 @@ static inline int soverflow_handler(uint32_t nr, void *data) {
 	exception_flag = 1;
 
 	vmem_unmap_region(ctx, page, VMEM_PAGE_SIZE);
-	vmem_map_region(ctx, page, page, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE);
+	vmem_map_region(ctx, page, page, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ);
 
 	return 1;
 }

--- a/src/tests/mem/Mybuild
+++ b/src/tests/mem/Mybuild
@@ -39,7 +39,7 @@ module slab {
 module mmap {
 	source "mmap.c"
 
-	depends embox.mem.vmem_api
+	depends embox.arch.mmu
 	depends embox.kernel.task.resource.mmap_full
 	depends embox.compat.posix.sys.mman.mmap
 }

--- a/src/tests/mmu/Mybuild
+++ b/src/tests/mmu/Mybuild
@@ -4,7 +4,6 @@ module mmu_core {
 	source "mmu_core.c"
 
 	depends embox.framework.LibFramework
-	depends embox.mem.vmem_api
 
 	depends embox.arch.mmu
 	depends embox.arch.testtrap
@@ -14,8 +13,6 @@ module mmu_double_map {
 	option number vaddr_offset = 0x80000000
 
 	source "mmu_double_map.c"
-
-	depends embox.mem.vmem_api
 
 	depends embox.arch.mmu
 	depends embox.arch.testtrap

--- a/src/tests/mmu/mmu_core.c
+++ b/src/tests/mmu/mmu_core.c
@@ -36,7 +36,7 @@ static mmu_paddr_t paddr;
 
 /* MMU data access exception handler */
 static inline int dfault_handler(uint32_t trap_nr, void *data) {
-	vmem_set_flags((mmu_ctx_t) ctx, BIGADDR, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE);
+	vmem_set_flags((mmu_ctx_t) ctx, BIGADDR, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ );
 	exception_flag = 1;
 
 	test_assert_not_equal(*((volatile uint32_t *) paddr), UNIQ_VAL);
@@ -51,7 +51,7 @@ static inline int pagefault_handler(uint32_t nr, void *data) {
 	err_addr = mmu_get_fault_address();
 
 	vmem_map_region(ctx, (mmu_paddr_t) ((unsigned long) page),
-			(mmu_vaddr_t) err_addr, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE);
+			(mmu_vaddr_t) err_addr, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ );
 
 	exception_flag = 1;
 	return 1; // execute exception-cause instruction once more
@@ -76,7 +76,7 @@ static inline int readonly_handler(uint32_t nr, void *data) {
 
 	/* Remap page with write access */
 	vmem_unmap_region(ctx, (uintptr_t) page, VMEM_PAGE_SIZE);
-	vmem_map_region(ctx, (uintptr_t) page, (uintptr_t) page, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE);
+	vmem_map_region(ctx, (uintptr_t) page, (uintptr_t) page, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ );
 
 	return 1;
 }
@@ -115,6 +115,6 @@ static int mmu_case_setup(void) {
 
 static int mmu_case_teardown(void) {
 	mmu_sys_privileges();
-	vmem_map_region(ctx, (mmu_vaddr_t) page, (mmu_vaddr_t) page, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE);
+	vmem_map_region(ctx, (mmu_vaddr_t) page, (mmu_vaddr_t) page, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ );
 	return 0;
 }

--- a/src/tests/mmu/mmu_double_map.c
+++ b/src/tests/mmu/mmu_double_map.c
@@ -41,7 +41,7 @@ static int mmu_case_setup(void) {
 	ctx = vmem_current_context();
 
 	res = vmem_map_region(ctx, (mmu_vaddr_t) test_page,
-			(mmu_vaddr_t) TEST_VIRT_ADDR_MAP, VMEM_PAGE_SIZE, VMEM_PAGE_WRITABLE);
+			(mmu_vaddr_t) TEST_VIRT_ADDR_MAP, VMEM_PAGE_SIZE, PROT_WRITE | PROT_READ);
 
 	if (res) {
 		return res;

--- a/templates/arm/arria_v/mods.config
+++ b/templates/arm/arria_v/mods.config
@@ -19,7 +19,7 @@ configuration conf {
 	@Runlevel(2) include embox.mem.static_heap(heap_size=0x1000000)
 
 	@Runlevel(0) include embox.mem.mmap
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.kernel.critical
 
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0xFFFEC100,distributor_base_addr=0xFFFED000)

--- a/templates/arm/c++_demo/mods.config
+++ b/templates/arm/c++_demo/mods.config
@@ -13,7 +13,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(
 				domain_access=1,v5_format=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	include embox.compat.posix.sys.mman.mmap
 
 	include embox.lib.debug.whereami

--- a/templates/arm/el24d2/mods.config
+++ b/templates/arm/el24d2/mods.config
@@ -14,7 +14,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=3)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.arch.arm.libarch
 

--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -19,7 +19,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.kernel.thread.core(thread_stack_size=0x200000)
 

--- a/templates/arm/iwave_imx6_etnaviv/mods.config
+++ b/templates/arm/iwave_imx6_etnaviv/mods.config
@@ -17,7 +17,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.kernel.thread.core(thread_stack_size=0x300000)
 

--- a/templates/arm/qemu/mods.config
+++ b/templates/arm/qemu/mods.config
@@ -13,7 +13,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(
 				domain_access=1,v5_format=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.lib.debug.whereami
 

--- a/templates/arm/qt-app/mods.config
+++ b/templates/arm/qt-app/mods.config
@@ -12,7 +12,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(
 				domain_access=1,v5_format=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	@Runlevel(1) include embox.kernel.sched.sched
 

--- a/templates/arm/raspi/mods.config
+++ b/templates/arm/raspi/mods.config
@@ -9,7 +9,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.armlib.mem_barriers
 
 	include embox.arch.arm.mmu_small_page
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.arch.system(core_freq=70000000)
 	@Runlevel(0) include embox.kernel.stack(stack_size=2536,alignment=4)
 

--- a/templates/arm/sabrelite/mods.config
+++ b/templates/arm/sabrelite/mods.config
@@ -18,7 +18,7 @@ configuration conf {
 	@Runlevel(0) include embox.mem.phymem
 	//@Runlevel(0) include embox.arch.arm.mmu_section(domain_access=1)
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.arch.arm.libarch
 

--- a/templates/arm/sk_imx6q/mods.config
+++ b/templates/arm/sk_imx6q/mods.config
@@ -19,7 +19,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.kernel.thread.core(thread_stack_size=0x200000)
 

--- a/templates/arm/ti816x-qt/mods.config
+++ b/templates/arm/ti816x-qt/mods.config
@@ -22,7 +22,7 @@ configuration conf {
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.mem.bitmask
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(log_level=4, domain_access=3)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	include embox.fs.syslib.idesc_mmap_stub
 
 	@Runlevel(1) include embox.kernel.sched.strategy.priority_based

--- a/templates/arm/ti816x/mods.config
+++ b/templates/arm/ti816x/mods.config
@@ -25,7 +25,7 @@ configuration conf {
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.mem.bitmask
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(log_level=4, domain_access=3)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	@Runlevel(1) include embox.kernel.task.multi
 	@Runlevel(1) include embox.kernel.thread.core(stack_align=8, thread_pool_size=512, thread_stack_size=0x4000)

--- a/templates/arm/var_som_mx6/mods.config
+++ b/templates/arm/var_som_mx6/mods.config
@@ -19,7 +19,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.task.kernel_task
 	@Runlevel(0) include embox.mem.phymem
 	@Runlevel(0) include embox.arch.arm.mmu_small_page(domain_access=1)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	include embox.kernel.thread.core(thread_stack_size=0x200000)
 

--- a/templates/arm/vexpress-a9/mods.config
+++ b/templates/arm/vexpress-a9/mods.config
@@ -19,7 +19,7 @@ configuration conf {
 	@Runlevel(2) include embox.mem.static_heap(heap_size=0x1000000)
 
 	@Runlevel(0) include embox.mem.mmap
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.kernel.critical
 
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0x1e000100,distributor_base_addr=0x1e001000)

--- a/templates/microblaze/qemu/mods.config
+++ b/templates/microblaze/qemu/mods.config
@@ -24,7 +24,7 @@ configuration conf {
 	include embox.driver.char_dev_old
 
 	@Runlevel(0) include embox.arch.microblaze.mmu
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.mem.phymem
 
 	@Runlevel(1) include embox.kernel.critical

--- a/templates/ppc/qemu/mods.config
+++ b/templates/ppc/qemu/mods.config
@@ -10,7 +10,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=333000000)
 	/* TODO PowerPC MMU hasn't been implemented yet
 	@Runlevel(0) include embox.arch.ppc.mmu
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.mem.phymem
 	*/
 

--- a/templates/sparc/qemu/mods.config
+++ b/templates/sparc/qemu/mods.config
@@ -10,7 +10,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.arch.sparc.mmu
 	@Runlevel(0) include embox.mem.vmem_alloc_single_pool(mmu_tables_max=8192)
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.mem.phymem
 
 	include embox.arch.sparc.stackframe

--- a/templates/x86/dvfs/mods.config
+++ b/templates/x86/dvfs/mods.config
@@ -24,7 +24,7 @@ configuration conf {
 	include embox.arch.x86.kernel.context
 	include embox.arch.x86.kernel.interrupt
 
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.mem.phymem
 
 	include embox.arch.x86.mmu

--- a/templates/x86/qemu/mods.config
+++ b/templates/x86/qemu/mods.config
@@ -6,7 +6,7 @@ configuration conf {
 	include embox.arch.x86.kernel.context
 	include embox.arch.x86.kernel.interrupt
 
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	@Runlevel(0) include embox.mem.phymem
 
 	include embox.arch.x86.mmu

--- a/templates/x86/test/fs/mods.config
+++ b/templates/x86/test/fs/mods.config
@@ -12,7 +12,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.arch.x86.vfork
 
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 
 	@Runlevel(2) include embox.driver.interrupt.i8259
 	@Runlevel(2) include embox.driver.clock.pit

--- a/templates/x86/user_apps/mods.config
+++ b/templates/x86/user_apps/mods.config
@@ -115,7 +115,7 @@ configuration conf {
 	include embox.mem.mmap
 	include embox.arch.x86.mmu
 	include embox.arch.x86.vfork
-	@Runlevel(0) include embox.mem.vmem
+	//@Runlevel(0) include embox.mem.vmem
 	include embox.lib.LibExec
 
 

--- a/third-party/STLport/Mybuild
+++ b/third-party/STLport/Mybuild
@@ -9,7 +9,7 @@ static module libstlportg extends embox.lib.stl {
 	source "libstlportg.a"
 
 	depends embox.compat.posix.proc.atexit_api
-	@NoRuntime depends embox.mem.vmem_api /* include sys/mman.h */
+	@NoRuntime depends embox.compat.posix.sys.mman.mmap_api /* include sys/mman.h */
 	@NoRuntime depends embox.compat.libc.all
 	@NoRuntime depends embox.lib.libsupcxx
 	@NoRuntime depends embox.lib.libgcc

--- a/third-party/lib/opencv/Mybuild
+++ b/third-party/lib/opencv/Mybuild
@@ -19,7 +19,7 @@ static module opencv {
 	depends embox.compat.posix.util.gettimeofday
 	depends embox.compat.atomic.pseudo_atomic
 	depends embox.compat.libc.math
-	@NoRuntime depends embox.mem.vmem_api // include sys/mman.h
+	@NoRuntime depends embox.compat.posix.sys.mman.mmap_api // include sys/mman.h
 	@NoRuntime depends embox.compat.libc.all
 	@NoRuntime depends embox.compat.posix.pthread_key
 	@NoRuntime depends third_party.gcc.libstdcxx

--- a/third-party/samba/Mybuild
+++ b/third-party/samba/Mybuild
@@ -17,7 +17,7 @@ module core {
 	depends embox.compat.posix.idx.poll
 	depends embox.compat.posix.proc.exec
 	depends embox.net.lib.getifaddrs
-	depends embox.mem.vmem_api
+	depends embox.compat.posix.sys.mman.mmap_api
 	depends third_party.zlib.libs
 	depends embox.compat.posix.fs.chown_api
 	depends embox.compat.posix.fs.rewinddir_api


### PR DESCRIPTION
* Restructure vmem & mmu subsystem. Now embox.mem.vmem extends from abstract embox.arch.mmu & archs implementations extends from  one.
* Clean vmem API. Rm vmem_on() & vmem_off() & vmem_mmu_enabled()

