### PR TITLE
Aarch64 MMU implementation

### DIFF
--- a/src/arch/aarch64/include/asm/hal/env/traps_core.h
+++ b/src/arch/aarch64/include/asm/hal/env/traps_core.h
@@ -1,0 +1,21 @@
+/**
+ * @file traps_core.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version 0.1
+ * @date 2015-08-17
+ */
+
+#ifndef ASM_HAL_ENV_TRAPS_CORE_H_
+#define ASM_HAL_ENV_TRAPS_CORE_H_
+
+#include <stdint.h>
+
+/** Defines handler for traps_dispatcher in Aarch64 archecture */
+typedef int (*__trap_handler)(uint32_t nr, void *data);
+
+/** Defines traps environment for Aarch64 structure */
+typedef struct __traps_env {
+} __traps_env_t;
+
+#endif /* ASM_HAL_ENV_TRAPS_CORE_H_ */

--- a/src/arch/aarch64/include/asm/hal/mmu.h
+++ b/src/arch/aarch64/include/asm/hal/mmu.h
@@ -5,3 +5,8 @@
  * @version
  * @date 19.07.2019
  */
+
+#ifndef AARCH64_ASM_HAL_MMU_H_
+#define AARCH64_ASM_HAL_MMU_H_
+
+#endif /* AARCH64_ASM_HAL_MMU_H_ */

--- a/src/arch/aarch64/include/asm/hal/reg.h
+++ b/src/arch/aarch64/include/asm/hal/reg.h
@@ -158,8 +158,17 @@ static inline uint64_t aarch64_isr_el1(void) {
 	return read_system_reg(ISR_EL1);
 }
 
