### PR TITLE
ext2: Refactor some functions for further VFS rework

### DIFF
--- a/src/fs/driver/ext2/ext2_balloc.c
+++ b/src/fs/driver/ext2/ext2_balloc.c
@@ -147,12 +147,13 @@ static uint32_t ext2_alloc_block_bit(struct nas *nas, uint32_t goal) { /* try to
 	char update_bsearch = 0;
 	int i;
 	struct ext2_gd *gd;
-
+	struct super_block *sb;
 	struct ext2_file_info *fi;
 	struct ext2_fs_info *fsi;
 
 	fi = nas->fi->privdata;
-	fsi = nas->fs->sb_data;
+	sb = nas->fs;
+	fsi = sb->sb_data;
 
 	block = NO_BLOCK;
 	bit = -1;
@@ -188,7 +189,7 @@ static uint32_t ext2_alloc_block_bit(struct nas *nas, uint32_t goal) { /* try to
 			continue;
 		}
 
-		ext2_read_sector(nas, fi->f_buf, 1, gd->block_bitmap);
+		ext2_read_sector(sb, fi->f_buf, 1, gd->block_bitmap);
 
 		bit = ext2_setbit(b_bitmap(fi->f_buf), fsi->e2sb.s_blocks_per_group, word);
 		if (-1 == bit) {
@@ -206,12 +207,12 @@ static uint32_t ext2_alloc_block_bit(struct nas *nas, uint32_t goal) { /* try to
 			return 0;
 		}
 
-		ext2_write_sector(nas, fi->f_buf, 1, gd->block_bitmap);
+		ext2_write_sector(sb, fi->f_buf, 1, gd->block_bitmap);
 
 		fsi->e2sb.s_free_blocks_count--;
-		ext2_write_sblock(nas);
+		ext2_write_sblock(sb);
 		gd->free_blocks_count--;
-		ext2_write_gdblock(nas);
+		ext2_write_gdblock(sb);
 
 		if (update_bsearch && block != -1 && block != NO_BLOCK) {
 			/* We searched from the beginning, update bsearch. */
@@ -231,9 +232,11 @@ void ext2_free_block(struct nas *nas, uint32_t bit_returned) {
 	struct ext2_gd *gd;
 	struct ext2_file_info *fi;
 	struct ext2_fs_info *fsi;
+	struct super_block *sb;
 
 	fi = nas->fi->privdata;
-	fsi = nas->fs->sb_data;
+	sb = nas->fs;
+	fsi = sb->sb_data;
 
 	if (bit_returned >= fsi->e2sb.s_blocks_count ||
 		bit_returned < fsi->e2sb.s_first_data_block) {
@@ -258,17 +261,17 @@ void ext2_free_block(struct nas *nas, uint32_t bit_returned) {
 		return;
 	}
 
-	ext2_read_sector(nas, (char *) fi->f_buf, 1, gd->block_bitmap);
+	ext2_read_sector(sb, (char *) fi->f_buf, 1, gd->block_bitmap);
 	if (ext2_unsetbit(b_bitmap(fi->f_buf), bit)) {
 		return; /*Tried to free unused block*/
 	}
-	ext2_write_sector(nas, (char *) fi->f_buf, 1, gd->block_bitmap);
+	ext2_write_sector(sb, (char *) fi->f_buf, 1, gd->block_bitmap);
 
 
 	fsi->e2sb.s_free_blocks_count++;
-	ext2_write_sblock(nas);
+	ext2_write_sblock(sb);
 	gd->free_blocks_count++;
-	ext2_write_gdblock(nas);
+	ext2_write_gdblock(sb);
 
 	if (bit_returned < fsi->s_bsearch) {
 		fsi->s_bsearch = bit_returned;

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -276,7 +276,7 @@ static int ext3fs_mount(void *dev, void *dir) {
 
 	inode_sector = ino_to_fsba(fsi, EXT3_JOURNAL_SUPERBLOCK_INODE);
 
-	rsize = ext2_read_sector(dir_nas, buf, 1, inode_sector);
+	rsize = ext2_read_sector(dir_nas->fs, buf, 1, inode_sector);
 	if (rsize * fsi->s_block_size != fsi->s_block_size) {
 		return -EIO;
 	}

--- a/src/fs/driver/ext4/ext4_balloc.c
+++ b/src/fs/driver/ext4/ext4_balloc.c
@@ -192,7 +192,7 @@ static uint32_t ext4_alloc_block_bit(struct nas *nas, uint32_t goal) { /* try to
 			continue;
 		}
 
-		ext2_read_sector(nas, fi->f_buf, 1, ext4_block_bitmap_len(gd));
+		ext2_read_sector(nas->fs, fi->f_buf, 1, ext4_block_bitmap_len(gd));
 
 		bit = ext4_setbit(b_bitmap(fi->f_buf), fsi->e4sb.s_blocks_per_group, word);
 		if (-1 == bit) {
@@ -210,12 +210,12 @@ static uint32_t ext4_alloc_block_bit(struct nas *nas, uint32_t goal) { /* try to
 			return 0;
 		}
 
-		ext2_write_sector(nas, fi->f_buf, 1, ext4_block_bitmap_len(gd));
+		ext2_write_sector(nas->fs, fi->f_buf, 1, ext4_block_bitmap_len(gd));
 
 		fsi->e4sb.s_free_blocks_count--;
-		ext2_write_sblock(nas);
+		ext2_write_sblock(nas->fs);
 		ext4_inc_lo_hi(gd->free_blocks_count_lo, gd->free_blocks_count_hi);
-		ext2_write_gdblock(nas);
+		ext2_write_gdblock(nas->fs);
 
 		if (update_bsearch && block != -1 && block != EXT4_NO_BLOCK) {
 			/* We searched from the beginning, update bsearch. */
@@ -262,17 +262,17 @@ void ext4_free_block(struct nas *nas, uint32_t bit_returned) {
 		return;
 	}
 
-	ext2_read_sector(nas, (char *) fi->f_buf, 1, ext4_block_bitmap_len(gd));
+	ext2_read_sector(nas->fs, (char *) fi->f_buf, 1, ext4_block_bitmap_len(gd));
 	if (ext2_unsetbit(b_bitmap(fi->f_buf), bit)) {
 		return; /*Tried to free unused block*/
 	}
-	ext2_write_sector(nas, (char *) fi->f_buf, 1, ext4_block_bitmap_len(gd));
+	ext2_write_sector(nas->fs, (char *) fi->f_buf, 1, ext4_block_bitmap_len(gd));
 
 
 	fsi->e4sb.s_free_blocks_count++;
-	ext2_write_sblock(nas);
+	ext2_write_sblock(nas->fs);
 	ext4_inc_lo_hi(gd->free_blocks_count_lo, gd->free_blocks_count_hi);
-	ext2_write_gdblock(nas);
+	ext2_write_gdblock(nas->fs);
 
 	if (bit_returned < fsi->s_bsearch) {
 		fsi->s_bsearch = bit_returned;

--- a/src/include/fs/ext2.h
+++ b/src/include/fs/ext2.h
@@ -14,6 +14,7 @@
 #include <linux/types.h>
 #include <stdint.h>
 #include <fs/journal.h>
+#include <fs/super_block.h>
 #include <endian.h>
 #include <swab.h>
 /*
@@ -614,17 +615,17 @@ struct nas;
 extern uint32_t ext2_alloc_block(struct nas *nas, uint32_t goal);
 extern void ext2_free_block(struct nas *nas, uint32_t bit);
 
-extern int ext2_read_sector(struct nas *nas, char *buffer,
+extern int ext2_read_sector(struct super_block *sb, char *buffer,
 		uint32_t count, uint32_t sector);
-extern int ext2_write_sector(struct nas *nas, char *buffer,
+extern int ext2_write_sector(struct super_block *sb, char *buffer,
 		uint32_t count, uint32_t sector);
 extern struct ext2_gd* ext2_get_group_desc(unsigned int bnum, struct ext2_fs_info *fsi);
 
-extern int ext2_write_gdblock(struct nas *nas);
-extern int ext2_write_sblock(struct nas *nas);
+extern int ext2_write_gdblock(struct super_block *sb);
+extern int ext2_write_sblock(struct super_block *sb);
 
-extern void *ext2_buff_alloc(struct nas *nas, size_t size);
-extern int ext2_buff_free(struct nas *nas, char *buff);
+extern void *ext2_buff_alloc(struct ext2_fs_info *fsi, size_t size);
+extern int ext2_buff_free(struct ext2_fs_info *fsi, char *buff);
 
 extern uint32_t ext2_setbit(uint32_t *bitmap, uint32_t max_bits, unsigned int word);
 extern int ext2_unsetbit(uint32_t *bitmap, uint32_t bit);


### PR DESCRIPTION
Some function don't really need `nas` structure to be passed, in some
cases just passing `struct super_block` is fine

Most of `mount` handlers for old VFS drivers can be splitted into two parts:
1. Initilize FS-specific data (which corresponds to new VFS `fill_sb` handler)
2. Integrating all files into VFS tree

Due to VFS-specific ext2 function arguments it's hard to split it this way for ext2 (for example, `struct nas` is passed, while only corresponding bdev is required for function). So I fix some functions to become VFS-agnostic.