### PR TITLE
vfs: Free super block in kumount()

### DIFF
--- a/src/fs/driver/cifs/cifs.c
+++ b/src/fs/driver/cifs/cifs.c
@@ -193,7 +193,6 @@ static int embox_cifs_umount(struct inode *dir) {
 			}
 			pool_free(&cifs_fs_pool, fsi);
 		}
-		super_block_free(dir_nas->fs);
 	}
 
 	return 0;

--- a/src/fs/driver/ext2/ext2.c
+++ b/src/fs/driver/ext2/ext2.c
@@ -913,7 +913,6 @@ static void ext2_free_fs(struct nas *nas) {
 			}
 			pool_free(&ext2_fs_pool, fsi);
 		}
-		super_block_free(nas->fs);
 	}
 
 	if(NULL != (fi = inode_priv(nas->node))) {

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -829,7 +829,6 @@ static void ext4_free_fs(struct inode *node) {
 			}
 			pool_free(&ext4_fs_pool, fsi);
 		}
-		super_block_free(node->i_sb);
 	}
 
 	if (NULL != (fi = inode_priv(node))) {

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -120,7 +120,6 @@ static void fat_free_fs(struct nas *nas) {
 		if(NULL != fsi) {
 			fat_fs_free(fsi);
 		}
-		super_block_free(nas->fs);
 	}
 
 	if (NULL != inode_priv(nas->node)) {

--- a/src/fs/driver/iso9660/cdfs.c
+++ b/src/fs/driver/iso9660/cdfs.c
@@ -849,7 +849,6 @@ static void cdfs_free_fs(struct nas *nas) {
 		if(NULL != fsi) {
 			pool_free(&cdfs_fs_pool, fsi);
 		}
-		super_block_free(nas->fs);
 	}
 
 	if (NULL != (fi = inode_priv(nas->node))) {

--- a/src/fs/driver/jffs2/jffs2.c
+++ b/src/fs/driver/jffs2/jffs2.c
@@ -1456,7 +1456,6 @@ static int jffs2_free_fs(struct nas *nas) {
 		if(NULL != fsi) {
 			pool_free(&jffs2_fs_pool, fsi);
 		}
-		super_block_free(nas->fs);
 	}
 
 	if(NULL != (fi = inode_priv(nas->node))) {

--- a/src/fs/driver/nfs/nfs.c
+++ b/src/fs/driver/nfs/nfs.c
@@ -336,7 +336,6 @@ static void nfs_free_fs(struct inode *node) {
 			nfs_clnt_destroy(fsi);
 			pool_free(&nfs_fs_pool, fsi);
 		}
-		super_block_free(node->i_sb);
 	}
 
 	if(NULL != (fi = inode_priv(node))) {

--- a/src/fs/driver/ntfs/ntfs.c
+++ b/src/fs/driver/ntfs/ntfs.c
@@ -371,7 +371,6 @@ static int embox_ntfs_umount(struct inode *dir) {
 			}
 			pool_free(&ntfs_fs_pool, fsi);
 		}
-		super_block_free(dir_nas->fs);
 	}
 
 	return 0;

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -411,6 +411,7 @@ int kmount(const char *source, const char *dest, const char *fs_type) {
 
 	if (NULL == mount_table_add(&dir_node, root_path.node, dest)) {
 		drv->fsop->umount(dir_node.node);
+		super_block_free(sb);
 		//todo free root
 		errno = -res;
 		return -1;
@@ -649,9 +650,11 @@ int kumount(const char *dir) {
 		return res;
 	}
 
-	if(0 != (res = drv->fsop->umount(dir_node.node))) {
+	if (0 != (res = drv->fsop->umount(dir_node.node))) {
 		return res;
 	}
+
+	super_block_free(dir_node.node->i_sb);
 
 	if (dir_node.node != vfs_get_root()) {
 		node_free(dir_node.node);


### PR DESCRIPTION
Make super_block allocation/freeing symmetric: if it's allocated in `kmount()`, it probably should be freed in `kumount()`. Also it deduplicates some code in fs drivers.