### PR TITLE
Work on partition support

### DIFF
--- a/scripts/autotest/configs/mmc.sh
+++ b/scripts/autotest/configs/mmc.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+export TEST_CURRENT_CONFIG=mmc
+
+export EMBOX_IP=10.0.2.16
+export HOST_IP=10.0.2.10
+export EMBOX_PROMPT="#"
+export TEST_TARGET_CONNECTION_TYPE=telnet
+export TEST_BLKDEV0=/dev/mmc0
+export TEST_BLKDEV0_RAW_NAME=mmc0

--- a/scripts/autotest/run_scripts/run_qemu_mmc.sh
+++ b/scripts/autotest/run_scripts/run_qemu_mmc.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+QEMU=./scripts/qemu/auto_qemu
+IMG=$(mktemp -d)/mmc.img
+
+./scripts/disk/partitions.sh $IMG
+
+cd $TEST_EMBOX_ROOT
+$QEMU -sd $IMG
+rm -r $(dirname $IMG)
+cd -

--- a/scripts/autotest/testsuite/block_dev/partitions/test.exp
+++ b/scripts/autotest/testsuite/block_dev/partitions/test.exp
@@ -1,0 +1,8 @@
+TEST_CASE {Run partition test} {
+	global embox_prompt
+	global block_dev_raw
+
+	send "block_dev_test -p $block_dev_raw\r"
+	# Wait for 3 min
+	test_expect_strings_timeout 180 "OK" $embox_prompt
+}

--- a/scripts/disk/partitions.sh
+++ b/scripts/disk/partitions.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Create image file with 4 partitions
+
+print_usage() {
+	echo "Create image file with MBR partitions"
+	echo "Default size is 128MiB with 4 partitions formatted with fat"
+	echo ""
+	echo "Usage:"
+	echo "    $0 <target_file> <partitions> <fs_type> <size_mb>"
+}
+
+[ $# = 0 ] && print_usage && exit
+
+IMG=$1
+PARTS=$2 
+FS=$3
+SIZE=$4
+
+[ "$PARTS" == "" ] && PARTS=4
+[ "$FS" == "" ] && FS="fat"
+[ "$SIZE" == "" ] && SIZE=128
+
+if [[ ! $PARTS = 1 && ! $PARTS = 2 && ! $PARTS = 3 && ! $PARTS = 4 ]]; then
+	echo "MBR may have up to 4 partitions!"
+	exit 1
+fi
+
+MKFS_PATH=`sudo which mkfs.$FS 2> /dev/null`
+[ "$MKFS_PATH" == "" ] && echo "Command mkfs.$FS not found" && exit
+
+dd if=/dev/zero of=$IMG count=$SIZE bs=1M
+sudo parted $IMG -s mktable msdos || exit
+
+for i in $(seq 1 $PARTS)
+do
+	sudo parted $IMG -s mkpart primary fat32 \
+		$(( $i * $SIZE / ($PARTS + 1) )) $(( (1 + $i) * $SIZE / ($PARTS + 1) ))
+done
+
+sudo kpartx -d $IMG || exit
+
+LOOPDEV=$(sudo kpartx -av $IMG | head -n 1 | awk "{ print \$3"})
+LOOPDEV=${LOOPDEV::-1}
+
+for i in $(seq 1 $PARTS)
+do
+	sudo mkfs.$FS -n "PART$i" -I /dev/mapper/$LOOPDEV$i
+	sudo mount /dev/mapper/$LOOPDEV$i /mnt
+	sudo bash -c "echo Partition $i file >> /mnt/part$i\_file"
+	sudo umount /mnt
+	sync
+done

--- a/src/cmds/fs/chmod.c
+++ b/src/cmds/fs/chmod.c
@@ -121,7 +121,7 @@ static int change_mode(char *path, int recursive, char *mode_str) {
 		return -1;
 	}
 
