### PR TITLE
Improve autotest subsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ scripts/qemu/start_script_my
 scripts/qemu/stop_script_my
 scripts/qemu/tap_dev
 scripts/expect/*.log
+scripts/autotest/*.log
+scripts/autotest/*.img
 third-party/qt/.downloaded
 third-party/qt/qt-everywhere-opensource-src-4.8.4.tar.gz
 third-party/ti/ipc_1_24_00_16

--- a/scripts/autotest/configs/default.sh
+++ b/scripts/autotest/configs/default.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export TEST_CURRENT_CONFIG=default
+export TEST_HOST_NFS_DIR=/var/nfs_test

--- a/scripts/autotest/configs/ide.sh
+++ b/scripts/autotest/configs/ide.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export TEST_CURRENT_CONFIG=ide
+export TEST_BLKDEV0=/dev/hda
+export TEST_BLKDEV0_RAW_NAME=hda

--- a/scripts/autotest/configs/usb.sh
+++ b/scripts/autotest/configs/usb.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export TEST_CURRENT_CONFIG=usb
+export TEST_BLKDEV0=/dev/sda
+export TEST_BLKDEV0_RAW_NAME=sda

--- a/scripts/autotest/framework/cmd.exp
+++ b/scripts/autotest/framework/cmd.exp
@@ -1,0 +1,50 @@
+proc __expect_regexp {new_timeout pattern} {
+	set timeout $new_timeout
+	expect {
+		timeout { puts "\n\nautotest error: Waiting for \"$pattern\" pattern timeout\n\n"; exit 1 }
+		-re "$pattern" {}
+	}
+	return 0
+}
+
+# Sends $cmd to remote target (Embox) and sequentially waits for each
+# pattern from $args to appear
+proc test_expect_strings {args} {
+	foreach pattern $args {
+		__expect_regexp 10 $pattern
+	}
+	return 0
+}
+
+proc test_expect_strings_timeout {new_timeout args} {
+	foreach pattern $args {
+		__expect_regexp $new_timeout $pattern
+	}
+	return 0
+}
+
+proc test_exec_embox_cmd_timeout {new_timeout cmd} {
+	global embox_prompt
+
+	set timeout $new_timeout
+
+	send $cmd
+	expect {
+		timeout {
+			puts "\n\nautotest error: Timeout running \"$cmd\"\n\n"; exit 1
+		}
+		-re "error" {
+			puts "\n\nautotest error: Error running \"$cmd\"\n\n"; exit 1
+		}
+		-re "$embox_prompt" { }
+	}
+
+	set timeout 10
+
+	return 0
+}
+
+proc test_exec_embox_cmd {cmd} {
+	test_exec_embox_cmd_timeout 20 $cmd
+	return 0
+}

--- a/scripts/autotest/framework/core.exp
+++ b/scripts/autotest/framework/core.exp
@@ -1,0 +1,116 @@
+package provide autotest 1.0
+
+namespace eval ::autotest {
+	namespace export TEST_SETUP_HOST TEST_TEARDOWN_HOST \
+		TEST_SETUP_TARGET TEST_TEARDOWN_TARGET \
+		TEST_CASE \
+		TEST_CASE_DECLARE_FIXME
+
+	namespace export test_expect_strings
+	namespace export test_expect_strings_timeout
+	namespace export test_exec_embox_cmd
+	namespace export test_exec_embox_cmd_timeout
+
+	namespace export target_connect
+	namespace export target_disconnect
+
+	variable embox_prompt
+	variable embox_ip
+	variable host_ip
+}
+
+source [file join [file dirname [info script]] exec.exp]
+source [file join [file dirname [info script]] cmd.exp]
+
+# This variable is used to show that current test case is broken
+# currently. That is, test case is correct, but Embox errored while
+# running this test case because of some Embox's bugs.
+set current_test_case_fixme false
+
+proc ::autotest::TEST_SETUP_HOST {setup_body} {
+	eval $setup_body
+}
+
+proc ::autotest::TEST_TEARDOWN_HOST {teardown_body} {
+	eval $teardown_body
+}
+
+proc ::autotest::TEST_SETUP_TARGET {setup_body} {
+	telnet_connect
+	eval $setup_body
+	telnet_disconnect
+}
+
+proc ::autotest::TEST_TEARDOWN_TARGET {teardown_body} {
+	telnet_connect
+	eval $teardown_body
+	telnet_disconnect
+}
+
+proc ::autotest::TEST_CASE_DECLARE_FIXME {test_case_body} {
+	global current_test_case_fixme
+
+	set current_test_case_fixme true
+	eval $test_case_body
+	set current_test_case_fixme false
+}
+
+proc ::autotest::TEST_CASE {test_name test_body} {
+	global embox_ip
+	global current_test_case_fixme
+
+	# Do not execute test if it marked with TEST_CASE_DECLARE_FIXME
+	if {$current_test_case_fixme == true} {
+		set result_str "    FIXME: TEST CASE \"$test_name\" is known to be broken"
+		puts $result_str
+		return
+	}
+
+	puts "    TEST CASE \"$test_name\" running ..."
+	
+	# Execute test
+	set res [test_exec $test_body]
+
+	if {$res != 0} {
+		puts "    TEST CASE \"$test_name\" ERROR"
+		exit 1
+	} else {
+		puts "    TEST CASE \"$test_name\" OK"
+	}
+}
+
+proc wait_target_is_ready {} {
+	global embox_prompt
+	global embox_ip
+	global spawn_id
+
+	while true {
+		spawn telnet $embox_ip
+		expect -re "$embox_prompt" { break }
+	}
+	send "exit\r"
+	expect "Connection closed by foreign host"
+}
+
+namespace import autotest::*
+
+set embox_prompt "#"
+
+set testsuite   [lindex $::argv 0]
+set test        [lindex $::argv 1]
+set embox_ip    [lindex $::argv 2]
+set host_ip     [lindex $::argv 3]
+
+# Wait until Embox starts trying to connect through Telnet
+wait_target_is_ready
+
+cd $testsuite
+source setup.exp
+
+cd $test
+source test.exp
+
+cd $testsuite
+source finish.exp
+
+exit 0

--- a/scripts/autotest/framework/exec.exp
+++ b/scripts/autotest/framework/exec.exp
@@ -1,0 +1,24 @@
+proc ::autotest::target_connect {} {
+	# https://stackoverflow.com/questions/30532532/expect-fails-when-running-proc-inside-proc
+	global spawn_id
+	global embox_ip
+	global embox_prompt
+
+	spawn telnet $embox_ip
+
+	expect {
+		timeout | eof { puts "\ntelnet: connection timeout\n"; exit 1 }
+		-re "$embox_prompt" { }
+	}
+}
+
+proc ::autotest::target_disconnect {} {
+	global spawn_id
+	send "exit\r"
+	expect "Connection closed by foreign host"
+}
+
+proc ::autotest::test_exec {test_body} {
+	eval $test_body
+	return 0
+}

--- a/scripts/autotest/run.sh
+++ b/scripts/autotest/run.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+BASEDIR=$(realpath ${BASH_SOURCE%/*})
+TESTSUITE_DIR=$BASEDIR/testsuite
+TESTSUITE_LIST=$(ls $TESTSUITE_DIR)
+
+TESTCASE_DIR=
+TESTCASE_LIST=
+
+show_available_testsuites() {
+	echo "Available testsuites:"
+	echo $TESTSUITE_LIST
+}
+
+show_available_testcases() {
+	echo "Availables testcase for testsuite $TESTSUITE:"
+	echo $TESTCASE_LIST
+}
+
+if [ "$1" = "-h" ]; then
+	echo "Usage: $0 <testsuite> <test cases>"
+	echo "  You can 'export TEST_PRINT_ALL=true' to make tests echo to console"
+	exit 1
+fi
+
+TESTSUITE=$1
+
+if [ -z $TESTSUITE ]; then
+	show_available_testsuites
+	exit 1
+fi
+
+TESTCASE_DIR=$BASEDIR/testsuite/$TESTSUITE
+TESTCASE_LIST=$(for i in $(ls -d $TESTCASE_DIR/*/); do basename $i; done)
+
+shift
+TESTCASES=$@
+
+if [ -z "$TESTCASES" ]; then
+	show_available_testcases
+	exit 1
+fi
+
+for testcase in $TESTCASES; do
+	if [ -z "$(echo $TESTCASE_LIST | fgrep -w $testcase)" ]; then
+		echo "Test '$testcase' is not part of testsuite '$TESTSUITE'"
+		exit 1
+	fi
+done
+
+if [ -z "$TEST_EMBOX_ROOT" ]; then
+	printf "TEST_EMBOX_ROOT is not set. 'export TEST_EMBOX_ROOT=<path to embox>'\n"
+	exit 1
+fi
+
+if [ -z "$EMBOX_IP" ]; then
+	EMBOX_IP=10.0.2.16
+fi
+
+if [ -z "$HOST_IP" ]; then
+	HOST_IP=10.0.2.10
+fi
+
+echo "Starting testsuite $TESTSUITE ..."
+
+rm -f $TESTSUITE.log
+
+testsuite_res=0
+summary=
+for testcase in $TESTCASES; do
+	echo "  Starting test $TESTSUITE/$testcase ..."
+
+	if [ -z "${TEST_PRINT_ALL}" ]; then
+		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
+			$EMBOX_IP $HOST_IP > ${TESTSUITE}_$testcase.log
+	else
+		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
+			$EMBOX_IP $HOST_IP
+	fi
+	rc=$?
+
+	result="$TESTSUITE/$testcase:"
+
+	if [ $rc -ne 0 ]; then
+		result="$result FAILED"
+		testsuite_res=1
+	else
+		result="$result PASSED"
+	fi
+
+	echo "  $result"
+	summary="$summary$result\n"
+done
+
+if [ $testsuite_res -eq 0 ]; then
+	status="OK"
+else
+	status="ERROR"
+fi
+
+echo "Test summary:"
+printf "$summary\n"
+echo "Testsuite $TESTSUITE finished. STATUS = $status"
+
+exit ${testsuite_res}

