### PR TITLE
Mount rework

### DIFF
--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -60,11 +60,12 @@ extern struct dev_module **get_cdev_tab(void);
  * @brief Find file in directory
  *
  * @param name Name of file
- * @param dir  Pointer to directory
+ * @param dir  Not used in this driver as we assume there are no nested
+ * directories
  *
  * @return Pointer to inode structure or NULL if failed
  */
-static struct inode *devfs_lookup(char const *name, struct dentry const *dir) {
+static struct inode *devfs_lookup(char const *name, struct inode const *dir) {
 	int i;
 	struct inode *node;
 	struct block_dev **bdevtab = get_bdev_tab();

--- a/src/fs/driver/devfs/devfs_dvfs.c
+++ b/src/fs/driver/devfs/devfs_dvfs.c
@@ -70,7 +70,7 @@ static struct inode *devfs_lookup(char const *name, struct dentry const *dir) {
 	struct block_dev **bdevtab = get_bdev_tab();
 	struct dev_module **cdevtab = get_cdev_tab();
 
-	if (NULL == (node = dvfs_alloc_inode(dir->d_sb))) {
+	if (NULL == (node = dvfs_alloc_inode(dir->i_sb))) {
 		return NULL;
 	}
 
@@ -92,11 +92,6 @@ static struct inode *devfs_lookup(char const *name, struct dentry const *dir) {
 	dvfs_destroy_inode(node);
 
 	return NULL;
-}
-
-static int devfs_mount_end(struct super_block *sb) {
-	char_dev_init_all();
-	return block_devs_init();
 }
 
 extern struct idesc_ops idesc_bdev_ops;
@@ -153,13 +148,13 @@ static int devfs_fill_sb(struct super_block *sb, const char *source) {
 	sb->sb_fops = &devfs_fops;
 	sb->sb_ops  = &devfs_sbops;
 
-	return 0;
+	char_dev_init_all();
+	return block_devs_init();
 }
 
 static const struct fs_driver devfs_dumb_driver = {
 	.name      = "devfs",
 	.fill_sb   = devfs_fill_sb,
-	.mount_end = devfs_mount_end,
 };
 
 ARRAY_SPREAD_DECLARE(const struct fs_driver *const, fs_drivers_registry);

--- a/src/fs/driver/devfs/devfs_oldfs.c
+++ b/src/fs/driver/devfs/devfs_oldfs.c
@@ -121,11 +121,12 @@ extern struct dev_module **get_cdev_tab(void);
  * @brief Find file in directory
  *
  * @param name Name of file
- * @param dir  Pointer to directory
+ * @param dir  Not used in this driver as we assume there are no nested
+ * directories
  *
  * @return Pointer to inode structure or NULL if failed
  */
-static struct inode *devfs_lookup(char const *name, struct dentry const *dir) {
+static struct inode *devfs_lookup(char const *name, struct inode const *dir) {
 	struct block_dev **bdevs;
 	int i;
 	struct dev_module **cdevtab;

--- a/src/fs/driver/ext2fuse/ext2fuse.c
+++ b/src/fs/driver/ext2fuse/ext2fuse.c
@@ -27,14 +27,9 @@ static int ext2fuse_fill_sb(struct super_block *sb, const char *source) {
 	return 0;
 }
 
-static int ext2fuse_mount_end(struct super_block *sb) {
-	return 0;
-}
-
 static const struct fs_driver ext2fuse_dumb_driver = {
 	.name      = "ext2fuse",
 	.fill_sb   = ext2fuse_fill_sb,
-	.mount_end = ext2fuse_mount_end,
 };
 
 ARRAY_SPREAD_DECLARE(const struct fs_driver *const, fs_drivers_registry);

--- a/src/fs/driver/fat/fat_common.c
+++ b/src/fs/driver/fat/fat_common.c
@@ -2011,7 +2011,7 @@ int fat_fill_sb(struct super_block *sb, const char *source) {
 	struct fat_fs_info *fsi;
 	struct block_dev *bdev;
 	struct dirinfo *di = NULL;
-	int rc;
+	int rc = 0;
 
 	assert(sb);
 

--- a/src/fs/driver/fat/fat_dvfs.c
+++ b/src/fs/driver/fat/fat_dvfs.c
@@ -119,11 +119,11 @@ err_out:
  * as it wipes dirinfo content
  *
  * @param name Full path to the extected node
- * @param dir  Not used now
+ * @param dir  Inode of corresponding parent directory
  *
  * @return Pointer of inode or NULL if not found
  */
-static struct inode *fat_ilookup(char const *name, struct dentry const *dir) {
+static struct inode *fat_ilookup(char const *name, struct inode const *dir) {
 	struct dirinfo *di;
 	struct fat_dirent de;
 	struct super_block *sb;
@@ -135,11 +135,10 @@ static struct inode *fat_ilookup(char const *name, struct dentry const *dir) {
 	int found = 0;
 
 	assert(name);
-	assert(dir->d_inode);
-	assert(S_ISDIR(dir->d_inode->i_mode));
+	assert(S_ISDIR(dir->i_mode));
 
-	sb = dir->d_sb;
-	di = dir->d_inode->i_data;
+	sb = dir->i_sb;
+	di = inode_priv(dir);
 
 	assert(di);
 

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -112,14 +112,6 @@ static int fat_create_dir_entry(struct nas *parent_nas,
 	return ENOERR;
 }
 
-static void fat_free_fs(struct super_block *sb) {
-	struct fat_fs_info *fsi = sb->sb_data;
-
-	if (NULL != fsi) {
-		fat_fs_free(fsi);
-	}
-}
-
 static int fatfs_umount_entry(struct inode *node) {
 	if (node_is_directory(node)) {
 		fat_dirinfo_free(inode_priv(node));
@@ -133,13 +125,13 @@ static int fatfs_umount_entry(struct inode *node) {
 extern struct file_operations fat_fops;
 
 struct inode_operations fat_iops;
+struct super_block_operations { };
 struct super_block_operations fat_sbops;
 extern int fat_fill_sb(struct super_block *sb, const char *source);
 extern int fat_clean_sb(struct super_block *sb);
 
 static int fatfs_mount(struct super_block *sb, struct inode *dest) {
 	struct dirinfo *di;
-	struct fat_fs_info *fsi;
 	struct fat_dirent de;
 
 	di = inode_priv(dest);

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -138,44 +138,13 @@ extern int fat_fill_sb(struct super_block *sb, const char *source);
 extern int fat_clean_sb(struct super_block *sb);
 
 static int fatfs_mount(struct super_block *sb, struct inode *dest) {
-	struct nas *dir_nas;
 	struct dirinfo *di;
 	struct fat_fs_info *fsi;
-	uint32_t pstart, psize;
-	uint8_t pactive, ptype;
 	struct fat_dirent de;
-	int rc;
 
-	dir_nas = dest->nas;
-	fsi = sb->sb_data;
+	di = inode_priv(dest);
 
-	/* allocate this directory info */
-	if (NULL == (di = fat_dirinfo_alloc())) {
-		rc = -ENOMEM;
-		goto error;
-	}
-	memset(di, 0, sizeof(struct dirinfo));
-	inode_priv_set(dest, di);
-	di->fi.fsi = fsi;
-	di->p_scratch = fat_sector_buff;
-	fsi->root = dest;
-
-	pstart = fat_get_ptn_start(sb->bdev, 0, &pactive, &ptype, &psize);
-	if (pstart == 0xffffffff) {
-		rc = -1;
-		goto error;
-	}
-
-	if (fat_open_rootdir(fsi, di)) {
-		return -EBUSY;
-	}
-
-	return fat_create_dir_entry(dir_nas, di, &de);
-
-error:
-	fat_free_fs(sb);
-
-	return rc;
+	return fat_create_dir_entry(dest->nas, di, &de);
 }
 
 static int fatfs_create(struct inode *parent_node, struct inode *node) {

--- a/src/fs/driver/fat/fat_oldfs.c
+++ b/src/fs/driver/fat/fat_oldfs.c
@@ -37,7 +37,7 @@ static int fat_create_dir_entry(struct nas *parent_nas,
 	struct inode *node;
 	mode_t mode;
 	int ret;
-	struct dirinfo *new_di;
+	struct dirinfo *new_di = NULL;
 	struct fat_fs_info *fsi = parent_nas->fs->sb_data;
 
 	fat_reset_dir(parent_di);

--- a/src/fs/driver/fuse/fuse_fs_driver.c
+++ b/src/fs/driver/fuse/fuse_fs_driver.c
@@ -204,15 +204,15 @@ static size_t fuse_write(struct file_desc *desc, void *buf, size_t size) {
 	return ret;
 }
 
-static struct inode *fuse_lookup(char const *name, struct dentry const *dir) {
+static struct inode *fuse_lookup(char const *name, struct inode const *dir) {
 	struct inode *node;
 	struct fuse_req_embox *req;
 	struct task *task;
 	struct fuse_sb_priv_data *sb_fuse_data;
 
-	sb_fuse_data = dir->d_sb->sb_data;
+	sb_fuse_data = dir->i_sb->sb_data;
 
-	if (NULL == (node = dvfs_alloc_inode(dir->d_sb))) {
+	if (NULL == (node = dvfs_alloc_inode(dir->i_sb))) {
 		return NULL;
 	}
 	if (NULL == (req = fuse_req_alloc())) {
@@ -221,7 +221,7 @@ static struct inode *fuse_lookup(char const *name, struct dentry const *dir) {
 
 	fuse_fill_req(req, node, NULL);
 	task = fuse_in(sb_fuse_data);
-	sb_fuse_data->fuse_lowlevel_ops->lookup((fuse_req_t) req, dir->d_inode->i_no, name);
+	sb_fuse_data->fuse_lowlevel_ops->lookup((fuse_req_t) req, dir->i_no, name);
 	fuse_out(sb_fuse_data, task);
 	fuse_req_free(req);
 

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -207,10 +207,12 @@ static int initfs_fill_sb(struct super_block *sb, const char *source) {
 	sb->bdev = NULL;
 
 	di = pool_alloc(&initfs_dir_pool);
-	assert(di);
+	if (di == NULL) {
+		return -ENOMEM;
+	}
 
 	memset(di, 0, sizeof(struct initfs_dir_info));
-	sb->sb_root->i_data = di;
+	inode_priv_set(sb->sb_root, di);
 
 	return 0;
 }

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -173,18 +173,6 @@ static int initfs_iterate(struct inode *next, char *name, struct inode *parent, 
 	return -1;
 }
 
-static int initfs_mount_end(struct super_block *sb) {
-	struct initfs_dir_info *di;
-
-	di = pool_alloc(&initfs_dir_pool);
-	assert(di);
-
-	memset(di, 0, sizeof(struct initfs_dir_info));
-	sb->root->d_inode->i_data = di;
-
-	return 0;
-}
-
 static int initfs_destroy_inode(struct inode *inode) {
 	if (!inode->i_data) {
 		return 0;
@@ -211,10 +199,18 @@ struct inode_operations initfs_iops = {
 extern struct file_operations initfs_fops;
 
 static int initfs_fill_sb(struct super_block *sb, const char *source) {
+	struct initfs_dir_info *di;
+
 	sb->sb_iops = &initfs_iops;
 	sb->sb_fops = &initfs_fops;
 	sb->sb_ops  = &initfs_sbops;
 	sb->bdev = NULL;
+
+	di = pool_alloc(&initfs_dir_pool);
+	assert(di);
+
+	memset(di, 0, sizeof(struct initfs_dir_info));
+	sb->sb_root->i_data = di;
 
 	return 0;
 }
@@ -222,7 +218,6 @@ static int initfs_fill_sb(struct super_block *sb, const char *source) {
 static const struct fs_driver initfs_dumb_driver = {
 	.name      = "initfs",
 	.fill_sb   = initfs_fill_sb,
-	.mount_end = initfs_mount_end,
 };
 
 ARRAY_SPREAD_DECLARE(const struct fs_driver *const, fs_drivers_registry);

--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -99,12 +99,12 @@ static int initfs_fill_inode(struct inode *node, char *cpio,
 	return 0;
 }
 
-static struct inode *initfs_lookup(char const *name, struct dentry const *dir) {
+static struct inode *initfs_lookup(char const *name, struct inode const *dir) {
 	extern char _initfs_start;
 	char *cpio = &_initfs_start;
 	struct cpio_entry entry;
 	struct inode *node = NULL;
-	struct initfs_dir_info *di = dir->d_inode->i_data;
+	struct initfs_dir_info *di = inode_priv(dir);
 
 	while ((cpio = cpio_parse_entry(cpio, &entry))) {
 		if (!memcmp(di->path, entry.name, di->path_len) &&
@@ -118,7 +118,7 @@ static struct inode *initfs_lookup(char const *name, struct dentry const *dir) {
 				break;
 			}
 
-			node = dvfs_alloc_inode(dir->d_sb);
+			node = dvfs_alloc_inode(dir->i_sb);
 			if (node == NULL) {
 				break;
 			}

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -187,10 +187,6 @@ struct super_block_operations ramfs_sbops = {
 	.destroy_inode = ramfs_destroy_inode,
 };
 
-static int ramfs_mount_end(struct super_block *sb) {
-	return 0;
-}
-
 static int ramfs_format(struct block_dev *bdev, void *priv) {
 	if (NULL == bdev) {
 		return -ENODEV;
@@ -206,7 +202,6 @@ static int ramfs_format(struct block_dev *bdev, void *priv) {
 static const struct fs_driver ramfs_dumb_driver = {
 	.name      = "ramfs",
 	.fill_sb   = ramfs_fill_sb,
-	.mount_end = ramfs_mount_end,
 	.format    = ramfs_format,
 };
 

--- a/src/fs/driver/ramfs/ramfs_dvfs.c
+++ b/src/fs/driver/ramfs/ramfs_dvfs.c
@@ -113,16 +113,15 @@ static int ramfs_truncate(struct inode *inode, size_t len) {
 	return 0;
 }
 
-static struct inode *ramfs_ilookup(char const *name, struct dentry const *dir) {
+static struct inode *ramfs_ilookup(char const *name, struct inode const *dir) {
 	struct inode *node;
 	struct super_block *sb;
 
 	assert(dir);
-	assert(dir->d_inode);
-	assert(dir->d_inode->i_sb);
-	assert(dir->d_inode->i_sb->sb_data);
+	assert(dir->i_sb);
+	assert(dir->i_sb->sb_data);
 
-	sb = dir->d_inode->i_sb;
+	sb = dir->i_sb;
 
 	for (int i = 0; i < RAMFS_FILES; i++) {
 		if (ramfs_files[i].fsi != sb->sb_data) {

--- a/src/fs/driver/ramfs/ramfs_oldfs.c
+++ b/src/fs/driver/ramfs/ramfs_oldfs.c
@@ -120,6 +120,7 @@ static int ramfs_format(struct block_dev *bdev, void *priv) {
 }
 
 struct inode_operations ramfs_iops;
+struct super_block_operations { };
 struct super_block_operations ramfs_sbops;
 static int ramfs_mount(struct super_block *sb, struct inode *dest) {
 	struct ramfs_file_info *fi;

--- a/src/fs/dvfs/dvfs.h
+++ b/src/fs/dvfs/dvfs.h
@@ -22,6 +22,7 @@
 #include <fs/dir_context.h>
 #include <fs/inode.h>
 #include <fs/dentry.h>
+#include <fs/super_block.h>
 #include <sys/stat.h>
 
 /*****************
@@ -43,19 +44,6 @@ struct super_block;
 struct lookup;
 struct inode_operations;
 struct dir_ctx;
-
-struct super_block {
-	const struct fs_driver *fs_drv; /* Assume that all FS have single driver */
-	struct block_dev            *bdev;
-	struct dentry               *root;
-	struct dlist_head           *inode_list;
-
-	struct super_block_operations *sb_ops;
-	struct inode_operations       *sb_iops;
-	struct file_operations        *sb_fops;
-
-	void *sb_data;
-};
 
 struct super_block_operations {
 	struct inode *(*alloc_inode)(struct super_block *sb);
@@ -108,9 +96,6 @@ extern struct dentry *dvfs_cache_lookup(const char *path, struct dentry *base);
 extern struct dentry *dvfs_cache_get(char *path, struct lookup *lookup);
 extern int dvfs_cache_del(struct dentry *dentry);
 extern int dvfs_cache_add(struct dentry *dentry);
-
-extern struct super_block *super_block_alloc(const char *fs_type, const char *source);
-extern int super_block_free(struct super_block *sb);
 
 extern struct block_dev *bdev_by_path(const char *source);
 extern int dvfs_mount(const char *dev, const char *dest, const char *fstype, int flags);

--- a/src/fs/dvfs/dvfs_dentry.c
+++ b/src/fs/dvfs/dvfs_dentry.c
@@ -129,7 +129,7 @@ int dvfs_path_walk(const char *path, struct dentry *parent, struct lookup *looku
 	assert(parent->d_sb->sb_iops);
 	assert(parent->d_sb->sb_iops->lookup);
 
-	if (!(in = parent->d_sb->sb_iops->lookup(buff, parent))) {
+	if (!(in = parent->d_sb->sb_iops->lookup(buff, parent->d_inode))) {
 		*lookup = (struct lookup) {
 			.item   = NULL,
 			.parent = parent,

--- a/src/fs/dvfs/file_desc.h
+++ b/src/fs/dvfs/file_desc.h
@@ -23,7 +23,7 @@ struct file_desc {
 
 	off_t pos;
 
-	struct file_operations *f_ops;
+	const struct file_operations *f_ops;
 };
 
 extern off_t file_get_pos(struct file_desc *file);

--- a/src/fs/dvfs/fs_driver.h
+++ b/src/fs/dvfs/fs_driver.h
@@ -19,7 +19,6 @@ struct fs_driver {
 	const char name[FS_DRV_NAME_LEN];
 	int (*format)(struct block_dev *dev, void *priv);
 	int (*fill_sb)(struct super_block *sb, const char *source);
-	int (*mount_end)(struct super_block *sb);
 	int (*clean_sb)(struct super_block *sb);
 };
 

--- a/src/fs/dvfs/inode.c
+++ b/src/fs/dvfs/inode.c
@@ -14,6 +14,6 @@ void inode_priv_set(struct inode *node, void *priv) {
 	node->i_data = priv;
 }
 
-void *inode_priv(struct inode *node) {
+void *inode_priv(const struct inode *node) {
 	return node->i_data;
 }

--- a/src/fs/dvfs/inode.h
+++ b/src/fs/dvfs/inode.h
@@ -31,7 +31,7 @@ struct inode {
 	void *i_data;
 };
 
-extern void *inode_priv(struct inode *node);
+extern void *inode_priv(const struct inode *node);
 extern void inode_priv_set(struct inode *node, void *priv);
 
 #endif /* SRC_FS_DVFS_INODE_H_ */

--- a/src/fs/inode.c
+++ b/src/fs/inode.c
@@ -121,7 +121,7 @@ void node_free(struct inode *node) {
 	pool_free(&node_pool, member_cast_out(node, struct node_tuple, node));
 }
 
-void *inode_priv(struct inode *node) {
+void *inode_priv(const struct inode *node) {
 	assert(node);
 
 	return node->nas->fi->privdata;

--- a/src/fs/inode.c
+++ b/src/fs/inode.c
@@ -95,8 +95,7 @@ struct inode *node_alloc(const char *name, size_t name_len) {
 		name_len = strlen(name);
 	}
 
-	if (!*name || name_len > NAME_MAX) {
-		/* TODO behave more clever here? -- Eldar */
+	if (name_len > NAME_MAX) {
 		return NULL;
 	}
 
@@ -109,7 +108,7 @@ struct inode *node_alloc(const char *name, size_t name_len) {
 	node->name[name_len] = '\0';
 
 	/* it's for permanent linked inode to file tree */
-	node->i_nlink ++;
+	node->i_nlink++;
 
 	return node;
 }

--- a/src/fs/inode.h
+++ b/src/fs/inode.h
@@ -91,7 +91,7 @@ extern void inode_del(struct inode *node);
 extern struct inode *node_alloc(const char *name, size_t name_len);
 
 extern void node_free(struct inode *node);
-extern void *inode_priv(struct inode *node);
+extern void *inode_priv(const struct inode *node);
 extern void inode_priv_set(struct inode *node, void *priv);
 
 static inline int node_is_directory(struct inode *node) {

--- a/src/fs/super_block.c
+++ b/src/fs/super_block.c
@@ -42,14 +42,18 @@ struct super_block *super_block_alloc(const char *fs_type, const char *source) {
 	return sb;
 }
 
-void super_block_free(struct super_block *sb) {
+int super_block_free(struct super_block *sb) {
+	int ret = 0;
+
 	if (NULL == sb) {
 		return;
 	}
 
 	if (sb->fs_drv->clean_sb) {
-		sb->fs_drv->clean_sb(sb);
+		ret = sb->fs_drv->clean_sb(sb);
 	}
 
 	pool_free(&super_block_pool, sb);
+
+	return ret;
 }

--- a/src/fs/super_block.c
+++ b/src/fs/super_block.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include <embox/unit.h>
+#include <fs/dentry.h>
 #include <fs/fs_driver.h>
 #include <fs/inode.h>
 #include <fs/super_block.h>
@@ -31,8 +32,10 @@ struct super_block *super_block_alloc(const char *fs_type, const char *source) {
 		return NULL;
 	}
 
-	node = node_alloc("/", 0);
+	node = node_alloc("", 0);
 	node->i_sb = node->nas->fs = sb;
+	node->i_mode = S_IFDIR;
+	node->i_dentry->flags = S_IFDIR;
 
 	*sb = (struct super_block) {
 		.fs_drv = drv,

--- a/src/fs/super_block.c
+++ b/src/fs/super_block.c
@@ -7,17 +7,20 @@
  */
 
 #include <string.h>
+
 #include <embox/unit.h>
-#include <fs/super_block.h>
 #include <fs/fs_driver.h>
-#include <util/array.h>
+#include <fs/inode.h>
+#include <fs/super_block.h>
 #include <mem/misc/pool.h>
+#include <util/array.h>
 
 POOL_DEF(super_block_pool, struct super_block, OPTION_GET(NUMBER,fs_quantity));
 
 struct super_block *super_block_alloc(const char *fs_type, const char *source) {
 	struct super_block *sb;
 	const struct fs_driver *drv;
+	struct inode *node;
 
 	drv = fs_driver_find(fs_type);
 	if (NULL == drv) {
@@ -28,8 +31,12 @@ struct super_block *super_block_alloc(const char *fs_type, const char *source) {
 		return NULL;
 	}
 
+	node = node_alloc("/", 0);
+	node->i_sb = node->nas->fs = sb;
+
 	*sb = (struct super_block) {
-		.fs_drv    = drv,
+		.fs_drv = drv,
+		.sb_root   = node,
 	};
 
 	if (drv->fill_sb) {
@@ -46,12 +53,14 @@ int super_block_free(struct super_block *sb) {
 	int ret = 0;
 
 	if (NULL == sb) {
-		return;
+		return EINVAL;
 	}
 
 	if (sb->fs_drv->clean_sb) {
 		ret = sb->fs_drv->clean_sb(sb);
 	}
+
+	node_free(sb->sb_root);
 
 	pool_free(&super_block_pool, sb);
 

--- a/src/fs/syslib/kfsop.c
+++ b/src/fs/syslib/kfsop.c
@@ -374,7 +374,7 @@ struct block_dev *bdev_by_path(const char *source) {
 }
 
 int kmount(const char *source, const char *dest, const char *fs_type) {
-	struct path dir_node, root_path;
+	struct path dir_node;
 	const struct fs_driver *drv;
 	struct super_block *sb;
 	const char *lastpath;
@@ -395,21 +395,13 @@ int kmount(const char *source, const char *dest, const char *fs_type) {
 		return -1;
 	}
 
-	if (0 == strcmp(dest, "/")) {
-		root_path.node = dir_node.node;
-	} else {
-		root_path.node = vfs_create_root();
-	}
-
-	root_path.node->i_sb = root_path.node->nas->fs = sb;
-
-	if (ENOERR != (res = drv->fsop->mount(sb, root_path.node))) {
+	if (ENOERR != (res = drv->fsop->mount(sb, sb->sb_root))) {
 		//todo free root
 		errno = -res;
 		return -1;
 	}
 
-	if (NULL == mount_table_add(&dir_node, root_path.node, dest)) {
+	if (NULL == mount_table_add(&dir_node, sb->sb_root, dest)) {
 		super_block_free(sb);
 		//todo free root
 		errno = -res;

--- a/src/fs/vfs.c
+++ b/src/fs/vfs.c
@@ -67,11 +67,15 @@ int vfs_get_pathbynode_tilln(struct path *node, struct path *parent, char *path,
 		size_t nnlen;
 
 		if_root_follow_up(node);
-		nnlen = strlen(node->node->name);
 
-		if (nnlen + 1 > ll) {
-			return -ERANGE;
-		}
+		/* Some root nodes are marked with "/" name which leads
+		 * to pathes like "///dev", so we want to avoid it  */
+		if (strcmp(node->node->name, "/") && node->node->name[0] != '\0') {
+			nnlen = strlen(node->node->name);
+
+			if (nnlen + 1 > ll) {
+				return -ERANGE;
+			}
 #ifdef __GNUC__
 #if __GNUC__ > 7
 #pragma GCC diagnostic push
@@ -79,14 +83,15 @@ int vfs_get_pathbynode_tilln(struct path *node, struct path *parent, char *path,
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 #endif
-		p = strncpy(p - nnlen, node->node->name, nnlen);
+			p = strncpy(p - nnlen, node->node->name, nnlen);
 #ifdef __GNUC__
 #if __GNUC__ > 7
 #pragma GCC diagnostic pop
 #endif
 #endif
-		*--p = '/';
-		ll -= nnlen + 1;
+			*--p = '/';
+			ll -= nnlen + 1;
+		}
 
 		vfs_get_parent(node, node);
 	}

--- a/src/include/fs/inode_operation.h
+++ b/src/include/fs/inode_operation.h
@@ -16,7 +16,7 @@ struct dir_ctx;
 
 struct inode_operations {
 	int           (*create)(struct inode *i_new, struct inode *i_dir, int mode);
-	struct inode *(*lookup)(char const *name, struct dentry const *dir);
+	struct inode *(*lookup)(char const *name, struct inode const *dir);
 	int           (*remove)(struct inode *inode);
 	int           (*mkdir)(struct dentry *d_new, struct dentry *d_parent);
 	int           (*rmdir)(struct dentry *dir);

--- a/src/include/fs/super_block.h
+++ b/src/include/fs/super_block.h
@@ -14,21 +14,22 @@ struct file_operations;
 struct fs_driver;
 struct inode_operations;
 struct super_block_operations;
-
-/* Stubs */
-struct super_block_operations { };
+struct dlist_head;
 
 struct super_block {
 	const struct fs_driver *fs_drv;
 	struct block_dev       *bdev;
-	void                   *sb_data;
+	struct dlist_head      *inode_list;
 
 	struct super_block_operations *sb_ops;
 	struct inode_operations       *sb_iops;
 	const struct file_operations  *sb_fops;
+
+	struct inode           *sb_root;
+	void                   *sb_data;
 };
 
 extern struct super_block *super_block_alloc(const char *fs_driver, const char *source);
-extern void super_block_free(struct super_block *sb);
+extern int super_block_free(struct super_block *sb);
 
 #endif /* SUPER_BLOCK_H_ */


### PR DESCRIPTION
A bunch of changes for VFS:
* Don't use dentries at all for FS drivers. It's achieved by:
  * Now each superblock has inode root pointer instead of dentry pointer. Previously it was used just to reference to inode date (e.g. `sb->root->d_inode->data = new_data;`)
  * `.lookup()` handlers now use inode as well
* Simplify `mount()`
  * Create and destroy root inode during super_block_alloc()/super_block_free(), so no need to do it in every FS driver
  * Get rid of `.mount_end()` handler. It turned out that all the stuff from this handler could be done in `.fill_sb()` if root inode is provided
* Finally, `struct super_block` is the same for both VFS versions
* Minor fixes for memory leaks and other bugs