### PR TITLE
Fix opencv

### DIFF
--- a/platform/opencv/templates/stm32f764g-discovery/mods.config
+++ b/platform/opencv/templates/stm32f764g-discovery/mods.config
@@ -10,7 +10,9 @@ configuration conf {
 
 	//@Runlevel(0) include embox.arch.arm.fpu.cortex_m7_fp
 	//@Runlevel(0) include embox.arch.arm.fpu.fpv5(log_level=3)
-	@Runlevel(0) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
+	@Runlevel(0) include embox.arch.arm.armmlib.interrupt(
+					nvic_use_prio=true, nvic_prio_shift=4)
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
 	@Runlevel(1) include embox.driver.clock.cortexm_systick
 	@Runlevel(1) include embox.driver.serial.stm_usart_f7(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")

--- a/third-party/lib/opencv/Makefile
+++ b/third-party/lib/opencv/Makefile
@@ -24,6 +24,7 @@ endif
 
 OPENCV_FLAGS = \
 		-DBUILD_SHARED_LIBS=OFF -DBUILD_opencv_python_bindings_generator=OFF -DBUILD_JAVA=OFF -DBUILD_TESTS=OFF -DBUILD_opencv_apps=OFF BUILD_opencv_java_bindings_generator=OFF -DBUILD_opencv_ml=OFF -DWITH_FFMPEG=OFF -DWITH_EIGEN=OFF -DBUILD_IPP_IW=OFF -DBUILD_ITT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_PROTOBUF=OFF \
+		-DOPENCV_FORCE_3RDPARTY_BUILD=ON \
 		-DBUILD_opencv_calib3d=OFF \
 		-DBUILD_opencv_dnn=OFF \
 		-DBUILD_opencv_features2d=ON \


### PR DESCRIPTION
* Fix build when host already has zlib preinstalled.
* Fix run on stm32f764g-discovery after 3246a20 (since `loader` now uses interrupts with priorities, embox with opencv should too).