--- a/scripts/autotest/run_scripts/run_qemu_default.sh
+++ b/scripts/autotest/run_scripts/run_qemu_default.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+QEMU=./scripts/qemu/auto_qemu
+
+cd $TEST_EMBOX_ROOT
+$QEMU
+cd -

--- a/scripts/autotest/run_scripts/run_qemu_ide.sh
+++ b/scripts/autotest/run_scripts/run_qemu_ide.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+QEMU=./scripts/qemu/auto_qemu
+IMG=$(mktemp -d)/hda_vfat.img
+
+dd if=/dev/zero of=$IMG bs=1M count=64
+/sbin/mkfs.vfat -n "LINUX" $IMG -I
+
+cd $TEST_EMBOX_ROOT
+$QEMU -hda $IMG
+rm -r $(dirname $IMG)
+cd -

--- a/scripts/autotest/run_scripts/run_qemu_usb.sh
+++ b/scripts/autotest/run_scripts/run_qemu_usb.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+QEMU=./scripts/qemu/auto_qemu
+image_file_name=usbdisk.img
+
+qemu-img create -f qcow2 $image_file_name 512M
+
+/sbin/mkfs.vfat $image_file_name
+
+cd $TEST_EMBOX_ROOT
+$QEMU -drive id=my_usb_disk,file=$image_file_name,if=none,format=raw -device usb-storage,drive=my_usb_disk $@
+cd -

