### PR TITLE
opencv/edges: pixel loop optimization

### DIFF
--- a/platform/opencv/cmds/edges.cpp
+++ b/platform/opencv/cmds/edges.cpp
@@ -62,8 +62,9 @@ int main(int argc, const char** argv) {
 	printf("Framebuffer: %dx%d %dbpp\n", fbi->var.xres, fbi->var.yres, fbi->var.bits_per_pixel);
 	printf("Image: %dx%d; Threshold=%d\n", cedge.cols, cedge.rows, edgeThresh);
 
-	for (int x = 0; x < cedge.cols; x++) {
-		for (int y = 0; y < cedge.rows; y++) {
+
+	for (int y = 0; y < cedge.rows; y++) {
+		for (int x = 0; x < cedge.cols; x++) {
 			Vec3b intensity = cedge.at<Vec3b>(y, x);
 			unsigned rgb888	=
 				0xFF000000 |

--- a/platform/opencv/cmds/edges.cpp
+++ b/platform/opencv/cmds/edges.cpp
@@ -64,13 +64,13 @@ int main(int argc, const char** argv) {
 
 
 	for (int y = 0; y < cedge.rows; y++) {
-		for (int x = 0; x < cedge.cols; x++) {
-			Vec3b intensity = cedge.at<Vec3b>(y, x);
+		const uchar *row = &cedge.at<uchar>(y, 0);
+		for (int x = 0; x < 3 * cedge.cols; x += 3) {
 			unsigned rgb888	=
 				0xFF000000 |
-				intensity.val[0] |
-				((intensity.val[1]) << 8) |
-				((intensity.val[2]) << 16);
+				unsigned(row[x]) |
+				(unsigned(row[x + 1]) << 8) |
+				(unsigned(row[x + 2]) << 16);
 
 			((uint32_t *) fbi->screen_base)[fbi->var.xres * y + x] = rgb888;
 		}

--- a/platform/opencv/cmds/edges.cpp
+++ b/platform/opencv/cmds/edges.cpp
@@ -62,16 +62,16 @@ int main(int argc, const char** argv) {
 	printf("Framebuffer: %dx%d %dbpp\n", fbi->var.xres, fbi->var.yres, fbi->var.bits_per_pixel);
 	printf("Image: %dx%d; Threshold=%d\n", cedge.cols, cedge.rows, edgeThresh);
 
-	for (int i = 0; i < cedge.cols; i++) {
-		for (int j = 0; j < cedge.rows; j++) {
-			Vec3b intensity = cedge.at<Vec3b>(j, i);
+	for (int x = 0; x < cedge.cols; x++) {
+		for (int y = 0; y < cedge.rows; y++) {
+			Vec3b intensity = cedge.at<Vec3b>(y, x);
 			unsigned rgb888	=
 				0xFF000000 |
 				intensity.val[0] |
 				((intensity.val[1]) << 8) |
 				((intensity.val[2]) << 16);
 
-			((uint32_t *) fbi->screen_base)[fbi->var.xres * j + i] = rgb888;
+			((uint32_t *) fbi->screen_base)[fbi->var.xres * y + x] = rgb888;
 		}
 	}
 


### PR DESCRIPTION
```	
	int t1 = clock();
	for (int y = 0; y < cedge.rows; y++) {
		const uchar *row = &cedge.at<uchar>(y, 0);
		for (int x = 0; x < 3 * cedge.cols; x += 3) {
			unsigned rgb888	=
				0xFF000000 |
				unsigned(row[x]) |
				(unsigned(row[x + 1]) << 8) |
				(unsigned(row[x + 2]) << 16);
		}
	}
	int t2 = clock();
	std::cout << (t2 - t1)/double(CLOCKS_PER_SEC) << std::endl;

	int t3 = clock();
	for (int i = 0; i < cedge.cols; i++) {
		for (int j = 0; j < cedge.rows; j++) {
			Vec3b intensity = cedge.at<Vec3b>(j, i);
			unsigned rgb888	=
				0xFF000000 |
				intensity.val[0] |
				((intensity.val[1]) << 8) |
				((intensity.val[2]) << 16);
		}
	}
	int t4 = clock();
	std::cout << (t4 - t3)/double(CLOCKS_PER_SEC) << std::endl;
```

Program output:
Image: 1024x1024; Threshold=1
0.003581 <- optimized time (seconds)
0.014571 <- initial variant