### PR TITLE
Add l3g4200d gyro driver

### DIFF
--- a/src/cmds/hardware/sensors/l3g4200d/Mybuild
+++ b/src/cmds/hardware/sensors/l3g4200d/Mybuild
@@ -1,0 +1,9 @@
+package embox.cmd.hardware.sensors
+
+@AutoCmd
+@Cmd(name="l3g4200d", help="l3g4200d sensor demo")
+module l3g4200d {
+	source "l3g4200d.c"
+
+	depends embox.driver.sensors.l3g4200d
+}

--- a/src/cmds/hardware/sensors/l3g4200d/l3g4200d.c
+++ b/src/cmds/hardware/sensors/l3g4200d/l3g4200d.c
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 06.02.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <drivers/sensors/l3g4200d.h>
+
+int main(int argc, char **argv) {
+	printf("Testing l3g4200d gyroscope output\n");
+
+	if (0 != l3g4200d_init()) {
+		printf("Failed to init L3G4200D!\n");
+		return -1;
+	}
+
+	while (1) {
+		int x = l3g4200d_get_angular_rate_x();
+		int y = l3g4200d_get_angular_rate_y();
+		int z = l3g4200d_get_angular_rate_z();
+
+		printf("X: %4d    Y: %4d    Z: %4d\n", x, y, z);
+	}
+}