--- a/scripts/autotest/testsuite/block_dev/block_dev_test/test.exp
+++ b/scripts/autotest/testsuite/block_dev/block_dev_test/test.exp
@@ -1,0 +1,19 @@
+TEST_CASE {Run block_dev_test once} {
+	global embox_prompt
+	global block_dev_raw
+
+	send "block_dev_test $block_dev_raw\r"
+	# Wait for 3 min
+	test_expect_strings_timeout 180 "OK" $embox_prompt
+}
+
+TEST_CASE {Run block_dev_test multiple times} {
+	global embox_prompt
+	global block_dev_raw
+
+	for {set i 0} {$i < 4} {incr i} {
+		send "block_dev_test $block_dev_raw\r"
+		# Wait for 3 min
+		test_expect_strings_timeout 180 "OK" $embox_prompt
+	}
+}

--- a/scripts/autotest/testsuite/block_dev/finish.exp
+++ b/scripts/autotest/testsuite/block_dev/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/block_dev/setup.exp
+++ b/scripts/autotest/testsuite/block_dev/setup.exp
@@ -1,0 +1,3 @@
+set block_dev_raw $env(TEST_BLKDEV0_RAW_NAME)
+
+target_connect

--- a/scripts/autotest/testsuite/fs-devfs/devfs/test.exp
+++ b/scripts/autotest/testsuite/fs-devfs/devfs/test.exp
@@ -1,0 +1,17 @@
+TEST_CASE {Is there /dev/ttyS0} {
+	global embox_prompt
+
+	send "ls /dev/ttyS0\r"
+	test_expect_strings "/dev/ttyS0" $embox_prompt
+}
+
+TEST_CASE {Touch and rm on /dev/ should be rejected} {
+	global embox_prompt
+
+	send "touch /dev/1.txt\r"
+	test_expect_strings "error" $embox_prompt
+	send "mv /dev/zero .\r"
+	test_expect_strings "error" $embox_prompt
+	send "rm /dev\r"
+	test_expect_strings "error" $embox_prompt
+}

