### PR TITLE
aarch64: Fix mmu_pte_unpack() return value

### DIFF
--- a/src/arch/aarch64/mmu/mmu.c
+++ b/src/arch/aarch64/mmu/mmu.c
@@ -309,7 +309,7 @@ uintptr_t mmu_pte_unpack(uintptr_t pte, int *flags) {
 		log_warning("Corrupted PTE cache properties");
 	}
 
-	return 0;
+	return pte & ~MMU_PAGE_MASK;
 }
 
 void set_fault_handler(enum fault_type type, fault_handler_t handler) {


### PR DESCRIPTION
Fix #1650