### PR TITLE
stm32f4: Add workaround for spi1 due to stm32f4 errata

### DIFF
--- a/src/drivers/spi/stm32/stm32_spi1.c
+++ b/src/drivers/spi/stm32/stm32_spi1.c
@@ -9,8 +9,10 @@
 #include <string.h>
 #include <drivers/spi.h>
 #include <drivers/spi/stm32_spi_conf.h>
-
+#include <framework/mod/options.h>
 #include <embox/unit.h>
+
+#include <config/third_party/bsp/stmf4cube/arch.h>
 
 #include "stm32_spi.h"
 
@@ -23,6 +25,11 @@ static struct stm32_spi stm32_spi1 = {
 
 static int stm32_spi1_init(void) {
 	GPIO_InitTypeDef  GPIO_InitStruct;
+
+#if !OPTION_MODULE_GET(third_party__bsp__stmf4cube__arch,BOOLEAN,errata_spi_wrong_last_bit)
+	#error errata_spi_wrong_last_bit is not enabled for SPI1! \
+	       Please, enable this option in third_party.bsp.stmf4cube.arch
+#endif
 
 	spi1_enable_gpio_clocks();
 	spi1_enable_spi_clocks();

--- a/third-party/bsp/stmf4cube/Mybuild
+++ b/third-party/bsp/stmf4cube/Mybuild
@@ -127,6 +127,14 @@ static module stm32f4_discovery_bsp {
 @Build(stage=1,script="true")
 @BuildDepends(core)
 module arch extends embox.arch.arch {
+	/* STM32F40x and STM32F41x Errata sheet:
+	 *
+	 * https://www.st.com/content/ccc/resource/technical/document/errata_sheet/0a/98/58/84/86/b6/47/a2/DM00037591.pdf/files/DM00037591.pdf/jcr:content/translations/en.DM00037591.pdf
+	 *
+	 *  "2.5.2 Corrupted last bit of data and/or CRC,
+	 *  received in Master mode with delayed SCK feedback" */
+	option boolean errata_spi_wrong_last_bit = false
+
 	source "arch.c"
 
 	depends system_init

--- a/third-party/bsp/stmf4cube/arch.c
+++ b/third-party/bsp/stmf4cube/arch.c
@@ -49,8 +49,16 @@ static void SystemClock_Config(void)
   RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+#if OPTION_GET(BOOLEAN,errata_spi_wrong_last_bit)
+	/* One of possible workarounds, as suggested by
+	 * STM32F40x and STM32F41x Errata sheet is to decrease
+	 * APB clock speed. */
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV8;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV4;
+#else
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+#endif
   HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5);
 
   /* STM32F405x/407x/415x/417x Revision Z devices: prefetch is supported  */


### PR DESCRIPTION
Last bit on SPI1 with l3g4200d was wrong. Now it is fixed due to "STM32F40x and STM32F41x
Errata sheet" recommended workaround - "2.5.2 Corrupted last bit of data and/or CRC, received in Master mode with delayed SCK feedback"