### PR TITLE
Add duktape

### DIFF
--- a/src/compat/libc/math/math_builtins.c
+++ b/src/compat/libc/math/math_builtins.c
@@ -438,3 +438,18 @@ int __isfinitel(long double e) {
 	/* Long double format is platform-specific, so just use stub */
 	return 1;
 }
+
+double cbrt(double x) {
+	// TODO
+	return 0.0;
+}
+
+float cbrtf(float x) {
+	// TODO
+	return 0.0;
+}
+
+long double cbrtl(long double x) {
+	// TODO
+	return 0.0;
+}

--- a/src/compat/libc/math/math_builtins.h
+++ b/src/compat/libc/math/math_builtins.h
@@ -149,6 +149,10 @@ extern double hypot(double x, double y);
 extern float hypotf(float x, float y);
 extern long double hypotl(long double x, long double y);
 
+extern double cbrt(double x);
+extern float cbrtf(float x);
+extern long double cbrtl(long double x);
+
 __END_DECLS
 
 #define FP_NAN 0

--- a/src/compat/libc/time/Mybuild
+++ b/src/compat/libc/time/Mybuild
@@ -3,4 +3,5 @@ package embox.compat.libc
 static module time {
 	source "ctime.c"
 	source "strftime.c"
+	source "strptime.c"
 }

--- a/src/compat/libc/time/strptime.c
+++ b/src/compat/libc/time/strptime.c
@@ -1,0 +1,11 @@
+/**
+ * @file
+ * @brief Convert a string representation of time to a time tm structure
+ */
+
+#include <time.h>
+
+char *strptime(const char *s, const char *fmt, struct tm *tm) {
+	// TODO
+	return NULL;
+}

--- a/src/compat/posix/include/time.h
+++ b/src/compat/posix/include/time.h
@@ -119,6 +119,8 @@ static inline double difftime(time_t time1, time_t time0) {
 	return (time1 - time0);
 }
 
+extern char *strptime(const char *s, const char *fmt, struct tm *tm);
+
 __END_DECLS
 
 #endif /* TIME_H_ */

--- a/templates/x86/test/lang/mods.conf
+++ b/templates/x86/test/lang/mods.conf
@@ -113,6 +113,7 @@ configuration conf {
 	include third_party.tcl.tclsh
 	include third_party.tcl.tcludp
 	include third_party.mruby.mruby
+	include third_party.cmd.duktape
 
 	include embox.cmd.help
 	include embox.cmd.man

--- a/templates/x86/test/lang/start_script.inc
+++ b/templates/x86/test/lang/start_script.inc
@@ -25,6 +25,9 @@
 "lua tofi_mod.lua /tmp/new_file.txt",
 "cat /tmp/new_file.txt",
 "lua http_request.lua http://example.com",
+
 "tclsh run_embox_cmd.tcl",
 "tclsh fib.tcl",
 "tclsh tcludp_localhost.tcl",
+
+"duk fib.js",

--- a/third-party/duktape/Makefile
+++ b/third-party/duktape/Makefile
@@ -1,0 +1,20 @@
+
+PKG_NAME := duktape
+PKG_VER  := 2.5.0
+
+PKG_SOURCES := https://duktape.org/duktape-2.5.0.tar.xz
+PKG_MD5     := e55fe3830f0d469dc67205b380515af0
+
+PKG_PATCHES := pkg_patch.txt
+
+include $(EXTBLD_LIB)
+
+$(BUILD) :
+	cd $(PKG_SOURCE_DIR) && ( \
+		$(MAKE) -f Makefile.cmdline MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)' CC=$(EMBOX_GCC); \
+	)
+	touch $@
+
+$(INSTALL) :
+	cp $(PKG_SOURCE_DIR)/duk $(PKG_INSTALL_DIR)/duk.o
+	touch $@

--- a/third-party/duktape/Mybuild
+++ b/third-party/duktape/Mybuild
@@ -1,0 +1,24 @@
+package third_party.cmd
+
+@App
+@AutoCmd
+@Build(stage=2,script="$(EXTERNAL_MAKE)")
+@Cmd(name = "duk",
+	help = "Javascript interpreter",
+	man = '''
+		NAME
+			duk - Javascript interpreter
+		SYNOPSIS
+			duk [script]
+		AUTHORS
+			Nikolay Korotkiy - Adaptation for Embox
+	''')
+module duktape {
+	source "^BUILD/extbld/^MOD_PATH/install/duk.o"
+
+	@InitFS
+	source "fib.js"
+
+	depends embox.compat.libc.math
+	depends embox.compat.libc.time
+}

--- a/third-party/duktape/fib.js
+++ b/third-party/duktape/fib.js
@@ -1,0 +1,15 @@
+function fib(n) {
+    if (n == 0) { return 0; }
+    if (n == 1) { return 1; }
+    return fib(n-1) + fib(n-2);
+}
+
+function test() {
+    var res = [];
+    for (i = 0; i < 20; i++) {
+        res.push(fib(i));
+    }
+    print(res.join(' '));
+}
+
+test();

--- a/third-party/duktape/pkg_patch.txt
+++ b/third-party/duktape/pkg_patch.txt
@@ -1,0 +1,15 @@
+--- duktape-2.5.0/Makefile.cmdline.orig	2020-01-12 15:22:12.776509893 +0300
++++ duktape-2.5.0/Makefile.cmdline	2020-01-12 15:22:30.552679308 +0300
+@@ -8,10 +8,10 @@
+ CMDLINE_SOURCES = \
+ 	examples/cmdline/duk_cmdline.c
+ 
+-CC = gcc
++#CC = gcc
+ CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+ CCOPTS += -I./examples/cmdline -I./src   # duktape.h and duk_config.h must be in include path
+-CCLIBS = -lm
++CCLIBS = -DDUK_USE_DATE_FMT_STRFTIME
+ 
+ # Enable print() and alert() for command line using an optional extra module.
+ CCOPTS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert


### PR DESCRIPTION
> Duktape is an embeddable Javascript engine, with a focus on portability and compact footprint.
https://github.com/svaarala/duktape

Build steps:
1. `make confload-arm/qemu`
2. Add `include third_party.cmd.duktape` to `conf/mods.config`
3. `make`

*NOTE*: `strptime` and `cbrt` are not implemented.

Run steps:
```
root@embox:/#duk ./fib.js                                                       


  ______
 |  ____|                                            __          __
 | |___  _ __ ___            ____  ____  ____  _____/ /   _____ / /
 |  ___|| '_ ` _ \          / __ \/ __ \/ __ \/ ___/ /   |_____| |
 | |____| | | | | |_ _ _   / /_/ / /_/ / /_/ (__  )_/    |_____| |
 |______|_| |_| |_(_|_|_)  \____/\____/ .___/____(_)           | |
                                     /_/                        \_\
 ASSERTION FAILED on CPU 0
	at src/kernel/irq.c:168
	in function irq_dispatch

__next_at_line_168
Data abort exception!
regs:
00090078 09e0aa04 e59ff018 fffffff8
001b8004 00000000 00000000 00000000
00000000 00000000 00000000 09e0aa04
09e0a9e0 00002e3c
```