### PR TITLE
cmds/fs/mkramdisk: Print name of the created device

### DIFF
--- a/src/cmds/fs/mkramdisk.c
+++ b/src/cmds/fs/mkramdisk.c
@@ -6,10 +6,13 @@
  * @date    20.05.2014
  */
 
-#include <util/err.h>
-#include <unistd.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+
+#include <drivers/block_dev.h>
 #include <drivers/block_dev/ramdisk/ramdisk.h>
+#include <util/err.h>
 
 #define MKRAMDISK_DEFAULT_SIZE 8192;
 
@@ -34,5 +37,10 @@ int main(int argc, char *argv[]) {
 	}
 
 	rd = ramdisk_create(ramdisk_path, ramdisk_size);
+
+	if (NULL != rd) {
+		printf("%s\n", rd->bdev->name);
+	}
+
 	return err(rd);
 }


### PR DESCRIPTION
This is helpful for two reasons:
1) You don't need to remember, what's the default name for ramdisk (ramX
vs ramdiskX vs whateverX)
2) If you create multiple ramdisks, you don't need to track indices