### PR TITLE
Fix stm32 i2c

### DIFF
--- a/src/drivers/i2c/adapters/stm32/stm32_i2c.c
+++ b/src/drivers/i2c/adapters/stm32/stm32_i2c.c
@@ -39,7 +39,15 @@ static int stm32_i2c_rx(struct stm32_i2c *adapter, uint16_t addr,
 
 	while (HAL_I2C_GetState(i2c_handle) != HAL_I2C_STATE_READY)
 		;
-	if (HAL_I2C_Master_Receive_IT(i2c_handle, addr, buf, len) != HAL_OK) {
+
+	/*
+	 * I2C address _must_ be shifted as it stated in
+	 * Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c:
+	 *
+	 * @param  DevAddress Target device address: The device 7 bits address value
+	 *      in datasheet must be shift at right before call interface
+	 */
+	if (HAL_I2C_Master_Receive_IT(i2c_handle, addr << 1, buf, len) != HAL_OK) {
 		return -1;
 	}
 
@@ -54,7 +62,15 @@ static int stm32_i2c_tx(struct stm32_i2c *adapter, uint16_t addr,
 
 	while (HAL_I2C_GetState(i2c_handle) != HAL_I2C_STATE_READY)
 		;
-	if (HAL_I2C_Master_Transmit_IT(i2c_handle, addr, buf, len) != HAL_OK) {
+
+	/*
+	 * I2C address _must_ be shifted as it stated in
+	 * Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c:
+	 *
+	 * @param  DevAddress Target device address: The device 7 bits address value
+	 *      in datasheet must be shift at right before call interface
+	 */
+	if (HAL_I2C_Master_Transmit_IT(i2c_handle, addr << 1, buf, len) != HAL_OK) {
 		return -1;
 	}
 	while (HAL_I2C_GetState(i2c_handle) != HAL_I2C_STATE_READY)

--- a/src/drivers/sensors/gy_30/gy_30.c
+++ b/src/drivers/sensors/gy_30/gy_30.c
@@ -11,7 +11,8 @@
 
 #include "gy_30.h"
 
-#define GY30_ADDR       0x46
+/* http://www.elechouse.com/elechouse/images/product/Digital%20light%20Sensor/bh1750fvi-e.pdf */
+#define GY30_ADDR       0x23
 
 uint16_t gy_30_read_light_level(unsigned char id) {
 	uint16_t level = 0;


### PR DESCRIPTION
There is a part of bad Cube API:

```
  * @param  DevAddress Target device address: The device 7 bits address value
  *         in datasheet must be shift at right before call interface
```

It means we need to shift the address before transmit. Moreover, we need to shift to _left_, not  _right_.
