### PR TITLE
FB init with overlay

### DIFF
--- a/src/drivers/video/Mybuild
+++ b/src/drivers/video/Mybuild
@@ -25,6 +25,7 @@ module fb {
 	depends fonts
 	depends embox.driver.char_dev
 	depends embox.driver.video.fb_devfs
+	@NoRuntime depends fb_overlay
 }
 
 module fb_overlay {
@@ -33,7 +34,7 @@ module fb_overlay {
 
 	source "fb_overlay.c"
 
-	depends fb
+	@NoRuntime depends fb
 	depends fonts
 }
 

--- a/src/drivers/video/pl110/pl110.c
+++ b/src/drivers/video/pl110/pl110.c
@@ -113,9 +113,9 @@ static int pl110_lcd_init(void) {
 	REG32_CLEAR(PL110_CONTROL, PL110_BPP_MASK);
 	REG32_ORIN(PL110_CONTROL, 5 << PL110_BPP_OFFT);
 
-	fb_create(&pl110_lcd_ops, mmap_base, mmap_len);
-
 	memset(mmap_base, 0, PL110_DISPLAY_WIDTH * PL110_DISPLAY_HEIGHT);
+
+	fb_create(&pl110_lcd_ops, mmap_base, mmap_len);
 
 	return 0;
 }


### PR DESCRIPTION

Non-function change; just print Embox version on FB init (I think it looks better than just a blank screen).


![Screenshot_2019-07-16_20-49-56](https://user-images.githubusercontent.com/2498673/61317254-4f4c0700-a80b-11e9-9864-2435d6b1141c.png)