--- a/scripts/autotest/testsuite/fs-devfs/finish.exp
+++ b/scripts/autotest/testsuite/fs-devfs/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/fs-devfs/setup.exp
+++ b/scripts/autotest/testsuite/fs-devfs/setup.exp
@@ -1,0 +1,1 @@
+target_connect

--- a/scripts/autotest/testsuite/fs-nfs/cd
+++ b/scripts/autotest/testsuite/fs-nfs/cd
@@ -1,0 +1,1 @@
+../fs-ramfs/cd

--- a/scripts/autotest/testsuite/fs-nfs/dd
+++ b/scripts/autotest/testsuite/fs-nfs/dd
@@ -1,0 +1,1 @@
+../fs-ramfs/dd

--- a/scripts/autotest/testsuite/fs-nfs/echo
+++ b/scripts/autotest/testsuite/fs-nfs/echo
@@ -1,0 +1,1 @@
+../fs-ramfs/echo

--- a/scripts/autotest/testsuite/fs-nfs/finish.exp
+++ b/scripts/autotest/testsuite/fs-nfs/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/fs-nfs/pwd
+++ b/scripts/autotest/testsuite/fs-nfs/pwd
@@ -1,0 +1,1 @@
+../fs-ramfs/pwd

--- a/scripts/autotest/testsuite/fs-nfs/setup.exp
+++ b/scripts/autotest/testsuite/fs-nfs/setup.exp
@@ -1,0 +1,11 @@
+global embox_prompt
+global host_ip
+
+set mount_dir "/fs_test"
+set mount_nfs_dir $env(TEST_HOST_NFS_DIR)
+
+target_connect
+
+test_exec_embox_cmd "mkdir -v $mount_dir\r"
+test_exec_embox_cmd "mount -t nfs $host_ip:$mount_nfs_dir $mount_dir\r"
+test_exec_embox_cmd "cd $mount_dir\r"

--- a/scripts/autotest/testsuite/fs-nfs/touch
+++ b/scripts/autotest/testsuite/fs-nfs/touch
@@ -1,0 +1,1 @@
+../fs-ramfs/touch

--- a/scripts/autotest/testsuite/fs-ramfs/cd/test.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/cd/test.exp
@@ -1,0 +1,10 @@
+TEST_CASE {Reject cd into file} {
+	global embox_prompt
+
+	test_exec_embox_cmd "touch 1.txt\r"
+
+	send "cd 1.txt\r"
+	test_expect_strings "failed to exec cd" $embox_prompt
+
+	test_exec_embox_cmd "rm 1.txt\r"
+}

--- a/scripts/autotest/testsuite/fs-ramfs/dd/test.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/dd/test.exp
@@ -1,0 +1,9 @@
+TEST_CASE {dd if=/dev/zero of=1.txt count=1} {
+	global embox_prompt
+
+	test_exec_embox_cmd "touch 1.txt\r"
+	test_exec_embox_cmd "dd if=/dev/zero of=1.txt count=1\r"
+
+	send "md5sum 1.txt\r"
+	test_expect_strings "bf619eac0cdf3f68d496ea9344137e8b" $embox_prompt
+}

