### PR TITLE
OpenLibm fix

### DIFF
--- a/third-party/lib/estransform/Mybuild
+++ b/third-party/lib/estransform/Mybuild
@@ -5,4 +5,6 @@ module estransform {
 	source "esTransform.h"
 
 	source "esTransform.c"
+
+	depends embox.compat.libc.math
 }

--- a/third-party/lib/openlibm/Mybuild
+++ b/third-party/lib/openlibm/Mybuild
@@ -2,7 +2,8 @@
 package third_party.lib
 
 @Build(stage=1, script="$(EXTERNAL_MAKE)")
-static module OpenLibm {
+static module OpenLibm extends embox.compat.libc.math {
 	source "^BUILD/extbld/^MOD_PATH/install/libopenlibm.a"
+	@IncludeExport(target_name="math.h")
 	source "impl.h"
 }


### PR DESCRIPTION
* Use OpenLibM module as an extension for `embox.compat.libc.math` to avoid automatic include for math_stubs
* Provide `math.h` with OpenLibM
* Fix dependency for ESTransform lib