### PR TITLE
vfs: Set superblock pointer for inode in common code

### DIFF
--- a/src/compat/posix/fs/dirent/dirent_oldfs.c
+++ b/src/compat/posix/fs/dirent/dirent_oldfs.c
@@ -110,6 +110,7 @@ struct dirent *readdir(DIR *dir) {
 				node_free(node);
 				return NULL;
 			}
+			node->nas->fs = node->i_sb = dir->path.node->nas->fs;
 			vfs_add_leaf(node, dir->path.node);
 			slist_add_first_link(&node->dirent_link, &dir->inodes_list);
 		} else {

--- a/src/fs/driver/cifs/cifs.c
+++ b/src/fs/driver/cifs/cifs.c
@@ -74,7 +74,6 @@ embox_set_node (struct nas *nas, char *filename, int mode)
 	if (!node) {
 		return NULL;
 	}
-	node->nas->fs = nas->fs;
 	return node;
 }
 
@@ -195,7 +194,6 @@ static int embox_cifs_umount(struct inode *dir) {
 			pool_free(&cifs_fs_pool, fsi);
 		}
 		super_block_free(dir_nas->fs);
-		dir_nas->fs = NULL;
 	}
 
 	return 0;
@@ -400,8 +398,6 @@ static int embox_cifs_node_create(struct inode *parent_node, struct inode *new_n
 			return -errno;
 		}
 	}
-
-	new_node->nas->fs = parent_node->nas->fs;
 
 	return 0;
 }

