### PR TITLE
scripts/continuous/run.sh: Avoid system crash on running this script

### DIFF
--- a/scripts/continuous/run.sh
+++ b/scripts/continuous/run.sh
@@ -115,7 +115,14 @@ run_check() {
 }
 
 kill_bg() {
-	pstree -A -p $sim_bg | sed 's/[0-9a-z{}_\.+`-]*(\([0-9]\+\))/\1 /g' | xargs sudo kill
+	# Sometimes $sim_bg is empty string, so we should make sure pstree is
+	# called with acual PID (otherwise it will print every process running)
+	if test -z "$sim_bg"
+	then
+		echo "warning: No background process running"
+	else
+		pstree -A -p $sim_bg | sed 's/[0-9a-z{}_\.+`-]*(\([0-9]\+\))/\1 /g' | xargs sudo kill
+	fi
 
 	cat $OUTPUT_FILE
 


### PR DESCRIPTION
Sometimes kill_bg() is called with empty $sim_bg string, which causes
pstree to print every single process in the system, which leads to
killing all processes in the system.

Solution is to make sure $sim_bg is not empty before calling pstree