### PR TITLE
Work on VFS

### DIFF
--- a/src/fs/driver/fat/fat.h
+++ b/src/fs/driver/fat/fat.h
@@ -268,7 +268,7 @@ struct dirinfo {
 #define FAT_MAX_SECTOR_SIZE OPTION_MODULE_GET(embox__fs__driver__fat, NUMBER, fat_max_sector_size)
 
 static inline int fat_sec_by_clus(struct fat_fs_info *fsi, int clus) {
-	return clus > 2 ? (clus - 2) * fsi->vi.secperclus + fsi->vi.dataarea : 0;
+	return fsi->vi.secperclus * clus;
 }
 
 extern void fat_set_filetime(struct fat_dirent *de);

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -752,8 +752,8 @@ uint32_t fat_open_dir(struct fat_fs_info *fsi,
 		ret = fat_read_sector(fsi, dirinfo->p_scratch,
 				dirinfo->currentsector + dirinfo->currentcluster * volinfo->secperclus);
 
-		dirinfo->currentsector = volinfo->rootdir;
-		dirinfo->currentcluster = 2;
+		dirinfo->currentsector = volinfo->rootdir % volinfo->secperclus;
+		dirinfo->currentcluster = volinfo->rootdir / volinfo->secperclus;
 
 		return ret;
 	} else {
@@ -854,7 +854,7 @@ uint32_t fat_get_next(struct fat_fs_info *fsi,
 
 	log_debug("dir->currententry %d", dir->currententry);
 	/* Do we need to read the next sector of the directory? */
-	if (dir->currententry >= ent_per_sec) {
+	if (dir->currententry >= ent_per_sec - 1) {
 		dir->currententry = 0;
 		dir->currentsector++;
 
@@ -913,8 +913,7 @@ uint32_t fat_get_next(struct fat_fs_info *fsi,
 						dir->currentcluster);
 			}
 
-			read_sector  = (dir->currentcluster - 2) * volinfo->secperclus;
-			read_sector += volinfo->dataarea + dir->currentsector;
+			read_sector = dir->currentcluster * volinfo->secperclus + dir->currentsector;
 
 			if (fat_read_sector(fsi, dir->p_scratch, read_sector))
 				return DFS_ERRMISC;
@@ -1772,8 +1771,7 @@ int fat_reset_dir(struct dirinfo *di) {
 			di->currentcluster = 2;
 		} else {
 			di->currentsector = (vi->rootdir % vi->secperclus);
-			di->currentsector = vi->rootdir;
-			di->currentcluster = 2;
+			di->currentcluster = vi->rootdir / vi->secperclus;
 		}
 
 		di->currententry = 1;

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -1856,6 +1856,8 @@ int fat_create_file(struct fat_file_info *fi, struct dirinfo *di, char *name, in
 
 			fat_get_next(fsi, di, &de);
 		}
+	} else {
+		memcpy(filename, name, sizeof(filename));
 	}
 
 	cluster = fat_get_free_fat_(fsi, fat_sector_buff);

--- a/src/fs/dvfs/compat.c
+++ b/src/fs/dvfs/compat.c
@@ -28,7 +28,8 @@ int mount(char *dev, char *dir, char *fs_type) {
 	if (fm) {
 		return fuse_module_mount(fm, dev, dir);
 	}
-	return dvfs_mount(dev, dir, fs_type, 0);
+	errno = dvfs_mount(dev, dir, fs_type, 0); /* Compatibility with old VFS */
+	return errno;
 }
 
 /**

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -180,6 +180,7 @@ extern int            dvfs_destroy_file(struct file *desc);
 
 extern struct dentry *dvfs_alloc_dentry(void);
 extern int            dvfs_destroy_dentry(struct dentry *dentry);
+extern int            dvfs_fs_dentry_try_free(struct super_block *sb);
 
 extern struct dvfsmnt *dvfs_alloc_mnt(void);
 extern int             dvfs_destroy_mnt(struct dvfsmnt *mnt);

--- a/src/fs/dvfs/dvfs_util.c
+++ b/src/fs/dvfs/dvfs_util.c
@@ -211,6 +211,26 @@ int dvfs_destroy_dentry(struct dentry *dentry) {
 		return -EBUSY;
 }
 
+/*
+ * @brief Try to free a single dentry from given FS
+ *
+ * @retval Number of freed dentries
+ */
+int dvfs_fs_dentry_try_free(struct super_block *sb) {
+	struct dentry *dentry;
+
+	assert(sb);
+
+	dlist_foreach_entry(dentry, &dentry_dlist, d_lnk) {
+		if (sb == dentry->d_sb && dentry->usage_count == 0) {
+			dvfs_destroy_dentry(dentry);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 /**
  * @brief Update dentry flags according to it's inode content
  *


### PR DESCRIPTION
* Fix double usage increase counter for dentry when open existing files
* Handle `-ENOMEM` error or FS driver `create()` in a more sane way
* Fix mount() return value to be compatible with old VFS
* Fix FAT driver for long dentries