### PR TITLE
Buildfix nuklear/stm32

### DIFF
--- a/platform/nuklear/templates/stm32f7/mods.config
+++ b/platform/nuklear/templates/stm32f7/mods.config
@@ -1,3 +1,5 @@
+package genconfig
+
 configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
@@ -60,6 +62,7 @@ configuration conf {
 	include embox.compat.libc.stdio.print(support_floating=0)
 
 	include embox.mem.heap_bm
+	include embox.mem.static_heap(heap_size=0x4000)
 	include embox.mem.fixed_heap(heap_start=0xc0200000, heap_size=0x800000)
 	include embox.mem.bitmask(page_size=64)
 


### PR DESCRIPTION
Since static_heap and fixed_heap can be used together, static_heap is included
by default as a dependence of embox.mem.heap_bm with size=1M. Just decrease this size.