### PR TITLE
Fix strnlen bug. Now maxlen works correctly.

### DIFF
--- a/src/compat/libc/string/strnlen.c
+++ b/src/compat/libc/string/strnlen.c
@@ -11,7 +11,7 @@ size_t strnlen(const char *str, size_t maxlen) {
 	size_t len;
 	const char *s = str;
 
-	for (len = 0; len <= maxlen; len++) {
+	for (len = 0; len < maxlen; len++) {
 		if ('\0' == *s++) {
 			break;
 		}


### PR DESCRIPTION
Early: strnlen("helloworld", 4) == 5
Now: strnlen("helloworld", 4) == 4