### PR TITLE
l3g4200d gyro add SPI mode

### DIFF
--- a/src/cmds/hardware/sensors/l3g4200d/Mybuild
+++ b/src/cmds/hardware/sensors/l3g4200d/Mybuild
@@ -4,6 +4,4 @@ package embox.cmd.hardware.sensors
 @Cmd(name="l3g4200d", help="l3g4200d sensor demo")
 module l3g4200d {
 	source "l3g4200d.c"
-
-	depends embox.driver.sensors.l3g4200d
 }

--- a/src/drivers/sensors/l3g4200d/Mybuild
+++ b/src/drivers/sensors/l3g4200d/Mybuild
@@ -1,11 +1,23 @@
 package embox.driver.sensors
 
-static module l3g4200d {
-	option number log_level = 1
-	option number i2c_bus = 0
-
+/* TODO There can be both I2C and SPI versions in one config,
+ * this must be removed after we will add sensors API. */
+abstract module l3g4200d {
 	@IncludeExport(path="drivers/sensors", target_name="l3g4200d.h")
 	source "l3g4200d.h"
 
 	source "l3g4200d.c"
+}
+
+static module l3g4200d_i2c extends l3g4200d {
+	option number log_level = 1
+	option number i2c_bus = 0
+	source "l3g4200d_i2c.c"
+}
+
+static module l3g4200d_spi extends l3g4200d {
+	option number log_level = 1
+	option number spi_bus = 0
+
+	source "l3g4200d_spi.c"
 }

--- a/src/drivers/sensors/l3g4200d/l3g4200d_i2c.c
+++ b/src/drivers/sensors/l3g4200d/l3g4200d_i2c.c
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 06.02.2020
+ * @author Alexander Kalmuk
+ */
+#include <stdint.h>
+#include <framework/mod/options.h>
+#include <drivers/i2c/i2c.h>
+
+#include "l3g4200d.h"
+#include "l3g4200d_transfer.h"
+
+#define L3G4200D_I2C_ADDR  0x69
+#define L3G4200D_I2C_BUS   OPTION_GET(NUMBER, i2c_bus)
+
+struct l3g4200d_dev {
+	int i2c_bus;
+	int i2c_addr;
+};
+
+struct l3g4200d_dev l3g4200d_dev0 = {
+	.i2c_bus  = L3G4200D_I2C_BUS,
+	.i2c_addr = L3G4200D_I2C_ADDR
+};
+
+int l3g4200d_hw_init(struct l3g4200d_dev *dev) {
+	/* Do nothing */
+	return 0;
+}
+
+int l3g4200d_readb(struct l3g4200d_dev *dev, int offset, uint8_t *ret) {
+	if (i2c_bus_write(dev->i2c_bus, dev->i2c_addr,
+	        (uint8_t *) &offset, 1) < 0) {
+		return -1;
+	}
+	if (i2c_bus_read(dev->i2c_bus, dev->i2c_addr, ret, 1) < 0) {
+		return -1;
+	}
+	return 0;
+}
+
+int l3g4200d_writeb(struct l3g4200d_dev *dev,
+	    int offset, uint8_t val) {
+	uint16_t tmp = (offset & 0xFF) | (val << 8);
+	if (i2c_bus_write(dev->i2c_bus, dev->i2c_addr, (void *) &tmp, 2)) {
+		return -1;
+	}
+	return 0;
+}

--- a/src/drivers/sensors/l3g4200d/l3g4200d_spi.c
+++ b/src/drivers/sensors/l3g4200d/l3g4200d_spi.c
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 06.02.2020
+ * @author Alexander Kalmuk
+ */
+#include <stdint.h>
+#include <framework/mod/options.h>
+#include <util/log.h>
+#include <drivers/spi.h>
+
+#include "l3g4200d.h"
+#include "l3g4200d_transfer.h"
+
+#define L3G4200D_SPI_BUS   OPTION_GET(NUMBER, spi_bus)
+
+#define L3G4200D_SPI_READ   0x80
+#define L3G4200D_SPI_WRITE  0x00
+
+struct l3g4200d_dev {
+	int spi_bus;
+	struct spi_device *spi_dev;
+};
+
+struct l3g4200d_dev l3g4200d_dev0 = {
+	.spi_bus  = L3G4200D_SPI_BUS,
+};
+
+int l3g4200d_readb(struct l3g4200d_dev *dev, int offset, uint8_t *ret) {
+	uint8_t in[2];
+	uint8_t out[2];
+
+	in[0] = offset | L3G4200D_SPI_READ;
+	in[1] = 0;
+	if (spi_transfer(dev->spi_dev, in, out, 2) < 0) {
+		log_debug("failed");
+		return -1;
+	}
+	*ret = out[1];
+
+	return 0;
+}
+
+int l3g4200d_writeb(struct l3g4200d_dev *dev,
+	    int offset, uint8_t val) {
+	uint8_t in[2];
+	uint8_t out[2];
+
+	in[0] = offset | L3G4200D_SPI_WRITE;
+	in[1] = val;
+	if (spi_transfer(dev->spi_dev, in, out, 2) < 0) {
+		log_debug("failed");
+		return -1;
+	}
+	return 0;
+}
+
+int l3g4200d_hw_init(struct l3g4200d_dev *dev) {
+	dev->spi_dev = spi_dev_by_id(dev->spi_bus);
+	if (!dev->spi_dev) {
+		return -1;
+	}
+	spi_set_master_mode(dev->spi_dev);
+
+	dev->spi_dev->flags |= SPI_CS_ACTIVE;
+	dev->spi_dev->flags |= SPI_CS_INACTIVE;
+	return 0;
+}

--- a/src/drivers/sensors/l3g4200d/l3g4200d_transfer.h
+++ b/src/drivers/sensors/l3g4200d/l3g4200d_transfer.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * @data 06.02.2020
+ * @author Alexander Kalmuk
+ */
+
+#ifndef L3G4200D_TRANSFER_H_
+#define L3G4200D_TRANSFER_H_
+
+struct l3g4200d_dev;
+
+extern int l3g4200d_hw_init(struct l3g4200d_dev *dev);
+extern int l3g4200d_readb(struct l3g4200d_dev *dev, int offset, uint8_t *ret);
+extern int l3g4200d_writeb(struct l3g4200d_dev *dev, int offset, uint8_t val);
+
+#endif /* L3G4200D_TRANSFER_H_ */

--- a/src/drivers/spi/stm32/spi_conf_f4.h
+++ b/src/drivers/spi/stm32/spi_conf_f4.h
@@ -13,20 +13,20 @@
 #include <drivers/gpio/gpio.h>
 
 /* SPI1 */
-#define SPI1_SCK_PIN               GPIO_PIN_5
-#define SPI1_SCK_GPIO_PORT         GPIOA
+#define SPI1_SCK_PIN               GPIO_PIN_3
+#define SPI1_SCK_GPIO_PORT         GPIOB
 #define SPI1_SCK_AF                GPIO_AF5_SPI1
-#define SPI1_MISO_PIN              GPIO_PIN_6
-#define SPI1_MISO_GPIO_PORT        GPIOA
+#define SPI1_MISO_PIN              GPIO_PIN_4
+#define SPI1_MISO_GPIO_PORT        GPIOB
 #define SPI1_MISO_AF               GPIO_AF5_SPI1
-#define SPI1_MOSI_PIN              GPIO_PIN_7
-#define SPI1_MOSI_GPIO_PORT        GPIOA
+#define SPI1_MOSI_PIN              GPIO_PIN_5
+#define SPI1_MOSI_GPIO_PORT        GPIOB
 #define SPI1_MOSI_AF               GPIO_AF5_SPI1
-#define SPI1_NSS_GPIO_PORT         GPIOA
-#define SPI1_NSS_PIN               GPIO_PIN_4
+#define SPI1_NSS_GPIO_PORT         GPIOB
+#define SPI1_NSS_PIN               GPIO_PIN_2
 
 static inline void spi1_enable_gpio_clocks(void) {
-	__HAL_RCC_GPIOA_CLK_ENABLE();
+	__HAL_RCC_GPIOB_CLK_ENABLE();
 }
 
 static inline void spi1_enable_spi_clocks(void) {

--- a/src/drivers/spi/stm32/stm32.c
+++ b/src/drivers/spi/stm32/stm32.c
@@ -28,7 +28,7 @@ static int stm32_spi_setup(struct stm32_spi *dev, void *instance, bool is_master
 	handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
 	handle->Init.Direction         = SPI_DIRECTION_2LINES;
 	handle->Init.CLKPhase          = SPI_PHASE_1EDGE;
-	handle->Init.CLKPolarity       = SPI_POLARITY_HIGH;
+	handle->Init.CLKPolarity       = SPI_POLARITY_LOW;
 	handle->Init.CRCCalculation    = SPI_CRCCALCULATION_DISABLE;
 	handle->Init.CRCPolynomial     = 7;
 	handle->Init.DataSize          = SPI_DATASIZE_8BIT;

--- a/src/drivers/spi/stm32/stm32.c
+++ b/src/drivers/spi/stm32/stm32.c
@@ -80,8 +80,6 @@ static int stm32_spi_transfer(struct spi_device *dev, uint8_t *inbuf,
 		/* Note: we suppose that there's a single slave device
 		 * on the SPI bus, so we lower the same pin all the tiem */
 		HAL_GPIO_WritePin(priv->nss_port, priv->nss_pin, GPIO_PIN_RESET);
-
-		__HAL_SPI_ENABLE(handle);
 	}
 
 	ret = HAL_SPI_TransmitReceive(handle, inbuf, outbuf, count, 5000);
@@ -93,7 +91,6 @@ static int stm32_spi_transfer(struct spi_device *dev, uint8_t *inbuf,
 		;
 
 	if (dev->flags & SPI_CS_INACTIVE && dev->is_master) {
-		__HAL_SPI_DISABLE(handle);
 		/* Note: we suppose that there's a single slave device
 		 * on the SPI bus, so we raise the same pin all the tiem */
 		HAL_GPIO_WritePin(priv->nss_port, priv->nss_pin, GPIO_PIN_SET);

--- a/src/drivers/spi/stm32/stm32_spi1.c
+++ b/src/drivers/spi/stm32/stm32_spi1.c
@@ -35,23 +35,25 @@ static int stm32_spi1_init(void) {
 	GPIO_InitStruct.Pull      = GPIO_PULLUP;
 	GPIO_InitStruct.Speed     = GPIO_SPEED_LOW;
 	GPIO_InitStruct.Alternate = SPI1_SCK_AF;
-
 	HAL_GPIO_Init(SPI1_SCK_GPIO_PORT, &GPIO_InitStruct);
 
 	GPIO_InitStruct.Pin = SPI1_MISO_PIN;
 	GPIO_InitStruct.Alternate = SPI1_MISO_AF;
-
 	HAL_GPIO_Init(SPI1_MISO_GPIO_PORT, &GPIO_InitStruct);
 
 	GPIO_InitStruct.Pin = SPI1_MOSI_PIN;
 	GPIO_InitStruct.Alternate = SPI1_MOSI_AF;
-
 	HAL_GPIO_Init(SPI1_MOSI_GPIO_PORT, &GPIO_InitStruct);
 
-	GPIO_InitStruct.Pin = SPI1_NSS_PIN;
-	GPIO_InitStruct.Alternate = SPI1_MOSI_AF;
+	/* Chip Select is usual GPIO pin. */
+	GPIO_InitStruct.Pin       = SPI1_NSS_PIN;
+	GPIO_InitStruct.Mode      = GPIO_MODE_OUTPUT_PP;
+	GPIO_InitStruct.Pull      = GPIO_PULLUP;
+	GPIO_InitStruct.Speed     = GPIO_SPEED_FAST;
+	HAL_GPIO_Init(SPI1_NSS_GPIO_PORT, &GPIO_InitStruct);
 
-	HAL_GPIO_Init(SPI1_MOSI_GPIO_PORT, &GPIO_InitStruct);
+	/* Chip Select is in inactive state by default. */
+	HAL_GPIO_WritePin(SPI1_NSS_GPIO_PORT, SPI1_NSS_PIN, GPIO_PIN_SET);
 
 	return 0;
 }

--- a/src/drivers/spi/stm32/stm32_spi2.c
+++ b/src/drivers/spi/stm32/stm32_spi2.c
@@ -35,23 +35,25 @@ static int stm32_spi2_init(void) {
 	GPIO_InitStruct.Pull      = GPIO_PULLUP;
 	GPIO_InitStruct.Speed     = GPIO_SPEED_LOW;
 	GPIO_InitStruct.Alternate = SPI2_SCK_AF;
-
 	HAL_GPIO_Init(SPI2_SCK_GPIO_PORT, &GPIO_InitStruct);
 
 	GPIO_InitStruct.Pin = SPI2_MISO_PIN;
 	GPIO_InitStruct.Alternate = SPI2_MISO_AF;
-
 	HAL_GPIO_Init(SPI2_MISO_GPIO_PORT, &GPIO_InitStruct);
 
 	GPIO_InitStruct.Pin = SPI2_MOSI_PIN;
 	GPIO_InitStruct.Alternate = SPI2_MOSI_AF;
-
 	HAL_GPIO_Init(SPI2_MOSI_GPIO_PORT, &GPIO_InitStruct);
 
-	GPIO_InitStruct.Pin = SPI2_NSS_PIN;
-	GPIO_InitStruct.Alternate = SPI2_MOSI_AF;
-
+	/* Chip Select is usual GPIO pin. */
+	GPIO_InitStruct.Pin       = SPI2_NSS_PIN;
+	GPIO_InitStruct.Mode      = GPIO_MODE_OUTPUT_PP;
+	GPIO_InitStruct.Pull      = GPIO_PULLUP;
+	GPIO_InitStruct.Speed     = GPIO_SPEED_FAST;
 	HAL_GPIO_Init(SPI2_NSS_GPIO_PORT, &GPIO_InitStruct);
+
+	/* Chip Select is in inactive state by default. */
+	HAL_GPIO_WritePin(SPI2_NSS_GPIO_PORT, SPI2_NSS_PIN, GPIO_PIN_SET);
 
 	return 0;
 }


### PR DESCRIPTION
* Fix stm32 SPI
* Add SPI setup for l3g4200d

There can be both I2C and SPI module at once in one configuration, but it requires more complex sensors storage, so I currently add abstract module l3g4200d and two implementations - l3g4200d_i2c and l3g4200d_spi.