### PR TITLE
Qt stm32 optimization

### DIFF
--- a/src/drivers/video/Mybuild
+++ b/src/drivers/video/Mybuild
@@ -6,6 +6,12 @@ module fb_header {
 	source "fb.h"
 }
 
+static module fb_section {
+	option number size = 0
+
+	source "fb.lds.S"
+}
+
 module fb {
 	source "fb.c"
 

--- a/src/drivers/video/fb.lds.S
+++ b/src/drivers/video/fb.lds.S
@@ -1,0 +1,11 @@
+#include <asm-generic/embox.lds.h>
+
+#include <framework/mod/options.h>
+
+SECTIONS {
+	.framebuffer (NOLOAD): ALIGN(DEFAULT_DATA_ALIGNMENT) {
+		__framebuffer_start = .;
+		. += OPTION_GET(NUMBER,size);
+		__framebuffer_end = .;
+	}
+}

--- a/src/drivers/video/stm32f7_lcd/Mybuild
+++ b/src/drivers/video/stm32f7_lcd/Mybuild
@@ -3,6 +3,11 @@ package embox.driver.video
 @BuildDepends(third_party.bsp.stmf7cube.core)
 module stm32f7_lcd {
 	option number fb_base = 0xc0000000
+	option number height = 272
+	option number width = 480
+	option number bpp = 32
+	option boolean use_fb_section = false
+	option string fb_section_start = ""
 
 	source "stm32f7_lcd.c"
 

--- a/src/drivers/video/stm32f7_lcd/stm32f7_lcd.c
+++ b/src/drivers/video/stm32f7_lcd/stm32f7_lcd.c
@@ -23,7 +23,18 @@
 #include <embox/unit.h>
 EMBOX_UNIT_INIT(stm32f7_lcd_init);
 
-#define LCD_FRAMEBUFFER  OPTION_GET(NUMBER, fb_base)
+#define USE_FB_SECTION OPTION_GET(BOOLEAN,use_fb_section)
+
+#if USE_FB_SECTION
+#define STM32_FB_SECTION_START OPTION_GET(STRING,fb_section_start)
+extern char STM32_FB_SECTION_START;
+#else
+#define STM32_FB_START  OPTION_GET(NUMBER, fb_base)
+#endif
+
+#define STM32_LCD_HEIGHT  OPTION_GET(NUMBER, height)
+#define STM32_LCD_WIDTH   OPTION_GET(NUMBER, width)
+#define STM32_LCD_BPP     OPTION_GET(NUMBER, bpp)
 
 static int stm32f7_lcd_set_var(struct fb_info *info,
 		struct fb_var_screeninfo const *var) {
@@ -36,8 +47,19 @@ static int stm32f7_lcd_get_var(struct fb_info *info,
 
 	var->xres_virtual = var->xres = BSP_LCD_GetXSize();
 	var->yres_virtual = var->yres = BSP_LCD_GetYSize();
-	var->bits_per_pixel = 32;
-	var->fmt = RGBA8888;
+	var->bits_per_pixel = STM32_LCD_BPP;
+
+	switch (STM32_LCD_BPP) {
+	case 16:
+		var->fmt = RGB565;
+		break;
+	case 32:
+		var->fmt = RGBA8888;
+		break;
+	default:
+		log_error("stm32f7_lcd_get_var unknown BPP = %d\n", STM32_LCD_BPP);
+		return -1;
+	}
 
 	return 0;
 }
@@ -56,6 +78,8 @@ static uint32_t stm32f7_get_image_color(const struct fb_image *image, int num) {
 		} else {
 			return image->bg_color;
 		}
+	case 16:
+		return ((uint16_t *) image->data)[num];
 	case 32:
 		return ((uint32_t *) image->data)[num];
 	default:
@@ -85,7 +109,7 @@ static struct fb_ops stm32f7_lcd_ops = {
 };
 
 static int stm32f7_lcd_init(void) {
-	char *mmap_base = (void*) LCD_FRAMEBUFFER;
+	char *mmap_base;
 	size_t mmap_len = 0;
 
 	if (BSP_LCD_Init() != LCD_OK) {
@@ -93,7 +117,27 @@ static int stm32f7_lcd_init(void) {
 		return -1;
 	}
 
-	BSP_LCD_LayerDefaultInit(LTDC_ACTIVE_LAYER, LCD_FRAMEBUFFER);
+#if USE_FB_SECTION
+	mmap_base = (char *) &STM32_FB_SECTION_START;
+#else
+	mmap_base = (char *) STM32_FB_START;
+#endif
+
+	BSP_LCD_SetXSize(STM32_LCD_WIDTH);
+	BSP_LCD_SetYSize(STM32_LCD_HEIGHT);
+
+	switch (STM32_LCD_BPP) {
+	case 16:
+		BSP_LCD_LayerRgb565Init(LTDC_ACTIVE_LAYER, (unsigned int) mmap_base);
+		break;
+	case 32:
+		BSP_LCD_LayerDefaultInit(LTDC_ACTIVE_LAYER, (unsigned int) mmap_base);
+		break;
+	default:
+		log_error("Failed to init LCD Layer!");
+		return -1;
+	}
+
 	BSP_LCD_SelectLayer(LTDC_ACTIVE_LAYER);
 	BSP_LCD_Clear(LCD_COLOR_BLACK);
 

--- a/templates/arm/qt-stm32f7discovery/build.conf
+++ b/templates/arm/qt-stm32f7discovery/build.conf
@@ -14,8 +14,8 @@ CFLAGS += -ffreestanding
 CFLAGS += -mcpu=cortex-m7
 
 /* Switch between FPU and non-FPU modes */
-CFLAGS += -msoft-float
-#CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
+#CFLAGS += -msoft-float
+CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 CXXFLAGS += -Os -g
 CXXFLAGS += -ffreestanding
@@ -24,7 +24,7 @@ CXXFLAGS += -fno-rtti
 CXXFLAGS += -fno-exceptions
 CXXFLAGS += -mcpu=cortex-m7
 
-CXXFLAGS += -msoft-float
-#CXXFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
+#CXXFLAGS += -msoft-float
+CXXFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/templates/arm/qt-stm32f7discovery/lds.conf
+++ b/templates/arm/qt-stm32f7discovery/lds.conf
@@ -13,6 +13,9 @@ rodata (ROM)
 data   (RAM, ROM)
 bss    (RAM)
 
+section (framebuffer, RAM, RAM)
+phdr    (framebuffer, PT_LOAD, FLAGS(6))
+
 section (qt_text, SDRAM, SDRAM)
 phdr    (qt_text, PT_LOAD, FLAGS(5))
 

--- a/templates/arm/qt-stm32f7discovery/mods.config
+++ b/templates/arm/qt-stm32f7discovery/mods.config
@@ -7,45 +7,39 @@ configuration conf {
 	@Runlevel(0) include third_party.bsp.stmf7cube.arch
 	include embox.arch.arm.vfork
 
-	//@Runlevel(0) include embox.arch.arm.fpu.cortex_m7_fp
-	//@Runlevel(0) include embox.arch.arm.fpu.fpv5(log_level=3)
+	@Runlevel(0) include embox.driver.flash.stm32f7_qspi
+	@Runlevel(0) include third_party.bsp.stmf7cube.sdram(fmc_swap = true)
+	@Runlevel(0) include embox.arch.arm.fpu.cortex_m7_fp
+	@Runlevel(0) include embox.arch.arm.fpu.fpv5(log_level=3)
 	@Runlevel(0) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
-	@Runlevel(1) include embox.driver.clock.cortexm_systick
-	@Runlevel(1) include embox.driver.serial.stm_usart_f7(baud_rate=115200, usartx=1)
-	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
+	@Runlevel(0) include embox.driver.clock.cortexm_systick
+	@Runlevel(0) include embox.driver.serial.stm_usart_f7(baud_rate=115200, usartx=1)
+	@Runlevel(0) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
 	include embox.driver.serial.core_notty
 
+	@Runlevel(0) include embox.mem.static_heap(heap_size=0x2000)
+	@Runlevel(0) include embox.kernel.stack(stack_size=31744)
+
+	@Runlevel(1) include embox.mem.fixed_heap(heap_start=0x60100000, heap_size=0x200000)
 	include embox.mem.heap_bm
-
-	@Runlevel(0) include embox.mem.fixed_heap(heap_start=0x60100000, heap_size=0x200000)
-	include embox.mem.static_heap(heap_size=0x2000)
-
-	@Runlevel(2) include embox.driver.video.stm32f7_lcd(fb_base = 0x60000000)
-	include embox.driver.video.fb
-
-	@Runlevel(2) include embox.test.kernel.thread.thread_systimer_irq_test
-	@Runlevel(2) include embox.test.kernel.thread.thread_test
-
-	//include embox.kernel.thread.thread_local_none
-	include embox.kernel.thread.thread_cancel_disable
-	include embox.kernel.thread.signal_stub
 
 	include embox.kernel.timer.sleep
 
-	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(1) include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=16)
 	include embox.kernel.task.resource.sig_table(sig_table_size=10)
 	include embox.kernel.task.resource.env(env_per_task=8,env_str_len=24)
 
-	@Runlevel(0) include embox.kernel.stack(stack_size=31744)
-	@Runlevel(2) include embox.kernel.thread.core(thread_pool_size=3, thread_stack_size=30720)
+	@Runlevel(1) include embox.kernel.thread.core(thread_pool_size=1, thread_stack_size=2048)
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.thread.signal_stub
 
-	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
-	@Runlevel(2) include embox.kernel.irq
-	@Runlevel(2) include embox.kernel.critical
+	@Runlevel(1) include embox.kernel.sched.strategy.priority_based
+	@Runlevel(1) include embox.kernel.irq
+	@Runlevel(1) include embox.kernel.critical
 
-	@Runlevel(2) include embox.mem.pool_adapter
-	@Runlevel(2) include embox.mem.bitmask(page_size=1024)
+	@Runlevel(1) include embox.mem.pool_adapter
+	@Runlevel(1) include embox.mem.bitmask(page_size=1024)
 
 	@Runlevel(1) include embox.test.critical
 	@Runlevel(1) include embox.test.framework.mod.member.ops_test
@@ -66,13 +60,20 @@ configuration conf {
 	@Runlevel(1) include embox.test.util.indexator_test
 	@Runlevel(1) include embox.test.math.math_test
 	@Runlevel(1) include embox.test.mem.pool_test
-	//@Runlevel(1) include embox.test.util.hashtable_test
+
+	@Runlevel(2) include embox.driver.video.stm32f7_lcd(
+		height=272, width=272, bpp=16,
+		use_fb_section=true, fb_section_start="__framebuffer_start")
+	include embox.driver.video.fb_section(size=147968)
 
 	@Runlevel(2) include embox.cmd.sh.tish(
-		prompt="%u@%h:%w%$", rich_prompt_support=1, builtin_commands="exit logout cd export mount umount moveblocks animatedtiles")
+		prompt="%u@%h:%w%$", rich_prompt_support=1,
+		builtin_commands="exit logout cd export mount umount moveblocks animatedtiles memcpy mem")
 	include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
 
 	include embox.cmd.help
+	include embox.cmd.mem
+	include embox.cmd.memcpy
 
 	include embox.cmd.sys.uname
 	include embox.cmd.sys.env
@@ -80,12 +81,12 @@ configuration conf {
 
 	include embox.cmd.testing.ticker
 
-	@Runlevel(2) include embox.util.LibUtil
-	@Runlevel(2) include embox.framework.LibFramework
+	include embox.util.LibUtil
+	include embox.framework.LibFramework
 
-	@Runlevel(2) include embox.fs.node(fnode_quantity=12)
-	@Runlevel(2) include embox.fs.driver.initfs
-	@Runlevel(2) include embox.fs.rootfs
+	include embox.fs.node(fnode_quantity=12)
+	include embox.fs.driver.initfs
+	include embox.fs.rootfs
 
 	include embox.net.skbuff(amount_skb=0)
 	include embox.net.skbuff_data(amount_skb_data=0)
@@ -113,7 +114,6 @@ configuration conf {
 
 	include embox.fs.syslib.idesc_mmap
 
-	@Runlevel (2) include embox.lib.cxx.ConstructionGlobal
 	include embox.lib.cxx.DestructionStatic(table_size=32)
 
 	include embox.compat.atomic.pseudo_atomic

--- a/templates/arm/qt-stm32f7discovery/start_script.inc
+++ b/templates/arm/qt-stm32f7discovery/start_script.inc
@@ -1,4 +1,4 @@
 "export PWD=/",
 "export HOME=/",
 "export QT_QPA_FONTDIR=/fonts",
-"moveblocks -platform emboxfb",
+//"moveblocks -platform emboxfb"


### PR DESCRIPTION
* Enable Qt to run faster on stm32f7discovery
* Optionally put framebuffer into a separate linker section, not at the specified fixed address.