--- a/src/fs/driver/devfs/devfs_oldfs.c
+++ b/src/fs/driver/devfs/devfs_oldfs.c
@@ -87,7 +87,6 @@ int devfs_add_block(struct block_dev *bdev) {
 
 static int devfs_add_char(struct dev_module *cdev, struct inode **inode) {
 	struct path node;
-	struct nas *dev_nas;
 
 	if (vfs_lookup("/dev", &node)) {
 		return -ENOENT;
@@ -102,8 +101,6 @@ static int devfs_add_char(struct dev_module *cdev, struct inode **inode) {
 		return -1;
 	}
 
-	dev_nas = node.node->nas;
-	dev_nas->fs = devfs_sb;
 	node.node->nas->fi->privdata = (void *)cdev;
 
 	*inode = node.node;
@@ -116,7 +113,6 @@ void devfs_fill_inode(struct inode *inode, struct dev_module *devmod, int flags)
 	assert(devmod);
 
 	inode->nas->fi->privdata = devmod;
-	inode->nas->fs = devfs_sb;
 	inode->i_mode = flags;
 }
 

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -563,8 +563,6 @@ static struct fs_driver ext2fs_driver = {
 static ext2_file_info_t *ext2_fi_alloc(struct nas *nas, void *fs) {
 	ext2_file_info_t *fi;
 
-	nas->fs = fs;
-
 	fi = pool_alloc(&ext2_file_pool);
 	if (fi) {
 		nas->fi->ni.size = fi->f_pointer = 0;

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -673,7 +673,6 @@ static ext4_file_info_t *ext4_fi_alloc(struct nas *nas, void *fs) {
 	if (fi) {
 		nas->fi->ni.size = fi->f_pointer = 0;
 		nas->fi->privdata = fi;
-		nas->fs = fs;
 	}
 
 	return fi;

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -96,7 +96,6 @@ static int fat_create_dir_entry(struct nas *parent_nas,
 		fi->mode         = mode;
 
 		nas = node->nas;
-		nas->fs = parent_nas->fs;
 		nas->fi->privdata = fi;
 		nas->fi->ni.size = fi->filelen;
 
@@ -224,7 +223,6 @@ static int fatfs_create(struct inode *parent_node, struct inode *node) {
 
 	fsi = di->fi.fsi;
 	nas->fi->privdata = fi;
-	nas->fs = parent_node->nas->fs;
 	*fi = (struct fat_file_info) {
 		.fsi     = fsi,
 		.volinfo = &fsi->vi,

--- a/src/fs/driver/initfs/initfs_oldfs.c
+++ b/src/fs/driver/initfs/initfs_oldfs.c
@@ -42,13 +42,10 @@ POOL_DEF(file_pool, struct initfs_file_info_tmp, OPTION_GET(NUMBER,file_quantity
 static int initfs_mount(struct super_block *sb, struct inode *dest) {
 	extern char _initfs_start, _initfs_end;
 	char *cpio = &_initfs_start;
-	struct nas *dir_nas;
 	struct inode *node;
 	struct initfs_file_info_tmp *fi;
 	struct cpio_entry entry;
 	char name[PATH_MAX + 1];
-
-	dir_nas = dest->nas;
 
 	if (&_initfs_start == &_initfs_end) {
 		return -1;
@@ -78,7 +75,6 @@ static int initfs_mount(struct super_block *sb, struct inode *dest) {
 		fi->ni.mtime = entry.mtime;
 
 		node->nas->fi = (struct node_fi *) fi;
-		node->nas->fs = dir_nas->fs;
 	}
 
 	return 0;

--- a/src/fs/driver/iso9660/cdfs.c
+++ b/src/fs/driver/iso9660/cdfs.c
@@ -989,11 +989,9 @@ static int cdfs_create_file_node(struct inode *dir_node, cdfs_t *cdfs, int dir) 
 	int flags;
 	struct cdfs_file_info *fi;
 	struct inode *node;
-	struct nas *nas, *dir_nas;
+	struct nas *nas;
 	wchar_t *wname;
 	char name[PATH_MAX];
-
-	dir_nas = dir_node->nas;
 
 	/* The first two directory records are . (current) and .. (parent) */
 	blk = cdfs->path_table[dir]->extent;
@@ -1077,7 +1075,6 @@ static int cdfs_create_file_node(struct inode *dir_node, cdfs_t *cdfs, int dir) 
 
 			nas = node->nas;
 
-			nas->fs = dir_nas->fs;
 			nas->fi->privdata = (void *)fi;
 
  		} else {
@@ -1133,7 +1130,6 @@ static int cdfs_create_dir_entry (struct nas *root_nas) {
 			}
 
 			nas = node->nas;
-			nas->fs = root_nas->fs;
 			nas->fi->privdata = (void *)fi;
 		}
 

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -1514,7 +1514,6 @@ static jffs2_file_info_t *jffs2_fi_alloc(struct nas *nas, void *fs) {
 		memset(fi, 0, sizeof(struct jffs2_file_info));
 		nas->fi->ni.size = 0;
 		nas->fi->privdata = fi;
-		nas->fs = fs;
 	}
 
 	return fi;

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -509,7 +509,6 @@ static struct inode *nfs_create_file(struct nas *parent_nas, readdir_desc_t *pre
 		nas = node->nas;
 	}
 
-	nas->fs = parent_nas->fs;
 	nas->fi->privdata = fi;
 	return node;
 }
@@ -608,7 +607,6 @@ static int nfsfs_create(struct inode *parent_node, struct inode *node) {
 
 	nas = node->nas;
 	parent_nas = parent_node->nas;
-	nas->fs = parent_nas->fs;
 
 	parent_fi = (nfs_file_info_t *) parent_nas->fi->privdata;
 

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -129,8 +129,6 @@ static int embox_ntfs_node_create(struct inode *parent_node, struct inode *new_n
 
 	free(ufilename);
 
-	new_node->nas->fs = parent_node->nas->fs;
-
 	return 0;
 }
 
@@ -284,7 +282,6 @@ static int embox_ntfs_filldir(void *dirent, const ntfschar *name,
 			errno = ENOMEM;
 			return -1;
 		}
-		node->nas->fs = dir_nas->fs;
 	}
 
 	fsi = dir_nas->fs->sb_data;
@@ -375,7 +372,6 @@ static int embox_ntfs_umount(struct inode *dir) {
 			pool_free(&ntfs_fs_pool, fsi);
 		}
 		super_block_free(dir_nas->fs);
-		dir_nas->fs = NULL;
 	}
 
 	return 0;

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -68,7 +68,6 @@ static int ramfs_create(struct inode *parent_node, struct inode *node) {
 	struct nas *nas;
 
 	nas = node->nas;
-	nas->fs = parent_node->nas->fs;
 
 	if (!node_is_directory(node)) {
 		if (!(nas->fi->privdata = ramfs_create_file(nas))) {

--- a/src/fs/vfs.c
+++ b/src/fs/vfs.c
@@ -336,6 +336,8 @@ static struct inode *__vfs_subtree_create_child(struct inode *parent, const char
 		child->uid = getuid();
 		child->gid = getgid();
 
+		child->nas->fs = child->i_sb = parent->i_sb;
+
 		vfs_add_leaf(child, parent);
 	}
 


### PR DESCRIPTION
When inode is created, `node->nas->fs` and `node->i_sb` are set in every FS driver, but it makes more sense to set it in `vfs_subtree_create_child()`, because it's called anyway to integrate new node into VFS tree.