### PR TITLE
fs: Change mount handlers signature

### DIFF
--- a/src/fs/driver/binfs/binfs.c
+++ b/src/fs/driver/binfs/binfs.c
@@ -14,28 +14,24 @@
 
 #define BINFS_NAME "binfs"
 
-static int binfs_mount(void *dev, void *dir) {
-	struct inode *dir_node = dir;
+static int binfs_mount(const char *source, struct inode *dest) {
 	const struct cmd *cmd;
 
-	dir_node = dir;
-
 	cmd_foreach(cmd) {
-		vfs_subtree_create_child(dir_node, cmd_name(cmd),
+		vfs_subtree_create_child(dest, cmd_name(cmd),
 				S_IFREG | S_IXUSR | S_IXGRP | S_IXOTH);
 	}
 
-	if (NULL == (dir_node->nas->fs = super_block_alloc(BINFS_NAME, NULL))) {
+	if (NULL == (dest->nas->fs = super_block_alloc(BINFS_NAME, NULL))) {
 		return -ENOMEM;
 	}
 	return 0;
 }
 
-static int binfs_umount(void *dir) {
-	struct inode *dir_node = dir;
+static int binfs_umount(struct inode *dir) {
 	struct inode *child;
 
-	while (NULL != (child = vfs_subtree_get_child_next(dir_node, NULL))) {
+	while (NULL != (child = vfs_subtree_get_child_next(dir, NULL))) {
 		vfs_del_leaf(child);
 	}
 
@@ -50,7 +46,6 @@ static struct fsop_desc binfs_fsop = {
 static struct fs_driver binfs_driver = {
 	.name = BINFS_NAME,
 	.fsop = &binfs_fsop,
-	.mount_dev_by_string = true,
 };
 
 DECLARE_FILE_SYSTEM_DRIVER(binfs_driver);

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -144,8 +144,8 @@ struct inode_operations devfs_iops = {
 };
 
 extern struct file_operations devfs_fops ;
-static int devfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
-	if (bdev) {
+static int devfs_fill_sb(struct super_block *sb, const char *source) {
+	if (source) {
 		return -1;
 	}
 

--- a/src/fs/driver/devfs/devfs_oldfs.c
+++ b/src/fs/driver/devfs/devfs_oldfs.c
@@ -30,14 +30,12 @@ extern struct inode_operations devfs_iops;
 
 static struct super_block *devfs_sb;
 
-static int devfs_mount(void *dev, void *dir) {
+static int devfs_mount(const char *source, struct inode *dest) {
 	int ret;
-	struct inode *dir_node;
 	struct nas *dir_nas;
 
-	dir_node = dir;
-	dir_node->i_ops = &devfs_iops;
-	dir_nas = dir_node->nas;
+	dest->i_ops = &devfs_iops;
+	dir_nas = dest->nas;
 
 	ret = char_dev_init_all();
 	if (ret != 0) {

--- a/src/fs/driver/dfs/dfs.c
+++ b/src/fs/driver/dfs/dfs.c
@@ -598,7 +598,7 @@ struct super_block *dfs_sb(void) {
 	return dfs_super;
 }
 
-static int dfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
+static int dfs_fill_sb(struct super_block *sb, const char *source) {
 	int i;
 
 	assert(NAND_PAGES_MAX >= NAND_PAGES_PER_BLOCK);
@@ -612,6 +612,7 @@ static int dfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 		.sb_iops    = &dfs_iops,
 		.sb_fops    = &dfs_fops,
 		.sb_data    = &dfs_info,
+		.bdev       = bdev_by_path(source),
 	};
 
 	if (!sb->bdev)

--- a/src/fs/driver/ext2fuse/ext2fuse.c
+++ b/src/fs/driver/ext2fuse/ext2fuse.c
@@ -14,7 +14,7 @@
 
 struct fuse_sb_priv_data ext2fuse_sb_priv_data;
 
-static int ext2fuse_fill_sb(struct super_block *sb, struct block_dev *bdev) {
+static int ext2fuse_fill_sb(struct super_block *sb, const char *source) {
 	assert(sb);
 
 	sb->sb_data = &ext2fuse_sb_priv_data;

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -343,11 +343,13 @@ struct super_block_operations fat_sbops = {
  *
  * @return Negative error code
  */
-static int fat_fill_sb(struct super_block *sb, struct block_dev *bdev) {
+static int fat_fill_sb(struct super_block *sb, const char *source) {
 	struct fat_fs_info *fsi;
+	struct block_dev *bdev;
 
 	assert(sb);
 
+	bdev = bdev_by_path(source);
 	if (!bdev) {
 		/* FAT always uses block device, so we can't fill superblock */
 		return -ENOENT;
@@ -361,6 +363,8 @@ static int fat_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	sb->sb_iops = &fat_iops;
 	sb->sb_fops = &fat_fops;
 	sb->sb_ops  = &fat_sbops;
+	sb->bdev    = bdev;
+
 
 	if (fat_get_volinfo(bdev, &fsi->vi, 0))
 		goto err_out;

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -210,11 +210,7 @@ struct inode_operations initfs_iops = {
 
 extern struct file_operations initfs_fops;
 
-static int initfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
-	if (bdev) {
-		return -1;
-	}
-
+static int initfs_fill_sb(struct super_block *sb, const char *source) {
 	sb->sb_iops = &initfs_iops;
 	sb->sb_fops = &initfs_fops;
 	sb->sb_ops  = &initfs_sbops;

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -187,10 +187,16 @@ struct super_block_operations ramfs_sbops = {
 	.destroy_inode = ramfs_destroy_inode,
 };
 
-static int ramfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
+static int ramfs_fill_sb(struct super_block *sb, const char *source) {
 	struct ramfs_fs_info *fsi;
+	struct block_dev *bdev;
 
 	assert(sb);
+
+	bdev = bdev_by_path(source);
+	if (NULL == bdev) {
+		return -ENODEV;
+	}
 
 	if (NULL == (fsi = pool_alloc(&ramfs_fs_pool))) {
 		return -ENOMEM;
@@ -206,6 +212,7 @@ static int ramfs_fill_sb(struct super_block *sb, struct block_dev *bdev) {
 	sb->sb_iops = &ramfs_iops;
 	sb->sb_fops = &ramfs_fops;
 	sb->sb_ops  = &ramfs_sbops;
+	sb->bdev    = bdev;
 
 	return 0;
 }

--- a/src/fs/dvfs/compat.c
+++ b/src/fs/dvfs/compat.c
@@ -16,19 +16,20 @@
 /**
  * @brief Mount given device on given directory
  *
- * @param dev Path to device
- * @param dir Path to mount point
+ * @param source Path to device or another source of data
+ * @param target Path to mount point
  * @param fs_type Name of FS driver
  *
  * @return Negative error number or 0 if succeed
  */
-int mount(char *dev, char *dir, char *fs_type) {
+int mount(const char *source, const char *target,
+	const char *fs_type) {
 	struct fuse_module *fm;
 	fm = fuse_module_lookup(fs_type);
 	if (fm) {
-		return fuse_module_mount(fm, dev, dir);
+		return fuse_module_mount(fm, source, target);
 	}
-	errno = dvfs_mount(dev, dir, fs_type, 0); /* Compatibility with old VFS */
+	errno = dvfs_mount(source, target, fs_type, 0); /* Compatibility with old VFS */
 	return errno;
 }
 

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -109,9 +109,10 @@ extern struct dentry *dvfs_cache_get(char *path, struct lookup *lookup);
 extern int dvfs_cache_del(struct dentry *dentry);
 extern int dvfs_cache_add(struct dentry *dentry);
 
-extern struct super_block *dvfs_alloc_sb(const struct fs_driver *drv, struct block_dev *bdev);
-extern int dvfs_destroy_sb(struct super_block *sb);
+extern struct super_block *super_block_alloc(const char *fs_type, const char *source);
+extern int super_block_free(struct super_block *sb);
 
+extern struct block_dev *bdev_by_path(const char *source);
 extern int dvfs_mount(const char *dev, const char *dest, const char *fstype, int flags);
 extern int dvfs_umount(struct dentry *d);
 

--- a/src/fs/dvfs/dvfs_idesc_ops.c
+++ b/src/fs/dvfs/dvfs_idesc_ops.c
@@ -19,7 +19,6 @@ extern const struct idesc_ops idesc_file_ops;
 
 static void idesc_file_ops_close(struct idesc *idesc) {
 	assert(idesc);
-	assert(idesc->idesc_ops == &idesc_file_ops);
 	dvfs_close((struct file_desc *)idesc);
 }
 

--- a/src/fs/dvfs/fs_driver.h
+++ b/src/fs/dvfs/fs_driver.h
@@ -18,7 +18,7 @@ struct file_desc;
 struct fs_driver {
 	const char name[FS_DRV_NAME_LEN];
 	int (*format)(struct block_dev *dev, void *priv);
-	int (*fill_sb)(struct super_block *sb, struct block_dev *dev);
+	int (*fill_sb)(struct super_block *sb, const char *source);
 	int (*mount_end)(struct super_block *sb);
 	int (*clean_sb)(struct super_block *sb);
 };

--- a/src/fs/fuse/fuse_linux.c
+++ b/src/fs/fuse/fuse_linux.c
@@ -19,7 +19,7 @@
 
 ARRAY_SPREAD_DEF(const struct fuse_module *const, fuse_module_repo);
 
-struct fuse_module *fuse_module_lookup(char *fuse_type) {
+struct fuse_module *fuse_module_lookup(const char *fuse_type) {
 	struct fuse_module *fm;
 	array_spread_foreach(fm, fuse_module_repo) {
 		if (0 == strcmp(fuse_type, fm->fuse_module_name)) {
@@ -103,7 +103,7 @@ static void *fuse_module_mount_process(void *arg) {
 
 	params->fm = NULL;
 
-	sb = dvfs_alloc_sb(fs_drv, NULL);
+	sb = super_block_alloc(fs_drv, NULL);
 	fuse_fill_dentry(sb, argv2);
 
 	cmd_exec(cmd, 3, argv); /* will not return */
@@ -111,7 +111,7 @@ static void *fuse_module_mount_process(void *arg) {
 	return NULL;
 }
 
-int fuse_module_mount(struct fuse_module *fm, char *dev, char *dest) {
+int fuse_module_mount(struct fuse_module *fm, const char *dev, const char *dest) {
 	int res;
 	struct fuse_mount_params params = {fm, dev, dest};
 

--- a/src/fs/fuse/fuse_module_linux.h
+++ b/src/fs/fuse/fuse_module_linux.h
@@ -14,9 +14,9 @@ struct fuse_module {
 	const char *fuse_module_cmd_mount;
 };
 
-extern struct fuse_module *fuse_module_lookup(char *fuse_type);
+extern struct fuse_module *fuse_module_lookup(const char *fuse_type);
 
-extern int fuse_module_mount(struct fuse_module *fm, char *dev, char *dest);
+extern int fuse_module_mount(struct fuse_module *fm, const char *dev, const char *dest);
 
 extern int fuse_module_umount(struct fuse_module *fm);
 

--- a/src/fs/fuse/fuse_module_none.h
+++ b/src/fs/fuse/fuse_module_none.h
@@ -10,9 +10,9 @@
 
 struct fuse_module;
 
-extern struct fuse_module *fuse_module_lookup(char *fuse_type);
+extern struct fuse_module *fuse_module_lookup(const char *fuse_type);
 
-extern int fuse_module_mount(struct fuse_module *fm, char *dev, char *dest);
+extern int fuse_module_mount(struct fuse_module *fm, const char *dev, const char *dest);
 
 extern int fuse_module_umount(struct fuse_module *fm);
 

--- a/src/fs/fuse/fuse_none.c
+++ b/src/fs/fuse/fuse_none.c
@@ -9,11 +9,12 @@
 
 #include <fs/fuse_module.h>
 
-struct fuse_module *fuse_module_lookup(char *fuse_type) {
+struct fuse_module *fuse_module_lookup(const char *fuse_type) {
 	return NULL;
 }
 
-int fuse_module_mount(struct fuse_module *fm, char *dev, char *dest) {
+int fuse_module_mount(struct fuse_module *fm,
+		const char *dev, const char *dest) {
 	return -ENOSUPP;
 }
 

--- a/src/fs/syslib/fsop.c
+++ b/src/fs/syslib/fsop.c
@@ -16,8 +16,8 @@
 #include <fs/kfile.h>
 #include <sys/types.h>
 
-int mount(char *dev,  char *dir, char *fs_type) {
-	return kmount(dev, dir, fs_type);
+int mount(const char *source, const char *target, const char *fs_type) {
+	return kmount(source, target, fs_type);
 }
 
 int format(const char *pathname, const char *fs_type) {

--- a/src/fs/syslib/nokfsop.c
+++ b/src/fs/syslib/nokfsop.c
@@ -34,7 +34,7 @@ int klstat(const char *path, struct stat *buf) {
 	return -1;
 }
 
-int kmount(const char *dev, const char *dir, const char *fs_type) {
+int kmount(const char *source, const char *dest, const char *fs_type) {
 	return -1;
 }
 

--- a/src/include/fs/fs_driver.h
+++ b/src/include/fs/fs_driver.h
@@ -18,7 +18,7 @@ struct block_dev;
 
 struct fsop_desc {
 	int (*format)(struct block_dev *bdev, void *priv);
-	int (*mount)(void *dev_node, void *dir_node);
+	int (*mount)(const char *source, struct inode *dest);
 	int (*create_node)(struct inode *parent_node, struct inode *new_node);
 	int (*delete_node)(struct inode *node);
 
@@ -30,7 +30,7 @@ struct fsop_desc {
 	int (*listxattr)(struct inode *node, char *list, size_t len);
 
 	int (*truncate)(struct inode *node, off_t length);
-	int (*umount)(void *dir_node);
+	int (*umount)(struct inode *dir);
 };
 
 struct file_operations;
@@ -41,10 +41,9 @@ struct file_operations;
  * our system.
  */
 struct fs_driver {
-	const char                    *name;
-	bool		mount_dev_by_string;
+	const char                   *name;
 	const struct file_operations *file_op;
-	const struct fsop_desc        *fsop;
+	const struct fsop_desc       *fsop;
 };
 
 #define DECLARE_FILE_SYSTEM_DRIVER(fs_driver_)      \

--- a/src/include/fs/mount.h
+++ b/src/include/fs/mount.h
@@ -13,6 +13,7 @@
 
 struct inode;
 struct path;
+struct block_dev;
 
 #define MOUNT_DESC_STRINFO_LEN 16
 struct mount_descriptor {
@@ -31,10 +32,12 @@ extern struct mount_descriptor *mount_table_add(struct path *mnt_point_path,
 
 extern int mount_table_del(struct mount_descriptor *mdesc);
 
-extern struct mount_descriptor *mount_table_get_child(struct mount_descriptor *parent, struct inode *mnt_point);
+extern struct mount_descriptor *mount_table_get_child(
+		struct mount_descriptor *parent, struct inode *mnt_point);
 
-extern int mount(char *dev,  char *dir, char *fs_type);
+extern struct block_dev *bdev_by_path(const char *source);
 
+extern int mount(const char *source, const char *target, const char *fs_type);
 extern int umount(char *dir);
 
 #endif /* FS_MOUNT_H_ */


### PR DESCRIPTION
Use `char *` instead of `struct block_dev *` as a source of FS data as
different FS require different parameters which makes common VFS part a
bit complex. Instead, driver should decide how to interpret mount
argument.

Also `umount` handlers now should work with `struct inode *` argument instead of `void *` which all the time was interpreted as `struct nas *`