--- a/src/drivers/i2c/adapters/stm32/Mybuild
+++ b/src/drivers/i2c/adapters/stm32/Mybuild
@@ -5,6 +5,7 @@ abstract module stm32_i2c {}
 @BuildDepends(third_party.bsp.stmf4cube.core)
 module stm32_i2c_f4 extends stm32_i2c {
 	option number log_level=1
+	option boolean use_i2c_irq=false
 
 	@IncludeExport(path="drivers/i2c", target_name="stm32_i2c_conf.h")
 	source "i2c_conf_f4.h"

--- a/src/drivers/sensors/l3g4200d/Mybuild
+++ b/src/drivers/sensors/l3g4200d/Mybuild
@@ -1,0 +1,11 @@
+package embox.driver.sensors
+
+static module l3g4200d {
+	option number log_level = 1
+	option number i2c_bus = 0
+
+	@IncludeExport(path="drivers/sensors", target_name="l3g4200d.h")
+	source "l3g4200d.h"
+
+	source "l3g4200d.c"
+}

--- a/src/drivers/sensors/l3g4200d/l3g4200d.c
+++ b/src/drivers/sensors/l3g4200d/l3g4200d.c
@@ -1,0 +1,110 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 06.02.2020
+ * @author Alexander Kalmuk
+ */
+#include <unistd.h>
+#include <util/log.h>
+#include <framework/mod/options.h>
+#include <drivers/i2c/i2c.h>
+
+#include "l3g4200d.h"
+
+#define L3G4200D_WHO_AM_I     0xf
+#define L3G4200D_CTRL_REG(i)  (0x20 + i)
+#define L3G4200D_STATUS_REG   0x27
+#define L3G4200D_OUT_X_L      0x28
+#define L3G4200D_OUT_X_H      0x29
+#define L3G4200D_OUT_Y_L      0x2A
+#define L3G4200D_OUT_Y_H      0x2B
+#define L3G4200D_OUT_Z_L      0x2C
+#define L3G4200D_OUT_Z_H      0x2D
+
+#define L3G4200D_WHO_AM_I_VALUE 0xd3
+
+#define L3G4200D_I2C_ADDR  0x69
+#define L3G4200D_I2C_BUS   OPTION_GET(NUMBER, i2c_bus)
+
+struct l3g4200d_dev {
+	int i2c_bus;
+	int i2c_addr;
+};
+
+static struct l3g4200d_dev l3g4200d_dev0 = {
+	.i2c_bus  = L3G4200D_I2C_BUS,
+	.i2c_addr = L3G4200D_I2C_ADDR
+};
+
+static int l3g4200d_readb(struct l3g4200d_dev *dev, int offset, uint8_t *ret) {
+	if (i2c_bus_write(dev->i2c_bus, dev->i2c_addr,
+	        (uint8_t *) &offset, 1) < 0) {
+		return -1;
+	}
+	if (i2c_bus_read(dev->i2c_bus, dev->i2c_addr, ret, 1) < 0) {
+		return -1;
+	}
+	return 0;
+}
+
+static int l3g4200d_writeb(struct l3g4200d_dev *dev,
+	    int offset, uint8_t val) {
+	uint16_t tmp = (offset & 0xFF) | (val << 8);
+	if (i2c_bus_write(dev->i2c_bus, dev->i2c_addr, (void *) &tmp, 2)) {
+		return -1;
+	}
+	return 0;
+}
+
+int16_t l3g4200d_get_angular_rate_x(void) {
+	uint8_t l, h;
+	struct l3g4200d_dev *dev = &l3g4200d_dev0;
+	l3g4200d_readb(dev, L3G4200D_OUT_X_L, &l);
+	l3g4200d_readb(dev, L3G4200D_OUT_X_H, &h);
+	return l | ((int16_t) h << 8);
+}
+
+int16_t l3g4200d_get_angular_rate_y(void) {
+	uint8_t l, h;
+	struct l3g4200d_dev *dev = &l3g4200d_dev0;
+	l3g4200d_readb(dev, L3G4200D_OUT_Y_L, &l);
+	l3g4200d_readb(dev, L3G4200D_OUT_Y_H, &h);
+	return l | ((int16_t) h << 8);
+}
+
+int16_t l3g4200d_get_angular_rate_z(void) {
+	uint8_t l, h;
+	struct l3g4200d_dev *dev = &l3g4200d_dev0;
+	l3g4200d_readb(dev, L3G4200D_OUT_Z_L, &l);
+	l3g4200d_readb(dev, L3G4200D_OUT_Z_H, &h);
+	return l | ((int16_t) h << 8);
+}
+
+int l3g4200d_init(void) {
+	int i;
+	uint8_t tmp;
+	struct l3g4200d_dev *dev = &l3g4200d_dev0;
+
+	if (l3g4200d_readb(dev, L3G4200D_WHO_AM_I, &tmp) < 0) {
+		return -1;
+	}
+	log_info("WHO_AM_I = 0x%02x", tmp);
+	if (tmp != L3G4200D_WHO_AM_I_VALUE) {
+		log_error("L3G4200D Device ID mismatch! %2x", tmp);
+		return -1;
+	}
+
+	tmp = 0x7; /* Enable X, Y, Z */
+	tmp |= (1 << 3); /* Enable power */
+	l3g4200d_writeb(dev, L3G4200D_CTRL_REG(0), tmp);
+
+	for (i = 0; i < 5; i++) {
+		l3g4200d_readb(dev, L3G4200D_CTRL_REG(i), &tmp);
+		log_info("CTRL_REG%d = 0x%02x", i + 1, tmp);
+	}
+	l3g4200d_readb(dev, L3G4200D_STATUS_REG, &tmp);
+	log_info("STATUS_REG = 0x%02x", tmp);
+
+	return 0;
+}

--- a/src/drivers/sensors/l3g4200d/l3g4200d.h
+++ b/src/drivers/sensors/l3g4200d/l3g4200d.h
@@ -1,0 +1,16 @@
+/**
+ * @file
+ *
+ * @data 06.02.2020
+ * @author Alexander Kalmuk
+ */
+
+#ifndef L3G4200D_H_
+#define L3G4200D_H_
+
+extern int l3g4200d_init(void);
+extern int16_t l3g4200d_get_angular_rate_x(void);
+extern int16_t l3g4200d_get_angular_rate_y(void);
+extern int16_t l3g4200d_get_angular_rate_z(void);
+
+#endif /* L3G4200D_H_ */


### PR DESCRIPTION
* Fix i2c driver for stm32 - use polling, irq variant seems to be broken in Cube (but it should be checked more accurate, probably with reworking the driver without using Cube)
With l3g4200d something was wrong with SDA line - there was not STOP i2c condition on that line after register reading

* Add l3g4200d gyro driver in I2C mode