-	if (!(sb.st_mode & S_IFDIR && recursive)) {
+	if (!(S_ISDIR(sb.st_mode) && recursive)) {
 		return chmod(path, mode);
 	}
 
@@ -151,7 +151,7 @@ static int change_mode(char *path, int recursive, char *mode_str) {
 
 		chmod(line, mode);
 
-		if (sb.st_mode & S_IFDIR && recursive) {
+		if (S_ISDIR(sb.st_mode) && recursive) {
 			DIR *d;
 
 			if (NULL == (d = opendir(line))) {

--- a/src/cmds/fs/ls.c
+++ b/src/cmds/fs/ls.c
@@ -114,7 +114,7 @@ static void print(char *path, DIR *dir, int recursive, item_print *printer) {
 
 		printer(line, &sb);
 
-		if (sb.st_mode & S_IFDIR && recursive) {
+		if (S_ISDIR(sb.st_mode) && recursive) {
 			DIR *d;
 
 			if (NULL == (d = opendir(line))) {
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
 			return -errno;
 		}
 
-		if (~sb.st_mode & S_IFDIR) {
+		if (!S_ISDIR(sb.st_mode)) {
 			printer(argv[optind], &sb);
 			return 0;
 		}

--- a/src/cmds/fs/mount.c
+++ b/src/cmds/fs/mount.c
@@ -66,16 +66,27 @@ extern struct dlist_head dentry_dlist;
 static void show_mount_list(void) {
 	struct dentry *d;
 	char mount_path[DVFS_MAX_PATH_LEN];
+	char bdev_path[DVFS_MAX_PATH_LEN];
+	struct file *bdev_file;
 
 	dlist_foreach_entry(d, &dentry_dlist, d_lnk) {
 		if (d->flags & DVFS_MOUNT_POINT) {
-			if (dentry_full_path(d, mount_path))
+			if (dentry_full_path(d, mount_path)) {
 				continue;
+			}
+
+			bdev_file = d->d_sb->bdev_file;
+
+			if (bdev_file && bdev_file->f_dentry) {
+				dentry_full_path(bdev_file->f_dentry, bdev_path);
+			} else {
+				strcpy(bdev_path, d->d_sb->fs_drv->name);
+			}
 
 			printf("%s on %s type %s\n",
-			d->d_sb->fs_drv->name,
-			mount_path,
-			d->d_sb->fs_drv->name);
+					bdev_path,
+					mount_path,
+					d->d_sb->fs_drv->name);
 		}
 	}
 }

--- a/src/compat/libc/stdio/rename_dvfs.c
+++ b/src/compat/libc/stdio/rename_dvfs.c
@@ -25,7 +25,7 @@
  * @return 0 if succeed and -1 if failed, errno is set
  */
 int rename(const char *src_name, const char *dst_name) {
-	struct lookup lu;
+	struct lookup lu = {};
 	struct dentry *from, *to, *dst_parent;
 	char dst_parent_path[DVFS_MAX_PATH_LEN + 1];
 	int err;

--- a/src/compat/posix/fs/chown/chown_dvfs.c
+++ b/src/compat/posix/fs/chown/chown_dvfs.c
@@ -11,7 +11,7 @@
 #include <fs/dvfs.h>
 
 int chown(const char *path, uid_t owner, gid_t group) {
-	struct lookup lookup;
+	struct lookup lookup = {};
 	int res;
 
 	if (!path) {

--- a/src/compat/posix/fs/dvfs/chmod.c
+++ b/src/compat/posix/fs/dvfs/chmod.c
@@ -11,7 +11,7 @@
 #include <fs/dvfs.h>
 
 int chmod(const char *path, mode_t mode) {
-	struct lookup l;
+	struct lookup l = {};
 	int res = dvfs_lookup(path, &l);
 	struct dentry *d = l.item;
 

--- a/src/compat/posix/fs/dvfs/xattr.c
+++ b/src/compat/posix/fs/dvfs/xattr.c
@@ -12,7 +12,7 @@
 #include <fs/dvfs.h>
 
 int getxattr(const char *path, const char *name, char *value, size_t size) {
-	struct lookup lookup;
+	struct lookup lookup = {};
 	struct inode *inode;
 	int err;
 
@@ -30,7 +30,7 @@ int getxattr(const char *path, const char *name, char *value, size_t size) {
 
 int setxattr(const char *path, const char *name, const char *value, size_t size,
 	       	int flags) {
-	struct lookup lookup;
+	struct lookup lookup = {};
 	struct inode *inode;
 	int err;
 

--- a/src/drivers/block_dev/block_dev.c
+++ b/src/drivers/block_dev/block_dev.c
@@ -395,6 +395,12 @@ struct block_dev *block_dev_create(const char *path, const struct block_dev_driv
 int block_dev_destroy(void *dev) {
 	struct dev_module *devmod = dev;
 
+	for (int i = 0; i < MAX_DEV_QUANTITY; i++) {
+		if (devtab[i] && devtab[i]->parent_bdev == devmod->dev_priv) {
+			block_dev_destroy(devtab[i]->dev_module);
+		}
+	}
+
 	devfs_del_block(devmod->dev_priv);
 
 	block_dev_free(devmod->dev_priv);

--- a/src/drivers/block_dev/block_dev.c
+++ b/src/drivers/block_dev/block_dev.c
@@ -217,6 +217,10 @@ int block_dev_read(void *dev, char *buffer, size_t count, blkno_t blkno) {
 	}
 	bdev = block_dev(dev);
 
+	if (blkno >= bdev->size / bdev->block_size) {
+		return -EINVAL;
+	}
+
 	if (bdev->parent_bdev != NULL) {
 		blkno += bdev->start_offset;
 		bdev = bdev->parent_bdev;
@@ -238,6 +242,10 @@ int block_dev_write(void *dev, const char *buffer, size_t count, blkno_t blkno) 
 	}
 
 	bdev = block_dev(dev);
+
+	if (blkno >= bdev->size / bdev->block_size) {
+		return -EINVAL;
+	}
 
 	if (bdev->parent_bdev != NULL) {
 		blkno += bdev->start_offset;

--- a/src/drivers/block_dev/block_dev.c
+++ b/src/drivers/block_dev/block_dev.c
@@ -217,6 +217,11 @@ int block_dev_read(void *dev, char *buffer, size_t count, blkno_t blkno) {
 	}
 	bdev = block_dev(dev);
 
+	if (bdev->parent_bdev != NULL) {
+		blkno += bdev->start_offset;
+		bdev = bdev->parent_bdev;
+	}
+
 	blksize = block_dev_block_size(bdev);
 	if (blksize < 0) {
 		return blksize;
@@ -233,6 +238,11 @@ int block_dev_write(void *dev, const char *buffer, size_t count, blkno_t blkno) 
 	}
 
 	bdev = block_dev(dev);
+
+	if (bdev->parent_bdev != NULL) {
+		blkno += bdev->start_offset;
+		bdev = bdev->parent_bdev;
+	}
 
 	blksize = block_dev_block_size(bdev);
 	if (blksize < 0) {

--- a/src/drivers/block_dev/block_dev.c
+++ b/src/drivers/block_dev/block_dev.c
@@ -107,6 +107,18 @@ struct block_dev *block_dev_find(const char *bd_name) {
 	return NULL;
 }
 
+int block_dev_max_id(void) {
+	return MAX_DEV_QUANTITY;
+}
+
+struct block_dev *block_dev_by_id(int id) {
+	if (id < 0 || id >= MAX_DEV_QUANTITY) {
+		return NULL;
+	}
+
+	return devtab[id];
+}
+
 struct block_dev *block_dev(void *dev) {
 	return (struct block_dev *)dev;
 }

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -38,7 +38,7 @@ struct block_dev {
 
 	/* partitions */
 	size_t start_offset;
-	struct block_dev *parrent_bdev;
+	struct block_dev *parent_bdev;
 };
 
 struct block_dev_driver {

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -37,7 +37,7 @@ struct block_dev {
 	struct dev_module *dev_module;
 
 	/* partitions */
-	size_t start_offset;
+	uint64_t start_offset;
 	struct block_dev *parent_bdev;
 };
 

--- a/src/drivers/block_dev/block_dev.h
+++ b/src/drivers/block_dev/block_dev.h
@@ -88,6 +88,9 @@ extern struct block_dev_module *block_dev_lookup(const char *name);
 extern void block_dev_free(struct block_dev *dev);
 extern struct block_dev *block_dev_find(const char *bd_name);
 
+extern int block_dev_max_id(void);
+extern struct block_dev *block_dev_by_id(int id);
+
 extern uint64_t block_dev_size(struct block_dev *dev);
 extern size_t block_dev_block_size(struct block_dev *dev);
 

--- a/src/drivers/block_dev/block_dev_idesc_dvfs.c
+++ b/src/drivers/block_dev/block_dev_idesc_dvfs.c
@@ -37,13 +37,13 @@ static ssize_t bdev_idesc_read(struct idesc *desc, const struct iovec *iov, int 
 
 	devmod = file->f_inode->i_data;
 	bdev = devmod->dev_priv;
-	if (!bdev->parrent_bdev) {
+	if (!bdev->parent_bdev) {
 		/* It's not a partition */
 		blk_no = file->pos / bdev->block_size;
 	} else {
 		/* It's a partition */
 		blk_no = bdev->start_offset + (file->pos / bdev->block_size);
-		bdev = bdev->parrent_bdev;
+		bdev = bdev->parent_bdev;
 	}
 
 	assert(bdev->driver);
@@ -72,13 +72,13 @@ static ssize_t bdev_idesc_write(struct idesc *desc, const struct iovec *iov, int
 
 	devmod = file->f_inode->i_data;
 	bdev = devmod->dev_priv;
-	if (!bdev->parrent_bdev) {
+	if (!bdev->parent_bdev) {
 		/* It's not a partition */
 		blk_no = file->pos / bdev->block_size;
 	} else {
 		/* It's a partition */
 		blk_no = bdev->start_offset + (file->pos / bdev->block_size);
-		bdev = bdev->parrent_bdev;
+		bdev = bdev->parent_bdev;
 	}
 
 	assert(bdev->driver);
@@ -112,8 +112,8 @@ static int bdev_idesc_ioctl(struct idesc *idesc, int cmd, void *args) {
 	case IOCTL_GETBLKSIZE:
 		return bdev->block_size;
 	default:
-		if (bdev->parrent_bdev) {
-			bdev = bdev->parrent_bdev;
+		if (bdev->parent_bdev) {
+			bdev = bdev->parent_bdev;
 		}
 		assert(bdev->driver);
 		if (NULL == bdev->driver->ioctl)

--- a/src/drivers/block_dev/block_dev_idesc_oldfs.c
+++ b/src/drivers/block_dev/block_dev_idesc_oldfs.c
@@ -38,13 +38,13 @@ static ssize_t bdev_idesc_read(struct idesc *desc, const struct iovec *iov, int 
 
 	devmod = file->node->nas->fi->privdata;
 	bdev = devmod->dev_priv;
-	if (!bdev->parrent_bdev) {
+	if (!bdev->parent_bdev) {
 		/* It's not a partition */
 		blk_no = file->cursor / bdev->block_size;
 	} else {
 		/* It's a partition */
 		blk_no = bdev->start_offset + (file->cursor / bdev->block_size);
-		bdev = bdev->parrent_bdev;
+		bdev = bdev->parent_bdev;
 	}
 
 	assert(bdev->driver);
@@ -73,13 +73,13 @@ static ssize_t bdev_idesc_write(struct idesc *desc, const struct iovec *iov, int
 
 	devmod = file->node->nas->fi->privdata;
 	bdev = devmod->dev_priv;
-	if (!bdev->parrent_bdev) {
+	if (!bdev->parent_bdev) {
 		/* It's not a partition */
 		blk_no = file->cursor / bdev->block_size;
 	} else {
 		/* It's a partition */
 		blk_no = bdev->start_offset + (file->cursor / bdev->block_size);
-		bdev = bdev->parrent_bdev;
+		bdev = bdev->parent_bdev;
 	}
 
 	assert(bdev->driver);
@@ -113,8 +113,8 @@ static int bdev_idesc_ioctl(struct idesc *idesc, int cmd, void *args) {
 	case IOCTL_GETBLKSIZE:
 		return bdev->block_size;
 	default:
-		if (bdev->parrent_bdev) {
-			bdev = bdev->parrent_bdev;
+		if (bdev->parent_bdev) {
+			bdev = bdev->parent_bdev;
 		}
 		assert(bdev->driver);
 		if (NULL == bdev->driver->ioctl)

--- a/src/drivers/block_dev/partition/partition.c
+++ b/src/drivers/block_dev/partition/partition.c
@@ -50,15 +50,15 @@ int create_partitions(struct block_dev *bdev) {
 			return -ENOMEM;
 		}
 
-		part_bdev->start_offset = (uint32_t)(mbr.ptable[part_n].start_3) << 24 |
+		part_bdev->start_offset = (int64_t) ((uint32_t)(mbr.ptable[part_n].start_3) << 24 |
 				(uint32_t)(mbr.ptable[part_n].start_2) << 16 |
 				(uint32_t)(mbr.ptable[part_n].start_1) << 8 |
-				(uint32_t)(mbr.ptable[part_n].start_0) << 0;
+				(uint32_t)(mbr.ptable[part_n].start_0) << 0);
 
-		part_bdev->size = (uint32_t)(mbr.ptable[part_n].size_3) << 24 |
+		part_bdev->size = (int64_t) ((uint32_t)(mbr.ptable[part_n].size_3) << 24 |
 				(uint32_t)(mbr.ptable[part_n].size_2) << 16 |
 				(uint32_t)(mbr.ptable[part_n].size_1) << 8 |
-				(uint32_t)(mbr.ptable[part_n].size_0) << 0;
+				(uint32_t)(mbr.ptable[part_n].size_0) << 0);
 
 		part_bdev->parent_bdev = bdev;
 		part_bdev->block_size = bdev->block_size;

--- a/src/drivers/block_dev/partition/partition.c
+++ b/src/drivers/block_dev/partition/partition.c
@@ -25,6 +25,7 @@ int create_partitions(struct block_dev *bdev) {
 	struct mbr mbr;
 	int rc;
 	int part_n;
+	int last_digit = 0;
 	char part_name[PART_NAME_MAX];
 	struct block_dev *part_bdev;
 
@@ -38,13 +39,18 @@ int create_partitions(struct block_dev *bdev) {
 	if ((mbr.sig_55 != 0x55) || (mbr.sig_aa != 0xAA)) {
 		return 0;
 	}
+
+	if (isdigit(bdev->name[strlen(bdev->name) - 1])) {
+		last_digit = 1;
+	}
+
 	for (part_n = 0; part_n < 4; part_n ++) {
 
 		if(mbr.ptable[part_n].type == 0) {
 			return part_n;
 		}
 
-		sprintf(part_name, "/dev/%s%d", bdev->name, part_n + 1);
+		sprintf(part_name, "/dev/%s%s%d", bdev->name, last_digit ? "p" : "", part_n + 1);
 		part_bdev = block_dev_create(part_name, bdev->driver, NULL);
 		if (!part_bdev) {
 			return -ENOMEM;

--- a/src/drivers/block_dev/partition/partition.c
+++ b/src/drivers/block_dev/partition/partition.c
@@ -60,7 +60,7 @@ int create_partitions(struct block_dev *bdev) {
 				(uint32_t)(mbr.ptable[part_n].size_1) << 8 |
 				(uint32_t)(mbr.ptable[part_n].size_0) << 0;
 
-		part_bdev->parrent_bdev = bdev;
+		part_bdev->parent_bdev = bdev;
 		part_bdev->block_size = bdev->block_size;
 	}
 

--- a/src/drivers/block_dev/partition/partition.c
+++ b/src/drivers/block_dev/partition/partition.c
@@ -66,6 +66,8 @@ int create_partitions(struct block_dev *bdev) {
 				(uint32_t)(mbr.ptable[part_n].size_1) << 8 |
 				(uint32_t)(mbr.ptable[part_n].size_0) << 0);
 
+		part_bdev->size *= bdev->block_size;
+
 		part_bdev->parent_bdev = bdev;
 		part_bdev->block_size = bdev->block_size;
 	}

--- a/src/drivers/mmc/core/Mybuild
+++ b/src/drivers/mmc/core/Mybuild
@@ -19,4 +19,6 @@ module mmc_core {
 	source "sdio.c",
 		"sd.c",
 		"mmc.c"
+
+	depends embox.driver.block.partition
 }

--- a/src/drivers/mmc/core/mmc_host.c
+++ b/src/drivers/mmc/core/mmc_host.c
@@ -9,6 +9,7 @@
 #include <limits.h>
 
 #include <drivers/block_dev.h>
+#include <drivers/block_dev/partition.h>
 #include <drivers/mmc/mmc.h>
 #include <drivers/mmc/mmc_core.h>
 #include <drivers/mmc/mmc_host.h>
@@ -200,18 +201,21 @@ int mmc_scan(struct mmc_host *host) {
 	/* The order is important! */
 	if (!mmc_try_sdio(host)) {
 		log_debug("SDIO detected");
+		create_partitions(host->bdev);
 		return 0;
 	}
 
 	mmc_go_idle(host);
 	if (!mmc_try_sd(host)) {
 		log_debug("SD detected");
+		create_partitions(host->bdev);
 		return 0;
 	}
 
 	mmc_go_idle(host);
 	if (!mmc_try_mmc(host)) {
 		log_debug("MMC detected");
+		create_partitions(host->bdev);
 		return 0;
 	}
 

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -507,12 +507,18 @@ static int fat_format(void *dev, void *priv) {
  */
 static int fat_clean_sb(struct super_block *sb) {
 	struct fat_fs_info *fsi;
+	struct dirinfo *di;
 
 	assert(sb);
+	assert(sb->root);
+	assert(sb->root->d_inode);
+
+	di = sb->root->d_inode->i_data;
+	assert(di);
+	fat_dirinfo_free(di);
 
 	fsi = sb->sb_data;
 	assert(fsi);
-
 	fat_fs_free(fsi);
 
 	return 0;

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -389,7 +389,11 @@ static int fat_fill_sb(struct super_block *sb, struct file *bdev_file) {
 	struct fat_fs_info *fsi;
 	struct block_dev *dev;
 	assert(sb);
-	assert(bdev_file);
+	if (!bdev_file) {
+		/* FAT always uses block device, so we can't fill superblock */
+		return -ENOENT;
+	}
+
 	assert(bdev_file->f_inode);
 	assert(bdev_file->f_inode->i_data);
 

--- a/src/fs/dvfs/compat.c
+++ b/src/fs/dvfs/compat.c
@@ -44,7 +44,7 @@ int mount(char *dev, char *dir, char *fs_type) {
  * @retval -EINVAL File is not a mount point
  */
 int umount(char *dir) {
-	struct lookup lu;
+	struct lookup lu = {};
 	int err;
 
 	if ((err = dvfs_lookup(dir, &lu))) {

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -185,7 +185,7 @@ struct idesc *dvfs_file_open_idesc(struct lookup *lookup, int __oflag) {
  * @retval -1 File not found
  */
 int dvfs_remove(const char *path) {
-	struct lookup lookup;
+	struct lookup lookup = {};
 	struct inode  *i_no;
 	int res;
 
@@ -318,7 +318,7 @@ int dvfs_fstat(struct file *desc, struct stat *sb) {
 
 static struct file *dvfs_get_mount_bdev(const char *dev_name) {
 	struct file *bdev_file;
-	struct lookup lookup;
+	struct lookup lookup = {};
 	int res;
 
 	if (!dev_name) {
@@ -390,7 +390,7 @@ extern int set_rootfs_sb(struct super_block *sb);
  * @retval -ENOENT Mount point or device not found
  */
 int dvfs_mount(const char *dev, const char *dest, const char *fstype, int flags) {
-	struct lookup lookup;
+	struct lookup lookup = {};
 	const struct dumb_fs_driver *drv;
 	struct super_block *sb;
 	struct dentry *d = NULL;

--- a/src/fs/dvfs/dvfs_xattr.c
+++ b/src/fs/dvfs/dvfs_xattr.c
@@ -11,7 +11,7 @@
 #include <fs/dvfs.h>
 
 int dvfs_xattr_get(const char *path, const char *name, char *value, size_t size) {
-	struct lookup lu;
+	struct lookup lu = {};
 	struct inode *inode;
 	int err;
 

--- a/src/fs/fuse/fuse_linux.c
+++ b/src/fs/fuse/fuse_linux.c
@@ -37,7 +37,7 @@ struct fuse_mount_params {
 
 static int fuse_fill_dentry(struct super_block *sb, char *dest) {
 	struct dentry *d;
-	struct lookup lookup;
+	struct lookup lookup = {};
 	int err;
 
 	if ((err = dvfs_lookup(dest, &lookup))) {

--- a/src/fs/rootfs_dvfs.c
+++ b/src/fs/rootfs_dvfs.c
@@ -44,7 +44,7 @@ static int rootfs_mount(void) {
 	const char *dev, *fs_type;
 	const struct dumb_fs_driver *fsdrv;
 	const struct auto_mount *auto_mnt;
-	struct lookup lu;
+	struct lookup lu = {};
 	char *tmp;
 	int err;
 


### PR DESCRIPTION
Extend support for block device partitions:
* Add intensive partition test to `block_dev_test`
* Create partitions in MMC subsystem
* Fix read/write operation for partitions
* Add script to generate disk image with partitions

Minor fixes:
* Change partition naming: if block device name is finished with digit, add 'p' prefix, so `mmc0` will have partitions like `mmc0p1`, not `mmc01`
* Fix memory leaks for FAT
* Fix `mount` output for new VFS
* Fix filetype check in some fs commands
* Fix some typos

To run partition test on QEMU, use `arm/qemu` template and pass `-sd card.img` option. Then run `block_dev_test -p mmc0`.

To generate card image with partitions, run `scripts/disk/partitions.sh`, for example:
`./scripts/disk/partitions.sh card.img 4 fat 16`