### PR TITLE
Fix block and char devices close ops

### DIFF
--- a/src/drivers/block_dev/block_dev_idesc.c
+++ b/src/drivers/block_dev/block_dev_idesc.c
@@ -16,7 +16,12 @@
 #include <drivers/device.h>
 #include <fs/file_desc.h>
 
+extern const struct idesc_ops idesc_file_ops;
 static void bdev_idesc_close(struct idesc *desc) {
+	/* It's assumed that block device may be accesed
+	 * via idesc ops only if they were opened from /dev/,
+	 * so we need to close bdev idesc as it as a file */
+	idesc_file_ops.close(desc);
 }
 
 static ssize_t bdev_idesc_read(struct idesc *desc, const struct iovec *iov, int cnt) {

--- a/src/drivers/char/char_dev.c
+++ b/src/drivers/char/char_dev.c
@@ -83,6 +83,7 @@ int char_dev_idesc_fstat(struct idesc *idesc, void *buff) {
 }
 
 static void char_dev_idesc_close(struct idesc *idesc) {
+	char_dev_default_close(idesc);
 }
 
 static const struct idesc_ops idesc_char_dev_def_ops = {

--- a/src/fs/file_desc.c
+++ b/src/fs/file_desc.c
@@ -71,7 +71,6 @@ struct file_desc *file_desc_create(struct inode *node, int flag) {
 
 int file_desc_destroy(struct file_desc *fdesc) {
 	assert(fdesc);
-	assert(fdesc->f_idesc.idesc_ops == &idesc_file_ops);
 
 	inode_del(fdesc->f_inode);
 


### PR DESCRIPTION
Before these changes there was a bug that could be reproduced like this:
* Load `arm/qemu` conf
* Comment out new VFS modules, uncommend old VFS commends
* `make && ./scripts/qemu/auto_qemu -sd fat.img`, where `fat.img` is image with FAT FS
* `dd if=/dev/mmc0 format=hex_c` (`mmc0` should be the name of block device)
* `mkdir -v /mnt`
* `mount -t vfat /dev/mmc0 /mnt` On this step `mount` fails as there's a trash content in `/dev/mmc0` FS node due to invalid file close in `dd` which leads to duplicating nodes.

Now it works fine.
