### PR TITLE
mk: Remove hardcoded path

### DIFF
--- a/mk/image2.mk
+++ b/mk/image2.mk
@@ -51,7 +51,7 @@ $(ROOTFS_DIR)/% :
 	$(CP) -r $(cp_T_if_supported) $(src_file) $@$(if \
 		$(and $(chmod),$(findstring $(chmod),'')),,;chmod $(chmod) $@)
 	@touch $@ # workaround when copying directories
-	@find $@ -name .gitkeep -type f -print0 | xargs -0 /bin/rm -rf
+	@find $@ -name .gitkeep -type f -print0 | xargs -0 rm -rf
 
 fmt_line = $(addprefix \$(\n)$(\t)$(\t),$1)
 

--- a/mk/image3.mk
+++ b/mk/image3.mk
@@ -283,7 +283,7 @@ $(__cpio_files) : FORCE
 		$(foreach c,chmod chown,$(if $(and $($c),$(findstring $($c),'')),,$c $($c) $f;)) \
 		$(foreach a,$(strip $(subst ',,$(xattr))), \
 			attr -s $(basename $(subst =,.,$a)) -V $(subst .,,$(suffix $(subst =,.,$a))) $f;) \
-		find $f -name .gitkeep -type f -print0 | xargs -0 /bin/rm -rf)
+		find $f -name .gitkeep -type f -print0 | xargs -0 rm -rf)
 
 __copy_user_rootfs :
 	if [ -d $(USER_ROOTFS_DIR) ]; \


### PR DESCRIPTION
On NixOS:
```sh
$ which rm
/run/current-system/sw/bin/rm
```