### PR TITLE
drivers/block_dev: Avoid memory corruption for unaligned read/write ops

### DIFF
--- a/src/drivers/block_dev/block_dev.c
+++ b/src/drivers/block_dev/block_dev.c
@@ -228,6 +228,10 @@ int block_dev_read(void *dev, char *buffer, size_t count, blkno_t blkno) {
 	}
 	bdev = block_dev(dev);
 
+	if (count % bdev->block_size != 0) {
+		return -EINVAL;
+	}
+
 	if (blkno >= bdev->size / bdev->block_size) {
 		return -EINVAL;
 	}
@@ -253,6 +257,10 @@ int block_dev_write(void *dev, const char *buffer, size_t count, blkno_t blkno) 
 	}
 
 	bdev = block_dev(dev);
+
+	if (count % bdev->block_size != 0) {
+		return -EINVAL;
+	}
 
 	if (blkno >= bdev->size / bdev->block_size) {
 		return -EINVAL;


### PR DESCRIPTION
Block devices operate with blocks; so if someone wants to read or write
a single byte, they should either provide large buffer or this should be
done somewhere in driver. Currently there are no such support in
drivers, so it's better to restrict such calls.

Closes #623