### PR TITLE
fs/fs_driver: Remove functions for dynamic fs driver allocation

### DIFF
--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -62,7 +62,7 @@ static struct fs_driver ext3fs_driver;
  * file_operation
  */
 static struct idesc *ext3fs_open(struct inode *node, struct idesc *idesc) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 
 	if(NULL == (drv = fs_driver_find_drv(EXT2_NAME))) {
 		return err_ptr(EINVAL);
@@ -72,7 +72,7 @@ static struct idesc *ext3fs_open(struct inode *node, struct idesc *idesc) {
 }
 
 static int ext3fs_close(struct file_desc *desc) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 
 	if(NULL == (drv = fs_driver_find_drv(EXT2_NAME))) {
 		return -1;
@@ -82,7 +82,7 @@ static int ext3fs_close(struct file_desc *desc) {
 }
 
 static size_t ext3fs_read(struct file_desc *desc, void *buff, size_t size) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 
 	if(NULL == (drv = fs_driver_find_drv(EXT2_NAME))) {
 		return -1;
@@ -92,7 +92,7 @@ static size_t ext3fs_read(struct file_desc *desc, void *buff, size_t size) {
 }
 
 static size_t ext3fs_write(struct file_desc *desc, void *buff, size_t size) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int res;
 	size_t datablocks;
 	struct ext2_fs_info *fsi;
@@ -117,7 +117,7 @@ static size_t ext3fs_write(struct file_desc *desc, void *buff, size_t size) {
 }
 
 static int ext3fs_create(struct inode *parent_node, struct inode *node) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	struct ext2_fs_info *fsi;
 	journal_handle_t *handle;
 	int res = -1;
@@ -141,7 +141,7 @@ static int ext3fs_create(struct inode *parent_node, struct inode *node) {
 }
 
 static int ext3fs_delete(struct inode *node) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	struct ext2_fs_info *fsi;
 	journal_handle_t *handle;
 	int res;
@@ -235,7 +235,7 @@ static int ext3_journal_load(journal_t *jp, struct block_dev *jdev, block_t star
 }
 
 static int ext3fs_mount(void *dev, void *dir) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	struct ext2fs_dinode *dip = sysmalloc(sizeof(struct ext2fs_dinode));
 	char buf[SECTOR_SIZE * 2];
 	struct ext2_fs_info *fsi;
@@ -312,7 +312,7 @@ static int ext3fs_truncate (struct inode *node, off_t length) {
 }
 
 static int ext3fs_umount(void *dir) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	struct ext2_fs_info *fsi;
 	ext3_journal_specific_t *data;
 	int res;

--- a/src/fs/driver/fs_driver.c
+++ b/src/fs/driver/fs_driver.c
@@ -6,96 +6,22 @@
  * @author Nikolay Korotky
  */
 
-#include <stdio.h>
-#include <errno.h>
 #include <string.h>
-#include <embox/unit.h>
-
-#include <mem/misc/pool.h>
-#include <util/dlist.h>
 
 #include <util/array.h>
 #include <fs/fs_driver.h>
 #include <util/member.h>
 
-EMBOX_UNIT_INIT(fs_driver_init);
-
-typedef struct fs_driver_head {
-	struct dlist_head link;
-	struct fs_driver *drv;
-} fs_driver_head_t;
-
-POOL_DEF(fs_driver_pool, struct fs_driver_head, OPTION_GET(NUMBER,drivers_quantity));
-
 ARRAY_SPREAD_DEF(const struct fs_driver *const, __fs_drivers_registry);
 
-static DLIST_DEFINE(file_systems);
-
-
-static fs_driver_head_t *fs_driver_alloc(struct fs_driver *drv) {
-	fs_driver_head_t *head;
-
-	head = pool_alloc(&fs_driver_pool);
-	head->drv = drv;
-
-	dlist_add_next(dlist_head_init(&head->link), &file_systems);
-
-	return head;
-}
-
-static void fs_driver_free(struct fs_driver *drv) {
-	fs_driver_head_t *head = member_cast_out(drv, fs_driver_head_t, drv);
-
-	dlist_del((struct dlist_head *)head);
-	pool_free(&fs_driver_pool, head);
-	return;
-}
-
-static int fs_driver_init(void) {
-	fs_driver_head_t *head;
+const struct fs_driver *fs_driver_find_drv(const char *name) {
 	const struct fs_driver *fs_drv;
 
 	array_spread_foreach(fs_drv, __fs_drivers_registry) {
-		if (NULL == (head = fs_driver_alloc((struct fs_driver *)fs_drv))) {
-			return -EINVAL;
+		if (!strcmp(name, fs_drv->name)) {
+			return fs_drv;
 		}
 	}
 
-	return ENOERR;
-}
-
-struct fs_driver *fs_driver_find_drv(const char *name) {
-	struct fs_driver_head *fs_driver;
-
-	dlist_foreach_entry(fs_driver, &file_systems, link) {
-		if (0 == strcmp(fs_driver->drv->name, name)) {
-			return fs_driver->drv;
-		}
-	}
 	return NULL;
-}
-
-int fs_driver_register_drv(struct fs_driver *fs) {
-	int res = 0;
-	struct fs_driver *p;
-
-	if (NULL == fs) {
-		return EINVAL;
-	}
-
-	p = fs_driver_find_drv(fs->name);
-	if (NULL != p) {
-		return -EBUSY;
-	}
-
-	return res;
-}
-
-int fs_driver_unregister_drv(struct fs_driver *fs) {
-	if (NULL == fs) {
-		return -EINVAL;
-	}
-	fs_driver_free(fs);
-
-	return ENOERR;
 }

--- a/src/fs/file_system.c
+++ b/src/fs/file_system.c
@@ -30,7 +30,7 @@ struct filesystem *filesystem_create(const char *drv_name) {
 	if (0 != *drv_name) {
 		fs->drv = fs_driver_find_drv(drv_name);
 	}
-	
+
 	if (fs && fs->drv)
 		fs->file_op = fs->drv->file_op;
 

--- a/src/fs/syslib/kfile_node.c
+++ b/src/fs/syslib/kfile_node.c
@@ -26,7 +26,7 @@
 int ktruncate(struct inode *node, off_t length) {
 	int ret;
 	struct nas *nas;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 
 	if (node_is_directory(node)) {
 		SET_ERRNO(EISDIR);

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -40,7 +40,7 @@ POOL_DEF(flock_pool, struct flock_shared, MAX_FLOCK_QUANTITY);
 
 static int create_new_node(struct path *parent, const char *name, mode_t mode) {
 	struct path node;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int retval = 0;
 
 	if(NULL == parent->node->nas->fs) {
@@ -115,7 +115,7 @@ int kmkdir(const char *pathname, mode_t mode) {
 }
 
 int kcreat(struct path *dir_path, const char *path, mode_t mode, struct path *child) {
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int ret;
 
 	assert(dir_path->node);
@@ -181,7 +181,7 @@ int kcreat(struct path *dir_path, const char *path, mode_t mode, struct path *ch
 int kremove(const char *pathname) {
 	struct path node;
 	struct nas *nas;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int res;
 
 	if (0 != (res = fs_perm_lookup(pathname, NULL, &node))) {
@@ -206,7 +206,7 @@ int kremove(const char *pathname) {
 
 int kunlink(const char *pathname) {
 	struct path node, parent;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int res;
 
 	if (0 != (res = fs_perm_lookup(pathname, NULL, &node))) {
@@ -245,7 +245,7 @@ int kunlink(const char *pathname) {
 
 int krmdir(const char *pathname) {
 	struct path node, parent;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int res;
 
 	if (0 != (res = fs_perm_lookup(pathname, NULL, &node))) {
@@ -311,7 +311,7 @@ int kutime(const char *path,const struct utimbuf *times) {
 
 int kformat(const char *pathname, const char *fs_type) {
 	struct path node;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	int res;
 	struct block_dev *bdev;
 
@@ -349,7 +349,7 @@ int kformat(const char *pathname, const char *fs_type) {
 
 int kmount(const char *dev, const char *dir, const char *fs_type) {
 	struct path dev_node, dir_node, root_path;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	const char *lastpath;
 	int res;
 
@@ -612,7 +612,7 @@ int krename(const char *oldpath, const char *newpath) {
 
 int kumount(const char *dir) {
 	struct path dir_node, node;
-	struct fs_driver *drv;
+	const struct fs_driver *drv;
 	const char *lastpath;
 	int res;
 

--- a/src/include/fs/file_system.h
+++ b/src/include/fs/file_system.h
@@ -17,9 +17,9 @@ struct fs_driver;
 struct block_dev;
 
 struct filesystem {
-	struct fs_driver *drv;    			/* file system driver */
-	struct block_dev *bdev;   			/* block device, where is this file system */
-	void             *fsi;    			/* file system information (extended information) */
+	const struct fs_driver *drv;  /* file system driver */
+	struct block_dev       *bdev; /* block device, where is this file system */
+	void                   *fsi;  /* file system information (extended information) */
 
 	const struct file_operations *file_op;
 };

--- a/src/include/fs/fs_driver.h
+++ b/src/include/fs/fs_driver.h
@@ -53,29 +53,6 @@ struct fs_driver {
 	ARRAY_SPREAD_ADD(__fs_drivers_registry, \
 			&fs_driver_)
 
-/**
- * allocate structure for fs_driver structure
- * @return pointer to allocated memory
- */
-extern struct fs_driver *alloc_fs_drivers(void);
-
-/**
- * free early allocated driver with function alloc_fs_drivers
- */
-extern void free_fs_drivers(struct fs_driver *);
-
-extern struct fs_driver *fs_driver_find_drv(const char *name);
-
-/**
- * register a new filesystem driver
- * @param fs the file system structure
- */
-extern int fs_driver_register_drv(struct fs_driver *);
-
-/**
- * unregister a file system driver
- * @param fs filesystem to unregister
- */
-extern int fs_driver_unregister_drv(struct fs_driver *);
+extern const struct fs_driver *fs_driver_find_drv(const char *name);
 
 #endif /* FS_DRV_H_ */


### PR DESCRIPTION
As it turned out, we don't really need to create FS driver in runtime as
all of them are registered statically. This way we can remove a lot of
code.

Also declare drivers as const objects so they are not changed by
accident