### PR TITLE
net: Remove ICMP discard when neighbour is not resolved

### DIFF
--- a/src/net/neighbour.c
+++ b/src/net/neighbour.c
@@ -132,17 +132,6 @@ static int nbr_send_request(struct neighbour *nbr) {
 	}
 }
 
-#include <net/l3/icmpv4.h>
-static void nbr_drop_w_queue(struct neighbour *nbr) {
-	struct sk_buff *skb;
-
-	while ((skb = skb_queue_pop(&nbr->w_queue)) != NULL) {
-		icmp_discard(skb, ICMP_DEST_UNREACH, ICMP_HOST_UNREACH);
-	}
-
-	nbr->sent_times = 0;
-}
-
 static int nbr_build_and_send_pkt(struct sk_buff *skb,
 		const struct net_header_info *hdr_info) {
 	int ret;
@@ -454,7 +443,6 @@ static void nbr_timer_handler(struct sys_timer *tmr, void *param) {
 			if (nbr->incomplete) {
 				if (nbr->resend <= MODOPS_NEIGHBOUR_TMR_FREQ) {
 					if (nbr->sent_times == MODOPS_NEIGHBOUR_ATTEMPT) {
-						(void)nbr_drop_w_queue(nbr);
 						nbr_free(nbr);
 					}
 					else {


### PR DESCRIPTION
There is no need to send ICMP DISCARD messages about packets
we haven't sent. Linux just sends ARP's to the neighbor, there are no ICMP packets. 

From RFC 792:
```
If the gateway processing a datagram finds the time to live field
is zero it must discard the datagram.  The gateway may also notify
the source host via the time exceeded message.

If a host reassembling a fragmented datagram cannot complete the
reassembly due to missing fragments within its time limit it
discards the datagram, and it may send a time exceeded message.
```