### PR TITLE
mk: Stop building if used with make 4.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ $(error Unsupported Make version. \
 	please use GNU Make 3.81 or above.)
 endif
 
+ifeq (4.3, $(MAKE_VERSION))
+$(error Make 4.3 is not supported. \
+	Please consider downgrading to 4.2 or using newer version)
+endif
+
 # Disable everything, turn on undefined variables check.
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables


### PR DESCRIPTION
There's a known issue #1690 with make 4.3.

This is a temporary solution to print meaningful error if used with `make` 4.3.