### PR TITLE
ehci: Use IOC interrupt instead of IAA

### DIFF
--- a/src/drivers/usb/hc/ehci_q.c
+++ b/src/drivers/usb/hc/ehci_q.c
@@ -87,6 +87,7 @@ qh_completions (struct ehci_hcd *ehci, struct ehci_qh *qh) {
 	}
 	log_debug("\n");
 
+	req->req_stat = USB_REQ_NOERR;
 	usb_request_complete(req);
 
 	return 0;


### PR DESCRIPTION
This PR fixes qemu warnings "update active QH" during block_dev_test.

IAA is used to unlink current QH. So it is more correct to use it when you need to delete QH safely (not used now, but should be used), not to monitor transfer completion. For transfer completion IOC interrupt is used - we just set up this interrupt for the last QTD in QH's qtds list, so IOC will be generated only after all qtds will be handled.