### PR TITLE
x86: Multiboot header uses address fields

### DIFF
--- a/src/arch/x86/boot/multiboot_header.S
+++ b/src/arch/x86/boot/multiboot_header.S
@@ -31,7 +31,8 @@
 #define VIDEO_MODE_HEIGTH OPTION_GET(NUMBER,video_height)
 #define VIDEO_MODE_DEPTH OPTION_GET(NUMBER,video_depth)
 
-#define MULTIBOOT_HEADER_FULL_FLAGS (MULTIBOOT_HEADER_FLAGS | (VIDEO_MODE_ENABLE << 2))
+#define MULTIBOOT_HEADER_FULL_FLAGS \
+	(MULTIBOOT_HEADER_FLAGS | (VIDEO_MODE_ENABLE << 2) | MULTIBOOT_AOUT_KLUDGE)
 
 	.section .multiboot
 	/* Align 32 bits boundary.  */
@@ -45,17 +46,25 @@ multiboot_header:
 	.long	MULTIBOOT_HEADER_FULL_FLAGS
 	/* checksum */
 	.long	-(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FULL_FLAGS)
-/* we always use elf format */
+	/*
+	 * Since we use ELF format we actually do not need to fill the following
+	 * 5 fields (take a look at the description of MULTIBOOT_AOUT_KLUDGE in
+	 * src/arch/x86/include/asm/multiboot.h). But we fill them to tell
+	 * to the bootloader that we have zero-length BSS. Why? Because we
+	 * are using large BSS in x86 templates and qemu bootloader loads
+	 * BSS very slow (> 10 sec). Actually, we zero BSS by ourselves in boot.S,
+	 * so we can safely provide zero-length BSS to the bootloader, I believe.
+	 **/
 	/* header_addr */
-	.long	0
+	.long	_text_lma
 	/* load_addr */
-	.long	0
+	.long	_text_lma
 	/* load_end_addr */
-	.long	0
+	.long	_bss_lma
 	/* bss_end_addr */
 	.long	0
 	/* entry_addr */
-	.long	0
+	.long	_start
 
 	/* we must setup bit 2 in flags for validate next value */
 	/* mode type */


### PR DESCRIPTION
It is introduced to overcome Qemu's slow BSS loading.

See the comment in code.