### PR TITLE
fs/dvfs: Get rid of bdev_file from super_block

### DIFF
--- a/src/cmds/fs/mount.c
+++ b/src/cmds/fs/mount.c
@@ -66,9 +66,9 @@ extern struct dlist_head dentry_dlist;
 
 static void show_mount_list(void) {
 	struct dentry *d;
+	static const char *devfs_path = "/dev/";
 	char mount_path[DVFS_MAX_PATH_LEN];
 	char bdev_path[DVFS_MAX_PATH_LEN];
-	struct file_desc *bdev_file;
 
 	dlist_foreach_entry(d, &dentry_dlist, d_lnk) {
 		if (d->flags & DVFS_MOUNT_POINT) {
@@ -76,13 +76,9 @@ static void show_mount_list(void) {
 				continue;
 			}
 
-			bdev_file = d->d_sb->bdev_file;
-
-			if (bdev_file && bdev_file->f_dentry) {
-				dentry_full_path(bdev_file->f_dentry, bdev_path);
-			} else {
-				strcpy(bdev_path, d->d_sb->fs_drv->name);
-			}
+			strcpy(bdev_path, devfs_path);
+			strncat(bdev_path, d->d_sb->fs_drv->name,
+					sizeof(bdev_path) - strlen(devfs_path));
 
 			printf("%s on %s type %s\n",
 					bdev_path,

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -144,11 +144,11 @@ struct inode_operations devfs_iops = {
 };
 
 extern struct file_operations devfs_fops ;
-static int devfs_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
+static int devfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	sb->sb_iops = &devfs_iops;
 	sb->sb_fops = &devfs_fops;
 	sb->sb_ops  = &devfs_sbops;
-	if (bdev_file) {
+	if (bdev) {
 		return -1;
 	}
 	return 0;

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -145,12 +145,14 @@ struct inode_operations devfs_iops = {
 
 extern struct file_operations devfs_fops ;
 static int devfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
-	sb->sb_iops = &devfs_iops;
-	sb->sb_fops = &devfs_fops;
-	sb->sb_ops  = &devfs_sbops;
 	if (bdev) {
 		return -1;
 	}
+
+	sb->sb_iops = &devfs_iops;
+	sb->sb_fops = &devfs_fops;
+	sb->sb_ops  = &devfs_sbops;
+
 	return 0;
 }
 

--- a/src/fs/driver/dfs/dfs.c
+++ b/src/fs/driver/dfs/dfs.c
@@ -598,7 +598,7 @@ struct super_block *dfs_sb(void) {
 	return dfs_super;
 }
 
-static int dfs_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
+static int dfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	int i;
 
 	assert(NAND_PAGES_MAX >= NAND_PAGES_PER_BLOCK);

--- a/src/fs/driver/ext2fuse/ext2fuse.c
+++ b/src/fs/driver/ext2fuse/ext2fuse.c
@@ -14,7 +14,7 @@
 
 struct fuse_sb_priv_data ext2fuse_sb_priv_data;
 
-static int ext2fuse_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
+static int ext2fuse_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	assert(sb);
 
 	sb->sb_data = &ext2fuse_sb_priv_data;

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -343,31 +343,26 @@ struct super_block_operations fat_sbops = {
  *
  * @return Negative error code
  */
-static int fat_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
+static int fat_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	struct fat_fs_info *fsi;
-	struct block_dev *dev;
+
 	assert(sb);
-	if (!bdev_file) {
+
+	if (!bdev) {
 		/* FAT always uses block device, so we can't fill superblock */
 		return -ENOENT;
 	}
 
-	assert(bdev_file->f_inode);
-	assert(bdev_file->f_inode->i_data);
-
-	dev = ((struct dev_module *) bdev_file->f_inode->i_data)->dev_priv;
-	assert(dev);
-
 	fsi = fat_fs_alloc();
 	*fsi = (struct fat_fs_info) {
-		.bdev = dev,
+		.bdev = bdev,
 	};
 	sb->sb_data = fsi;
 	sb->sb_iops = &fat_iops;
 	sb->sb_fops = &fat_fops;
 	sb->sb_ops  = &fat_sbops;
 
-	if (fat_get_volinfo(dev, &fsi->vi, 0))
+	if (fat_get_volinfo(bdev, &fsi->vi, 0))
 		goto err_out;
 
 	return 0;

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -211,14 +211,14 @@ struct inode_operations initfs_iops = {
 extern struct file_operations initfs_fops;
 
 static int initfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
+	if (bdev) {
+		return -1;
+	}
+
 	sb->sb_iops = &initfs_iops;
 	sb->sb_fops = &initfs_fops;
 	sb->sb_ops  = &initfs_sbops;
 	sb->bdev = NULL;
-
-	if (bdev) {
-		return -1;
-	}
 
 	return 0;
 }

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -210,13 +210,13 @@ struct inode_operations initfs_iops = {
 
 extern struct file_operations initfs_fops;
 
-static int initfs_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
+static int initfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	sb->sb_iops = &initfs_iops;
 	sb->sb_fops = &initfs_fops;
 	sb->sb_ops  = &initfs_sbops;
 	sb->bdev = NULL;
 
-	if (bdev_file) {
+	if (bdev) {
 		return -1;
 	}
 

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -187,13 +187,10 @@ struct super_block_operations ramfs_sbops = {
 	.destroy_inode = ramfs_destroy_inode,
 };
 
-static int ramfs_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
+static int ramfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	struct ramfs_fs_info *fsi;
 
 	assert(sb);
-	assert(bdev_file);
-	assert(bdev_file->f_inode);
-	assert(bdev_file->f_inode->i_data);
 
 	if (NULL == (fsi = pool_alloc(&ramfs_fs_pool))) {
 		return -ENOMEM;
@@ -202,8 +199,8 @@ static int ramfs_fill_sb(struct super_block *sb, struct file_desc *bdev_file) {
 	memset(fsi, 0, sizeof(struct ramfs_fs_info));
 	fsi->block_per_file = MAX_FILE_SIZE / PAGE_SIZE();
 	fsi->block_size = PAGE_SIZE();
-	fsi->numblocks = block_dev(bdev_file->f_inode->i_data)->size / PAGE_SIZE();
-	fsi->bdev = block_dev(bdev_file->f_inode->i_data);
+	fsi->numblocks = bdev->size / PAGE_SIZE();
+	fsi->bdev = bdev;
 
 	sb->sb_data = fsi;
 	sb->sb_iops = &ramfs_iops;

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -48,7 +48,6 @@ struct dir_ctx;
 struct super_block {
 	const struct fs_driver *fs_drv; /* Assume that all FS have single driver */
 	struct block_dev            *bdev;
-	struct file_desc            *bdev_file;
 	struct dentry               *root;
 	struct dlist_head           *inode_list;
 
@@ -112,7 +111,7 @@ extern struct dentry *dvfs_cache_get(char *path, struct lookup *lookup);
 extern int dvfs_cache_del(struct dentry *dentry);
 extern int dvfs_cache_add(struct dentry *dentry);
 
-extern struct super_block *dvfs_alloc_sb(const struct fs_driver *drv, struct file_desc *bdev_file);
+extern struct super_block *dvfs_alloc_sb(const struct fs_driver *drv, struct block_dev *bdev);
 extern int dvfs_destroy_sb(struct super_block *sb);
 
 extern int dvfs_mount(const char *dev, const char *dest, const char *fstype, int flags);
@@ -127,15 +126,4 @@ extern int dentry_ref_dec(struct dentry *dentry);
 extern int dentry_disconnect(struct dentry *dentry);
 extern int dentry_reconnect(struct dentry *parent, const char *name);
 
-extern int dvfs_bdev_read(
-		struct file_desc *bdev_file,
-		char *buff,
-		size_t count,
-		int blkno);
-
-extern int dvfs_bdev_write(
-		struct file_desc *bdev_file,
-		char *buff,
-		size_t count,
-		int blkno);
 #endif

--- a/src/fs/dvfs/fs_driver.h
+++ b/src/fs/dvfs/fs_driver.h
@@ -18,7 +18,7 @@ struct file_desc;
 struct fs_driver {
 	const char name[FS_DRV_NAME_LEN];
 	int (*format)(struct block_dev *dev, void *priv);
-	int (*fill_sb)(struct super_block *sb, struct file_desc *dev);
+	int (*fill_sb)(struct super_block *sb, struct block_dev *dev);
 	int (*mount_end)(struct super_block *sb);
 	int (*clean_sb)(struct super_block *sb);
 };


### PR DESCRIPTION
This field was never actually used in any FS and also doesn't seem to be
useful at all. It's used just to bass block device pointer, so getting
rid of this field simplifies code.

Also remove related unused functions.