### PR TITLE
Fix devfs mount

### DIFF
--- a/src/compat/posix/fs/dirent/dirent_oldfs.c
+++ b/src/compat/posix/fs/dirent/dirent_oldfs.c
@@ -96,6 +96,7 @@ struct dirent *readdir(DIR *dir) {
 		SET_ERRNO(EBADF);
 		return NULL;
 	}
+	if_mounted_follow_down(&dir->path);
 	res = vfs_get_child_next(&dir->path,(struct inode *) (uintptr_t) dir->current.d_ino, &child);
 	if (0 != res) {
 		if (dir->path.node->i_ops && dir->path.node->i_ops->iterate) {

--- a/src/fs/driver/devfs/devfs_oldfs.c
+++ b/src/fs/driver/devfs/devfs_oldfs.c
@@ -28,17 +28,12 @@ static struct filesystem *devfs_file_system;
 
 static int devfs_mount(void *dev, void *dir) {
 	int ret;
-	struct path node, root;
-	mode_t mode;
+	struct inode *dir_node;
+	struct nas *dir_nas;
 
-	mode = S_IFDIR | S_IRALL | S_IWALL | S_IXALL;
-
-	vfs_get_root_path(&root);
-
-	if (0 != vfs_create(&root, dev, mode, &node)) {
-		return -1;
-	}
-	node.node->i_ops = &devfs_iops;
+	dir_node = dir;
+	dir_node->i_ops = &devfs_iops;
+	dir_nas = dir_node->nas;
 
 	ret = char_dev_init_all();
 	if (ret != 0) {
@@ -53,6 +48,7 @@ static int devfs_mount(void *dev, void *dir) {
 	if (devfs_file_system == NULL) {
 		return -ENOMEM;
 	}
+	dir_nas->fs = devfs_file_system;
 
 	return 0;
 }

--- a/src/fs/mount_table.c
+++ b/src/fs/mount_table.c
@@ -80,7 +80,12 @@ struct mount_descriptor *mount_table_add(struct path *mnt_point_path,
 		dlist_add_next(&mdesc->mnt_child, &mnt_point_path->mnt_desc->mnt_mounts);
 	}
 
-	strncpy(mdesc->mnt_dev, dev, MOUNT_DESC_STRINFO_LEN);
+	if (dev != NULL) {
+		strncpy(mdesc->mnt_dev, dev, MOUNT_DESC_STRINFO_LEN);
+	} else {
+		mdesc->mnt_dev[0] = '\0';
+	}
+
 	mdesc->mnt_dev[MOUNT_DESC_STRINFO_LEN - 1] = '\0';
 
 	return mdesc;

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -371,7 +371,7 @@ int kmount(const char *dev, const char *dir, const char *fs_type) {
 
 	if (drv->mount_dev_by_string) {
 		dev_node.node = (struct inode *) dev;
-	} else {
+	} else if (dev != NULL) {
 		if (ENOERR != (res = fs_perm_lookup(dev, &lastpath, &dev_node))) {
 			errno = res == -ENOENT ? ENODEV : -res;
 			return -1;
@@ -381,6 +381,8 @@ int kmount(const char *dev, const char *dir, const char *fs_type) {
 			errno = EACCES;
 			return -1;
 		}
+	} else {
+		dev_node.node = NULL;
 	}
 
 	if (ENOERR != (res = fs_perm_lookup(dir, &lastpath, &dir_node))) {

--- a/src/fs/syslib/perm.c
+++ b/src/fs/syslib/perm.c
@@ -92,6 +92,7 @@ int fs_perm_lookup(const char *path, const char **pathlast,
 		}
 
 		dir_path = node_path;
+		if_mounted_follow_down(&node_path);
 		dnode = node_path.node;
 		vfs_lookup_childn(&node_path, path, len, &node_path);
 


### PR DESCRIPTION
Don't create /dev/ node in devfs driver itself, just mount it with regular mount() call in rootfs_mount()

As a little bonus, `devfs` is now listed in `mount` command for old VFS.