### PR TITLE
tcp_sock fix

### DIFF
--- a/src/fs/Mybuild
+++ b/src/fs/Mybuild
@@ -11,6 +11,7 @@ module node {
 	@IncludeExport(path="fs")
 	source "dentry.h"
 
+	depends embox.driver.block_dev
 	depends embox.kernel.thread.mutex
 	@NoRuntime depends embox.util.tree
 }

--- a/src/net/socket/tcp_sock.c
+++ b/src/net/socket/tcp_sock.c
@@ -383,7 +383,7 @@ static int tcp_write(struct tcp_sock *tcp_sk, struct msghdr * msg) {
 	size_t skb_len;
 	int tran_len;
 	int cp_len;
-	int cp_off;
+	int cp_off = 0;
 	int i;
 
 	full_len = 0;


### PR DESCRIPTION
Now `arm/qt-stm32f7discovery` compiles and works with GCC 9.2.0 :)