### PR TITLE
Autotest fix prompt

### DIFF
--- a/scripts/autotest/framework/core.exp
+++ b/scripts/autotest/framework/core.exp
@@ -94,12 +94,11 @@ proc wait_target_is_ready {} {
 
 namespace import autotest::*
 
-set embox_prompt "#"
-
-set testsuite   [lindex $::argv 0]
-set test        [lindex $::argv 1]
-set embox_ip    [lindex $::argv 2]
-set host_ip     [lindex $::argv 3]
+set testsuite    [lindex $::argv 0]
+set test         [lindex $::argv 1]
+set embox_ip     [lindex $::argv 2]
+set host_ip      [lindex $::argv 3]
+set embox_prompt [lindex $::argv 4]
 
 # Wait until Embox starts trying to connect through Telnet
 wait_target_is_ready

--- a/scripts/autotest/run.sh
+++ b/scripts/autotest/run.sh
@@ -19,7 +19,7 @@ show_available_testcases() {
 
 if [ "$1" = "-h" ]; then
 	echo "Usage: $0 <testsuite> <test cases>"
-	echo "  You can 'export TEST_PRINT_ALL=true' to make tests echo to console"
+	echo "  You can 'export TEST_PRINT_ALL=1' to make tests echo to console"
 	exit 1
 fi
 
@@ -61,6 +61,10 @@ if [ -z "$HOST_IP" ]; then
 	HOST_IP=10.0.2.10
 fi
 
+if [ -z "$TEST_PRINT_ALL" ]; then
+	TEST_PRINT_ALL=1
+fi
+
 echo "Starting testsuite $TESTSUITE ..."
 
 rm -f $TESTSUITE.log
@@ -70,7 +74,7 @@ summary=
 for testcase in $TESTCASES; do
 	echo "  Starting test $TESTSUITE/$testcase ..."
 
-	if [ -z "${TEST_PRINT_ALL}" ]; then
+	if [ ${TEST_PRINT_ALL} -eq 0 ]; then
 		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
 			$EMBOX_IP $HOST_IP > ${TESTSUITE}_$testcase.log
 	else

--- a/scripts/autotest/run.sh
+++ b/scripts/autotest/run.sh
@@ -61,6 +61,10 @@ if [ -z "$HOST_IP" ]; then
 	HOST_IP=10.0.2.10
 fi
 
+if [ -z "$EMBOX_PROMPT" ]; then
+	EMBOX_PROMPT="#"
+fi
+
 if [ -z "$TEST_PRINT_ALL" ]; then
 	TEST_PRINT_ALL=1
 fi
@@ -76,10 +80,10 @@ for testcase in $TESTCASES; do
 
 	if [ ${TEST_PRINT_ALL} -eq 0 ]; then
 		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
-			$EMBOX_IP $HOST_IP > ${TESTSUITE}_$testcase.log
+			$EMBOX_IP $HOST_IP $EMBOX_PROMPT > ${TESTSUITE}_$testcase.log
 	else
 		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
-			$EMBOX_IP $HOST_IP
+			$EMBOX_IP $HOST_IP $EMBOX_PROMPT
 	fi
 	rc=$?
 


### PR DESCRIPTION
* Currenly prompts on QEMU "#" and stm32 ">" differ, so add the ability to setup prompt.
* Tests print all by default.