### PR TITLE
X86 vfork stackframe

### DIFF
--- a/src/arch/x86/include/asm/entry.h
+++ b/src/arch/x86/include/asm/entry.h
@@ -54,16 +54,22 @@
 	iret;
 
 #define CALL_WPTREGS \
+	push    %ebp;               \
+	mov     %esp, %ebp;         \
 	subl 	$28, %esp;          \
 	SAVE_ALL_REGS;              \
-	movl	PT_END(%esp), %ecx; \
+	movl    %esp, %eax;         \
+	addl    $PT_EBP, %eax;      \
+	push    SAVED_EBP(%esp);    \
+	pop     (%eax);             \
+	movl	FRAME_END(%esp), %ecx; \
 	movl	%ecx, PT_EIP(%esp); \
 	push	%cs;				\
 	popl	PT_CS(%esp);		\
 	pushf;                      \
 	popl	PT_EFLAGS(%esp);    \
 	movl	%esp, %eax;         \
-	addl	$PT_END+4, %eax;    \
+	addl	$FRAME_END+4, %eax; \
 	movl	%eax, PT_ESP(%esp); \
 	push    %esp;               \
 	call
@@ -103,6 +109,7 @@
 #define PT_EIP     52
 #define PT_EIP_N   13
 #define PT_CS      56
+#define PT_CS_N    14
 #define PT_EFLAGS  60
 #define PT_EFLAGS_N 15
 #define PT_ESP     64
@@ -110,7 +117,11 @@
 #define PT_SS      68
 #define PT_SS_N    17
 
-#define PT_END     72
+#define SAVED_EBP     72
+#define SAVED_EBP_N   18
+
+#define FRAME_END    76
+#define FRAME_END_N   19
 
 #endif /* __ASSEMBLER__ */
 

--- a/src/arch/x86/include/asm/entry.h
+++ b/src/arch/x86/include/asm/entry.h
@@ -55,22 +55,22 @@
 
 #define CALL_WPTREGS \
 	push    %ebp;               \
-	mov     %esp, %ebp;         \
-	subl 	$28, %esp;          \
+	movl    %esp, %ebp;         \
+	subl    $28, %esp;          \
 	SAVE_ALL_REGS;              \
 	movl    %esp, %eax;         \
 	addl    $PT_EBP, %eax;      \
 	push    SAVED_EBP(%esp);    \
-	pop     (%eax);             \
-	movl	FRAME_END(%esp), %ecx; \
-	movl	%ecx, PT_EIP(%esp); \
-	push	%cs;				\
-	popl	PT_CS(%esp);		\
+	popl    (%eax);             \
+	movl    FRAME_END(%esp), %ecx; \
+	movl    %ecx, PT_EIP(%esp); \
+	push    %cs;                \
+	popl    PT_CS(%esp);        \
 	pushf;                      \
-	popl	PT_EFLAGS(%esp);    \
-	movl	%esp, %eax;         \
-	addl	$FRAME_END+4, %eax; \
-	movl	%eax, PT_ESP(%esp); \
+	popl    PT_EFLAGS(%esp);    \
+	movl    %esp, %eax;         \
+	addl    $FRAME_END+4, %eax; \
+	movl    %eax, PT_ESP(%esp); \
 	push    %esp;               \
 	call
 

--- a/src/arch/x86/lib/ptregs_jmp.S
+++ b/src/arch/x86/lib/ptregs_jmp.S
@@ -17,14 +17,15 @@ ptregs_jmp:
 	/* Need to set new ESP now, correct value
 	 * in pt_regs can be overwriten by movsd */
 	movl	PT_ESP(%eax),%esp
-	subl	$PT_ESP, %esp
+	subl	$PT_SS, %esp
 
 	movl	%eax, %esi
 	addl	$PT_ESP, %esi
 	movl	PT_ESP(%eax), %edi
+	subl    $4, %edi
 	movl	$PT_SS_N, %ecx
 	std
 	rep		movsd
+	cld
 
 	RESTORE_ALL
-

--- a/src/arch/x86/lib/ptregs_jmp.S
+++ b/src/arch/x86/lib/ptregs_jmp.S
@@ -12,20 +12,20 @@
 	.global ptregs_jmp
 
 ptregs_jmp:
-	movl	4(%esp), %eax
+	movl    4(%esp), %eax
 
 	/* Need to set new ESP now, correct value
 	 * in pt_regs can be overwriten by movsd */
-	movl	PT_ESP(%eax),%esp
-	subl	$PT_SS, %esp
+	movl    PT_ESP(%eax),%esp
+	subl    $PT_SS, %esp
 
-	movl	%eax, %esi
-	addl	$PT_ESP, %esi
-	movl	PT_ESP(%eax), %edi
+	movl    %eax, %esi
+	addl    $PT_ESP, %esi
+	movl    PT_ESP(%eax), %edi
 	subl    $4, %edi
-	movl	$PT_SS_N, %ecx
+	movl    $PT_SS_N, %ecx
 	std
-	rep		movsd
+	rep     movsd
 	cld
 
 	RESTORE_ALL

--- a/src/arch/x86/lib/vfork.S
+++ b/src/arch/x86/lib/vfork.S
@@ -15,4 +15,3 @@
 
 vfork:
 	CALL_WPTREGS vfork_body
-


### PR DESCRIPTION
backtrace now work everywhere except a few lines in `ptregs_jmp`, because in this function we jump on previous frame and change values of stack and registers. 