### PR TITLE
Fix mount-related memory leaks

### DIFF
--- a/scripts/autotest/run_scripts/run_qemu_mmc.sh
+++ b/scripts/autotest/run_scripts/run_qemu_mmc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 QEMU=./scripts/qemu/auto_qemu
 IMG=$(mktemp -d)/mmc.img
@@ -6,6 +6,6 @@ IMG=$(mktemp -d)/mmc.img
 ./scripts/disk/partitions.sh $IMG
 
 cd $TEST_EMBOX_ROOT
-$QEMU -sd $IMG
+$QEMU -sd $IMG $@
 rm -r $(dirname $IMG)
 cd -

--- a/scripts/autotest/testsuite/fs-vfat/mount/test.exp
+++ b/scripts/autotest/testsuite/fs-vfat/mount/test.exp
@@ -4,6 +4,7 @@ TEST_CASE {Mount/umount should work multiple times} {
 	global mount_dir
 	global fs_type
 
+	test_exec_embox_cmd "cd /\r"
 	test_exec_embox_cmd "umount $mount_dir\r"
 
 	for {set i 0} {$i < 8} {incr i} {

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -1674,7 +1674,7 @@ static void fat_dir_clean_long(struct dirinfo *di, struct fat_file_info *fi) {
 static int fat_dir_empty(struct fat_file_info *fi) {
 	struct dirinfo *di = (void *) fi;
 	struct fat_dirent de = { };
-	int res;
+	int res = 0;
 
 	fat_reset_dir(di);
 

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -30,6 +30,7 @@
 #define DVFS_CHILD_VIRTUAL 0x02000000
 #define DVFS_MOUNT_POINT   0x04000000
 #define DVFS_NO_LSEEK      0x08000000
+#define DVFS_DISCONNECTED  0x10000000
 
 #define FILE_TYPE(flags, ftype) ((((flags) & S_IFMT) == (ftype)) ? (ftype) : 0)
 
@@ -211,6 +212,8 @@ extern void dentry_upd_flags(struct dentry *dentry);
 extern int dentry_full_path(struct dentry *dentry, char *buf);
 extern int dentry_ref_inc(struct dentry *dentry);
 extern int dentry_ref_dec(struct dentry *dentry);
+extern int dentry_disconnect(struct dentry *dentry);
+extern int dentry_reconnect(struct dentry *parent, const char *name);
 
 extern int dvfs_bdev_read(
 		struct file_desc *bdev_file,

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -643,6 +643,10 @@ int kumount(const char *dir) {
 		return res;
 	}
 
+	if (dir_node.node != vfs_get_root()) {
+		node_free(dir_node.node);
+	}
+
 	mount_table_del(node.mnt_desc);
 
 //	/*restore previous fs type from parent dir */


### PR DESCRIPTION
* Don't call fs->sb_clean_up() if root inode was not created due to
mount error
* Close bdev file desc on umount
* Reconnect "shadowed" dentry after umount
* Minor ref inc/dec balance fix
* Minor fix for autotest/mount script

As a result, `./scripts/autotest/run.sh fs-vfat mount` can be run successfully with at least 8192 iterations. Longer runs cause exceptions in `util/ring_buff` from time to time, but this seems to be terminal-related issue.