### PR TITLE
Mirror Linux lsblk command

### DIFF
--- a/src/cmds/hardware/lsblk/lsblk.c
+++ b/src/cmds/hardware/lsblk/lsblk.c
@@ -5,9 +5,35 @@
  * @date Anton Bondarev
  */
 #include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
 #include <inttypes.h>
+#include <getopt.h>
 
 #include <drivers/block_dev.h>
+
+static const char *convert_unit(uint64_t *size) {
+	const char *unit;
+	if (*size < 1024) {
+		unit = "B";
+	}
+	else if (*size < 1024 * 1024) {
+		unit = "KB";
+		*size = *size/1024.0;
+	}
+	else if (*size < 1024ull * 1024 * 1024) {
+		unit = "MB";
+		*size = *size/(1024.0 * 1024);
+	}
+	else if (*size < 1024ull * 1024 * 1024 * 1024) {
+		unit = "GB";
+		*size = *size/(1024.0 * 1024 * 1024);
+	} else {
+		unit = "TB";
+		*size = *size/(1024.0 * 1024 * 1024 * 1024);
+	}
+	return unit;
+}
 
 int main(int argc, char **argv) {
 	int i;
@@ -15,6 +41,19 @@ int main(int argc, char **argv) {
 
 	bdevs = get_bdev_tab();
 	assert(bdevs);
+
+	int c;
+    bool is_bytes = false;
+
+	while ((c = getopt(argc, argv, "b")) != -1) {
+        switch (c) {
+            case 'b':
+                is_bytes = true;
+                break;
+            default:
+                break;
+        }
+    }
 
 	printf("Block devices:\n");
 	printf("  ID |  NAME          |    SIZE    | TYPE\n");
@@ -24,22 +63,36 @@ int main(int argc, char **argv) {
 			int j;
 			dev_t id;
 			const char *name;
+			const char *unit;
 			uint64_t size;
 
 			name = block_dev_name(bdevs[i]);
 			size = block_dev_size(bdevs[i]);
 			id = block_dev_id(bdevs[i]);
 
-			printf("%4d | %6s         | %10"PRId64" | %s\n",
-					id, name, size, "disk");
+			if (is_bytes) {
+				printf("%4d | %6s         | %10" PRId64 " | %s\n",
+					   id, name, size, "disk");
+			} else {
+				unit = convert_unit(&size);
+				printf("%4d | %6s         | %8" PRId64 "%s | %s\n",
+					   id, name, size, unit, "disk");
+			}
+
 			for (j = 0; j < MAX_BDEV_QUANTITY; j++) {
 				if (bdevs[j] && (bdevs[i] == block_dev_parent(bdevs[j]))) {
 					name = block_dev_name(bdevs[j]);
 					size = block_dev_size(bdevs[j]);
 					id = block_dev_id(bdevs[j]);
 
-					printf("%4d |      |--%6s | %10"PRId64" | %s\n",
-							id, name, size, "part");
+					if (is_bytes) {
+						printf("%4d |      |--%6s | %10" PRId64 " | %s\n",
+							   id, name, size, "part");
+					} else {
+						unit = convert_unit(&size);
+						printf("%4d | %6s         | %10" PRId64 "%s | %s\n",
+							   id, name, size, unit, "disk");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #1699 

- This PR improves the available `lsblk` command in Embox. It mirrors the linux [lsblk](http://man7.org/linux/man-pages/man8/lsblk.8.html) command adding the `-b, --bytes` flags to choose the unit of displaying size.

    ![lsblk](https://user-images.githubusercontent.com/20889958/75101222-af94f980-55e1-11ea-9539-814ff7b52885.PNG)

_I tried multiple ways to round the value of size to the nearest integer but they all failed resulting in the error message posted on the issue page. The current behavior is typecasting the `float` to `uint64_t` (flooring)._