--- a/scripts/autotest/testsuite/fs-ramfs/echo/test.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/echo/test.exp
@@ -1,0 +1,45 @@
+TEST_CASE {Echo to regular file} {
+	global embox_prompt
+
+	test_exec_embox_cmd "touch 1.txt\r"
+	test_exec_embox_cmd "echo 0123456789 > 1.txt\r"
+
+	send "cat 1.txt\r"
+	test_expect_strings "0123456789" $embox_prompt
+
+	#test_exec_embox_cmd "rm 1.txt\r"
+}
+
+TEST_CASE {Multiple echo to file} {
+	global embox_prompt
+
+	for {set i 0} {$i < 32} {incr i} {
+		test_exec_embox_cmd "echo hello$i > echotest.txt\r"
+		send "cat echotest.txt\r"
+		test_expect_strings "hello$i" $embox_prompt
+	}
+}
+
+TEST_CASE {Multiple echo's with append} {
+	global embox_prompt
+
+	for {set i 0} {$i < 8} {incr i} {
+		test_exec_embox_cmd "echo a >> echotest2.txt\r"
+	}
+	send "cat echotest2.txt\r"
+	test_expect_strings "aaaaaaaa" $embox_prompt
+}
+
+# Sometimes this test failed.
+TEST_CASE_DECLARE_FIXME {
+TEST_CASE {Echo multiple times to regular file} {
+	global embox_prompt
+
+	test_exec_embox_cmd "touch 1.txt\r"
+	for {set i 0} {$i < 1000} {incr i} {
+		test_exec_embox_cmd "echo 0123456789 > 1.txt\r"
+		send "cat 1.txt\r"
+		test_expect_strings "0123456789" $embox_prompt
+	}
+}
+}

--- a/scripts/autotest/testsuite/fs-ramfs/finish.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/fs-ramfs/pwd/test.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/pwd/test.exp
@@ -1,0 +1,9 @@
+TEST_CASE {pwd should show correct directory} {
+	test_exec_embox_cmd "mkdir pwd_test_dir\r"
+	test_exec_embox_cmd "cd pwd_test_dir\r"
+
+	send "pwd\r"
+	test_expect_strings "pwd_test_dir"
+
+	#test_exec_embox_cmd "cd ..\r"
+}

--- a/scripts/autotest/testsuite/fs-ramfs/setup.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/setup.exp
@@ -1,0 +1,1 @@
+target_connect

--- a/scripts/autotest/testsuite/fs-ramfs/touch/test.exp
+++ b/scripts/autotest/testsuite/fs-ramfs/touch/test.exp
@@ -1,0 +1,20 @@
+TEST_CASE {Touch one file} {
+	global embox_prompt
+
+	test_exec_embox_cmd "touch f1.txt\r"
+	send "ls\r"
+	test_expect_strings "f1.txt" $embox_prompt
+}
+
+TEST_CASE {Touch multiple files} {
+	global embox_prompt
+
+	# Touch 8 files - file0.txt, file1.txt, ..., file7.txt
+	for {set i 0} {$i < 8} {incr i} {
+		exec sleep 0.5
+		test_exec_embox_cmd "touch file$i.txt\r"
+	}
+	# Check first and last files are created
+	send "ls\r"
+	test_expect_strings "file0.txt" "file7.txt" $embox_prompt
+}

--- a/scripts/autotest/testsuite/fs-vfat/cd
+++ b/scripts/autotest/testsuite/fs-vfat/cd
@@ -1,0 +1,1 @@
+../fs-ramfs/cd

--- a/scripts/autotest/testsuite/fs-vfat/dd
+++ b/scripts/autotest/testsuite/fs-vfat/dd
@@ -1,0 +1,1 @@
+../fs-ramfs/dd

--- a/scripts/autotest/testsuite/fs-vfat/echo
+++ b/scripts/autotest/testsuite/fs-vfat/echo
@@ -1,0 +1,1 @@
+../fs-ramfs/echo

--- a/scripts/autotest/testsuite/fs-vfat/finish.exp
+++ b/scripts/autotest/testsuite/fs-vfat/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/fs-vfat/long_names/test.exp
+++ b/scripts/autotest/testsuite/fs-vfat/long_names/test.exp
@@ -1,0 +1,7 @@
+TEST_CASE {Create file with a long name} {
+	global embox_prompt
+
+	test_exec_embox_cmd "touch veryverylonglongname.txt\r"
+	send "ls\r"
+	test_expect_strings "veryverylonglongname.txt" $embox_prompt
+}

