### PR TITLE
Clean/unify VFS

### DIFF
--- a/src/cmds/fs/mkfs.c
+++ b/src/cmds/fs/mkfs.c
@@ -54,6 +54,7 @@ static int mkfs_do_operation(size_t blocks, char *path, const char *fs_name,
 	static int mkfs_do_operation(size_t blocks, char *path, const char *fs_name,
 		int fs_type, int operation_flag, char *fs_specific) {
 		const struct dumb_fs_driver *drv = dumb_fs_driver_find(fs_name);
+		struct block_dev *bdev;
 		struct lookup lu = {};
 		int err;
 
@@ -74,7 +75,8 @@ static int mkfs_do_operation(size_t blocks, char *path, const char *fs_name,
 		assert(lu.item->d_inode);
 		assert(lu.item->d_inode->i_data);
 
-		return drv->format(lu.item->d_inode->i_data, fs_specific);
+		bdev = ((struct dev_module *) lu.item->d_inode->i_data)->dev_priv;
+		return drv->format(bdev, fs_specific);
 	}
 #endif
 

--- a/src/drivers/block_dev/block_dev_idesc.c
+++ b/src/drivers/block_dev/block_dev_idesc.c
@@ -52,10 +52,6 @@ static ssize_t bdev_idesc_read(struct idesc *desc, const struct iovec *iov, int 
 	assert(bdev->driver);
 	assert(bdev->driver->read);
 	res = bdev->driver->read(bdev, buf, nbyte, blk_no);
-	if (res < 0) {
-		return res;
-	}
-	file_set_pos(file, pos + res);
 
 	return res;
 }
@@ -90,10 +86,6 @@ static ssize_t bdev_idesc_write(struct idesc *desc, const struct iovec *iov, int
 	assert(bdev->driver);
 	assert(bdev->driver->write);
 	res = bdev->driver->write(bdev, (void *)iov->iov_base, iov->iov_len, blk_no);
-	if (res < 0) {
-		return res;
-	}
-	file_set_pos(file, pos + res);
 
 	return res;
 }

--- a/src/fs/driver/cifs/cifs.c
+++ b/src/fs/driver/cifs/cifs.c
@@ -293,7 +293,7 @@ static struct idesc *cifs_open(struct node *node, struct file_desc *file_desc,
 	file_desc->file_info = file;
 
 	// Yet another bullshit: size is not valid until open
-	node->nas->fi->ni.size = st.st_size;
+	file_set_size(file_desc, st.st_size);
 
 	return &file_desc->idesc;
 }
@@ -362,7 +362,7 @@ static size_t cifs_write(struct file_desc *file_desc, void *buf, size_t size) {
 	res = smbc_getFunctionWrite(fsi->ctx)(fsi->ctx, file, buf, size);
 
 	if (res > 0) {
-		file_desc->node->nas->fi->ni.size = max(file_desc->node->nas->fi->ni.size, pos);
+		file_set_size(file_desc, max(file_get_size(file_desc), pos));
 	}
 
 	return res;

--- a/src/fs/driver/cifs/cifs.c
+++ b/src/fs/driver/cifs/cifs.c
@@ -336,10 +336,6 @@ static size_t cifs_read(struct file_desc *file_desc, void *buf, size_t size)
 
 	res = smbc_getFunctionRead(fsi->ctx)(fsi->ctx, file, buf, size);
 
-	if (res > 0) {
-		file_set_pos(file_desc, pos + res);
-	}
-
 	return res;
 }
 
@@ -366,7 +362,6 @@ static size_t cifs_write(struct file_desc *file_desc, void *buf, size_t size) {
 	res = smbc_getFunctionWrite(fsi->ctx)(fsi->ctx, file, buf, size);
 
 	if (res > 0) {
-		pos = file_set_pos(file_desc, pos + res);
 		file_desc->node->nas->fi->ni.size = max(file_desc->node->nas->fi->ni.size, pos);
 	}
 

--- a/src/fs/driver/devfs/devfs_oldfs.c
+++ b/src/fs/driver/devfs/devfs_oldfs.c
@@ -15,10 +15,6 @@
 #include <drivers/char_dev.h>
 #include <drivers/block_dev.h>
 
-static int devfs_init(void *par) {
-	return 0;
-}
-
 static int devfs_mount(void *dev, void *dir) {
 	int ret;
 	struct path node, root;
@@ -41,7 +37,6 @@ static int devfs_mount(void *dev, void *dir) {
 }
 
 static struct fsop_desc devfs_fsop = {
-	.init = devfs_init,
 	.mount = devfs_mount,
 };
 

--- a/src/fs/driver/dfs/dfs.c
+++ b/src/fs/driver/dfs/dfs.c
@@ -556,7 +556,7 @@ static size_t dfs_write(struct file_desc *desc, void *buf, size_t size) {
 	assert(buf);
 
 	pos = desc->f_inode->start_pos + desc->pos;
-	l = min(size, desc->f_inode->length - desc->pos);
+	l = min(size, file_get_size(desc) - desc->pos);
 
 	if (l <= 0)
 		return -1;
@@ -572,7 +572,7 @@ size_t dfs_read(struct file_desc *desc, void *buf, size_t size) {
 	assert(buf);
 
 	int pos = desc->f_inode->start_pos + desc->pos;
-	int l   = min(size, desc->f_inode->length - desc->pos);
+	int l   = min(size, file_get_size(desc) - desc->pos);
 
 	if (l < 0)
 		return -1;

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -538,7 +538,7 @@ static int ext2_unlink(struct nas *dir_nas, struct nas *nas);
 static void ext2_free_fs(struct nas *nas);
 static int ext2_umount_entry(struct nas *nas);
 
-static int ext2fs_format(void *path);
+static int ext2fs_format(struct block_dev *bdev, void *priv);
 static int ext2fs_mount(void *dev, void *dir);
 static int ext2fs_create(struct node *parent_node, struct node *node);
 static int ext2fs_delete(struct node *node);
@@ -767,12 +767,7 @@ static int ext2_mark_bitmap(void *bdev, struct ext2sb *sb,
 }
 
 
-static int ext2fs_format(void *dev) {
-	int rc;
-	struct node *dev_node;
-	struct nas *dev_nas;
-	struct node_fi *dev_fi;
-	struct block_dev *bdev;
+static int ext2fs_format(struct block_dev *bdev, void *priv) {
 	struct ext2sb sb;
 	struct ext2_gd gd;
 	struct ext2fs_dinode *di;
@@ -782,18 +777,9 @@ static int ext2fs_format(void *dev) {
 	int sector;
 	float dev_factor;
 
-	dev_node = dev;
-	dev_nas = dev_node->nas;
-
-	if (NULL == (dev_fi = dev_nas->fi)) {
-		rc = ENODEV;
-		return -rc;
-	}
-
 	memset(&sb, 0, sizeof(struct ext2sb));
 	memset(&gd, 0, sizeof(struct ext2_gd));
 
-	bdev = (struct block_dev *) dev_fi->privdata;
 	dev_size = block_dev_size(bdev);
 	dev_bsize = block_dev_block_size(bdev);
 	dev_factor = SBSIZE / dev_bsize;

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -460,7 +460,7 @@ static struct idesc *ext2fs_open(struct node *node, struct file_desc *desc, int 
 		return err_ptr(rc);
 	}
 	else {
-		nas->fi->ni.size = fi->f_di.i_size;
+		file_set_size(desc, fi->f_di.i_size);
 	}
 
 	return &desc->idesc;
@@ -527,7 +527,7 @@ static size_t ext2fs_write(struct file_desc *desc, void *buff, size_t size) {
 
 	bytecount = ext2_write_file(nas, buff, size);
 
-	nas->fi->ni.size = fi->f_di.i_size;
+	file_set_size(desc, fi->f_di.i_size);
 
 	return bytecount;
 }

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -513,8 +513,6 @@ static size_t ext2fs_read(struct file_desc *desc, void *buff, size_t size) {
 		size -= csize;
 	}
 
-	file_set_pos(desc, fi->f_pointer);
-
 	return (addr - (char *) buff);
 }
 
@@ -529,7 +527,6 @@ static size_t ext2fs_write(struct file_desc *desc, void *buff, size_t size) {
 
 	bytecount = ext2_write_file(nas, buff, size);
 
-	file_set_pos(desc, fi->f_pointer);
 	nas->fi->ni.size = fi->f_di.i_size;
 
 	return bytecount;

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -538,7 +538,6 @@ static int ext2_unlink(struct nas *dir_nas, struct nas *nas);
 static void ext2_free_fs(struct nas *nas);
 static int ext2_umount_entry(struct nas *nas);
 
-static int ext2fs_init(void * par);
 static int ext2fs_format(void *path);
 static int ext2fs_mount(void *dev, void *dir);
 static int ext2fs_create(struct node *parent_node, struct node *node);
@@ -548,7 +547,6 @@ static int ext2fs_umount(void *dir);
 
 
 static struct fsop_desc ext2_fsop = {
-	.init	     = ext2fs_init,
 	.format	     = ext2fs_format,
 	.mount	     = ext2fs_mount,
 	.create_node = ext2fs_create,
@@ -560,10 +558,6 @@ static struct fsop_desc ext2_fsop = {
 
 	.truncate    = ext2fs_truncate,
 	.umount      = ext2fs_umount,
-};
-
-static int ext2fs_init(void * par) {
-	return 0;
 };
 
 static struct fs_driver ext2fs_driver = {

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -117,11 +117,6 @@ static size_t ext3fs_write(struct file_desc *desc, void *buff, size_t size) {
 	return res;
 }
 
-
-static int ext3fs_init(void *par) {
-	return 0;
-};
-
 static int ext3fs_create(struct node *parent_node, struct node *node) {
 	struct fs_driver *drv;
 	struct ext2_fs_info *fsi;
@@ -351,7 +346,6 @@ static struct file_operations ext3_fop = {
 };
 
 static struct fsop_desc ext3_fsop = {
-	.init	     = ext3fs_init,
 	.format	     = ext3fs_format,
 	.mount	     = ext3fs_mount,
 	.create_node = ext3fs_create,

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -167,16 +167,13 @@ static int ext3fs_delete(struct node *node) {
 
 extern int main_mke2fs(int argc, char **argv);
 
-static int ext3fs_format(void *dev) {
-	struct node *dev_node;
+static int ext3fs_format(struct block_dev *bdev, void *priv) {
 	int argc = 6;
 	char *argv[6];
 	char dev_path[64];
 
-	dev_node = dev;
-
 	strcpy(dev_path, "/dev/");
-	strcat(dev_path, dev_node->name);
+	strcat(dev_path, bdev->name);
 
 	argv[0] = "mke2fs";
 	argv[1] = "-b";

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -49,8 +49,7 @@ static size_t ext3fs_read(struct file_desc *desc, void *buf, size_t size);
 static size_t ext3fs_write(struct file_desc *desc, void *buf, size_t size);
 
 /* fs operations */
-static int ext3fs_init(void * par);
-static int ext3fs_format(void *path);
+static int ext3fs_format(struct block_dev *bdev, void *priv);
 static int ext3fs_mount(void *dev, void *dir);
 static int ext3fs_create(struct node *parent_node, struct node *node);
 static int ext3fs_delete(struct node *node);

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -617,8 +617,6 @@ static size_t ext4fs_read(struct file_desc *desc, void *buff, size_t size) {
 		size -= csize;
 	}
 
-	file_set_pos(desc, fi->f_pointer);
-
 	return (addr - (char *) buff);
 }
 
@@ -633,7 +631,6 @@ static size_t ext4fs_write(struct file_desc *desc, void *buff, size_t size) {
 
 	bytecount = ext4_write_file(nas, buff, size);
 
-	file_set_pos(desc, fi->f_pointer);
 	nas->fi->ni.size = ext4_file_size(fi->f_di);
 
 	return bytecount;

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -642,7 +642,7 @@ static int ext4_unlink(struct nas *dir_nas, struct nas *nas);
 static void ext4_free_fs(struct nas *nas);
 static int ext4_umount_entry(struct nas *nas);
 
-static int ext4fs_format(void *dev);
+static int ext4fs_format(struct block_dev *dev, void *priv);
 static int ext4fs_mount(void *dev, void *dir);
 static int ext4fs_create(struct node *parent_node, struct node *node);
 static int ext4fs_delete(struct node *node);
@@ -707,16 +707,13 @@ static int ext4fs_create(struct node *parent_node, struct node *node) {
 
 extern int main_mke2fs(int argc, char **argv);
 
-static int ext4fs_format(void *dev) {
-	struct node *dev_node;
+static int ext4fs_format(struct block_dev *dev, void *priv) {
 	int argc = 6;
 	char *argv[6];
 	char dev_path[64];
 
-	dev_node = dev;
-
 	strcpy(dev_path, "/dev/");
-	strcat(dev_path, dev_node->name);
+	strcat(dev_path, dev->name);
 
 	argv[0] = "mke2fs";
 	argv[1] = "-b";

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -642,7 +642,6 @@ static int ext4_unlink(struct nas *dir_nas, struct nas *nas);
 static void ext4_free_fs(struct nas *nas);
 static int ext4_umount_entry(struct nas *nas);
 
-static int ext4fs_init(void * par);
 static int ext4fs_format(void *dev);
 static int ext4fs_mount(void *dev, void *dir);
 static int ext4fs_create(struct node *parent_node, struct node *node);
@@ -652,7 +651,6 @@ static int ext4fs_umount(void *dir);
 
 
 static struct fsop_desc ext4_fsop = {
-	.init	     = ext4fs_init,
 	.format      = ext4fs_format,
 	.mount	     = ext4fs_mount,
 	.create_node = ext4fs_create,
@@ -664,10 +662,6 @@ static struct fsop_desc ext4_fsop = {
 
 	.truncate    = ext4fs_truncate,
 	.umount      = ext4fs_umount,
-};
-
-static int ext4fs_init(void * par) {
-	return 0;
 };
 
 static struct fs_driver ext4fs_driver = {

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -564,7 +564,7 @@ static struct idesc *ext4fs_open(struct node *node, struct file_desc *desc, int 
 		return err_ptr(rc);
 	}
 	else {
-		nas->fi->ni.size = ext4_file_size(fi->f_di);
+		file_set_size(desc, ext4_file_size(fi->f_di));
 	}
 
 	return &desc->idesc;
@@ -631,7 +631,7 @@ static size_t ext4fs_write(struct file_desc *desc, void *buff, size_t size) {
 
 	bytecount = ext4_write_file(nas, buff, size);
 
-	nas->fi->ni.size = ext4_file_size(fi->f_di);
+	file_set_size(desc, ext4_file_size(fi->f_di));
 
 	return bytecount;
 }

--- a/src/fs/driver/fat/Mybuild
+++ b/src/fs/driver/fat/Mybuild
@@ -3,6 +3,7 @@ package embox.fs.driver
 @DefaultImpl(fat_old)
 abstract module fat {
 	option number log_level = 0
+	option number default_fat_version = 32
 
 	option number inode_quantity=16
 	option number fat_descriptor_quantity=4
@@ -13,6 +14,8 @@ abstract module fat {
 	source "fat_common.c"
 	source "fatfs_subr.c"
 	source "fat_common_mem.c"
+
+	depends embox.driver.block_dev
 }
 
 module fat_old extends fat {
@@ -25,10 +28,7 @@ module fat_old extends fat {
 }
 
 module fat_dvfs extends fat {
-	option number default_fat_version = 32
-
 	source "fat_dvfs.c"
 
-	depends embox.driver.block_dev
 	depends embox.fs.dvfs.core
 }

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -2188,3 +2188,33 @@ size_t fat_write(struct file_desc *desc, void *buf, size_t size) {
 int fat_close(struct file_desc *desc) {
 	return 0;
 }
+
+#define DEFAULT_FAT_VERSION OPTION_GET(NUMBER, default_fat_version)
+/**
+ * @brief Format given block device
+ * @param dev Pointer to device
+ * @note Should be block device
+ *
+ * @return Negative error code or 0 if succeed
+ */
+int fat_format(struct block_dev *dev, void *priv) {
+	int fat_n = priv ? atoi((char*) priv) : 0;
+	struct block_dev *bdev = dev;
+
+	assert(dev);
+
+	if (!fat_n) {
+		fat_n = DEFAULT_FAT_VERSION;
+	}
+
+	if (fat_n != 12 && fat_n != 16 && fat_n != 32) {
+		log_error("Unsupported FAT version: FAT%d "
+				"(FAT12/FAT16/FAT32 available)", fat_n);
+		return -EINVAL;
+	}
+
+	fat_create_partition(bdev, fat_n);
+	fat_root_dir_record(bdev);
+
+	return 0;
+}

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -2142,3 +2142,49 @@ uint8_t fat_canonical_name_checksum(const char *name) {
 
 	return res;
 }
+
+#include <fs/file_desc.h>
+size_t fat_read(struct file_desc *desc, void *buf, size_t size) {
+	size_t rezult;
+	uint32_t bytecount;
+	struct fat_file_info *fi;
+
+	fi = file_get_inode_data(desc);
+	fi->pointer = file_get_pos(desc);
+
+	rezult = fat_read_file(fi, fat_sector_buff, buf, &bytecount, size);
+	if (DFS_OK == rezult) {
+		return bytecount;
+	}
+	return 0;
+}
+
+size_t fat_write(struct file_desc *desc, void *buf, size_t size) {
+	size_t rezult;
+	uint32_t bytecount;
+	struct fat_file_info *fi;
+	size_t new_sz;
+	int old_pos = file_get_pos(desc);
+
+	fi = file_get_inode_data(desc);
+	fi->pointer = old_pos;
+	fi->mode = O_RDWR; /* XXX */
+
+	rezult = fat_write_file(fi, fat_sector_buff, (uint8_t *)buf,
+			&bytecount, size, &new_sz);
+
+	if (DFS_OK == rezult || DFS_EOF == rezult) {
+		if (old_pos + bytecount > file_get_size(desc)) {
+			file_set_size(desc, old_pos + bytecount);
+		}
+
+		file_set_pos(desc, old_pos + bytecount);
+		return bytecount;
+	}
+
+	return 0;
+}
+
+int fat_close(struct file_desc *desc) {
+	return 0;
+}

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -238,32 +238,6 @@ static int fat_close(struct file_desc *desc) {
 	return 0;
 }
 
-static size_t fat_read(struct file_desc *desc, void *buf, size_t size) {
-	uint32_t res;
-	struct fat_file_info *fi;
-
-	fi = file_get_inode_data(desc);
-	fi->pointer = file_get_pos(desc);
-
-	fat_read_file(fi, fat_sector_buff, buf, &res, min(size, fi->filelen - desc->pos));
-
-	return res;
-}
-
-static size_t fat_write(struct file_desc *desc, void *buf, size_t size) {
-	uint32_t res;
-	struct fat_file_info *fi;
-
-	fi = file_get_inode_data(desc);
-	fi->pointer = file_get_pos(desc);
-
-	fi->mode = O_RDWR; /* XXX */
-
-	fat_write_file(fi, fat_sector_buff, buf, &res, size, &desc->f_inode->length);
-	fi->filelen = desc->f_inode->length;
-	return res;
-}
-
 /* @brief Get next inode in directory
  * @param inode   Structure to be filled
  * @param parent  Inode of parent directory
@@ -359,6 +333,9 @@ struct inode_operations fat_iops = {
 	.truncate = fat_truncate,
 };
 
+extern size_t fat_read(struct file_desc *desc, void *buf, size_t size);
+extern size_t fat_write(struct file_desc *desc, void *buf, size_t size);
+extern int    fat_close(struct file_desc *desc);
 static struct file_operations fat_fops = {
 	.close = fat_close,
 	.write = fat_write,

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -22,8 +22,6 @@
 
 #include "fat.h"
 
-#define DEFAULT_FAT_VERSION OPTION_GET(NUMBER, default_fat_version)
-
 /**
  * @brief Set appropriate flags and i_data for given inode
  *
@@ -452,37 +450,6 @@ static int fat_mount_end(struct super_block *sb) {
 	return 0;
 }
 
-
-/**
- * @brief Format given block device
- * @param dev Pointer to device
- * @note Should be block device
- *
- * @return Negative error code or 0 if succeed
- */
-static int fat_format(void *dev, void *priv) {
-	int fat_n = priv ? atoi((char*) priv) : 0;
-	struct block_dev *bdev;
-
-	assert(dev);
-
-	if (!fat_n) {
-		fat_n = DEFAULT_FAT_VERSION;
-	}
-
-	if (fat_n != 12 && fat_n != 16 && fat_n != 32) {
-		log_error("Unsupported FAT version: FAT%d "
-				"(FAT12/FAT16/FAT32 available)", fat_n);
-		return -EINVAL;
-	}
-
-	bdev = dev_module_to_bdev(dev);
-	fat_create_partition(bdev, fat_n);
-	fat_root_dir_record(bdev);
-
-	return 0;
-}
-
 /**
  * @brief Cleanup FS-specific stuff. No need to clean all files: VFS should
  * do it by itsekft
@@ -510,6 +477,7 @@ static int fat_clean_sb(struct super_block *sb) {
 	return 0;
 }
 
+extern int fat_format(struct block_dev *dev, void *priv);
 static const struct dumb_fs_driver dfs_fat_driver = {
 	.name      = "vfat",
 	.fill_sb   = fat_fill_sb,

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -275,11 +275,6 @@ static size_t fatfs_write(struct file_desc *desc, void *buf, size_t size) {
 	return rezult;
 }
 
-/* File system operations */
-static int fatfs_init(void * par) {
-	return 0;
-}
-
 static int fatfs_format(void *dev) {
 	struct node *dev_node;
 	struct nas *dev_nas;
@@ -445,7 +440,6 @@ static int fatfs_umount(void *dir) {
 }
 
 static struct fsop_desc fatfs_fsop = {
-	.init = fatfs_init,
 	.format = fatfs_format,
 	.mount = fatfs_mount,
 	.create_node = fatfs_create,

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -213,6 +213,7 @@ static struct idesc *fatfs_open(struct node *node, struct file_desc *desc,  int 
 	char path [PATH_MAX];
 	struct fat_file_info *fi;
 	int res;
+	size_t new_sz;
 
 	nas = node->nas;
 	fi = nas->fi->privdata;
@@ -224,7 +225,8 @@ static struct idesc *fatfs_open(struct node *node, struct file_desc *desc,  int 
 		strcpy(path, path + 1);
 	}
 
-	res = fat_open_file(fi, (uint8_t *) path, flag, fat_sector_buff, &nas->fi->ni.size);
+	res = fat_open_file(fi, (uint8_t *) path, flag, fat_sector_buff, &new_sz);
+	file_set_size(desc, new_sz);
 	if (DFS_OK == res) {
 		fi->pointer = file_get_pos(desc);
 		return &desc->idesc;

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -252,7 +252,6 @@ static size_t fatfs_read(struct file_desc *desc, void *buf, size_t size) {
 
 	rezult = fat_read_file(fi, fat_sector_buff, buf, &bytecount, size);
 	if (DFS_OK == rezult) {
-		file_set_pos(desc, fi->pointer);
 		return bytecount;
 	}
 	return rezult;
@@ -271,7 +270,6 @@ static size_t fatfs_write(struct file_desc *desc, void *buf, size_t size) {
 	rezult = fat_write_file(fi, fat_sector_buff, (uint8_t *)buf,
 			&bytecount, size, &desc->node->nas->fi->ni.size);
 	if (DFS_OK == rezult) {
-		file_set_pos(desc, fi->pointer);
 		return bytecount;
 	}
 	return rezult;

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -245,11 +245,6 @@ static size_t fatfs_read(struct file_desc *desc, void *buf, size_t size) {
 	fi = file_get_inode_data(desc);
 	fi->pointer = file_get_pos(desc);
 
-	/* Don't try to read past EOF */
-	if (size > desc->node->nas->fi->ni.size - fi->pointer) {
-		size = desc->node->nas->fi->ni.size - fi->pointer;
-	}
-
 	rezult = fat_read_file(fi, fat_sector_buff, buf, &bytecount, size);
 	if (DFS_OK == rezult) {
 		return bytecount;

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -233,22 +233,6 @@ static struct idesc *fatfs_open(struct node *node, struct file_desc *desc,  int 
 	return err_ptr(res);
 }
 
-static int fatfs_format(void *dev) {
-	struct node *dev_node;
-	struct nas *dev_nas;
-
-	if (NULL == (dev_node = dev)) {
-		return -ENODEV;/*device not found*/
-	}
-
-	dev_nas = dev_node->nas;
-
-	fat_create_partition(dev_nas->fi->privdata, 12);
-	fat_root_dir_record(dev_nas->fi->privdata);
-
-	return 0;
-}
-
 static int fatfs_mount(void *dev, void *dir) {
 	struct node *dir_node, *dev_node;
 	struct nas *dir_nas, *dev_nas;
@@ -397,8 +381,9 @@ static int fatfs_umount(void *dir) {
 	return 0;
 }
 
+extern int fat_format(struct block_dev *dev, void *priv);
 static struct fsop_desc fatfs_fsop = {
-	.format = fatfs_format,
+	.format = fat_format,
 	.mount = fatfs_mount,
 	.create_node = fatfs_create,
 	.delete_node = fatfs_delete,

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -194,15 +194,15 @@ static int fat_umount_entry(struct nas *nas) {
 
 /* File operations */
 static struct idesc *fatfs_open(struct node *node, struct file_desc *file_desc, int flags);
-static int    fatfs_close(struct file_desc *desc);
-static size_t fatfs_read(struct file_desc *desc, void *buf, size_t size);
-static size_t fatfs_write(struct file_desc *desc, void *buf, size_t size);
 
+extern size_t fat_read(struct file_desc *desc, void *buf, size_t size);
+extern size_t fat_write(struct file_desc *desc, void *buf, size_t size);
+extern int    fat_close(struct file_desc *desc);
 static struct file_operations fatfs_fop = {
 	.open = fatfs_open,
-	.close = fatfs_close,
-	.read = fatfs_read,
-	.write = fatfs_write,
+	.close = fat_close,
+	.read = fat_read,
+	.write = fat_write,
 };
 
 /*
@@ -231,43 +231,6 @@ static struct idesc *fatfs_open(struct node *node, struct file_desc *desc,  int 
 	}
 
 	return err_ptr(res);
-}
-
-static int fatfs_close(struct file_desc *desc) {
-	return 0;
-}
-
-static size_t fatfs_read(struct file_desc *desc, void *buf, size_t size) {
-	size_t rezult;
-	uint32_t bytecount;
-	struct fat_file_info *fi;
-
-	fi = file_get_inode_data(desc);
-	fi->pointer = file_get_pos(desc);
-
-	rezult = fat_read_file(fi, fat_sector_buff, buf, &bytecount, size);
-	if (DFS_OK == rezult) {
-		return bytecount;
-	}
-	return rezult;
-}
-
-static size_t fatfs_write(struct file_desc *desc, void *buf, size_t size) {
-	size_t rezult;
-	uint32_t bytecount;
-	struct fat_file_info *fi;
-
-	fi = file_get_inode_data(desc);
-	fi->pointer = file_get_pos(desc);
-
-	fi->mode = O_RDWR; /* XXX */
-
-	rezult = fat_write_file(fi, fat_sector_buff, (uint8_t *)buf,
-			&bytecount, size, &desc->node->nas->fi->ni.size);
-	if (DFS_OK == rezult) {
-		return bytecount;
-	}
-	return rezult;
 }
 
 static int fatfs_format(void *dev) {

--- a/src/fs/driver/fs_driver.c
+++ b/src/fs/driver/fs_driver.c
@@ -59,10 +59,6 @@ static int fs_driver_init(void) {
 		if (NULL == (head = fs_driver_alloc((struct fs_driver *)fs_drv))) {
 			return -EINVAL;
 		}
-
-		if (NULL != fs_drv->fsop->init) {
-			fs_drv->fsop->init(NULL);
-		}
 	}
 
 	return ENOERR;

--- a/src/fs/driver/initfs/initfs.c
+++ b/src/fs/driver/initfs/initfs.c
@@ -59,10 +59,6 @@ static size_t initfs_read(struct file_desc *desc, void *buf, size_t size) {
 		return -ENOENT;
 	}
 
-	if (size > fi->ni.size - pos) {
-		size = fi->ni.size - pos;
-	}
-
 	memcpy(buf, fi->addr + pos, size);
 
 	return size;

--- a/src/fs/driver/initfs/initfs.c
+++ b/src/fs/driver/initfs/initfs.c
@@ -64,7 +64,6 @@ static size_t initfs_read(struct file_desc *desc, void *buf, size_t size) {
 	}
 
 	memcpy(buf, fi->addr + pos, size);
-	file_set_pos(desc, pos + size);
 
 	return size;
 }

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -52,10 +52,6 @@ static size_t initfs_read(struct file_desc *desc, void *buf, size_t size) {
 
 	inode = desc->f_inode;
 
-	if (size > inode->length - desc->pos) {
-		size = inode->length - desc->pos;
-	}
-
 	memcpy(buf, (char *) (uintptr_t) (inode->start_pos + desc->pos), size);
 
 	return size;

--- a/src/fs/driver/iso9660/cdfs.c
+++ b/src/fs/driver/iso9660/cdfs.c
@@ -836,13 +836,10 @@ static size_t cdfsfs_read(struct file_desc *desc, void *buf, size_t size) {
 }
 
 /* File system operations*/
-
-static int cdfsfs_init(void * par);
 static int cdfsfs_mount(void * dev, void *dir);
 static int cdfsfs_umount(void *dir);
 
 static struct fsop_desc cdfsfs_fsop = {
-	.init = cdfsfs_init,
 	.mount = cdfsfs_mount,
 	.umount = cdfsfs_umount,
 };
@@ -854,11 +851,6 @@ static struct fs_driver cdfsfs_driver = {
 };
 
 DECLARE_FILE_SYSTEM_DRIVER(cdfsfs_driver);
-
-static int cdfsfs_init(void * par) {
-
-	return 0;
-}
 
 static void cdfs_free_fs(struct nas *nas) {
 	struct cdfs_file_info *fi;

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -1475,7 +1475,7 @@ static int jffs2_free_fs(struct nas *nas) {
 	return 0;
 }
 
-static int jffs2fs_format(void *path);
+static int jffs2fs_format(struct block_dev *bdev, void *priv);
 static int jffs2fs_mount(void *dev, void *dir);
 static int jffs2fs_create(struct node *parent_node, struct node *node);
 static int jffs2fs_delete(struct node *node);
@@ -1637,13 +1637,10 @@ static int jffs_flash_name(struct node *dev_node, char flash_name[PATH_MAX]) {
 	return snprintf(flash_name, PATH_MAX, "%s_flash", dev_node_path);
 }
 
-static int jffs2fs_format(void *dev) {
-	struct node *dev_node = dev;
+static int jffs2fs_format(struct block_dev *bdev, void *priv) {
 	char flash_node_name[PATH_MAX];
 
-	if (0 > jffs_flash_name(dev_node, flash_node_name)) {
-		return -ERANGE;
-	}
+	snprintf(flash_node_name, PATH_MAX, "%s_flash", bdev->name);
 
 	return flash_emu_dev_create(flash_node_name, 16 * 1024, 1024);
 }

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -931,8 +931,6 @@ static int jffs2_fo_write(struct file_desc *desc, char *buf, ssize_t size) {
 		inode->i_size = pos;
 	}
 
-	file_set_pos(desc, pos);
-
 	return writtenlen;
 }
 
@@ -1438,8 +1436,6 @@ static size_t jffs2fs_read(struct file_desc *desc, void *buff, size_t size) {
 		SET_ERRNO(rc);
 		return 0;
 	}
-
-	file_set_pos(desc, pos + len);
 
 	return len;
 }

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -1387,7 +1387,7 @@ static struct idesc *jffs2fs_open(struct node *node, struct file_desc *desc, int
 	fi = nas->fi->privdata;
 	fsi = nas->fs->fsi;
 
-	nas->fi->ni.size = fi->_inode->i_size;
+	file_set_size(desc, fi->_inode->i_size);
 
 	vfs_get_relative_path(nas->node, path, PATH_MAX);
 
@@ -1407,7 +1407,7 @@ static int jffs2fs_close(struct file_desc *desc) {
 	}
 	nas = desc->node->nas;
 	fi = nas->fi->privdata;
-	nas->fi->ni.size = fi->_inode->i_size;
+	file_set_size(desc, fi->_inode->i_size);
 
 	return jffs2_fo_close(fi->_inode);
 }
@@ -1450,7 +1450,7 @@ static size_t jffs2fs_write(struct file_desc *desc, void *buff, size_t size) {
 
 	bytecount = jffs2_fo_write(desc, buff, size);
 
-	nas->fi->ni.size = fi->_inode->i_size;
+	file_set_size(desc, fi->_inode->i_size);
 
 	return bytecount;
 }

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -1475,7 +1475,6 @@ static int jffs2_free_fs(struct nas *nas) {
 	return 0;
 }
 
-static int jffs2fs_init(void * par);
 static int jffs2fs_format(void *path);
 static int jffs2fs_mount(void *dev, void *dir);
 static int jffs2fs_create(struct node *parent_node, struct node *node);
@@ -1485,7 +1484,6 @@ static int jffs2fs_umount(void *dir);
 
 
 static struct fsop_desc jffs2_fsop = {
-	.init	     = jffs2fs_init,
 	.format	     = jffs2fs_format,
 	.mount	     = jffs2fs_mount,
 	.create_node = jffs2fs_create,
@@ -1497,10 +1495,6 @@ static struct fsop_desc jffs2_fsop = {
 
 	.truncate    = jffs2fs_truncate,
 	.umount      = jffs2fs_umount,
-};
-
-static int jffs2fs_init(void * par) {
-	return 0;
 };
 
 static struct fs_driver jffs2fs_driver = {

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -217,7 +217,6 @@ static int nfsfs_fseek(void *file, long offset, int whence) {
 
 /* File system operations */
 
-static int nfsfs_init(void * par);
 static int nfsfs_format(void * par);
 static int nfsfs_mount(void * dev, void *dir);
 static int nfsfs_create(struct node *parent_node, struct node *node);
@@ -226,7 +225,6 @@ static int nfsfs_truncate (struct node *node, off_t length);
 static int nfsfs_umount(void *dir);
 
 static struct fsop_desc nfsfs_fsop = {
-	.init = nfsfs_init,
 	.format = nfsfs_format,
 	.mount = nfsfs_mount,
 	.create_node = nfsfs_create,
@@ -242,11 +240,6 @@ static struct fs_driver nfsfs_driver = {
 	.fsop = &nfsfs_fsop,
 	.mount_dev_by_string = true,
 };
-
-static int nfsfs_init(void * par) {
-
-	return 0;
-}
 
 static int nfsfs_format(void *path) {
 	node_t *node;

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -95,7 +95,6 @@ static int nfsfs_close(struct file_desc *desc) {
 	nas = desc->node->nas;
 	fi = (nfs_file_info_t *)nas->fi->privdata;
 	fi->offset = 0;
-	file_set_pos(desc, 0);
 
 	return 0;
 }
@@ -144,7 +143,6 @@ static size_t nfsfs_read(struct file_desc *desc, void *buf, size_t size) {
 			break;
 		}
 	}
-	file_set_pos(desc, fi->offset);
 	return datalen;
 }
 
@@ -184,8 +182,6 @@ static size_t nfsfs_write(struct file_desc *desc, void *buf, size_t size) {
 	if (nas->fi->ni.size < pos) {
 		nas->fi->ni.size = pos;
 	}
-
-	file_set_pos(desc, fi->offset);
 
 	return reply.count;
 }

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -217,7 +217,7 @@ static int nfsfs_fseek(void *file, long offset, int whence) {
 
 /* File system operations */
 
-static int nfsfs_format(void * par);
+static int nfsfs_format(struct block_dev *bdev, void *priv);
 static int nfsfs_mount(void * dev, void *dir);
 static int nfsfs_create(struct node *parent_node, struct node *node);
 static int nfsfs_delete(struct node *node);
@@ -241,15 +241,7 @@ static struct fs_driver nfsfs_driver = {
 	.mount_dev_by_string = true,
 };
 
-static int nfsfs_format(void *path) {
-	node_t *node;
-	node_t *root;
-
-	root = vfs_get_root();
-
-	if (NULL == (node = vfs_subtree_lookup(root, path))) {
-		return -ENODEV;
-	}
+static int nfsfs_format(struct block_dev *bdev, void *priv) {
 	/* TODO format command support */
 	return 0;
 }

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -65,11 +65,6 @@ POOL_DEF(ntfs_desc_pool, struct ntfs_desc_info,
 
 static int embox_ntfs_simultaneous_mounting_descend(struct nas *nas, ntfs_inode *ni, bool);
 
-static int embox_ntfs_init (void *par) {
-
-	return 0;
-}
-
 static int embox_ntfs_node_create(struct node *parent_node, struct node *new_node) {
 	ntfs_inode *ni, *pni;
 	ntfschar *ufilename;
@@ -834,8 +829,6 @@ struct ntfs_device_operations ntfs_device_bdev_io_ops = {
 };
 
 static const struct fsop_desc ntfs_fsop = {
-	.init = embox_ntfs_init,
-	.format = NULL,
 	.create_node = embox_ntfs_node_create,
 	.delete_node = embox_ntfs_node_delete,
 	.mount = embox_ntfs_mount,

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -498,7 +498,7 @@ static struct idesc *ntfs_open(struct node *node, struct file_desc *file_desc,
 	file_desc->file_info = desc;
 
 	// Yet another bullshit: size is not valid until open
-	node->nas->fi->ni.size = attr->data_size;
+	file_set_size(file_desc, attr->data_size);
 
 	return &file_desc->idesc;
 }
@@ -548,7 +548,7 @@ static size_t ntfs_write(struct file_desc *file_desc, void *buf, size_t size) {
 	res = ntfs_attr_pwrite(desc->attr, pos, size, buf);
 
 	if (res > 0) {
-		file_desc->node->nas->fi->ni.size = desc->attr->data_size;
+		file_set_size(file_desc, desc->attr->data_size);
 	}
 
 	return res;

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -538,10 +538,6 @@ static size_t ntfs_read(struct file_desc *file_desc, void *buf, size_t size)
 
 	res = ntfs_attr_pread(desc->attr, pos, size, buf);
 
-	if (res > 0) {
-		file_set_pos(file_desc, pos + res);
-	}
-
 	return res;
 }
 
@@ -557,7 +553,6 @@ static size_t ntfs_write(struct file_desc *file_desc, void *buf, size_t size) {
 	res = ntfs_attr_pwrite(desc->attr, pos, size, buf);
 
 	if (res > 0) {
-		file_set_pos(file_desc, pos + res);
 		file_desc->node->nas->fi->ni.size = desc->attr->data_size;
 	}
 

--- a/src/fs/driver/ramfs/Mybuild
+++ b/src/fs/driver/ramfs/Mybuild
@@ -6,6 +6,8 @@ abstract module ramfs {
 	option number ramfs_descriptor_quantity=4
 	option number ramfs_file_size=4096
 
+	source "ramfs_ops.c"
+
 	depends embox.mem.pool
 	depends embox.driver.ramdisk
 }
@@ -15,8 +17,6 @@ module ramfs_old extends ramfs {
 
 	depends embox.fs.node
 	depends embox.fs.driver.repo
-
-
 }
 
 module ramfs_dvfs extends ramfs {

--- a/src/fs/driver/ramfs/ramfs.h
+++ b/src/fs/driver/ramfs/ramfs.h
@@ -11,8 +11,15 @@
 
 #include <stdint.h>
 
-#define RAMFS_DIR  "/"
-#define RAMFS_NAME_LEN	32
+#include <drivers/block_dev.h>
+#include <embox/unit.h>
+
+#include <module/embox/fs/driver/ramfs.h>
+
+#define MAX_FILE_SIZE     OPTION_MODULE_GET(embox__fs__driver__ramfs, NUMBER, ramfs_file_size)
+#define RAMFS_FILES       OPTION_MODULE_GET(embox__fs__driver__ramfs, NUMBER, inode_quantity)
+#define RAMFS_DESCRIPTORS OPTION_MODULE_GET(embox__fs__driver__ramfs, NUMBER, ramfs_descriptor_quantity)
+#define FILESYSTEM_SIZE   (MAX_FILE_SIZE * RAMFS_FILES)
 
 /* DOS attribute bits  */
 #define ATTR_READ_ONLY  0x01
@@ -25,18 +32,20 @@
 	(ATTR_READ_ONLY | ATTR_HIDDEN | ATTR_SYSTEM | ATTR_VOLUME_ID)
 
 struct ramfs_fs_info {
-	uint32_t numblocks;      /* number of block in volume */
-	uint32_t block_size;     /* size of block */
-	uint32_t block_per_file; /* max number of blocks filesize*/
+	uint32_t numblocks;			/* number of block in volume */
+	uint32_t block_size;		/* size of block */
+	uint32_t block_per_file;	/* max number of blocks filesize*/
+	struct block_dev *bdev;
 };
 
+#define RAMFS_NAME_LEN	32
 struct ramfs_file_info {
-	int     index;           /* number of file in FS*/
-	int     mode;            /* mode in which this file was opened */
-	uint32_t pointer;        /* current (BYTE) pointer */
+	int     index;		        /* number of file in FS*/
+	int     mode;				/* mode in which this file was opened */
+	uint32_t pointer;			/* current (BYTE) pointer */
 	char    name[RAMFS_NAME_LEN];
-	struct inode *inode;
+	void *inode;
 	struct ramfs_fs_info *fsi;
-} ramfs_file_info_t;
+};
 
 #endif /* RAMFS_H_ */

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -183,8 +183,6 @@ static size_t ramfs_write(struct file_desc *desc, void *buf, size_t size) {
 		desc->f_inode->length = fi->pointer;
 	}
 
-	file_set_pos(desc, fi->pointer);
-
 	return bytecount;
 }
 

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -371,7 +371,15 @@ static int ramfs_mount_end(struct super_block *sb) {
 	return 0;
 }
 
-static int ramfs_format(void *dev, void *priv) {
+static int ramfs_format(struct block_dev *bdev, void *priv) {
+	if (NULL == bdev) {
+		return -ENODEV;
+	}
+
+	if (MAX_FILE_SIZE > bdev->size) {
+		return -ENOSPC;
+	}
+
 	return 0;
 }
 

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -70,7 +70,8 @@ static size_t ramfs_read(struct file_desc *desc, void *buf, size_t size) {
 	pos = file_get_pos(desc);
 
 	pbuf = buf;
-	ebuf = buf + min(fi->inode->length - pos, size);
+	ebuf = buf + min(file_get_size(desc) - desc->pos, size);
+
 	while (pbuf < ebuf) {
 		blkno_t blk = pos / fsi->block_size;
 		int offset = pos % fsi->block_size;
@@ -179,8 +180,8 @@ static size_t ramfs_write(struct file_desc *desc, void *buf, size_t size) {
 		}
 	}
 	/* if we write over the last EOF, set new filelen */
-	if (desc->f_inode->length < fi->pointer) {
-		desc->f_inode->length = fi->pointer;
+	if (file_get_size(desc) < fi->pointer) {
+		file_set_size(desc, fi->pointer)
 	}
 
 	return bytecount;

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -384,7 +384,6 @@ static int ramfs_mount(void *dev, void *dir) {
 static int ramfs_init(void * par);
 
 static struct fsop_desc ramfs_fsop = {
-	.init = ramfs_init,
 	.format = ramfs_format,
 	.mount = ramfs_mount,
 	.create_node = ramfs_create,

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -171,7 +171,8 @@ static size_t ramfs_read(struct file_desc *desc, void *buf, size_t size) {
 	pos = file_get_pos(desc);
 
 	pbuf = buf;
-	ebuf = buf + min(desc->node->nas->fi->ni.size - pos, size);
+	ebuf = buf + min(file_get_size(desc) - pos, size);
+
 	while (pbuf < ebuf) {
 		blkno_t blk = pos / fsi->block_size;
 		int offset = pos % fsi->block_size;
@@ -275,8 +276,8 @@ static size_t ramfs_write(struct file_desc *desc, void *buf, size_t size) {
 		}
 	}
 	/* if we write over the last EOF, set new filelen */
-	if (nas->fi->ni.size < fi->pointer) {
-		nas->fi->ni.size = fi->pointer;
+	if (file_get_size(desc) < fi->pointer) {
+		file_set_size(desc, fi->pointer);
 	}
 
 	return bytecount;

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -152,8 +152,6 @@ static size_t ramfs_read(struct file_desc *desc, void *buf, size_t size) {
 		pbuf += read_n;
 	}
 
-	file_set_pos(desc, pos);
-
 	return pbuf - buf;
 }
 
@@ -241,7 +239,6 @@ static size_t ramfs_write(struct file_desc *desc, void *buf, size_t size) {
 		nas->fi->ni.size = fi->pointer;
 	}
 
-	file_set_pos(desc, fi->pointer);
 	return bytecount;
 }
 

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -35,65 +35,33 @@
 #include <drivers/block_dev/ramdisk/ramdisk.h>
 #include "ramfs.h"
 
-/* define sizes in 4096 blocks */
-#define MAX_FILE_SIZE   OPTION_GET(NUMBER, ramfs_file_size)
-#define RAMFS_FILES     OPTION_GET(NUMBER, inode_quantity)
-#define FILESYSTEM_SIZE (MAX_FILE_SIZE * RAMFS_FILES)
-
 /* ramfs filesystem description pool */
-POOL_DEF(ramfs_fs_pool, struct ramfs_fs_info, OPTION_GET(NUMBER,ramfs_descriptor_quantity));
+POOL_DEF(ramfs_fs_pool, struct ramfs_fs_info, RAMFS_DESCRIPTORS);
 
 /* ramfs file description pool */
 POOL_DEF(ramfs_file_pool, struct ramfs_file_info, RAMFS_FILES);
 
 INDEX_DEF(ramfs_file_idx, 0, RAMFS_FILES);
 
-static char sector_buff[PAGE_SIZE()];/* TODO */
-static char ramfs_dev[] = RAMFS_DEV;
-
 static int ramfs_format(struct block_dev *bdev, void *priv);
 static int ramfs_mount(void *dev, void *dir);
 
-static int ramfs_init(void * par) {
-	struct path dir_node;
-	struct node *dev_node;
-	int res;
-	struct ramdisk *ramdisk;
+static struct idesc *ramfs_open(struct node *node, struct file_desc *file_desc, int flags);
 
-	if (!par) {
-		return 0;
-	}
+int    ramfs_close(struct file_desc *desc);
+size_t ramfs_read(struct file_desc *desc, void *buf, size_t size);
+size_t ramfs_write(struct file_desc *desc, void *buf, size_t size);
 
-	/*TODO */
+static struct file_operations ramfs_fop = {
+	.open = ramfs_open,
+	.close = ramfs_close,
+	.read = ramfs_read,
+	.write = ramfs_write,
+};
 
-	vfs_lookup(RAMFS_DIR, &dir_node);
-
-	if (dir_node.node == NULL) {
-		return -ENOENT;
-	}
-
-	if (err(ramdisk = ramdisk_create(ramfs_dev, FILESYSTEM_SIZE))) {
-		return err(ramdisk);
-	}
-
-	dev_node = ramdisk->bdev->dev_vfs_info;
-	assert(dev_node != NULL);
-
-	/* format filesystem */
-	res = ramfs_format(dev_node->nas->fi->privdata, NULL);
-	if (res != 0) {
-		return res;
-	}
-
-	/* mount filesystem */
-	return ramfs_mount(dev_node, dir_node.node);
-}
-
-static int ramfs_ramdisk_fs_init(void) {
-	return ramfs_init(ramfs_dev);
->>>>>>> 3d11a6b0c... fs/drivers: Make `format()` function VFS-agnostic:src/fs/driver/ramfs/ramfs.c
-}
-
+/*
+ * file_operation
+ */
 static struct idesc *ramfs_open(struct node *node, struct file_desc *desc, int flags) {
 	struct nas *nas;
 	struct ramfs_file_info *fi;
@@ -106,189 +74,6 @@ static struct idesc *ramfs_open(struct node *node, struct file_desc *desc, int f
 	return &desc->idesc;
 }
 
-static int ramfs_read_sector(struct nas *nas, char *buffer,
-		uint32_t count, uint32_t sector) {
-	struct ramfs_fs_info *fsi;
-	size_t blksize;
-	int blkno, sectorsize;
-
-	fsi = nas->fs->fsi;
-
-	blksize = block_dev_block_size(nas->fs->bdev);
-	sectorsize = fsi->block_size;
-	assert(blksize > 0 && sectorsize > 0);
-	blkno = sector * (sectorsize / blksize);
-
-	if(0 > block_dev_read(nas->fs->bdev, (char *) buffer,
-			count * fsi->block_size, blkno)) {
-		return -1;
-	}
-	else {
-		return count;
-	}
-}
-
-static int ramfs_write_sector(struct nas *nas, char *buffer,
-		uint32_t count, uint32_t sector) {
-	struct ramfs_fs_info *fsi;
-	size_t blksize;
-	int blkno, sectorsize;
-
-	fsi = nas->fs->fsi;
-
-	blksize = block_dev_block_size(nas->fs->bdev);
-	sectorsize = fsi->block_size;
-	assert(blksize > 0 && sectorsize > 0);
-	blkno = sector * (sectorsize / blksize);
-
-	if(0 > block_dev_write(nas->fs->bdev, (char *) buffer,
-			count * fsi->block_size, blkno)) {
-		return -1;
-	}
-	else {
-		return count;
-	}
-}
-
-static size_t ramfs_read(struct file_desc *desc, void *buf, size_t size) {
-	struct ramfs_fs_info *fsi;
-	void *pbuf, *ebuf;
-	struct block_dev *bdev;
-	struct ramfs_file_info *fi;
-	off_t pos;
-
-	assert(desc);
-
-	fsi = desc->node->nas->fs->fsi;
-	assert(fsi);
-
-	fi = desc->node->nas->fi->privdata;
-	assert(fi);
-
-	bdev = desc->node->nas->fs->bdev;
-	assert(bdev);
-
-	pos = file_get_pos(desc);
-
-	pbuf = buf;
-	ebuf = buf + min(file_get_size(desc) - pos, size);
-
-	while (pbuf < ebuf) {
-		blkno_t blk = pos / fsi->block_size;
-		int offset = pos % fsi->block_size;
-		int read_n;
-
-		assert (blk < fsi->block_per_file);
-		assert (blk < fsi->numblocks);
-
-		assert(sizeof(sector_buff) == fsi->block_size);
-		if(1 != ramfs_read_sector(desc->node->nas, sector_buff, 1, blk)) {
-			break;
-		}
-
-		read_n = min(fsi->block_size - offset, ebuf - pbuf);
-		memcpy (pbuf, sector_buff + offset, read_n);
-
-		pos += read_n;
-		pbuf += read_n;
-	}
-
-	return pbuf - buf;
-}
-
-static size_t ramfs_write(struct file_desc *desc, void *buf, size_t size) {
-	struct ramfs_file_info *fi;
-	size_t len;
-	size_t current, cnt;
-	uint32_t end_pointer;
-	blkno_t blk;
-	uint32_t bytecount;
-	uint32_t start_block;
-	struct nas *nas;
-	struct ramfs_fs_info *fsi;
-	off_t pos;
-
-	pos = file_get_pos(desc);
-
-	nas = desc->node->nas;
-	fi = (struct ramfs_file_info *)nas->fi->privdata;
-	fsi = nas->fs->fsi;
-
-	bytecount = 0;
-
-	fi->pointer = pos;
-	len = size;
-	end_pointer = fi->pointer + len;
-	start_block = fi->index * fsi->block_per_file;
-
-	while(1) {
-		if(0 == fsi->block_size) {
-			break;
-		}
-		blk = fi->pointer / fsi->block_size;
-		/* check if block over the file */
-		if(blk >= fsi->block_per_file) {
-			bytecount = 0;
-			break;
-		}
-		else {
-			blk += start_block;
-		}
-		/* calculate pointer in scratch buffer */
-		current = fi->pointer % fsi->block_size;
-
-		/* set the counter how many bytes written in block */
-		if(end_pointer - fi->pointer > fsi->block_size) {
-			if(current) {
-				cnt = fsi->block_size - current;
-			}
-			else {
-				cnt = fsi->block_size;
-			}
-		}
-		else {
-			cnt = end_pointer - fi->pointer;
-			/* over the block ? */
-			if((current + cnt) > fsi->block_size) {
-				cnt -= (current + cnt) % fsi->block_size;
-			}
-		}
-
-		/* one 4096-bytes block read operation */
-		if(1 != ramfs_read_sector(nas, sector_buff, 1, blk)) {
-			bytecount = 0;
-			break;
-		}
-		/* set new data in block */
-		memcpy (sector_buff + current, buf, cnt);
-
-		/* write one block to device */
-		if(1 != ramfs_write_sector(nas, sector_buff, 1, blk)) {
-			bytecount = 0;
-			break;
-		}
-		bytecount += cnt;
-		buf = (void*) (((uint8_t*) buf) + cnt);
-		/* shift the pointer */
-		fi->pointer += cnt;
-		if(end_pointer <= fi->pointer) {
-			break;
-		}
-	}
-	/* if we write over the last EOF, set new filelen */
-	if (file_get_size(desc) < fi->pointer) {
-		file_set_size(desc, fi->pointer);
-	}
-
-	return bytecount;
-}
-
-static struct file_operations ramfs_fop = {
-	.open = ramfs_open,
-	.close = ramfs_close,
-	.read = ramfs_read,
-	.write = ramfs_write,
-};
 
 static struct ramfs_file_info *ramfs_create_file(struct nas *nas) {
 	struct ramfs_file_info *fi;
@@ -306,6 +91,7 @@ static struct ramfs_file_info *ramfs_create_file(struct nas *nas) {
 	}
 
 	fi->index = fi_index;
+	fi->fsi = nas->fs->fsi;
 	nas->fi->ni.size = fi->pointer = 0;
 
 	return fi;
@@ -315,14 +101,13 @@ static int ramfs_create(struct node *parent_node, struct node *node) {
 	struct nas *nas;
 
 	nas = node->nas;
+	nas->fs = parent_node->nas->fs;
 
 	if (!node_is_directory(node)) {
 		if (!(nas->fi->privdata = ramfs_create_file(nas))) {
 			return -ENOMEM;
 		}
 	}
-
-	nas->fs = parent_node->nas->fs;
 
 	return 0;
 }
@@ -400,6 +185,7 @@ static int ramfs_mount(void *dev, void *dir) {
 	fsi->block_per_file = MAX_FILE_SIZE / PAGE_SIZE();
 	fsi->block_size = PAGE_SIZE();
 	fsi->numblocks = block_dev(dev_fi->privdata)->size / PAGE_SIZE();
+	fsi->bdev = block_dev(dev_fi->privdata);
 
 	/* allocate this directory info */
 	if(NULL == (fi = pool_alloc(&ramfs_file_pool))) {
@@ -436,6 +222,7 @@ DECLARE_FILE_SYSTEM_DRIVER(ramfs_driver);
 EMBOX_UNIT_INIT(ramfs_ramdisk_fs_init); /*TODO*/
 
 #define RAMFS_DEV  "/dev/ram#"
+#define RAMFS_DIR  "/"
 static char ramfs_dev[] = RAMFS_DEV;
 
 static int ramfs_init(void * par) {
@@ -464,7 +251,7 @@ static int ramfs_init(void * par) {
 	assert(dev_node != NULL);
 
 	/* format filesystem */
-	res = ramfs_format(dev_node);
+	res = ramfs_format(ramdisk->bdev, NULL);
 	if (res != 0) {
 		return res;
 	}

--- a/src/fs/driver/ramfs/ramfs_ops.c
+++ b/src/fs/driver/ramfs/ramfs_ops.c
@@ -1,0 +1,146 @@
+#include <string.h>
+
+#include <drivers/block_dev.h>
+#include <fs/file_desc.h>
+#include <mem/phymem.h> /* PAGE_SIZE() */
+#include <util/math.h>
+
+#include "ramfs.h"
+
+static char sector_buff[PAGE_SIZE()];/* TODO */
+
+size_t ramfs_read(struct file_desc *desc, void *buf, size_t size) {
+	struct ramfs_file_info *fi;
+	struct ramfs_fs_info *fsi;
+	struct block_dev *bdev;
+	void *pbuf, *ebuf;
+	off_t pos;
+
+	assert(desc);
+
+	fi = file_get_inode_data(desc);
+	assert(fi);
+
+	fsi = fi->fsi;
+	assert(fsi);
+
+	bdev = fsi->bdev;
+	assert(bdev);
+
+	pos = file_get_pos(desc);
+
+	pbuf = buf;
+	ebuf = buf + min(file_get_size(desc) - pos, size);
+	while (pbuf < ebuf) {
+		blkno_t blk = pos / fsi->block_size;
+		int offset = pos % fsi->block_size;
+		int read_n;
+
+		assert (blk < fsi->block_per_file);
+		assert (blk < fsi->numblocks);
+
+		blk += fi->index * fsi->block_per_file;
+
+		assert(sizeof(sector_buff) == fsi->block_size);
+		if (0 > block_dev_read(bdev, sector_buff,
+					fsi->block_size, blk)) {
+			break;
+		}
+
+		read_n = min(fsi->block_size - offset, ebuf - pbuf);
+		memcpy (pbuf, sector_buff + offset, read_n);
+
+		pos += read_n;
+		pbuf += read_n;
+	}
+
+	return pbuf - buf;
+}
+
+size_t ramfs_write(struct file_desc *desc, void *buf, size_t size) {
+	struct ramfs_file_info *fi;
+	size_t len;
+	size_t current, cnt;
+	uint32_t end_pointer;
+	blkno_t blk;
+	uint32_t bytecount;
+	uint32_t start_block;
+	struct ramfs_fs_info *fsi;
+	struct block_dev *bdev;
+	off_t pos;
+
+	fi = file_get_inode_data(desc);
+	fsi = fi->fsi;
+	bdev = fsi->bdev;
+
+	pos = file_get_pos(desc);
+
+	bytecount = 0;
+
+	fi->pointer = pos;
+	len = size;
+	end_pointer = fi->pointer + len;
+	start_block = fi->index * fsi->block_per_file;
+
+	while(1) {
+		if (0 == fsi->block_size) {
+			break;
+		}
+		blk = fi->pointer / fsi->block_size;
+		/* check if block over the file */
+		if(blk >= fsi->block_per_file) {
+			bytecount = 0;
+			break;
+		} else {
+			blk += start_block;
+		}
+		/* calculate pointer in scratch buffer */
+		current = fi->pointer % fsi->block_size;
+
+		/* set the counter how many bytes written in block */
+		if(end_pointer - fi->pointer > fsi->block_size) {
+			if(current) {
+				cnt = fsi->block_size - current;
+			} else {
+				cnt = fsi->block_size;
+			}
+		} else {
+			cnt = end_pointer - fi->pointer;
+			/* over the block ? */
+			if((current + cnt) > fsi->block_size) {
+				cnt -= (current + cnt) % fsi->block_size;
+			}
+		}
+
+		/* one 4096-bytes block read operation */
+		if(0 > block_dev_read(bdev, sector_buff, fsi->block_size, blk)) {
+			bytecount = 0;
+			break;
+		}
+		/* set new data in block */
+		memcpy (sector_buff + current, buf, cnt);
+
+		/* write one block to device */
+		if(0 > block_dev_write(bdev, sector_buff, fsi->block_size, blk)) {
+			bytecount = 0;
+			break;
+		}
+		bytecount += cnt;
+		buf = (void*) (((uint8_t*) buf) + cnt);
+		/* shift the pointer */
+		fi->pointer += cnt;
+		if(end_pointer <= fi->pointer) {
+			break;
+		}
+	}
+	/* if we write over the last EOF, set new filelen */
+	if (file_get_size(desc) < fi->pointer) {
+		file_set_size(desc, fi->pointer);
+	}
+
+	return bytecount;
+}
+
+int ramfs_close(struct file_desc *desc) {
+	return 0;
+}

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -135,7 +135,7 @@ struct file_operations {
 
 struct dumb_fs_driver {
 	const char name[FS_NAME_LEN];
-	int (*format)(void *dev, void *priv);
+	int (*format)(struct block_dev *dev, void *priv);
 	int (*fill_sb)(struct super_block *sb, struct file_desc *dev);
 	int (*mount_end)(struct super_block *sb);
 	int (*clean_sb)(struct super_block *sb);

--- a/src/fs/dvfs/file_desc.c
+++ b/src/fs/dvfs/file_desc.c
@@ -18,6 +18,14 @@ off_t file_set_pos(struct file_desc *file, off_t off) {
 	return file->pos;
 }
 
+size_t file_get_size(struct file_desc *file) {
+	return file->f_inode->length;
+}
+
+void file_set_size(struct file_desc *file, size_t size) {
+	file->f_inode->length = size;
+}
+
 void *file_get_inode_data(struct file_desc *file) {
 	assert(file);
 	assert(file->f_inode);

--- a/src/fs/dvfs/file_desc.h
+++ b/src/fs/dvfs/file_desc.h
@@ -29,6 +29,9 @@ struct file_desc {
 extern off_t file_get_pos(struct file_desc *file);
 extern off_t file_set_pos(struct file_desc *file, off_t off);
 
+extern size_t file_get_size(struct file_desc *file);
+extern void file_set_size(struct file_desc *file, size_t size);
+
 extern void *file_get_inode_data(struct file_desc *file);
 
 extern struct file_desc *dvfs_alloc_file(void);

--- a/src/fs/file_desc.c
+++ b/src/fs/file_desc.c
@@ -107,6 +107,16 @@ off_t file_set_pos(struct file_desc *file, off_t off) {
 	return file->cursor;
 }
 
+size_t file_get_size(struct file_desc *file) {
+	struct nas *nas = file->node->nas;
+	return nas->fi->ni.size;
+}
+
+void file_set_size(struct file_desc *file, size_t size) {
+	struct nas *nas = file->node->nas;
+	nas->fi->ni.size = size;
+}
+
 void *file_get_inode_data(struct file_desc *file) {
 	assert(file->node);
 	assert(file->node->nas->fi->privdata);

--- a/src/fs/file_desc.h
+++ b/src/fs/file_desc.h
@@ -31,6 +31,9 @@ struct file_desc {
 extern off_t file_get_pos(struct file_desc *file);
 extern off_t file_set_pos(struct file_desc *file, off_t off);
 
+extern size_t file_get_size(struct file_desc *file);
+extern void file_set_size(struct file_desc *file, size_t size);
+
 extern void *file_get_inode_data(struct file_desc *file);
 
 extern struct file_desc *file_desc_create(struct node *node, int __oflag);

--- a/src/fs/syslib/kfile.c
+++ b/src/fs/syslib/kfile.c
@@ -124,6 +124,9 @@ ssize_t kwrite(const void *buf, size_t size, struct file_desc *file) {
 	}
 
 	ret = file->ops->write(file, (void *)buf, size);
+	if (ret > 0) {
+		file_set_pos(file, file_get_pos(file) + ret);
+	}
 
 end:
 	return ret;
@@ -148,6 +151,9 @@ ssize_t kread(void *buf, size_t size, struct file_desc *desc) {
 	}
 
 	ret = desc->ops->read(desc, buf, size);
+	if (ret > 0) {
+		file_set_pos(file, file_get_pos(file) + ret);
+	}
 
 end:
 	return ret;

--- a/src/fs/syslib/kfile.c
+++ b/src/fs/syslib/kfile.c
@@ -150,9 +150,14 @@ ssize_t kread(void *buf, size_t size, struct file_desc *desc) {
 		goto end;
 	}
 
+	/* Don't try to read past EOF */
+	if (size > desc->node->nas->fi->ni.size - file_get_pos(desc)) {
+		size = desc->node->nas->fi->ni.size - file_get_pos(desc);
+	}
+
 	ret = desc->ops->read(desc, buf, size);
 	if (ret > 0) {
-		file_set_pos(file, file_get_pos(file) + ret);
+		file_set_pos(desc, file_get_pos(desc) + ret);
 	}
 
 end:

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -308,6 +308,7 @@ int kformat(const char *pathname, const char *fs_type) {
 	struct path node;
 	struct fs_driver *drv;
 	int res;
+	struct block_dev *bdev;
 
 	if (0 != fs_type) {
 		drv = fs_driver_find_drv((const char *) fs_type);
@@ -332,7 +333,8 @@ int kformat(const char *pathname, const char *fs_type) {
 		return -1;
 	}
 
-	if (0 != (res = drv->fsop->format(node.node))) {
+	bdev = node.node->nas->fi->privdata;
+	if (0 != (res = drv->fsop->format(bdev, NULL))) {
 		errno = -res;
 		return -1;
 	}

--- a/src/include/fs/fs_driver.h
+++ b/src/include/fs/fs_driver.h
@@ -8,16 +8,17 @@
 #ifndef FS_DRV_H_
 #define FS_DRV_H_
 
-
-#include <util/array.h>
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/types.h>
+#include <util/array.h>
+
+#include <drivers/block_dev.h>
 
 struct node;
 
 struct fsop_desc {
-	int (*format)(void *par);
+	int (*format)(struct block_dev *bdev, void *priv);
 	int (*mount)(void *dev_node, void *dir_node);
 	int (*create_node)(struct node *parent_node, struct node *new_node);
 	int (*delete_node)(struct node *node);

--- a/src/include/fs/fs_driver.h
+++ b/src/include/fs/fs_driver.h
@@ -17,7 +17,6 @@
 struct node;
 
 struct fsop_desc {
-	int (*init)(void *par);
 	int (*format)(void *par);
 	int (*mount)(void *dev_node, void *dir_node);
 	int (*create_node)(struct node *parent_node, struct node *new_node);


### PR DESCRIPTION
* Remove `.init()` handler in FS drivers (as it turned out, they are not used anyway)
* Make `.format()` operation VFS-agnostic (i.e. it just operate block devices)
* Move `file_desc->pos` outsude of FS drivers
* Check reading out of EOF in `kread()` instead of FS `.read()` handlers