### PR TITLE
Fix telnet

### DIFF
--- a/platform/gpio_http_admin/templates/stm32f4_discovery/mods.config
+++ b/platform/gpio_http_admin/templates/stm32f4_discovery/mods.config
@@ -38,12 +38,12 @@ configuration conf {
 
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=16)
-	include embox.kernel.task.resource.sig_table(sig_table_size=10)
+	include embox.kernel.task.resource.sig_table(sig_table_size=20)
 	include embox.kernel.task.resource.env(env_per_task=4,env_str_len=64)
 
 	include embox.kernel.thread.thread_local_none
 	include embox.kernel.thread.thread_cancel_disable
-	include embox.kernel.thread.signal_stub
+	include embox.kernel.thread.signal.siginfoq(siginfo_pool_sz=4)
 	include embox.kernel.timer.sleep
 	include embox.net.skbuff(amount_skb=10)
 	include embox.net.skbuff_data(amount_skb_data=10)

--- a/src/cmds/net/telnetd/Makefile
+++ b/src/cmds/net/telnetd/Makefile
@@ -1,0 +1,12 @@
+CFLAGS := $(CFLAGS)
+CFLAGS += -g -O0 -DTELNETD_FOR_LINUX
+
+objs := telnetd.o telnet_util.o
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+telnetd: $(objs)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+all: telnetd

