### PR TITLE
STM32F4 SD driver fix

### DIFF
--- a/src/drivers/block_dev/stm32_sd/stm32f4_sd.c
+++ b/src/drivers/block_dev/stm32_sd/stm32f4_sd.c
@@ -47,7 +47,7 @@ static int stm32f4_sd_init(void) {
 		bdev = block_dev_create(STM32F4_SD_DEVNAME, &stm32f4_sd_driver, NULL);
 		assert(bdev);
 
-		bdev->size = stm32f4_sd_ioctl(bdev, IOCTL_GETDEVSIZE, NULL, 0);
+		bdev->size = (unsigned) stm32f4_sd_ioctl(bdev, IOCTL_GETDEVSIZE, NULL, 0);
 	} else {
 		log_debug("SD card is not present");
 	}


### PR DESCRIPTION
* Add ipl lock for read/write operations
* Add retry if operation fails

These changes are necessary beacause Cube SD driver sometimes fails to read FIFO registers in time, probably it's supposed to be compiled with `-Os`. DMA operations fail for some reason.

Current version is extremely slow (~30kB/s), but `block_dev_test` works fine.