### PR TITLE
cmds/record: Fix build for GCC 9 with -O2

### DIFF
--- a/src/cmds/record/record.c
+++ b/src/cmds/record/record.c
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
 	int opt;
 	int err;
 	int sleep_msec = MAX_REC_DURATION;
-	char *filename;
+	char *filename = NULL;
 	PaStream *stream = NULL;
 
 	struct PaStreamParameters in_par;


### PR DESCRIPTION
This commit fixes -O2 build for pjsip/x86-qemu template