### PR TITLE
Add l3g4200d gyro (spi mode) to DE0 Nano SOC

### DIFF
--- a/src/drivers/gpio/dwapb/Mybuild
+++ b/src/drivers/gpio/dwapb/Mybuild
@@ -2,7 +2,7 @@ package embox.driver.gpio
 
 module dwapb_gpio extends api {
 	option number gpio_chip_id = 0
-	option number log_level=0
+	option number log_level=1
 
 	option number base_addr=0x38034000
 

--- a/src/drivers/gpio/dwapb/Mybuild
+++ b/src/drivers/gpio/dwapb/Mybuild
@@ -4,7 +4,8 @@ module dwapb_gpio extends api {
 	option number gpio_chip_id = 0
 	option number log_level=1
 
-	option number base_addr=0x38034000
+	option number base_addr
+	option number gpio_ports
 
 	source "dwapb_gpio.c"
 

--- a/src/drivers/gpio/dwapb/dwapb_gpio.c
+++ b/src/drivers/gpio/dwapb/dwapb_gpio.c
@@ -38,7 +38,7 @@ static int dwapb_gpio_setup_mode(unsigned char port, gpio_mask_t mask, int mode)
 
 	gpio_port = (void *)(BASE_CTRL_ADDR + port * sizeof(struct gpio_dwapb_port));
 
-	log_debug("%p mask 0x%X mode %d", gpio_port, mask, mode);
+	log_debug("port %d mask 0x%X mode %d", port, mask, mode);
 	ctl = REG32_LOAD(&gpio_port->ctl);
 	ctl &= ~mask;
 	REG32_STORE(&gpio_port->ctl, ctl); /* all hardware pins */
@@ -68,7 +68,7 @@ static void dwapb_gpio_set(unsigned char port, gpio_mask_t mask, char level) {
 	} else {
 		dr &= ~mask;
 	}
-	log_debug("%p mask 0x%X mode %d", gpio_port, mask, level);
+	log_debug("%d mask 0x%X mode %d", port, mask, level);
 	REG32_STORE(&gpio_port->dr, dr);
 }
 

--- a/src/drivers/gpio/dwapb/dwapb_gpio.c
+++ b/src/drivers/gpio/dwapb/dwapb_gpio.c
@@ -19,9 +19,10 @@
 #include <drivers/gpio/gpio_driver.h>
 
 #define GPIO_CHIP_ID OPTION_GET(NUMBER,gpio_chip_id)
-#define BASE_CTRL_ADDR ((uintptr_t) OPTION_GET(NUMBER,base_addr))
+#define BASE_CTRL_ADDR(i) \
+	((uintptr_t) OPTION_GET(NUMBER,base_addr) + (i) * 0x1000)
 
-#define DWAPB_GPIO_PORTS_COUNT 4
+#define DWAPB_GPIO_PORTS_COUNT OPTION_GET(NUMBER,gpio_ports)
 
 EMBOX_UNIT_INIT(dwapb_gpio_init);
 
@@ -36,7 +37,7 @@ static int dwapb_gpio_setup_mode(unsigned char port, gpio_mask_t mask, int mode)
 	uint32_t direction;
 	uint32_t ctl;
 
-	gpio_port = (void *)(BASE_CTRL_ADDR + port * sizeof(struct gpio_dwapb_port));
+	gpio_port = (struct gpio_dwapb_port *) BASE_CTRL_ADDR(port);
 
 	log_debug("port %d mask 0x%X mode %d", port, mask, mode);
 	ctl = REG32_LOAD(&gpio_port->ctl);
@@ -60,7 +61,7 @@ static void dwapb_gpio_set(unsigned char port, gpio_mask_t mask, char level) {
 	struct gpio_dwapb_port *gpio_port;
 	uint32_t dr;
 
-	gpio_port = (void *)(BASE_CTRL_ADDR + port * sizeof(struct gpio_dwapb_port));
+	gpio_port = (struct gpio_dwapb_port *) BASE_CTRL_ADDR(port);
 	dr = REG32_LOAD(&gpio_port->dr);
 	if (level) {
 		dr |= mask;
@@ -76,7 +77,7 @@ static gpio_mask_t dwapb_gpio_get(unsigned char port, gpio_mask_t mask) {
 	struct gpio_dwapb_port *gpio_port;
 	uint32_t dr;
 
-	gpio_port = (void *)(BASE_CTRL_ADDR + port * sizeof(struct gpio_dwapb_port));
+	gpio_port = (struct gpio_dwapb_port *) BASE_CTRL_ADDR(port);
 	dr = REG32_LOAD(&gpio_port->dr);
 
 	return dr & mask;
@@ -93,4 +94,4 @@ static int dwapb_gpio_init(void) {
 	return gpio_register_chip(&dwapb_gpio_chip, GPIO_CHIP_ID);
 }
 
-PERIPH_MEMORY_DEFINE(arasan, BASE_CTRL_ADDR, 0x200);
+PERIPH_MEMORY_DEFINE(arasan, BASE_CTRL_ADDR(0), 0x1000 * DWAPB_GPIO_PORTS_COUNT);

--- a/src/drivers/sensors/l3g4200d/l3g4200d_spi.c
+++ b/src/drivers/sensors/l3g4200d/l3g4200d_spi.c
@@ -63,6 +63,8 @@ int l3g4200d_hw_init(struct l3g4200d_dev *dev) {
 	}
 	spi_set_master_mode(dev->spi_dev);
 
+	spi_select(dev->spi_dev, 0);
+
 	dev->spi_dev->flags |= SPI_CS_ACTIVE;
 	dev->spi_dev->flags |= SPI_CS_INACTIVE;
 	return 0;

--- a/src/drivers/spi/dw_spi/Mybuild
+++ b/src/drivers/spi/dw_spi/Mybuild
@@ -14,4 +14,5 @@ module dw_spi {
 
 	depends core
 	depends embox.driver.periph_memory
+	depends embox.driver.gpio.api
 }

--- a/src/drivers/spi/dw_spi/Mybuild
+++ b/src/drivers/spi/dw_spi/Mybuild
@@ -6,9 +6,9 @@ module dw_spi {
 	option number base_addr2 = 0
 	option number base_addr3 = 0
 
-	option number log_level = 0
+	option boolean spi_de0_nano_soc = false
 
-	option number bus_id = 0
+	option number log_level = 0
 
 	source "dw_spi.c"
 

--- a/src/drivers/spi/dw_spi/dw_spi.h
+++ b/src/drivers/spi/dw_spi/dw_spi.h
@@ -56,6 +56,4 @@ struct dw_spi {
 	uintptr_t base_addr;
 };
 
-extern int dw_spi_init(struct dw_spi *dw_spi, uintptr_t base_addr);
-
 #endif /* DW_SPI_H */

--- a/src/drivers/spi/dw_spi/dw_spi.h
+++ b/src/drivers/spi/dw_spi/dw_spi.h
@@ -15,6 +15,8 @@
 # define DW_SPI_CTRLR0_T         (1 << 8)
 # define DW_SPI_CTRLR0_R         (2 << 8)
 # define DW_SPI_CTRLR0_EEPROM    (3 << 8)
+# define DW_SPI_CTRLR0_SCPOL     (1 << 7)
+# define DW_SPI_CTRLR0_SCPH      (1 << 6)
 # define DW_SPI_CTRLR0_FRF_MOTO  (0 << 4)
 # define DW_SPI_CTRLR0_FRF_TI    (1 << 4)
 # define DW_SPI_CTRLR0_FRF_MIC   (2 << 4)
@@ -30,6 +32,7 @@
 #define DW_SPI_RXFLR             0x24
 #define DW_SPI_SR                0x28
 # define DW_SPI_SR_BUSY          (1 << 0)
+# define DW_SPI_SR_RFNE          (1 << 3)
 #define DW_SPI_IMR               0x2C
 #define DW_SPI_ISR               0x30
 #define DW_SPI_RISR              0x34

--- a/templates/arm/de0_nano_soc/mods.config
+++ b/templates/arm/de0_nano_soc/mods.config
@@ -28,18 +28,21 @@ configuration conf {
 	@Runlevel(2) include embox.driver.net.dwc_gmac(base_addr=0xff702000, irq_num=152)
 	@Runlevel(2) include embox.driver.net.loopback
 
-	@Runlevel(2) include embox.driver.gpio.dwapb_gpio(base_addr=0xff709000)
+	@Runlevel(2) include embox.driver.gpio.dwapb_gpio(
+		base_addr=0xff708000, gpio_ports=3, log_level=1)
 	@Runlevel(2) include embox.driver.mmc.host.dw_mmc_socfpga(log_level=1, base_addr=0xFF704000, irq_num=171)
 	@Runlevel(2) include embox.driver.mmc.mmc_core(log_level=1)
 
 	@Runlevel(2) include embox.driver.adapters.i2c_designware
 	@Runlevel(2) include embox.driver.adapters.i2c_designware_0
+	/* SPI1 shares the same pins with I2C1! */
 	@Runlevel(2) include embox.driver.adapters.i2c_designware_1
 
 	include embox.driver.sensors.adxl345
 	include embox.driver.fpga.socfpga
 
-	include embox.driver.spi.dw_spi(base_addr0=0xfff01000)
+	/* SPI1 shares the same pins with I2C1! */
+	/* include embox.driver.spi.dw_spi(base_addr1=0xfff01000, spi_de0_nano_soc=true, log_level=4) */
 
 	include embox.fs.syslib.file_system_none
 	include embox.fs.syslib.perm_stub
@@ -118,7 +121,6 @@ configuration conf {
 	include embox.cmd.i2c_tools.i2cdump
 	include embox.cmd.i2c_tools.i2cget
 	include embox.cmd.i2c_tools.i2cset
-
 
 	@Runlevel(2) include embox.mem.static_heap(heap_size=64000000)
 	@Runlevel(2) include embox.mem.heap_bm(heap_size=32000000)

--- a/templates/arm/el24d2/mods.config
+++ b/templates/arm/el24d2/mods.config
@@ -26,6 +26,9 @@ configuration conf {
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__el24d1_uart")
 	@Runlevel(0) include embox.driver.clock.cortexa9(periph_base_addr=0x39000000,irq_num=29)
 
+	@Runlevel(2) include embox.driver.gpio.dwapb_gpio(
+		base_addr=0x38034000, gpio_ports=3, log_level=1)
+
 	@Runlevel(2) include embox.driver.net.arasan(log_level=4, base_addr=0x3800f000, irq_num=105)
 	@Runlevel(2) include embox.driver.net.loopback
 


### PR DESCRIPTION
Fix DW SPI driver - in polling mode without DMA we have to fill tx fifo with data faster than fifo becomes empty, because this SPI controller automatically controls CS line state and if tx fifo becomes empty CS go high (inactive) state. Also, spi1 and i2c1 share the same GPIO pins, so I commented spi1 in mods.config and added comments. L3G4200D gyro currently works on SPI1 on DE0 Nano SOC.