### PR TITLE
Fix O_APPEND flag handling

### DIFF
--- a/src/compat/libc/stdio/fopen.c
+++ b/src/compat/libc/stdio/fopen.c
@@ -30,7 +30,7 @@ static int mode2flag(const char *mode) {
 	}
 
 	if (strchr(mode, 'a')) {
-		flags |= O_APPEND | O_CREAT;
+		flags |= O_APPEND | O_CREAT | O_RDWR;
 	}
 
 	return flags;

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -164,6 +164,15 @@ struct idesc *dvfs_file_open_idesc(struct lookup *lookup, int __oflag) {
 			return NULL;
 		}
 	}
+
+	if ((__oflag & O_APPEND) && (desc->f_inode)) {
+		/* XXX for some reason position of the last symbol
+		 * is zero both for empty and 1-byte files,  this
+		 * probably should be fixed  */
+		desc->pos = desc->f_inode->length == 0 ?
+			0 : desc->f_inode->length - 1;
+	}
+
 	return &desc->f_idesc;
 }
 


### PR DESCRIPTION
* Fix `fopen()` (now "a" also gives r/w permission)
* Fix `dvfs_file_open_idesc()` (set position to the end of the file)

`./scripts/autotest/run.sh fs-vfat echo` finally works (tested on `x86/arm` with SD-card emulation).