### PR TITLE
boot_thread: Fix build for GCC 9 with -Os

### DIFF
--- a/src/kernel/sched/boot_thread.c
+++ b/src/kernel/sched/boot_thread.c
@@ -15,6 +15,8 @@
 
 #include <module/embox/kernel/stack.h>
 
+#define KERNEL_STACK_SZ OPTION_MODULE_GET(embox__kernel__stack, NUMBER, stack_size)
+
 static void *boot_stub(void *arg) {
 	panic("Entering boot_stub");
 	return 0;
@@ -24,9 +26,8 @@ extern void thread_set_current(struct thread *t);
 struct schedee *boot_thread_create(void) {
 	struct thread *bootstrap;
 	extern char _stack_top;
-	const size_t kernel_stack_sz = OPTION_MODULE_GET(embox__kernel__stack, NUMBER, stack_size);
 
-	bootstrap = thread_init_stack(&_stack_top - kernel_stack_sz, kernel_stack_sz,
+	bootstrap = thread_init_stack((void *) ((uintptr_t) &_stack_top - KERNEL_STACK_SZ), KERNEL_STACK_SZ,
 			SCHED_PRIORITY_NORMAL, boot_stub, NULL);
 
 	task_set_main(task_kernel_task(), bootstrap);


### PR DESCRIPTION
Following error occurs:

src/kernel/sched/boot_thread.c:29:44: error: array subscript -31744 is outside
array bounds of 'char[1]' [-Werror=array-bounds]
   29 |  bootstrap = thread_init_stack(&_stack_top - kernel_stack_sz, kernel_stack_sz,
      |                                ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~

So cast it to uintptr_t for pointer arithmetic