### PR TITLE
PCI refactor

### DIFF
--- a/src/drivers/pci/pci.c
+++ b/src/drivers/pci/pci.c
@@ -26,19 +26,6 @@
 
 EMBOX_UNIT_INIT(pci_init);
 
-typedef struct pci_slot {
-	uint8_t bus;
-	uint8_t slot;
-	uint8_t func;
-	uint16_t ven;
-	uint16_t dev;
-	uint8_t base_clase;
-	uint8_t subclass;
-	uint8_t rev;
-	uint8_t irq;
-	uint32_t bar[6];
-} pci_slot_t;
-
 POOL_DEF(devs_pool, struct pci_slot_dev, OPTION_GET(NUMBER,dev_quantity));
 
 /* repository */

--- a/src/drivers/pci/pci.c
+++ b/src/drivers/pci/pci.c
@@ -23,6 +23,7 @@
 #include <drivers/pci/pci_driver.h>
 
 #define PCI_BUS_N_TO_SCAN OPTION_GET(NUMBER,bus_n_to_scan)
+#define PCI_IRQ_BASE      OPTION_GET(NUMBER,irq_base)
 
 EMBOX_UNIT_INIT(pci_init);
 
@@ -49,7 +50,8 @@ static int pci_get_slot_info(struct pci_slot_dev *dev) {
 	pci_read_config8(dev->busn, devfn, PCI_BASECLASS_CODE, &dev->baseclass);
 	pci_read_config8(dev->busn, devfn, PCI_SUBCLASS_CODE, &dev->subclass);
 	pci_read_config8(dev->busn, devfn, PCI_REVISION_ID, &dev->rev);
-	pci_read_config8(dev->busn, devfn, PCI_INTERRUPT_LINE, &dev->irq);
+	pci_read_config8(dev->busn, devfn, PCI_INTERRUPT_LINE, &dev->irq_line);
+	pci_read_config8(dev->busn, devfn, PCI_INTERRUPT_PIN, &dev->irq_pin);
 
 	for (bar_num = 0; bar_num < ARRAY_SIZE(dev->bar); bar_num ++) {
 		pci_read_config32(dev->busn, devfn,
@@ -57,6 +59,7 @@ static int pci_get_slot_info(struct pci_slot_dev *dev) {
 	}
 	dev->func = PCI_FUNC(devfn);
 	dev->slot = PCI_SLOT(devfn);
+	dev->irq = pci_irq_number(dev);
 
 	return 0;
 }

--- a/src/drivers/pci/pci.h
+++ b/src/drivers/pci/pci.h
@@ -171,7 +171,9 @@ struct pci_slot_dev {
 	uint16_t device;
 	uint8_t baseclass;
 	uint8_t subclass;
-	uint8_t irq;
+	unsigned int irq; /* IRQ number suitable for passing to irq_attach() */
+	uint8_t irq_pin;  /* IRQ pin from PCI configuration space */
+	uint8_t irq_line; /* IRQ line from PCI configuration space */
 	uint32_t bar[6];
 	uint8_t primary;
 	uint8_t secondary;

--- a/src/drivers/pci/pci_chip/pci_chip_elbrus.c
+++ b/src/drivers/pci/pci_chip/pci_chip_elbrus.c
@@ -118,3 +118,8 @@ uint32_t pci_write_config32(uint32_t bus, uint32_t dev_fn,
 		uint32_t where,	uint32_t value) {
 	return e2k_pci_config_write(bus, dev_fn, where, 4, value);
 }
+
+/* NOTE: this may be inaccurate! */
+unsigned int pci_irq_number(struct pci_slot_dev *dev) {
+	return (unsigned int) dev->irq_line;
+}

--- a/src/drivers/pci/pci_chip/pci_chip_x86.c
+++ b/src/drivers/pci/pci_chip/pci_chip_x86.c
@@ -99,3 +99,8 @@ uint32_t pci_write_config32(uint32_t bus, uint32_t dev_fn,
 	out32(value, PCI_CONFIG_DATA);
 	return PCIUTILS_SUCCESS;
 }
+
+/* NOTE: this may be inaccurate! */
+unsigned int pci_irq_number(struct pci_slot_dev *dev) {
+	return (unsigned int) dev->irq_line;
+}

--- a/src/drivers/pci/pci_chip/pci_utils.h
+++ b/src/drivers/pci/pci_chip/pci_utils.h
@@ -38,4 +38,9 @@ extern uint32_t pci_write_config16(uint32_t bus, uint32_t dev_fn,
 extern uint32_t pci_write_config32(uint32_t bus, uint32_t dev_fn,
 				uint32_t where, uint32_t value);
 
+/* PCI IRQ numbering depends on platform, this function calculates
+ * platform-specific IRQ number */
+struct pci_slot_dev;
+extern unsigned int pci_irq_number(struct pci_slot_dev *dev);
+
 #endif /* PCI_UTILS_H_ */

--- a/src/drivers/pci/pci_chip/ti81xx.c
+++ b/src/drivers/pci/pci_chip/ti81xx.c
@@ -301,6 +301,11 @@ static int ti81xx_pci_init(void) {
 	return 0;
 }
 
+/* NOTE: this may be inaccurate! */
+unsigned int pci_irq_number(struct pci_slot_dev *dev) {
+	return (unsigned int) dev->irq_line;
+}
+
 PERIPH_MEMORY_DEFINE(pci_chip, TI81_CM, 0x1000);
 
 PERIPH_MEMORY_DEFINE(pci_root, TI81_PRCM, 0x1000);


### PR DESCRIPTION
IRQ numbering can be complicated for PCI devices. Previously Embox drivers simply took `IRQ line` from PCI configuration space, but for some platforms that's not enough (e.g. qemu/aarch64).

I suggest to use different functions for different PCI chips. However, even this approach will not solve all problems as IRQ numbering can also depend on interrupt controller model according to [osdev wiki](https://wiki.osdev.org/PCI#IRQ_Handling).