### PR TITLE
Qt stm32

### DIFF
--- a/mk/gen_ld_section_symbols.sh
+++ b/mk/gen_ld_section_symbols.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Input
+CONFIG_LDS_H=$1
+# Output
+SECTION_SYMBOLS_LDS_H=$2
+
+rm -f $SECTION_SYMBOLS_LDS_H && touch $SECTION_SYMBOLS_LDS_H
+
+SECTIONS=`grep -o 'LDS_SECTION_VMA_[0-9a-zA-Z_]*' $CONFIG_LDS_H | \
+			sed 's/LDS_SECTION_VMA_//g' | uniq`
+
+SECTIONS=`echo $SECTIONS | sed -E 's/\b(text|rodata|data|bss)\b//g'`
+
+for section in $SECTIONS
+do
+	echo "SECTION_SYMBOLS($section)" >> $SECTION_SYMBOLS_LDS_H
+done

--- a/mk/image.lds.S
+++ b/mk/image.lds.S
@@ -25,6 +25,7 @@ SECTION_SYMBOLS(text)
 SECTION_SYMBOLS(rodata)
 SECTION_SYMBOLS(data)
 SECTION_SYMBOLS(bss)
+#include <section_symbols.lds.h>
 
 SECTIONS {
 	.text : ALIGN(TEXT_ALIGNMENT) {

--- a/mk/image2.mk
+++ b/mk/image2.mk
@@ -98,14 +98,18 @@ module_prereqs = $(o_files) $(a_files) $(common_prereqs)
 # 2. Section name - text, rodata, data, bss
 get_sections = $(filter .$2%, $(filter-out .$2..% .$2.embox%, $(shell $(OBJDUMP) -h $1)))
 
+section_in_region = \
+	$(shell grep LDS_SECTION_VMA_$1 $(SRCGEN_DIR)/config.lds.h)
+
 # 1. File name (objects *.o or libraries *.a)
 # 2. Section name - text, rodata, data, bss
 # 3. Name of section specified with @LinkerSection annonation
 rename_section = \
 	$(if $3, \
-		$(foreach section, $(call get_sections,$1,$2), \
-			$(section)=.$3.$(section).module.$(module_id) \
-		), \
+		$(if $(call section_in_region,$3), \
+			$(foreach section, $(call get_sections,$1,$2), \
+				$(section)=.$3.$(section).module.$(module_id) \
+		), .$2=.$2.module.$(module_id)), \
 		.$2=.$2.module.$(module_id) \
 	)
 

--- a/mk/script/build/oldconf-gen.mk
+++ b/mk/script/build/oldconf-gen.mk
@@ -42,8 +42,10 @@ config_lds_h := $(SRCGEN_DIR)/config.lds.h
 regions_lds_h  := $(SRCGEN_DIR)/regions.lds.h
 sections_lds_h := $(SRCGEN_DIR)/sections.lds.h
 phdrs_lds_h    := $(SRCGEN_DIR)/phdrs.lds.h
+section_symbols_lds_h := $(SRCGEN_DIR)/section_symbols.lds.h
 
-all : $(build_mk) $(config_lds_h) $(regions_lds_h) $(sections_lds_h) $(phdrs_lds_h)
+all : $(build_mk) $(config_lds_h) $(regions_lds_h) \
+	$(sections_lds_h) $(phdrs_lds_h) $(section_symbols_lds_h)
 
 $(build_mk)     : $(build_conf)
 $(config_lds_h) : $(lds_conf)
@@ -66,6 +68,9 @@ gen_sections = \
 gen_phdrs = \
 	$(abspath $(ROOT_DIR))/mk/gen_ld_phdrs.sh $1 $2
 
+gen_section_symbols = \
+	$(abspath $(ROOT_DIR))/mk/gen_ld_section_symbols.sh $1 $2
+
 $(config_lds_h) :
 	@$(call cmd_notouch_stdout,$@, \
 		$(HOSTCPP) -P -undef -nostdinc $(HOSTCC_CPPFLAGS) $(DEFS:%=-D%) \
@@ -81,6 +86,9 @@ $(sections_lds_h) : $(config_lds_h)
 
 $(phdrs_lds_h) : $(config_lds_h)
 	@$(call gen_phdrs, $(config_lds_h), $@)
+
+$(section_symbols_lds_h) : $(config_lds_h)
+	@$(call gen_section_symbols, $(config_lds_h), $@)
 
 $(AUTOCONF_DIR)/start_script.inc: $(CONF_DIR)/start_script.inc
 	@$(call cmd_notouch_stdout,$@,cat $<)

--- a/templates/arm/qt-fb-small/mods.config
+++ b/templates/arm/qt-fb-small/mods.config
@@ -31,9 +31,7 @@ configuration conf {
 	@Runlevel(2) include embox.driver.net.loopback
 
 	@Runlevel(2) include embox.fs.node(fnode_quantity=16)
-	@Runlevel(2) include embox.fs.driver.fat
 	@Runlevel(2) include embox.fs.driver.initfs
-	@Runlevel(2) include embox.fs.driver.ramfs
 	@Runlevel(2) include embox.fs.rootfs
 
 	@Runlevel(1) include embox.kernel.timer.sys_timer

--- a/templates/arm/qt-stm32f7discovery/lds.conf
+++ b/templates/arm/qt-stm32f7discovery/lds.conf
@@ -1,10 +1,8 @@
 /* region (origin, length) */
 
-/* QSPI */
 ROM (0x08000000, 1M)
 RAM (0x20000000, 320K)
-
-/* SDRAM */
+region (QSPI,  0x90000000, 16M)
 region (SDRAM, 0x60300000, 5M)
 
 /* section (region[, lma_region]) */
@@ -16,14 +14,14 @@ bss    (RAM)
 section (framebuffer, RAM, RAM)
 phdr    (framebuffer, PT_LOAD, FLAGS(6))
 
-section (qt_text, SDRAM, SDRAM)
+section (qt_text, SDRAM, QSPI)
 phdr    (qt_text, PT_LOAD, FLAGS(5))
 
-section (qt_rodata, SDRAM, SDRAM)
+section (qt_rodata, SDRAM, QSPI)
 phdr    (qt_rodata, PT_LOAD, FLAGS(5))
 
-section (qt_data, SDRAM, SDRAM)
+section (qt_data, SDRAM, QSPI)
 phdr    (qt_data, PT_LOAD, FLAGS(6))
 
-section (qt_bss, SDRAM, SDRAM)
+section (qt_bss, SDRAM, QSPI)
 phdr    (qt_bss, PT_LOAD, FLAGS(6))

--- a/templates/arm/qt-stm32f7discovery/mods.config
+++ b/templates/arm/qt-stm32f7discovery/mods.config
@@ -68,7 +68,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.cmd.sh.tish(
 		prompt="%u@%h:%w%$", rich_prompt_support=1,
-		builtin_commands="exit logout cd export mount umount moveblocks animatedtiles memcpy mem")
+		builtin_commands="exit logout cd export mount umount moveblocks animatedtiles memcpy mem qt_app_qspi_starter")
 	include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
 
 	include embox.cmd.help
@@ -109,6 +109,7 @@ configuration conf {
 		fonts_support=false,
 		vnc_support=false
 	)
+	include third_party.qt.example.qt_app_qspi_starter
 	include third_party.qt.example.moveblocks
 	include third_party.qt.plugin.platform.emboxfb
 

--- a/templates/arm/qt-stm32f7discovery/start_script.inc
+++ b/templates/arm/qt-stm32f7discovery/start_script.inc
@@ -1,4 +1,5 @@
 "export PWD=/",
 "export HOME=/",
 "export QT_QPA_FONTDIR=/fonts",
-//"moveblocks -platform emboxfb"
+"qt_app_qspi_starter",
+"moveblocks -platform emboxfb",

--- a/third-party/qt/Mybuild
+++ b/third-party/qt/Mybuild
@@ -1,5 +1,6 @@
 package third_party.qt
 
+@LinkerSection(text="qt_text",rodata="qt_rodata",data="qt_data",bss="qt_bss")
 @Build(stage=1,script="$(EXTERNAL_MAKE)")
 @BuildArtifactPath(cppflags="-I$(abspath $(EXTERNAL_BUILD_DIR))/third_party/qt/core/install/include -I$(abspath $(EXTERNAL_BUILD_DIR))/third_party/qt/core/install/include/QtCore")
 @BuildDepends(embox.lib.libsupcxx)

--- a/third-party/qt/examples/QtAppQSPIStarter.my
+++ b/third-party/qt/examples/QtAppQSPIStarter.my
@@ -1,0 +1,17 @@
+package third_party.qt.example
+
+@AutoCmd
+@BuildDepends(third_party.qt.core)
+@Cmd(name = "qt_app_qspi_starter",
+	help = "Loads an initializes qt from QSPI",
+	man = '''
+		AUTHORS
+			Alexander Kalmuk
+	''')
+module qt_app_qspi_starter {
+	source "qt_app_qspi_starter.c"
+
+	@NoRuntime depends third_party.qt.core
+
+	depends embox.lib.cxx.ConstructorsInvocator
+}

--- a/third-party/qt/examples/qt_app_qspi_starter.c
+++ b/third-party/qt/examples/qt_app_qspi_starter.c
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * @brief Hardcoded loader of qt library section
+ * from LMA section to VMA section
+ *
+ * @date 08.07.2019
+ * @author Alexander Kalmuk
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#define QT_TEXT_VMA   _qt_text_vma
+#define QT_TEXT_LMA   _qt_text_lma
+#define QT_TEXT_LEN   _qt_text_len
+
+#define QT_RODATA_VMA _qt_rodata_vma
+#define QT_RODATA_LMA _qt_rodata_lma
+#define QT_RODATA_LEN _qt_rodata_len
+
+#define QT_DATA_VMA   _qt_data_vma
+#define QT_DATA_LMA   _qt_data_lma
+#define QT_DATA_LEN   _qt_data_len
+
+#define QT_BSS_VMA    _qt_bss_vma
+#define QT_BSS_LEN    _qt_bss_len
+
+extern char QT_TEXT_VMA, QT_TEXT_LMA, QT_TEXT_LEN;
+extern char QT_RODATA_VMA, QT_RODATA_LMA, QT_RODATA_LEN;
+extern char QT_DATA_VMA, QT_DATA_LMA, QT_DATA_LEN;
+extern char QT_BSS_VMA, QT_BSS_LEN;
+
+static void load_section(void *vma, void *lma, unsigned int len) {
+	memcpy(vma, lma, len);
+}
+
+static void zero_bss_section(void *vma, unsigned int len) {
+	memset(vma, 0, len);
+}
+
+extern void cxx_invoke_constructors(void);
+
+int main(int argc, char **argv) {
+	load_section(&QT_TEXT_VMA, &QT_TEXT_LMA, (unsigned int) &QT_TEXT_LEN);
+	load_section(&QT_RODATA_VMA, &QT_RODATA_LMA, (unsigned int) &QT_RODATA_LEN);
+	load_section(&QT_DATA_VMA, &QT_DATA_LMA, (unsigned int) &QT_DATA_LEN);
+	zero_bss_section(&QT_BSS_VMA, (unsigned int) &QT_BSS_LEN);
+
+	cxx_invoke_constructors();
+
+	return 0;
+}


### PR DESCRIPTION
* Simplify Qt moveblocks example launching on STM32F7-Discovery. Now it works out of the box.
* buildsystem: @LinkerSection annotation is ignored if the specified sections wasn't assigned to any memory region in lds.conf