### PR TITLE
readdir() fix

### DIFF
--- a/scripts/autotest/testsuite/fs-rootfs/finish.exp
+++ b/scripts/autotest/testsuite/fs-rootfs/finish.exp
@@ -1,0 +1,1 @@
+target_disconnect

--- a/scripts/autotest/testsuite/fs-rootfs/ls/test.exp
+++ b/scripts/autotest/testsuite/fs-rootfs/ls/test.exp
@@ -1,0 +1,10 @@
+TEST_CASE {Print rootfs content lots of times} {
+	global embox_prompt
+
+	# Assume devfs presents
+	for {set i 0} {$i < 256} {incr i} {
+		exec sleep 0.1
+		send "ls /\r"
+		test_expect_strings "dev" $embox_prompt
+	}
+}

--- a/scripts/autotest/testsuite/fs-rootfs/setup.exp
+++ b/scripts/autotest/testsuite/fs-rootfs/setup.exp
@@ -1,0 +1,1 @@
+target_connect

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -588,6 +588,8 @@ int dvfs_iterate(struct lookup *lookup, struct dir_ctx *ctx) {
 		return -ENOMEM;
 	}
 
+	lookup->item = next_dentry;
+
 	res = sb->sb_iops->iterate(next_inode, next_dentry->name, lookup->parent->d_inode, ctx);
 	if (res) {
 		/* iterate virtual */

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -132,7 +132,7 @@ struct idesc *dvfs_file_open_idesc(struct lookup *lookup, int __oflag) {
 	};
 
 	assert(desc->f_ops);
-	if (desc->f_ops->open) {
+	if (desc->f_ops->open && !(__oflag & O_PATH)) {
 		res = desc->f_ops->open(i_no, &desc->f_idesc);
 		if (res == NULL) {
 			return NULL;

--- a/src/fs/dvfs/dvfs.c
+++ b/src/fs/dvfs/dvfs.c
@@ -610,6 +610,7 @@ int dvfs_iterate(struct lookup *lookup, struct dir_ctx *ctx) {
 		/* This node is already in the VFS tree */
 		dvfs_destroy_dentry(next_dentry);
 		lookup->item = cached;
+		dentry_ref_inc(cached);
 	} else {
 		/* Integrate next_dentry into VFS tree */
 		dentry_fill(sb, next_inode, next_dentry, lookup->parent);


### PR DESCRIPTION
Keep fixing stuff for FS.

* Decrease usage counter for previous dentry, not current in `readdir()`
* Fill `lookup` properly in `dvfs_iterate()`
* Make sure to free inodes that are not integrated to VFS
* Handle O_PATH for dvfs
* Add autotest to check this PR actually fixes something :)