### PR TITLE
fpu: Use numerical labels instead of characters in assembler

### DIFF
--- a/src/arch/arm/fpu/armv7m/fpv5.h
+++ b/src/arch/arm/fpu/armv7m/fpv5.h
@@ -45,17 +45,17 @@ static inline void arm_fpu_context_init(void *opaque) {
 	ldr       tmp, =FPU_CPACR; \
 	ldr       tmp, [tmp]; \
 	tst       tmp, #0xF00000; \
-	beq       fpu_out_save_inc; \
+	beq       1f; \
 	vstmia    stack!, {s0-s31}; \
-fpu_out_save_inc:
+1:
 
 #define ARM_FPU_CONTEXT_LOAD_INC(tmp, stack) \
 	ldr       tmp, =FPU_CPACR; \
 	ldr       tmp, [tmp]; \
 	tst       tmp, #0xF00000; \
-	beq       fpu_out_load_inc; \
+	beq       1f; \
 	vldmia    stack!, {s0-s31}; \
-fpu_out_load_inc:
+1:
 
 #endif /* __ASSEMBLER__ */
 

--- a/src/arch/arm/fpu/vfp.h
+++ b/src/arch/arm/fpu/vfp.h
@@ -40,37 +40,37 @@ extern int try_vfp_instructions(void);
 	mrc       p15, 0, tmp, c1, c0, 2; \
 	stmia     stack!, {tmp}; \
 	tst       tmp, #0xF00000; \
-	beq       fpu_out_save_inc; \
+	beq       1f;          \
 	vstmia    stack!, {d0-d15}; \
 	vstmia    stack!, {d16-d31}; \
-fpu_out_save_inc:
+1:
 
 #define ARM_FPU_CONTEXT_SAVE_DEC(tmp, stack) \
 	mrc       p15, 0, tmp, c1, c0, 2; \
 	tst       tmp, #0xF00000; \
-	beq       fpu_out_save_dec; \
+	beq       1f; \
 	vstmdb    stack!, {d0-d15}; \
 	vstmdb    stack!, {d16-d31}; \
-fpu_out_save_dec: \
+1: \
 	stmfd     stack!, {tmp};
 
 #define ARM_FPU_CONTEXT_LOAD_INC(tmp, stack) \
 	ldmia     stack!, {tmp}; \
 	mcr       p15, 0, tmp, c1, c0, 2; \
 	tst       tmp, #0xF00000; \
-	beq       fpu_out_load_inc; \
+	beq       1f; \
 	vldmia    stack!, {d0-d15}; \
 	vldmia    stack!, {d16-d31}; \
-fpu_out_load_inc:
+1:
 
 #define ARM_FPU_CONTEXT_LOAD_DEC(tmp, stack) \
 	ldmfd     stack!, {tmp}; \
 	mcr       p15, 0, tmp, c1, c0, 2; \
 	tst       tmp, #0xF00000; \
-	beq       fpu_out_load_dec; \
+	beq       1f; \
 	vldmia   stack!, {d16-d31}; \
 	vldmia   stack!, {d0-d15}; \
-fpu_out_load_dec:
+1:
 
 #endif /* __ASSEMBLER__ */
 

--- a/src/arch/arm/fpu/vfp9_s.h
+++ b/src/arch/arm/fpu/vfp9_s.h
@@ -39,17 +39,17 @@ extern int try_vfp_instructions(void /*struct pt_regs_fpu *vfp */);
 	vmrs      tmp, FPEXC ; \
 	stmia     stack!, {tmp}; \
 	ands      tmp, tmp, #1<<30; \
-	beq       fpu_out_save_inc; \
+	beq       1f; \
 	vstmia    stack!, {d0-d15}; \
-fpu_out_save_inc:
+1:
 
 #define ARM_FPU_CONTEXT_SAVE_DEC(tmp, stack) \
 	vmrs      tmp, FPEXC ;             \
 	sub       stack, stack, #(4 * 32); \
 	tst       tmp, #1<<30;             \
-	beq       fpu_skip_save_dec;       \
+	beq       1f;                   \
 	vstmia    stack, {d0-d15};         \
-fpu_skip_save_dec:                     \
+1:                                  \
 	stmfd     stack!, {tmp};
 
 
@@ -57,17 +57,17 @@ fpu_skip_save_dec:                     \
 	ldmia     stack!, {tmp}; \
 	vmsr      FPEXC, tmp; \
 	ands      tmp, tmp, #1<<30; \
-	beq       fpu_out_load_inc; \
+	beq       1f;            \
 	vldmia    stack!, {d0-d15}; \
-fpu_out_load_inc:
+1:
 
 #define ARM_FPU_CONTEXT_LOAD_DEC(tmp, stack) \
 	ldmfd     stack!, {tmp}; \
 	/* vmsr      FPEXC, tmp; */ \
 	ands      tmp, tmp, #1<<30; \
-	beq       fpu_skip_load_dec; \
-	vldmia    stack, {d0-d15}; \
-fpu_skip_load_dec: \
+	beq       1f;            \
+	vldmia    stack, {d0-d15};  \
+1:                           \
 	add       stack, stack, #4 * 32;
 
 #endif /* __ASSEMBLER__ */


### PR DESCRIPTION
Without that fix I permanently get infinity backtrace in GDB. GDB thinks these labels are functions, not local labels.
https://sourceware.org/binutils/docs/as/Symbol-Names.html