### PR TITLE
fs: Move vfs_del_node() from .delete_node to common VFS code

### DIFF
--- a/src/fs/driver/cifs/cifs.c
+++ b/src/fs/driver/cifs/cifs.c
@@ -429,8 +429,6 @@ static int embox_cifs_node_delete(struct inode *node) {
 		}
 	}
 
-	vfs_del_leaf(node);
-
 	return 0;
 }
 

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -607,8 +607,6 @@ static int ext2fs_delete(struct inode *node) {
 		return -rc;
 	}
 
-	vfs_del_leaf(node);
-
 	return 0;
 }
 

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -739,8 +739,6 @@ static int ext4fs_delete(struct inode *node) {
 		return -rc;
 	}
 
-	vfs_del_leaf(node);
-
 	return 0;
 }
 

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -287,7 +287,6 @@ static int fatfs_delete(struct inode *node) {
 		fat_file_free(fi);
 	}
 
-	vfs_del_leaf(node);
 	return 0;
 }
 

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -1625,8 +1625,6 @@ static int jffs2fs_delete(struct inode *node) {
 		pool_free(&jffs2_file_pool, fi);
 	}
 
-	vfs_del_leaf(node);
-
 	return 0;
 }
 

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -678,7 +678,7 @@ static int nfsfs_delete(struct inode *node) {
 	}
 
 	pool_free(&nfs_file_pool, fi);
-	vfs_del_leaf(node);
+
 	return 0;
 }
 

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -183,7 +183,6 @@ static int embox_ntfs_node_delete(struct inode *node) {
 	free(ufilename);
 
 	pool_free(&ntfs_file_pool, node->nas->fi->privdata);
-	vfs_del_leaf(node);
 
 	if (ntfs_inode_close(pni)) {
 		// ToDo: it is not exactly clear what to do in this case - IINM close does fsync.

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -96,8 +96,6 @@ static int ramfs_delete(struct inode *node) {
 		pool_free(&ramfs_file_pool, fi);
 	}
 
-	vfs_del_leaf(node);
-
 	return 0;
 }
 

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -237,7 +237,7 @@ int kunlink(const char *pathname) {
 		return -1;
 	}
 
-	/*vfs_del_leaf(node);*/
+	vfs_del_leaf(node.node);
 
 	return 0;
 
@@ -277,7 +277,7 @@ int krmdir(const char *pathname) {
 
 	dcache_delete(getenv("PWD"), pathname);
 
-	/*vfs_del_leaf(node);*/
+	vfs_del_leaf(node.node);
 
 	return 0;
 

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -244,7 +244,7 @@ int kunlink(const char *pathname) {
 }
 
 int krmdir(const char *pathname) {
-	struct path node, parent;
+	struct path node, parent, child;
 	const struct fs_driver *drv;
 	int res;
 
@@ -255,6 +255,12 @@ int krmdir(const char *pathname) {
 
 	if (0 != (res = fs_perm_check(node.node, S_IWOTH))) {
 		errno = EACCES;
+		return -1;
+	}
+
+	/* Remove directory only if it's empty */
+	if (0 == vfs_get_child_next(&node, NULL, &child)) {
+		errno = ENOTEMPTY;
 		return -1;
 	}
 


### PR DESCRIPTION
This function is called at the end of every .delete_node handler, so it
makes sense just to call it in common code after this handler.

This change allows to use the same delete handler for both VFS versions