### PR TITLE
cortexa9_timer: Fix after jiffies rework

### DIFF
--- a/src/drivers/clock/cortexa9_timer/cortexa9_timer.c
+++ b/src/drivers/clock/cortexa9_timer/cortexa9_timer.c
@@ -54,8 +54,8 @@ static irq_return_t clock_handler(unsigned int irq_nr, void *data) {
 }
 
 static int this_init(void) {
-	clock_source_register(&this_clock_source);
 	REG_STORE(PTIMER_CONTROL, 0);
+	clock_source_register(&this_clock_source);
 	return irq_attach(PTIMER_IRQ,
 	                  clock_handler,
 	                  0,


### PR DESCRIPTION
In commit 02e6bbeb3b82635eb6f71cf73e3acf713b76cb3b jiffies initization
was made as explicit call, which happened inside
clock_source_register(), while this driver supposed that jiffies were
intialized after module init, so changing order of function calls in
init helps to solve problem with timer