### PR TITLE
vfork: Copy idesc at the same position as in parent

### DIFF
--- a/src/cmds/net/telnetd/telnetd.c
+++ b/src/cmds/net/telnetd/telnetd.c
@@ -363,7 +363,6 @@ int main(int argc, char **argv) {
 		printf("telnet: listen() failed on main server socket\n");
 		goto listen_failed;
 	}
-	printf("telnetd started on port %d\n", TELNETD_PORT);
 
 	telnet_main_loop(server_sock);
 


### PR DESCRIPTION
Fix cloexec handling and idesc table fork'ing. Index descriptors in child must be at the same position as in parent, so do not allocate minimal index but copy at the same position. btw, it fixes telnet exits, when there are multiple clients connections.