--- a/scripts/autotest/testsuite/fs-vfat/mount/test.exp
+++ b/scripts/autotest/testsuite/fs-vfat/mount/test.exp
@@ -1,0 +1,13 @@
+TEST_CASE {Mount/umount should work multiple times} {
+	global embox_prompt
+	global mount_dev
+	global mount_dir
+	global fs_type
+
+	test_exec_embox_cmd "umount $mount_dir\r"
+
+	for {set i 0} {$i < 8} {incr i} {
+		test_exec_embox_cmd "mount -t $fs_type $mount_dev $mount_dir\r"
+		test_exec_embox_cmd "umount $mount_dir\r"
+	}
+}

--- a/scripts/autotest/testsuite/fs-vfat/pwd
+++ b/scripts/autotest/testsuite/fs-vfat/pwd
@@ -1,0 +1,1 @@
+../fs-ramfs/pwd

--- a/scripts/autotest/testsuite/fs-vfat/setup.exp
+++ b/scripts/autotest/testsuite/fs-vfat/setup.exp
@@ -1,0 +1,12 @@
+global embox_prompt
+
+set mount_dir "/fs_test"
+set fs_type   "vfat"
+set mount_dev $env(TEST_BLKDEV0)
+
+target_connect
+
+test_exec_embox_cmd "mkdir -v $mount_dir\r"
+test_exec_embox_cmd "ls /dev\r"
+test_exec_embox_cmd "mount -t $fs_type $mount_dev $mount_dir\r"
+test_exec_embox_cmd "cd $mount_dir\r"

--- a/scripts/autotest/testsuite/fs-vfat/touch
+++ b/scripts/autotest/testsuite/fs-vfat/touch
@@ -1,0 +1,1 @@
+../fs-ramfs/touch

--- a/scripts/autotest/testsuite/net/finish.exp
+++ b/scripts/autotest/testsuite/net/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/net/ntpdate/test.exp
+++ b/scripts/autotest/testsuite/net/ntpdate/test.exp
@@ -1,0 +1,41 @@
+# This test works in three steps:
+# 1. Execute 'ntpdate <host_ip>' on Embox.
+# 2. Get host's date in the format xxxx-xx-xx (e.g. 2014-01-05).
+# 3. Execute 'date' on Embox and compare result (first 10 symbols of output)
+#    with result of the item 2.
+
+set host_date ""
+
+TEST_SETUP_HOST {
+	global host_date
+	# Get current host's date in the format same as in Embox (e.g. 2014-01-05).
+	spawn date -u --rfc-3339=date
+	expect {
+		# 10 is a length of date - e.g. 2014-01-05
+		-regexp {.{10}}
+	}
+	set host_date $expect_out(0,string)
+}
+
+TEST_CASE {ntpdate test} {
+	global host_ip
+	global host_date
+
+	send "ntpdate $host_ip\r"
+	test_expect_strings ":/#"
+
+	# And compare the host date with the Embox's one.
+	# XXX: compare the both times too, not only dates
+	send "date\r"
+	expect {
+		timeout  { puts "ntpdate.exp: date command timeout\n"; exit 1 }
+		# Wait here only for date (not time) - 2014-01-05 is from class (2.{9})
+		-regexp {2.{9}} {
+			regexp {.{10}} $expect_out(0,string) embox_date
+			if {$embox_date != $host_date} {
+				puts "embox_date=$embox_date is not equal to host_date=$host_date"
+				exit 1
+			}
+		}
+	}
+}

--- a/scripts/autotest/testsuite/net/ping/test.exp
+++ b/scripts/autotest/testsuite/net/ping/test.exp
@@ -1,0 +1,11 @@
+TEST_CASE {Embox should ping host} {
+	global host_ip
+
+	send "ping -c 4 $host_ip\r"
+	test_expect_strings "0 errors"
+}
+
+TEST_CASE {Embox should ping google.com} {
+	send "ping -c 4 google.com\r"
+	test_expect_strings "0 errors"
+}

--- a/scripts/autotest/testsuite/net/setup.exp
+++ b/scripts/autotest/testsuite/net/setup.exp
@@ -1,0 +1,1 @@
+target_connect