-static inline uint64_t aarch64_current_el(void) {
+/* Raw CurrentEL register */
+static inline uint64_t aarch64_current_el_read(void) {
 	return read_system_reg(CurrentEL);
+}
+
+/* Convert CurrentEL to number from 0 to 3 */
+static inline int aarch64_current_el(void) {
+#define CURRENT_EL_OFFSET 2
+#define CURRENT_EL_MASK   6
+	return (int) ((aarch64_current_el_read() & CURRENT_EL_MASK)
+			>> CURRENT_EL_OFFSET);
 }
 
 static inline uint64_t aarch64_hcr_el2_read(void) {
@@ -170,8 +179,20 @@ static inline uint64_t aarch64_ttbr0_el2_read(void) {
 	return read_system_reg(TTBR0_EL2);
 }
 
+static inline void aarch64_ttbr0_el2_write(uint64_t reg) {
+	write_system_reg(TTBR0_EL2, reg);
+}
+
+static inline uint64_t aarch64_ttbr0_el1_read(void) {
+	return read_system_reg(TTBR0_EL1);
+}
+
+static inline void aarch64_ttbr0_el1_write(uint64_t reg) {
+	write_system_reg(TTBR0_EL1, reg);
+}
+
 static inline uint64_t aarch64_ttbr1_el2_read(void) {
-	return 0;//read_system_reg(TTBR1_EL2);
+	return read_system_reg(TTBR1_EL2);
 }
 
 static inline void aarch64_hcr_el2_write(uint64_t reg) {
@@ -182,8 +203,16 @@ static inline uint64_t aarch64_sctlr_el2_read(void) {
 	return read_system_reg(SCTLR_EL2);
 }
 
+static inline void aarch64_sctlr_el2_write(uint64_t reg) {
+	write_system_reg(SCTLR_EL2, reg);
+}
+
 static inline uint64_t aarch64_sctlr_el1_read(void) {
 	return read_system_reg(SCTLR_EL1);
+}
+
+static inline void aarch64_sctlr_el1_write(uint64_t reg) {
+	write_system_reg(SCTLR_EL1, reg);
 }
 
 static inline uint64_t aarch64_esr_el2_read(void) {
@@ -206,7 +235,32 @@ static inline uint64_t aarch64_far_el2_read(void) {
 	return read_system_reg(FAR_EL2);
 }
 
+static inline void aarch64_far_el2_write(uint64_t reg) {
+	write_system_reg(FAR_EL2, reg);
+}
+
 static inline uint64_t aarch64_far_el1_read(void) {
 	return read_system_reg(FAR_EL1);
 }
+
+static inline void aarch64_far_el1_write(uint64_t reg) {
+	write_system_reg(FAR_EL1, reg);
+}
+
+static inline uint64_t aarch64_tcr_el1_read(void) {
+	return read_system_reg(TCR_EL1);
+}
+
+static inline void aarch64_tcr_el1_write(uint64_t reg) {
+	write_system_reg(TCR_EL1, reg);
+}
+
+static inline uint64_t aarch64_tcr_el2_read(void) {
+	return read_system_reg(TCR_EL2);
+}
+
+static inline void aarch64_tcr_el2_write(uint64_t reg) {
+	write_system_reg(TCR_EL2, reg);
+}
+
 #endif /* AARCH_HAL_REG_ */

--- a/src/arch/aarch64/include/asm/hal/test/traps_core.h
+++ b/src/arch/aarch64/include/asm/hal/test/traps_core.h
@@ -1,0 +1,14 @@
+/**
+ * @file traps_core.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version 0.1
+ * @date 2015-08-17
+ */
+
+#ifndef ARM_HAL_TEST_TRAPS_CORE_H
+#define ARM_HAL_TEST_TRAPS_CORE_H
+
+/* Stub */
+
+#endif /* ARM_HAL_TEST_TRAPS_CORE_H */

--- a/src/arch/aarch64/include/asm/modes.h
+++ b/src/arch/aarch64/include/asm/modes.h
@@ -1,6 +1,6 @@
 /**
  * @file modes.h
- * @brief
+ * @brief Bits for system registers (DAIF/SPSR/SCTLR/etc)
  * @author Denis Deryugin <deryugin.denis@gmail.com>
  * @version
  * @date 22.07.2019
@@ -9,10 +9,25 @@
 #ifndef AARCH_ASM_MODES_H_
 #define AARCH_ASM_MODES_H_
 
-/** DAIF bits */
+/* DAIF bits */
 #define DAIF_D_BIT 0x200
 #define DAIF_A_BIT 0x100
 #define DAIF_I_BIT 0x080
 #define DAIF_F_BIT 0x040
+
+/* SCTLR bits */
+#define SCTLR_M    0x0001 /* MMU enable */
+#define SCTLR_A    0x0002 /* Alignment check enable */
+#define SCTLR_C    0x0004 /* Data cache enable */
+#define SCTLR_SA   0x0008 /* Stack alignment check enable */
+#define SCTLR_I    0x1000 /* Instruction cache enable */
+
+/* TCR bits */
+#define TCR_TG0_MASK 0x0000C000LL
+#define TCR_TG1_MASK 0xC0000000LL
+
+#define TCR_TG0_4KB  (0x0LL << 14)
+#define TCR_TG0_64KB (0x1LL << 14)
+#define TCR_TG0_16KB (0x2LL << 14)
 
 #endif /* AARCH_ASM_MODES_H_ */

--- a/src/arch/aarch64/mmu/Mybuild
+++ b/src/arch/aarch64/mmu/Mybuild
@@ -1,0 +1,13 @@
+package embox.arch.aarch64
+
+module mmu extends embox.mem.vmem {
+	source "mmu.c"
+	source "mmu.h"
+
+	option number granule = 4 /* size of pages, in kiB, can be 4, 16 or 64 */
+	option number log_level = 3
+
+	depends embox.mem.vmem_alloc
+	depends embox.mem.vmem_depends
+	depends embox.mem.vmem_header
+}

--- a/src/arch/aarch64/mmu/mmu.c
+++ b/src/arch/aarch64/mmu/mmu.c
@@ -1,0 +1,328 @@
+/**
+ * @file mmu.c
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 07.08.2019
+ */
+
+#include <assert.h>
+
+#include <asm/modes.h>
+#include <embox/unit.h>
+#include <hal/arch.h>
+#include <hal/mmu.h>
+#include <hal/reg.h>
+#include <hal/test/traps_core.h>
+#include <mem/vmem.h>
+#include <util/log.h>
+
+static int aarch64_mmu_init();
+void mmu_on(void) {
+	uint64_t r;
+
+	aarch64_mmu_init();
+
+	switch (aarch64_current_el()) {
+	case 2:
+		r = aarch64_sctlr_el2_read();
+		aarch64_sctlr_el2_write(r | SCTLR_M);
+		break;
+	case 1:
+		r = aarch64_sctlr_el1_read();
+		aarch64_sctlr_el1_write(r | SCTLR_M);
+		break;
+	default:
+		log_error("%s doesn't support EL%d\n",
+				__func__, aarch64_current_el());
+	}
+}
+
+void mmu_off(void) {
+	uint64_t r;
+	/* TODO: flush tlb */
+	switch (aarch64_current_el()) {
+	case 2:
+		r = aarch64_sctlr_el2_read();
+		aarch64_sctlr_el2_write(r & ~SCTLR_M);
+		break;
+	case 1:
+		r = aarch64_sctlr_el1_read();
+		aarch64_sctlr_el1_write(r & ~SCTLR_M);
+		break;
+	default:
+		log_error("%s doesn't support EL%d\n",
+				__func__, aarch64_current_el());
+	}
+}
+
+/* Assume mmu_ctx_t and ttbr0 are the same values for aarch64, so
+ * just set ASID=0 for now (as we have a single address space system-wide) */
+#define DEFAULT_ASID 0LL
+#define ASID_OFFSET  48
+#define ASID_MASK    (0xFFFFLL << ASID_OFFSET)
+mmu_ctx_t mmu_create_context(uintptr_t *pgd) {
+	if ((uintptr_t) pgd & ASID_MASK) {
+		log_error("16 most-significant bits of pgd should be zero, "
+				"but we have: %p", pgd);
+		return 0;
+	}
+
+
+	return ((uintptr_t) pgd) | (DEFAULT_ASID << ASID_OFFSET);
+}
+
+void mmu_set_context(mmu_ctx_t ctx) {
+	switch (aarch64_current_el()) {
+	case 2:
+		aarch64_ttbr0_el2_write(ctx);
+		break;
+	case 1:
+		aarch64_ttbr0_el1_write(ctx);
+		break;
+	default:
+		log_error("%s doesn't support EL%d",
+				__func__, aarch64_current_el());
+	}
+}
+
+uintptr_t *mmu_get_root(mmu_ctx_t ctx) {
+	return (uintptr_t *) (ctx & ~ASID_MASK);
+}
+
+void mmu_flush_tlb(void) {
+	switch (aarch64_current_el()) {
+	case 3:
+		asm volatile ("tlbi alle3");
+		break;
+	case 2:
+		asm volatile ("tlbi alle2");
+		break;
+	case 1:
+		asm volatile ("tlbi vmalle1");
+		break;
+	default:
+		log_error("%s doesn't support EL%d",
+				__func__, aarch64_current_el());
+	}
+}
+
+mmu_vaddr_t mmu_get_fault_address(void) {
+	switch (aarch64_current_el()) {
+	case 2:
+		return aarch64_far_el2_read();
+	case 1:
+		return aarch64_far_el1_read();
+	default:
+		log_error("%s doesn't support EL%d",
+				__func__, aarch64_current_el());
+	}
+	return 0;
+}
+
+static int aarch64_mmu_init(void) {
+	uint64_t tcr;
+
+	switch (aarch64_current_el()) {
+	case 2:
+		tcr = aarch64_tcr_el2_read();
+		break;
+	case 1:
+		tcr = aarch64_tcr_el1_read();
+		break;
+	default:
+		log_error("%s doesn't support EL%d\n",
+				__func__, aarch64_current_el());
+		return 0;
+
+	}
+
+	tcr &= ~TCR_TG0_MASK;
+
+	switch (AARCH64_MMU_GRANULE) {
+	case 4:
+		tcr |= TCR_TG0_4KB;
+		break;
+	case 16:
+		tcr |= TCR_TG0_16KB;
+		break;
+	case 64:
+		tcr |= TCR_TG0_64KB;
+		break;
+	default:
+		log_error("Wrong granule configuration");
+	}
+
+	switch (aarch64_current_el()) {
+	case 2:
+		aarch64_tcr_el2_write(tcr);
+		break;
+	case 1:
+		aarch64_tcr_el1_write(tcr);
+		break;
+	default:
+		log_error("%s doesn't support EL%d\n",
+				__func__, aarch64_current_el());
+	}
+
+	return 0;
+}
+
+uintptr_t *mmu_get(int lvl, uintptr_t *entry) {
+	if (entry == NULL) {
+		log_error("Entry is NULL!");
+		return 0;
+	}
+
+	return (uintptr_t *) (*entry & ~MMU_PAGE_MASK);
+}
+
+void mmu_set(int lvl, uintptr_t *entry, uintptr_t value) {
+	if (entry == 0) {
+		log_error("entry is NULL!");
+		return;
+	}
+
+	if (lvl < 0 || lvl >= MMU_LEVELS) {
+		log_error("Wrong MMU level: %d "
+				"(should be in range [0; %d)",
+				lvl, MMU_LEVELS);
+		return;
+	}
+
+	if (lvl == MMU_LEVELS - 1) {
+		*entry = value | AARCH64_MMU_TYPE_TABLE;
+	} else {
+		*entry = value | AARCH64_MMU_TYPE_PAGE;
+	}
+}
+
+void mmu_unset(int lvl, uintptr_t *entry) {
+	if (entry == 0) {
+		log_error("entry is NULL!");
+		return;
+	}
+
+	if (lvl < 0 || lvl >= MMU_LEVELS) {
+		log_error("Wrong MMU level: %d "
+				"(should be in range [0; %d)",
+				lvl, MMU_LEVELS);
+		return;
+	}
+
+	*entry = 0;
+}
+
+uintptr_t mmu_pte_pack(uintptr_t addr, int prot) {
+	uintptr_t ret;
+
+	if (addr & MMU_PAGE_MASK) {
+		log_error("address %p doesn't match mask %p",
+				(void *) addr, (void *) MMU_PAGE_MASK);
+		addr &= MMU_PAGE_MASK;
+	}
+
+	ret = addr | AARCH64_MMU_TYPE_PAGE
+	           | AARCH64_MMU_PROPERTY_AF;
+
+	if (prot & PROT_WRITE) {
+		ret |= AARCH64_MMU_PROPERTY_AP_RW;
+	} else {
+		ret |= AARCH64_MMU_PROPERTY_AP_RO;
+	}
+
+	if (!(prot & PROT_READ)) {
+		log_error("Setting page non-readable WTF");
+	}
+
+	if (prot & PROT_NOCACHE) {
+		ret |= AARCH64_MMU_PROPERTY_MEM_ATTR_DEVICE;
+	} else {
+		ret |= AARCH64_MMU_PROPERTY_MEM_ATTR_NORMAL;
+	}
+
+	if (!(prot & PROT_EXEC)) {
+		ret |= AARCH64_MMU_PROPERTY_UXN | AARCH64_MMU_PROPERTY_PXN;
+	}
+
+	return ret;
+}
+
+int mmu_pte_set(uintptr_t *entry, uintptr_t value) {
+	assert(entry);
+
+	*entry = value;
+
+	return 0;
+}
+
+uintptr_t mmu_pte_get(uintptr_t *entry) {
+	if (entry == NULL) {
+		log_error("Entry is NULL!");
+		return 0;
+	}
+
+	return *entry;
+}
+
+int mmu_present(int lvl, uintptr_t *entry) {
+	if (entry == NULL) {
+		log_error("Entry is NULL!");
+		return 0;
+	}
+
+	return !!(*entry & AARCH64_MMU_TYPE_MASK);
+}
+
+uintptr_t mmu_pte_unpack(uintptr_t pte, int *flags) {
+	assert(flags);
+
+	if ((pte & AARCH64_MMU_TYPE_MASK) != AARCH64_MMU_TYPE_PAGE) {
+		log_warning("Trying to unpack corrupted PTE");
+	}
+
+	*flags = 0;
+
+	if (!(pte & (AARCH64_MMU_PROPERTY_UXN | AARCH64_MMU_PROPERTY_PXN))) {
+		*flags |= PROT_EXEC;
+	}
+
+	switch (pte & AARCH64_MMU_PROPERTY_AP_MASK) {
+	case AARCH64_MMU_PROPERTY_AP_RW:
+		*flags |= PROT_READ | PROT_WRITE;
+		break;
+	case AARCH64_MMU_PROPERTY_AP_RO:
+		*flags |= PROT_READ;
+		break;
+	default:
+		log_warning("Corrupted PTE access properties");
+	}
+
+	switch (pte & AARCH64_MMU_PROPERTY_MEM_ATTR_MASK) {
+	case AARCH64_MMU_PROPERTY_MEM_ATTR_DEVICE:
+		*flags |= PROT_NOCACHE;
+		break;
+	case AARCH64_MMU_PROPERTY_MEM_ATTR_NORMAL:
+		/* Do nothing */
+		break;
+	default:
+		log_warning("Corrupted PTE cache properties");
+	}
+
+	return 0;
+}
+
+void set_fault_handler(enum fault_type type, fault_handler_t handler) {
+	log_error("%s is not implemented yet for Aarch64", __func__);
+}
+
+/* TODO it's impossible to simply drop priveleges as it
+ * requires using `eret` instruction, and this can be
+ * a little bit complicated */
+void mmu_drop_privileges(void) {
+	log_error("%s is not implemented yet for Aarch64", __func__);
+}
+
+void mmu_sys_privileges(void) {
+	log_error("%s is not implemented yet for Aarch64", __func__);
+}

--- a/src/arch/aarch64/mmu/mmu.h
+++ b/src/arch/aarch64/mmu/mmu.h
@@ -1,0 +1,68 @@
+/**
+ * @file mmu.h
+ * @brief
+ * @author Denis Deryugin <deryugin.denis@gmail.com>
+ * @version
+ * @date 07.08.2019
+ */
+
+#ifndef AARCH_MMU_H_
+#define AARCH_MMU_H_
+
+#include <stdint.h>
+
+#include <framework/mod/options.h>
+
+typedef uintptr_t __mmu_reg_t;
+typedef uintptr_t __mmu_vaddr_t;
+typedef uintptr_t __mmu_paddr_t;
+typedef uintptr_t __mmu_ctx_t;
+
+#define AARCH64_MMU_TYPE_MASK  0x3
+#define AARCH64_MMU_TYPE_BLOCK 0x1
+#define AARCH64_MMU_TYPE_TABLE 0x3 /* Translation walk level is 0, 1 or 2 */
+#define AARCH64_MMU_TYPE_PAGE  0x3 /* Translation walk level is 3 */
+
+/* Without extensions Aarch64 VA are 48-bit long */
+#define MMU_VADDR_WIDTH	48
+
+#define AARCH64_MMU_GRANULE \
+	OPTION_MODULE_GET(embox__arch__aarch64__mmu, NUMBER, granule)
+
+#if AARCH64_MMU_GRANULE == 4
+#define MMU_LEVELS 4
+#define __MMU_SHIFT_0   39
+#define __MMU_SHIFT_1   30
+#define __MMU_SHIFT_2   21
+#define __MMU_SHIFT_3   12
+
+#elif AARCH64_MMU_GRANULE == 16
+#define MMU_LEVELS 4
+#define __MMU_SHIFT_0  47
+#define __MMU_SHIFT_1  36
+#define __MMU_SHIFT_2  25
+#define __MMU_SHIFT_3  14
+
+#elif AARCH64_MMU_GRANULE == 64
+#define MMU_LEVELS 3
+#define __MMU_SHIFT_0  42
+#define __MMU_SHIFT_1  29
+#define __MMU_SHIFT_2  16
+
+#else
+#error No granule size specified
+#endif /* AARCH_MMU_GRANULE */
+
+/* All blocks and all pages have the same low property bits */
+#define AARCH64_MMU_PROPERTY_AF               0x0400 /* Access flag */
+#define AARCH64_MMU_PROPERTY_AP_MASK          0x00C0 /* Access permission */
+#define AARCH64_MMU_PROPERTY_AP_RW            0x0000 /* Read-write for all EL > 0 */
+#define AARCH64_MMU_PROPERTY_AP_RO            0x0080 /* Read-only for all EL > 0 */
+#define AARCH64_MMU_PROPERTY_MEM_ATTR_MASK    0x003C /* Properties for next level table */
+#define AARCH64_MMU_PROPERTY_MEM_ATTR_DEVICE  0x003C /* Refer D5.5.3 section in armv8-a manual for more details */
+#define AARCH64_MMU_PROPERTY_MEM_ATTR_NORMAL  0x0018
+
+#define AARCH64_MMU_PROPERTY_UXN              (1LL << 53) /* Unpriveleged eXecute-Never */
+#define AARCH64_MMU_PROPERTY_PXN              (1LL << 54) /* Priveleged eXecute-Never */
+
+#endif /* AARCH_MMU_H_ */

--- a/src/arch/microblaze/mmu/mmu.c
+++ b/src/arch/microblaze/mmu/mmu.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <sys/mman.h>
 
+#include <mem/vmem.h>
 #include <hal/mmu.h>
 
 static uintptr_t *context_table[0x100]  __attribute__((aligned(MMU_PAGE_SIZE)));

--- a/src/cmds/hardware/mm/mmutrans/mmutrans.c
+++ b/src/cmds/hardware/mm/mmutrans/mmutrans.c
@@ -16,7 +16,7 @@
 #include <mem/vmem.h>
 
 static void print_usage(void) {
-	printf("Usage: mmutrans [-h] virt_addr [-p pid] [-t] ");
+	printf("Usage: mmutrans [-h] virt_addr [-p pid] [-t]\n");
 }
 
 static int mmu_translate(pid_t pid, uintptr_t virt_addr) {

--- a/src/drivers/clock/pl031/pl031.c
+++ b/src/drivers/clock/pl031/pl031.c
@@ -6,6 +6,7 @@
  * @date 2019-07-18
  */
 
+#include <drivers/common/memory.h>
 #include <hal/clock.h>
 #include <hal/reg.h>
 #include <kernel/irq.h>
@@ -86,3 +87,5 @@ static struct clock_source pl031_clock_source = {
 EMBOX_UNIT_INIT(pl031_init);
 
 STATIC_IRQ_ATTACH(PL031_IRQ, clock_handler, &imx6_clock_source);
+
+PERIPH_MEMORY_DEFINE(pl031_mem, PL031_BASE, 0x20);

--- a/src/drivers/common/memory.c
+++ b/src/drivers/common/memory.c
@@ -15,6 +15,7 @@
 #ifndef NOMMU
 
 #include <drivers/common/memory.h>
+#include <mem/vmem.h>
 #include <hal/mmu.h>
 #include <kernel/task/kernel_task.h>
 #include <kernel/task/resource/mmap.h>

--- a/src/drivers/interrupt/cortex_a9_gic/cortex_a9_gic.c
+++ b/src/drivers/interrupt/cortex_a9_gic/cortex_a9_gic.c
@@ -175,4 +175,5 @@ void swi_handle(void) {
 	printk("swi!\n");
 }
 
-PERIPH_MEMORY_DEFINE(gic, GIC_CPU_BASE, 0x2020);
+PERIPH_MEMORY_DEFINE(gic_cpu, GIC_CPU_BASE, 0x2020);
+PERIPH_MEMORY_DEFINE(gic_distributor, GIC_DISTRIBUTOR_BASE, 0x1000);

--- a/src/include/hal/mmu.h
+++ b/src/include/hal/mmu.h
@@ -15,9 +15,6 @@
 #error "set MMU_LEVELS"
 #endif
 
-#define MMU_PAGE_SIZE     (4096)
-#define MMU_PAGE_MASK     (4095)
-
 #if MMU_LEVELS > 0
 typedef __mmu_paddr_t mmu_paddr_t;
 typedef __mmu_vaddr_t mmu_vaddr_t;

--- a/src/mem/vmem/vmem.h
+++ b/src/mem/vmem/vmem.h
@@ -59,7 +59,11 @@ extern int vmem_set_flags(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, ssize_t len, int
 #define __MMU_SHIFT_3 0
 #endif
 
-#define MMU_SHIFT(i) ((i == -1) ? 32 : \
+#ifndef MMU_VADDR_WIDTH
+#define MMU_VADDR_WIDTH (8 * sizeof(uintptr_t))
+#endif
+
+#define MMU_SHIFT(i) ((i == -1) ? MMU_VADDR_WIDTH : \
 			(i) == 0 ? __MMU_SHIFT_0 : \
 			(i) == 1 ? __MMU_SHIFT_1 : \
 			(i) == 2 ? __MMU_SHIFT_2 : __MMU_SHIFT_3)

--- a/src/mem/vmem/vmem.h
+++ b/src/mem/vmem/vmem.h
@@ -66,6 +66,9 @@ extern int vmem_set_flags(mmu_ctx_t ctx, mmu_vaddr_t virt_addr, ssize_t len, int
 
 #define MMU_ENTRIES(i) (1 << (MMU_SHIFT(i - 1) - MMU_SHIFT((i))))
 #define MMU_MASK(i) ((MMU_ENTRIES(i) - 1) << MMU_SHIFT(i))
-#define MMU_SIZE(i) (MMU_ENTRIES(i) * sizeof(mmu_vaddr_t))
+#define MMU_SIZE(i) (MMU_ENTRIES(i + 1) * sizeof(mmu_vaddr_t))
+
+#define MMU_PAGE_SIZE  (1 << MMU_SHIFT(MMU_LAST_LEVEL))
+#define MMU_PAGE_MASK  (MMU_PAGE_SIZE - 1)
 
 #endif /* MEM_VMEM_H_ */

--- a/templates/aarch64/qemu/mods.config
+++ b/templates/aarch64/qemu/mods.config
@@ -5,6 +5,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.aarch64.arch
 	@Runlevel(0) include embox.arch.aarch64.libarch
 	@Runlevel(0) include embox.arch.aarch64.vfork
+	@Runlevel(0) include embox.arch.aarch64.mmu(granule=64)
 	@Runlevel(0) include embox.arch.aarch64.exception_table
 	@Runlevel(0) include embox.kernel.cpu.bkl
 	@Runlevel(0) include embox.kernel.cpu.cpudata
@@ -65,7 +66,6 @@ configuration conf {
 	include embox.compat.atomic.pseudo_atomic
 
 	include embox.cmd.testing.ticker
-	include embox.test.posix.vfork_test
 	include embox.cmd.help
 	include embox.cmd.man
 
@@ -111,5 +111,10 @@ configuration conf {
 	@Runlevel(2) include embox.test.stdlib.qsort_test
 	@Runlevel(2) include embox.test.posix.environ_test
 	@Runlevel(2) include embox.test.posix.getopt_test
-}
 
+	@Runlevel(2) include embox.test.posix.vfork_test
+
+	include embox.mem.vmem_alloc_single_pool
+
+	include embox.cmd.hw.mmutrans
+}


### PR DESCRIPTION
Now it supports 4KiB, 16KiB and 64KiB page granules.

Also this PR fixes some memory issues (i.e. hard-coded 4KiB page size or missing headers)