### PR TITLE
fs: Split VFS mount handlers

### DIFF
--- a/src/fs/driver/binfs/binfs.c
+++ b/src/fs/driver/binfs/binfs.c
@@ -14,7 +14,7 @@
 
 #define BINFS_NAME "binfs"
 
-static int binfs_mount(const char *source, struct inode *dest) {
+static int binfs_mount(struct super_block *sb, struct inode *dest) {
 	const struct cmd *cmd;
 
 	cmd_foreach(cmd) {
@@ -22,9 +22,6 @@ static int binfs_mount(const char *source, struct inode *dest) {
 				S_IFREG | S_IXUSR | S_IXGRP | S_IXOTH);
 	}
 
-	if (NULL == (dest->nas->fs = super_block_alloc(BINFS_NAME, NULL))) {
-		return -ENOMEM;
-	}
 	return 0;
 }
 

--- a/src/fs/driver/devfs/devfs_oldfs.c
+++ b/src/fs/driver/devfs/devfs_oldfs.c
@@ -30,12 +30,10 @@ extern struct inode_operations devfs_iops;
 
 static struct super_block *devfs_sb;
 
-static int devfs_mount(const char *source, struct inode *dest) {
+static int devfs_mount(struct super_block *sb, struct inode *dest) {
 	int ret;
-	struct nas *dir_nas;
 
 	dest->i_ops = &devfs_iops;
-	dir_nas = dest->nas;
 
 	ret = char_dev_init_all();
 	if (ret != 0) {
@@ -46,11 +44,8 @@ static int devfs_mount(const char *source, struct inode *dest) {
 	if (ret != 0) {
 		return ret;
 	}
-	devfs_sb = super_block_alloc("devfs", NULL);
-	if (devfs_sb == NULL) {
-		return -ENOMEM;
-	}
-	dir_nas->fs = devfs_sb;
+
+	devfs_sb = sb;
 
 	return 0;
 }

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -337,45 +337,6 @@ struct super_block_operations fat_sbops = {
 	.destroy_inode = fat_destroy_inode,
 };
 
-/* @brief Initializing fat super_block
- * @param sb  Structure to be initialized
- * @param dev Storage device
- *
- * @return Negative error code
- */
-static int fat_fill_sb(struct super_block *sb, const char *source) {
-	struct fat_fs_info *fsi;
-	struct block_dev *bdev;
-
-	assert(sb);
-
-	bdev = bdev_by_path(source);
-	if (!bdev) {
-		/* FAT always uses block device, so we can't fill superblock */
-		return -ENOENT;
-	}
-
-	fsi = fat_fs_alloc();
-	*fsi = (struct fat_fs_info) {
-		.bdev = bdev,
-	};
-	sb->sb_data = fsi;
-	sb->sb_iops = &fat_iops;
-	sb->sb_fops = &fat_fops;
-	sb->sb_ops  = &fat_sbops;
-	sb->bdev    = bdev;
-
-
-	if (fat_get_volinfo(bdev, &fsi->vi, 0))
-		goto err_out;
-
-	return 0;
-
-err_out:
-	fat_fs_free(fsi);
-	return -1;
-}
-
 /**
 * @brief Initialize dirinfo for root FAT directory
 * @note  Should be called just after mounting FAT FS
@@ -448,6 +409,7 @@ static int fat_clean_sb(struct super_block *sb) {
 	return 0;
 }
 
+extern int fat_fill_sb(struct super_block *sb, const char *source);
 extern int fat_format(struct block_dev *dev, void *priv);
 static const struct fs_driver dfs_fat_driver = {
 	.name      = "vfat",

--- a/src/fs/driver/initfs/initfs_oldfs.c
+++ b/src/fs/driver/initfs/initfs_oldfs.c
@@ -39,7 +39,7 @@ struct initfs_file_info_tmp {
 };
 POOL_DEF(file_pool, struct initfs_file_info_tmp, OPTION_GET(NUMBER,file_quantity));
 
-static int initfs_mount(const char *source, struct inode *dest) {
+static int initfs_mount(struct super_block *sb, struct inode *dest) {
 	extern char _initfs_start, _initfs_end;
 	char *cpio = &_initfs_start;
 	struct nas *dir_nas;
@@ -49,7 +49,6 @@ static int initfs_mount(const char *source, struct inode *dest) {
 	char name[PATH_MAX + 1];
 
 	dir_nas = dest->nas;
-	dir_nas->fs = super_block_alloc("initfs", NULL);
 
 	if (&_initfs_start == &_initfs_end) {
 		return -1;

--- a/src/fs/driver/ramfs/ramfs.h
+++ b/src/fs/driver/ramfs/ramfs.h
@@ -51,5 +51,6 @@ struct ramfs_file_info {
 };
 
 extern struct file_operations ramfs_fops;
+int ramfs_fill_sb(struct super_block *sb, const char *source);
 
 #endif /* RAMFS_H_ */

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -187,36 +187,6 @@ struct super_block_operations ramfs_sbops = {
 	.destroy_inode = ramfs_destroy_inode,
 };
 
-static int ramfs_fill_sb(struct super_block *sb, const char *source) {
-	struct ramfs_fs_info *fsi;
-	struct block_dev *bdev;
-
-	assert(sb);
-
-	bdev = bdev_by_path(source);
-	if (NULL == bdev) {
-		return -ENODEV;
-	}
-
-	if (NULL == (fsi = pool_alloc(&ramfs_fs_pool))) {
-		return -ENOMEM;
-	}
-
-	memset(fsi, 0, sizeof(struct ramfs_fs_info));
-	fsi->block_per_file = MAX_FILE_SIZE / PAGE_SIZE();
-	fsi->block_size = PAGE_SIZE();
-	fsi->numblocks = bdev->size / PAGE_SIZE();
-	fsi->bdev = bdev;
-
-	sb->sb_data = fsi;
-	sb->sb_iops = &ramfs_iops;
-	sb->sb_fops = &ramfs_fops;
-	sb->sb_ops  = &ramfs_sbops;
-	sb->bdev    = bdev;
-
-	return 0;
-}
-
 static int ramfs_mount_end(struct super_block *sb) {
 	return 0;
 }

--- a/src/fs/inode.h
+++ b/src/fs/inode.h
@@ -52,6 +52,7 @@ struct inode {
 
 	/* node attribute structure (extended information about node)*/
 	struct nas            *nas;
+	struct super_block      *i_sb;
 	struct inode_operations *i_ops;
 
 	int                   mounted; /* is mount point*/

--- a/src/include/fs/fs_driver.h
+++ b/src/include/fs/fs_driver.h
@@ -15,10 +15,11 @@
 
 struct inode;
 struct block_dev;
+struct super_block;
 
 struct fsop_desc {
 	int (*format)(struct block_dev *bdev, void *priv);
-	int (*mount)(const char *source, struct inode *dest);
+	int (*mount)(struct super_block *sb, struct inode *dest);
 	int (*create_node)(struct inode *parent_node, struct inode *new_node);
 	int (*delete_node)(struct inode *node);
 
@@ -42,6 +43,7 @@ struct file_operations;
  */
 struct fs_driver {
 	const char                   *name;
+	int (*fill_sb)(struct super_block *sb, const char *source);
 	const struct file_operations *file_op;
 	const struct fsop_desc       *fsop;
 };

--- a/src/include/fs/super_block.h
+++ b/src/include/fs/super_block.h
@@ -15,6 +15,9 @@ struct fs_driver;
 struct inode_operations;
 struct super_block_operations;
 
+/* Stubs */
+struct super_block_operations { };
+
 struct super_block {
 	const struct fs_driver *fs_drv;
 	struct block_dev       *bdev;
@@ -25,7 +28,7 @@ struct super_block {
 	const struct file_operations  *sb_fops;
 };
 
-extern struct super_block *super_block_alloc(const char *fs_driver, struct block_dev *bdev);
+extern struct super_block *super_block_alloc(const char *fs_driver, const char *source);
 extern void super_block_free(struct super_block *sb);
 
 #endif /* SUPER_BLOCK_H_ */


### PR DESCRIPTION
Now use VFS-agnostic `fill_sb` handler to initliaze super block from given source (this handler can be used in both VFS implementations) and `mount` itself which mounts all the files.