--- a/scripts/autotest/testsuite/net/ssh/test.exp
+++ b/scripts/autotest/testsuite/net/ssh/test.exp
@@ -1,0 +1,57 @@
+target_disconnect
+
+TEST_CASE {Connect through SSH to Embox and execute "help" once} {
+	global spawn_id
+	global embox_ip
+	global embox_prompt
+
+	spawn ssh root@$embox_ip
+	expect {
+		timeout { puts "SSH connection error" }
+		-re "password:" {
+			send "root\r"
+			exp_continue
+		}
+		-re "Are you sure you want to continue connecting" {
+			send "yes\r"
+			exp_continue
+		}
+		-re $embox_prompt {}
+	}
+
+	send "help\r"
+	test_expect_strings "Available commands" $embox_prompt
+
+	send "exit\r"
+	test_expect_strings "Connection to .* closed"
+}
+
+TEST_CASE {Connect and exit several times SSH} {
+	global spawn_id
+	global embox_ip
+	global embox_prompt
+
+	for {set i 0} {$i < 32} {incr i} {
+		exec sleep 0.5
+		puts "\nCONNECT iter=$i"
+
+		spawn ssh root@$embox_ip
+		expect {
+			timeout { puts "SSH connection error" }
+			-re "password:" {
+				send "root\r"
+				exp_continue
+			}
+			-re "Are you sure you want to continue connecting" {
+				send "yes\r"
+				exp_continue
+			}
+			-re $embox_prompt {}
+		}
+
+		send "exit\r"
+		test_expect_strings "Connection to .* closed"
+	}
+}
+
+target_connect

--- a/scripts/autotest/testsuite/net/telnet/test.exp
+++ b/scripts/autotest/testsuite/net/telnet/test.exp
@@ -1,0 +1,36 @@
+TEST_CASE {Execute "help" command once} {
+	global embox_prompt
+
+	send "help\r"
+	test_expect_strings "Available commands" $embox_prompt
+}
+
+TEST_CASE {Execute "help" multiple times} {
+	global embox_prompt
+
+	for {set i 0} {$i < 128} {incr i} {
+		send "help\r"
+		test_expect_strings "Available commands" $embox_prompt
+		exec sleep 0.1
+	}
+}
+
+target_disconnect
+
+TEST_CASE {Connect and exit several times telnet} {
+	global spawn_id
+	global embox_ip
+	global embox_prompt
+
+	for {set i 0} {$i < 32} {incr i} {
+		exec sleep 0.5
+		puts "\nCONNECT iter=$i"
+
+		spawn telnet $embox_ip
+		test_expect_strings $embox_prompt
+		send "exit\r"
+		test_expect_strings "Connection closed by foreign host"
+	}
+}
+
+target_connect

--- a/scripts/autotest/testsuite/net/tftp/test.exp
+++ b/scripts/autotest/testsuite/net/tftp/test.exp
@@ -1,0 +1,19 @@
+TEST_CASE {Get one small file} {
+    global host_ip
+    global embox_prompt
+
+    test_exec_embox_cmd "tftp -g hello.txt $host_ip\r"
+    send "cat hello.txt\r"
+    test_expect_strings "hello123" $embox_prompt
+}
+
+TEST_CASE {Get file 4M file multiple times} {
+    global host_ip
+    global embox_prompt
+
+    for {set i 0} {$i < 8} {incr i} {
+        exec sleep 2.0
+        puts "\niter=$i"
+        test_exec_embox_cmd_timeout 60 "tftp -g file_4Mb $host_ip\r"
+    }
+}


### PR DESCRIPTION
I leave scripts/expects as is and introduced new version - scripts/autotest, which larger and more accurate structured. It runs for a longer time, so I decided do not add it Travis CI.

All tests are started from ./scripts/autotest directory.


```
$ cd scripts/autotest
$ export TEST_PRINT_ALL=true // If you want verbose mode
```
```
$ ./framework/run.sh -h
Usage: ./run.sh <testsuite> <test cases>

$ ./framework/run.sh 
Available testsuites:
fs net
```
```
$ ./framework/run.sh fs
Availables testcase for testsuite fs:
cd dd devfs echo pwd vfat
```
```
Run the test:
$ source configs/default.sh
$ ./framework/run.sh fs echo
```