--- a/src/cmds/net/telnetd/Mybuild
+++ b/src/cmds/net/telnetd/Mybuild
@@ -16,23 +16,18 @@ package embox.cmd.net
 			Vladimir Sokolov
 	''')
 module telnetd {
-	source "telnetd.c"
+	source "telnetd.c",
+		"telnet_util.c"
 
-	option number telnetd_use_pthread = 1
-	option number telnetd_max_connections = 5
+	option number port = 23
+	option number max_connections = 5
+	option string shell = "tish"
 
-	depends embox.net.socket
-	depends embox.net.tcp_sock
-	depends embox.net.tcp
-
-	depends embox.kernel.thread.core
 	depends embox.compat.posix.net.socket
-	depends embox.compat.posix.proc.signal
-	depends embox.cmd.sh.shell_api
-	depends embox.compat.posix.utmp_api
-	depends embox.compat.posix.proc.exec
 	depends embox.compat.posix.idx.ppty
 	depends embox.compat.posix.idx.select
+	depends embox.compat.posix.proc.signal
+	depends embox.compat.posix.proc.exec
 	depends embox.compat.posix.proc.waitpid
-	depends embox.arch.vfork_entry
+	depends embox.compat.posix.proc.vfork
 }

--- a/src/cmds/net/telnetd/telnet.h
+++ b/src/cmds/net/telnetd/telnet.h
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * @brief Tiny telnetd server
+ *
+ * @date 04.12.2019
+ * @author Alexander Kalmuk
+ */
+
+#ifndef TELNET_H_
+#define TELNET_H_
+
+/* http://www.tcpipguide.com/free/t_TelnetProtocolCommands-3.htm */
+#define T_WILL      251
+#define T_WONT      252
+#define T_DO        253
+#define T_DONT      254
+#define T_IAC       255
+#define T_INTERRUPT 244
+
+#define O_ECHO      1     /* Manage ECHO, RFC 857 */
+#define O_GO_AHEAD  3     /* Disable GO AHEAD, RFC 858 */
+
+#define DATA_BUF_LEN 128
+
+struct data_buffer {
+	unsigned char data[DATA_BUF_LEN];
+	unsigned char *p; /* Reader position in buf. */
+	size_t count; /* Bytes available for read */
+};
+
+struct telnet_session {
+	int sockfd;
+	int ptyfd;
+	int pid; /* PID of current session. */
+
+#ifndef TELNETD_FOR_LINUX
+	int pptyfds[2];
+#endif
+
+	/* These buffers are _not_ ring buffers. The logic of the buffer
+	 * is easy: we push data to buffer only when buffer is empty.
+	 */
+	struct data_buffer sock_buff;
+	struct data_buffer pty_buff;
+};
+
+extern void telnet_cmd(int sock, unsigned char op, unsigned char param);
+extern size_t telnet_handle_client_data(unsigned char *data, size_t len,
+		int sock);
+
+extern int telnet_open_master_pty(struct telnet_session *ts);
+extern int telnet_open_slave_pty(struct telnet_session *ts,
+	int master_pty);
+
+#endif /* TELNET_H_ */

--- a/src/cmds/net/telnetd/telnet_util.c
+++ b/src/cmds/net/telnetd/telnet_util.c
@@ -1,0 +1,183 @@
+/**
+ * @file
+ * @brief Tiny telnetd server
+ *
+ * @date 18.04.2012
+ * @author Vladimir Sokolov
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <fcntl.h>
+
+#include "telnet.h"
+
+/* Here we delete '\0' symbols from *buf:
+   abc\r\0de\r\0
+   abc\rde\r*/
+static int telnet_fix_crnul(unsigned char *buf, int len) {
+	unsigned char *bpi = buf, *bpo = buf;
+	while (bpi < buf + len) {
+		if (bpi < buf + len - 1 && 0 == memcmp(bpi, "\r\0", 2)) {
+			*bpo++ = *bpi;
+			bpi += 2;
+		} else {
+			*bpo++ = *bpi++;
+		}
+	}
+	return bpo - buf;
+}
+
+void telnet_cmd(int sock, unsigned char op, unsigned char param) {
+	unsigned char cmd[3];
+
+	cmd[0] = T_IAC;
+	cmd[1] = op;
+	cmd[2] = param;
+	write(sock, cmd, 3);
+}
+
+/* Handle telnet options. Returns bytes handled. */
+static size_t telnet_handle_options(const unsigned char *buf, size_t len,
+		int sock) {
+	unsigned char *p;
+	unsigned char op_type;
+	unsigned char op_param = '\0';
+	size_t n = 0;
+
+	if (len == 0) {
+		return 0;
+	}
+
+	p = (unsigned char *) buf;
+
+	while (1) {
+		if (*p++ != T_IAC || n++ >= len) {
+			return n < len ? n : len;
+		}
+
+		op_type = *p++;
+		n++;
+
+		if (op_type == T_WILL || op_type == T_DO ||
+				op_type == T_WONT || op_type == T_DONT) {
+			op_param = *p++;
+			n++;
+		}
+
+		if (n > len) {
+			/* XXX End of packet. It means, probably, it's something wrong
+			 * with telnet options, e.g. only part of options arrived
+			 * in this packet. So just return @len. */
+			return len;
+		}
+
+		if (op_type == T_WILL) {
+			if (op_param == O_GO_AHEAD) {
+				telnet_cmd(sock, T_DO, op_param);
+			} else {
+				telnet_cmd(sock, T_DONT, op_param);
+			}
+		} else if (op_type == T_DO) {
+			if ((op_param == O_GO_AHEAD) || (op_param == O_ECHO)) {
+				telnet_cmd(sock, T_WILL, op_param);
+			} else {
+				telnet_cmd(sock, T_WONT, op_param);
+			}
+		} else {
+			/* Currently do nothing, probably it's an answer for our request */
+		}
+	}
+	return 0;
+}
+
+/* Process raw client data from @data and save it back to original @data.
+ *
+ * Client data can contain not only client data, but also telnet options.
+ * Example of packets:
+ *  - |***client_data***telnet_options***|
+ *  - |***telnet_options***client_data***|
+ *  - |***client_data***telnet_options***client_data***|
+ */
+size_t telnet_handle_client_data(unsigned char *data, size_t len,
+		int sock) {
+	unsigned char *p;
+	unsigned char *out;
+	unsigned char *client_start; /* Start of client bytes */
+	size_t client_n; /* Number of client bytes */
+	size_t ops_n; /* Number of telnet options bytes */
+
+	p = data;
+	out = data;
+
+	while (len) {
+		/* Get client data till the next telnet options */
+		client_start = p;
+		client_n = 0;
+		while ((*p != T_IAC) && len) {
+			p++;
+			client_n++;
+			len--;
+		}
+		/* Process client data */
+		if (client_n > 0) {
+			client_n = telnet_fix_crnul(client_start, client_n);
+			memcpy(out, client_start, client_n);
+			out += client_n;
+		}
+
+		/* Precess telnet options till the next client data */
+		assert((*p == T_IAC) || (len == 0));
+		ops_n = telnet_handle_options(p, len, sock);
+		len -= ops_n;
+		p += ops_n;
+	}
+
+	/* Return size of client data copied */
+	return (out - data);
+}
+
+extern int ppty(int pptyfds[2]);
+
+int telnet_open_master_pty(struct telnet_session *ts) {
+	int master_pty;
+
+#ifdef TELNETD_FOR_LINUX
+	master_pty = open("/dev/ptmx", O_RDWR);
+	if (master_pty < 0) {
+		return -1;
+	}
+	grantpt(master_pty);
+	unlockpt(master_pty);
+#else
+	if (ppty(ts->pptyfds)) {
+		return -1;
+	}
+	master_pty = ts->pptyfds[0];
+#endif
+	return master_pty;
+}
+
+int telnet_open_slave_pty(struct telnet_session *ts, int master_pty) {
+	int slave_pty;
+
+#ifdef TELNETD_FOR_LINUX
+	pid_t pid;
+	char slave_name[32];
+
+	pid = getpid();
+	setsid();
+
+	ptsname_r(master_pty, slave_name, 32);
+	slave_pty = open(slave_name, O_RDWR);
+
+	tcsetpgrp(slave_pty, pid);
+#else
+	slave_pty = ts->pptyfds[1];
+#endif
+
+	return slave_pty;
+}

--- a/src/kernel/thread/signal/Mybuild
+++ b/src/kernel/thread/signal/Mybuild
@@ -11,7 +11,7 @@ module siginfoq_stub extends siginfoq_api {
 module siginfoq extends siginfoq_api {
 	source "siginfoq.h"
 	source "siginfoq.c"
-	option number pool_sz = 64
+	option number siginfo_pool_sz = 64
 }
 
 module sigstate_stub extends sigstate_api {

--- a/src/kernel/thread/signal/siginfoq.c
+++ b/src/kernel/thread/signal/siginfoq.c
@@ -19,8 +19,8 @@
 
 #include <framework/mod/options.h>
 
-#define LINK_POOL_SZ \
-	OPTION_GET(NUMBER, pool_sz)
+#define SIGINFO_POOL_SZ \
+	OPTION_GET(NUMBER, siginfo_pool_sz)
 
 struct siginfoq_link {
 	struct slist_link link;
@@ -28,7 +28,7 @@ struct siginfoq_link {
 };
 typedef member_t(struct siginfoq_link, link) siginfoq_member_t;
 
-OBJALLOC_DEF(siginfoq_link_pool, struct siginfoq_link, LINK_POOL_SZ);
+OBJALLOC_DEF(siginfoq_link_pool, struct siginfoq_link, SIGINFO_POOL_SZ);
 
 struct siginfoq *siginfoq_init(struct siginfoq *infoq) {
 	slist_init(&infoq->queue);

--- a/templates/arm/stm32f4-discovery/mods.config
+++ b/templates/arm/stm32f4-discovery/mods.config
@@ -35,12 +35,12 @@ configuration conf {
 
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=16)
-	include embox.kernel.task.resource.sig_table(sig_table_size=10)
+	include embox.kernel.task.resource.sig_table(sig_table_size=20)
 	include embox.kernel.task.resource.env(env_per_task=4,env_str_len=64)
 
 	include embox.kernel.thread.thread_local_none
 	include embox.kernel.thread.thread_cancel_disable
-	include embox.kernel.thread.signal_stub
+	include embox.kernel.thread.signal.siginfoq(siginfo_pool_sz=4)
 	include embox.kernel.timer.sleep
 	include embox.net.skbuff(amount_skb=10)
 	include embox.net.skbuff_data(amount_skb_data=10)

--- a/templates/arm/stm32f764g-discovery/mods.config
+++ b/templates/arm/stm32f764g-discovery/mods.config
@@ -46,7 +46,7 @@ configuration conf {
 
 	include embox.kernel.thread.thread_local_none
 	include embox.kernel.thread.thread_cancel_disable
-	include embox.kernel.thread.signal_stub
+	include embox.kernel.thread.signal.siginfoq(siginfo_pool_sz=8)
 	include embox.kernel.timer.sleep
 	include embox.net.skbuff(amount_skb=10)
 	include embox.net.skbuff_data(amount_skb_data=10)
@@ -57,7 +57,6 @@ configuration conf {
 	include embox.net.udp_sock
 	include embox.kernel.sched.sched
 	include embox.kernel.sched.idle_light
-	//include embox.kernel.thread.signal_stub
 
 	include embox.kernel.lthread.lthread
 	include embox.kernel.thread.core(thread_pool_size=16)

--- a/templates/arm/stm32f769i-discovery/mods.config
+++ b/templates/arm/stm32f769i-discovery/mods.config
@@ -28,7 +28,7 @@ configuration conf {
 
 	include embox.kernel.thread.thread_local_none
 	include embox.kernel.thread.thread_cancel_disable
-	include embox.kernel.thread.signal_stub
+	include embox.kernel.thread.signal.siginfoq(siginfo_pool_sz=8)
 	include embox.kernel.timer.sleep
 	include embox.net.skbuff(amount_skb=10)
 	include embox.net.skbuff_data(amount_skb_data=10)

--- a/templates/arm/test/units/mods.config
+++ b/templates/arm/test/units/mods.config
@@ -124,7 +124,7 @@ configuration conf {
 	include embox.cmd.net.tftp
 	include embox.cmd.net.snmpd
 	include embox.cmd.net.ntpdate
-	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
+	include embox.cmd.net.telnetd
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail

--- a/templates/microblaze/test/units/mods.config
+++ b/templates/microblaze/test/units/mods.config
@@ -63,7 +63,7 @@ configuration conf {
 	include embox.cmd.net.tftp
 	include embox.cmd.net.snmpd
 	include embox.cmd.net.ntpdate
-	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
+	include embox.cmd.net.telnetd
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail

--- a/templates/mips/test/units/mods.config
+++ b/templates/mips/test/units/mods.config
@@ -90,7 +90,7 @@ configuration conf {
 	include embox.cmd.net.tftp
 	include embox.cmd.net.snmpd
 	include embox.cmd.net.ntpdate
-	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
+	include embox.cmd.net.telnetd
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail

--- a/templates/x86/test/fs/mods.config
+++ b/templates/x86/test/fs/mods.config
@@ -66,7 +66,7 @@ configuration conf {
 	include embox.cmd.net.ntpdate
 	include embox.cmd.net.bootpc
 	include embox.cmd.net.httpd
-	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
+	include embox.cmd.net.telnetd
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail

--- a/templates/x86/test/net/mods.config
+++ b/templates/x86/test/net/mods.config
@@ -51,7 +51,7 @@ configuration conf {
 	include embox.cmd.net.ntpdate
 	include embox.cmd.net.bootpc
 	include embox.cmd.net.httpd
-	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
+	include embox.cmd.net.telnetd
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail

--- a/templates/x86/test/units/mods.config
+++ b/templates/x86/test/units/mods.config
@@ -124,7 +124,7 @@ configuration conf {
 	include embox.cmd.net.tftp
 	include embox.cmd.net.snmpd
 	include embox.cmd.net.ntpdate
-	include embox.cmd.net.telnetd(telnetd_use_pthread=0)
+	include embox.cmd.net.telnetd
 	include embox.cmd.net.nslookup
 	include embox.cmd.net.getmail
 	include embox.cmd.net.sendmail


### PR DESCRIPTION
Rework telnet:
* This implementation creates only one task per one client connection instead of a task and pthread as it was before. So for example, having now pool with 4 threads on stm32 we can handle 3 parallel connections instead of 1 as it was before.
* Logic is unified - there are no more two implementations (with and without pthreads)
* You can compile, run and debug this telnetd on Linux:
   ```
    $ cd src/cmds/net/telnetd
    $ make
    $ ./telnetd
    telnetd started on port 3023
   ```
   Then connect:
   ```
    $ telnet localhost 3023
   ```