### PR TITLE
block_dev: Use 64-bit value for block device size

### DIFF
--- a/src/cmds/hardware/ide.c
+++ b/src/cmds/hardware/ide.c
@@ -20,7 +20,8 @@ static void print_usage(void) {
 
 static void print_drive (struct ide_tab *ide) {
 	hd_t *drive;
-	int dev_size, dev_bsize;
+	uint64_t dev_size;
+	size_t dev_bsize;
 
 	for(int i  = 0; i < 4; i++) {
 		printf("\nIDE Channel %d-%d: ", i/2, i%2);
@@ -34,8 +35,9 @@ static void print_drive (struct ide_tab *ide) {
 			printf(" None");
 		} else {
 			drive = (hd_t *) ide->drive[i];
-			dev_bsize = block_dev_ioctl(drive->bdev, IOCTL_GETBLKSIZE, NULL, 0);
-			dev_size = block_dev_ioctl(drive->bdev, IOCTL_GETDEVSIZE, NULL, 0);
+			assert(drive);
+			dev_bsize = block_dev_block_size(drive->bdev);
+			dev_size = block_dev_size(drive->bdev);
 			printf(" %s;", ((struct node *)block_dev(drive->bdev)->dev_vfs_info)->name);
 			printf(" %s", drive->param.serial);
 			printf(" %s", drive->param.model);

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -32,7 +32,7 @@ typedef struct block_dev {
 	struct block_dev_driver *driver;
 	void *privdata;
 
-	size_t size;
+	uint64_t size;
 	size_t block_size;
 	struct block_dev_cache *cache;
 
@@ -62,7 +62,7 @@ typedef struct block_dev_cache {
 	blkno_t blkno;
 	blkno_t lastblkno;
 	char *data;
-	int blksize;
+	size_t blksize;
 	int blkfactor;
 	int depth;
 	char *pool;
@@ -93,6 +93,9 @@ extern struct block_dev_module *block_dev_lookup(const char *name);
 extern void block_dev_free(struct block_dev *dev);
 extern struct block_dev *block_dev_create_common(const char *path, void *driver, void *privdata);
 extern struct block_dev *block_dev_find(const char *bd_name);
+
+extern uint64_t block_dev_size(struct block_dev *dev);
+extern size_t block_dev_block_size(struct block_dev *dev);
 
 #include <util/array.h>
 

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -786,7 +786,8 @@ static int ext2fs_format(void *dev) {
 	struct ext2_gd gd;
 	struct ext2fs_dinode *di;
 	char buff[SBSIZE];
-	size_t dev_size, dev_bsize;
+	uint64_t dev_size;
+	size_t dev_bsize;
 	int sector;
 	float dev_factor;
 
@@ -802,8 +803,8 @@ static int ext2fs_format(void *dev) {
 	memset(&gd, 0, sizeof(struct ext2_gd));
 
 	bdev = (struct block_dev *) dev_fi->privdata;
-	dev_size = block_dev_ioctl(bdev, IOCTL_GETDEVSIZE, NULL, 0);
-	dev_bsize = block_dev_ioctl(bdev, IOCTL_GETBLKSIZE, NULL, 0);
+	dev_size = block_dev_size(bdev);
+	dev_bsize = block_dev_block_size(bdev);
 	dev_factor = SBSIZE / dev_bsize;
 
 	ext2_dflt_sb(&sb, dev_size, dev_factor);

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -205,7 +205,7 @@ static int ext3_journal_load(journal_t *jp, struct block_dev *jdev, block_t star
     assert(jdev);
 
     jp->j_dev = jdev;
-    jp->j_disk_sectorsize = block_dev_ioctl(jdev, IOCTL_GETBLKSIZE, NULL, 0);
+    jp->j_disk_sectorsize = block_dev_block_size(jdev);
 
     assert(jp->j_disk_sectorsize >= 512);
 

--- a/src/fs/driver/iso9660/cdfs.c
+++ b/src/fs/driver/iso9660/cdfs.c
@@ -415,8 +415,7 @@ int cdfs_mount(struct nas *root_nas)
 	fsi = root_nas->fs->fsi;
 
 	/* Check block size */
-	if (CDFS_BLOCKSIZE !=
-			block_dev_ioctl(root_nas->fs->bdev, IOCTL_GETBLKSIZE, NULL, 0)) {
+	if (CDFS_BLOCKSIZE != block_dev_block_size(root_nas->fs->bdev)) {
 		return -ENXIO;
 	}
 
@@ -424,8 +423,7 @@ int cdfs_mount(struct nas *root_nas)
 	cdfs = (cdfs_t *) sysmalloc(sizeof(cdfs_t));
 	memset(cdfs, 0, sizeof(cdfs_t));
 	cdfs->bdev = root_nas->fs->bdev;
-	cdfs->blks =
-			block_dev_ioctl(root_nas->fs->bdev, IOCTL_GETDEVSIZE, NULL, 0);
+	cdfs->blks = block_dev_size(root_nas->fs->bdev);
 	if (cdfs->blks < 0) {
 		return cdfs->blks;
 	}

--- a/src/fs/driver/iso9660/iso9660.h
+++ b/src/fs/driver/iso9660/iso9660.h
@@ -59,7 +59,7 @@ typedef int64_t off64_t;
 
 typedef struct cdfs {
 	void *bdev;
-	int blks;
+	uint64_t blks;
 	int volblks;
 	int vdblk;
 	int joliet;

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -729,7 +729,6 @@ static s64 ntfs_device_bdev_io_pread(struct ntfs_device *dev, void *buf,
 		s64 count, s64 offset)
 {
 	struct block_dev *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
-	//int blksize = block_dev_ioctl(bdev, IOCTL_GETBLKSIZE, NULL, 0);
 	if (count == block_dev_read_buffered(bdev, buf, count, offset)) {
 		return count;
 	}
@@ -752,7 +751,6 @@ static s64 ntfs_device_bdev_io_pwrite(struct ntfs_device *dev, const void *buf,
 		s64 count, s64 offset)
 {
 	struct block_dev *bdev = ((struct ntfs_bdev_desc*)dev->d_private)->dev;
-	//int blksize = block_dev_ioctl(bdev, IOCTL_GETBLKSIZE, NULL, 0);
 	if (NDevReadOnly(dev)) {
 		errno = EROFS;
 		return -1;

--- a/src/fs/driver/power_save/qnx6.h
+++ b/src/fs/driver/power_save/qnx6.h
@@ -104,10 +104,10 @@ static inline struct buffer_head *sb_bread(struct qnx6_superblock *sb, unsigned 
 	struct buffer_head *bh = bcache_getblk_locked(sb->s_bdev, block, sb->s_blocksize);
 	unsigned fs_blksize = sb->s_blocksize;
 	struct block_dev *bdev = bh->bdev;
-	unsigned bdev_blksize;
+	size_t bdev_blksize;
 
 	/* FIXME */
-       	bdev_blksize = block_dev_ioctl(bdev, IOCTL_GETBLKSIZE, NULL, 0);
+	bdev_blksize = block_dev_block_size(bdev);
 
 	if (bh && buffer_new(bh)) {
 		/* FIXME */

--- a/src/fs/driver/ramfs/ramfs.c
+++ b/src/fs/driver/ramfs/ramfs.c
@@ -134,11 +134,12 @@ static int ramfs_close(struct file_desc *desc) {
 static int ramfs_read_sector(struct nas *nas, char *buffer,
 		uint32_t count, uint32_t sector) {
 	struct ramfs_fs_info *fsi;
-	int blksize, blkno, sectorsize;
+	size_t blksize;
+	int blkno, sectorsize;
 
 	fsi = nas->fs->fsi;
 
-	blksize = block_dev_ioctl(nas->fs->bdev, IOCTL_GETBLKSIZE, NULL, 0);
+	blksize = block_dev_block_size(nas->fs->bdev);
 	sectorsize = fsi->block_size;
 	assert(blksize > 0 && sectorsize > 0);
 	blkno = sector * (sectorsize / blksize);
@@ -155,11 +156,12 @@ static int ramfs_read_sector(struct nas *nas, char *buffer,
 static int ramfs_write_sector(struct nas *nas, char *buffer,
 		uint32_t count, uint32_t sector) {
 	struct ramfs_fs_info *fsi;
-	int blksize, blkno, sectorsize;
+	size_t blksize;
+	int blkno, sectorsize;
 
 	fsi = nas->fs->fsi;
 
-	blksize = block_dev_ioctl(nas->fs->bdev, IOCTL_GETBLKSIZE, NULL, 0);
+	blksize = block_dev_block_size(nas->fs->bdev);
 	sectorsize = fsi->block_size;
 	assert(blksize > 0 && sectorsize > 0);
 	blkno = sector * (sectorsize / blksize);

--- a/templates/arm/stm32f4-discovery/mods.config
+++ b/templates/arm/stm32f4-discovery/mods.config
@@ -116,6 +116,6 @@ configuration conf {
 	include embox.fs.dvfs.core
 	include embox.compat.posix.fs.all_dvfs
 	include embox.fs.syslib.perm_stub
-	include embox.driver.block_common
+	include embox.driver.block_common(dev_quantity=4)
 	include embox.driver.block_dvfs
 }


### PR DESCRIPTION
Avoid errors for block devices larger than 4GiB.

Also rework some block dev handling to avoid 32/64-bit mistakes.