### PR TITLE
tempates: Add -mapcs-frame flag to arm templates

### DIFF
--- a/platform/etnaviv/templates/imx6/build.conf
+++ b/platform/etnaviv/templates/imx6/build.conf
@@ -9,9 +9,11 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -mtune=cortex-a9 -march=armv7-a
 CFLAGS += -mfloat-abi=soft -mno-unaligned-access -fno-omit-frame-pointer -mapcs-frame
+CFLAGS += -mapcs-frame
 
 CXXFLAGS += -fno-rtti -O0 -g -mno-unaligned-access
 CXXFLAGS += -fno-exceptions -mfloat-abi=soft -fno-omit-frame-pointer -mapcs-frame
 CXXFLAGS += -fno-threadsafe-statics -mtune=cortex-a9
+CXXFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/platform/fpga/templates/de0_nano_socfpga/build.conf
+++ b/platform/fpga/templates/de0_nano_socfpga/build.conf
@@ -11,5 +11,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mno-unaligned-access
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/platform/mesa/templates/integratorcp/build.conf
+++ b/platform/mesa/templates/integratorcp/build.conf
@@ -7,11 +7,13 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -mcpu=arm926ej-s -march=armv5te
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g
 
 CXXFLAGS += -fno-rtti -O0 -g
 CXXFLAGS += -fno-exceptions
 CXXFLAGS += -fno-threadsafe-statics -mcpu=arm926ej-s -march=armv5te
+CXXFLAGS += -mapcs-frame
 
 SYMBOLS_WITH_FILENAME ?= 0

--- a/platform/mesa/templates/mesa_imx6/build.conf
+++ b/platform/mesa/templates/mesa_imx6/build.conf
@@ -9,9 +9,11 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=soft -mno-unaligned-access
+CFLAGS += -mapcs-frame
 
 CXXFLAGS += -fno-rtti -O0 -g -mno-unaligned-access
 CXXFLAGS += -fno-exceptions -mfloat-abi=soft
 CXXFLAGS += -fno-threadsafe-statics -march=armv7-a -mtune=cortex-a9
+CXXFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/platform/nuklear/templates/arm_qemu/build.conf
+++ b/platform/nuklear/templates/arm_qemu/build.conf
@@ -7,6 +7,7 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -mcpu=arm926ej-s -march=armv5te
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g
 
@@ -14,6 +15,7 @@ LDFLAGS += -N -g
 CXXFLAGS += -fno-rtti -O0 -g -Wno-error=c++14-compat
 CXXFLAGS += -fno-exceptions
 CXXFLAGS += -fno-threadsafe-statics -mcpu=arm926ej-s -march=armv5te
+CXXFLAGS += -mapcs-frame
 #endif
 
 SYMBOLS_WITH_FILENAME ?= 0

--- a/platform/opencv/templates/arm-qemu/build.conf
+++ b/platform/opencv/templates/arm-qemu/build.conf
@@ -8,11 +8,13 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv5te -mtune=arm926ej-s
 CFLAGS += -mfloat-abi=soft
+CFLAGS += -mapcs-frame
 
 CXXFLAGS += -O0 -g -nostdinc
 CXXFLAGS += -march=armv5te -mtune=arm926ej-s
 CXXFLAGS += -mfloat-abi=soft
 CXXFLAGS += -fno-threadsafe-statics
+CXXFLAGS += -mapcs-frame
 
 /* C++ exceptions flags. Comment out these flags to enable exceptions. */
 //CXXFLAGS += -fno-rtti

--- a/platform/pjsip/templates/arm-qemu/build.conf
+++ b/platform/pjsip/templates/arm-qemu/build.conf
@@ -11,5 +11,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=soft
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/am3505/build.conf
+++ b/templates/arm/am3505/build.conf
@@ -13,6 +13,7 @@ CFLAGS += -mfloat-abi=softfp -mfpu=neon
 
 CFLAGS += -fno-stack-protector -fno-omit-frame-pointer -fno-optimize-sibling-calls
 CFLAGS += -mno-thumb-interwork -Uarm -mno-unaligned-access
+CFLAGS += -mapcs-frame
 
 
 LDFLAGS += -N -g

--- a/templates/arm/arria_v/build.conf
+++ b/templates/arm/arria_v/build.conf
@@ -11,5 +11,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/bpi/build.conf
+++ b/templates/arm/bpi/build.conf
@@ -9,6 +9,7 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a8
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g
 

--- a/templates/arm/c++_demo/build.conf
+++ b/templates/arm/c++_demo/build.conf
@@ -8,6 +8,7 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv5te -mtune=arm926ej-s
 CFLAGS += -mfpu=vfp -mfloat-abi=hard
+CFLAGS += -mapcs-frame
 
 CXXFLAGS += -O0 -g -nostdinc
 CXXFLAGS += -march=armv5te -mtune=arm926ej-s
@@ -17,5 +18,6 @@ CXXFLAGS += -fno-threadsafe-statics
 /* C++ exceptions flags. Comment out these flags to enable exceptions. */
 CXXFLAGS += -fno-rtti
 CXXFLAGS += -fno-exceptions
+CXXFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/de0_nano_soc/build.conf
+++ b/templates/arm/de0_nano_soc/build.conf
@@ -11,5 +11,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mno-unaligned-access
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/el24d2/build.conf
+++ b/templates/arm/el24d2/build.conf
@@ -11,5 +11,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/iwave_imx6/build.conf
+++ b/templates/arm/iwave_imx6/build.conf
@@ -9,5 +9,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g -mno-unaligned-access
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/omap/build.conf
+++ b/templates/arm/omap/build.conf
@@ -9,5 +9,6 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a8
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/qemu/build.conf
+++ b/templates/arm/qemu/build.conf
@@ -7,6 +7,7 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv5te -mtune=arm926ej-s
+CFLAGS += -mapcs-frame
 
 CFLAGS += -mfpu=vfp -mfloat-abi=hard
 

--- a/templates/arm/qt-app/build.conf
+++ b/templates/arm/qt-app/build.conf
@@ -7,6 +7,7 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv5te -mtune=arm926ej-s
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g
 
@@ -15,3 +16,4 @@ CXXFLAGS += -nostdinc -mcpu=arm926ej-s -march=armv5te -fno-stack-protector -Wno-
 CXXFLAGS += -fno-rtti
 CXXFLAGS += -fno-exceptions
 CXXFLAGS += -fno-threadsafe-statics
+CXXFLAGS += -mapcs-frame

--- a/templates/arm/raspi/build.conf
+++ b/templates/arm/raspi/build.conf
@@ -9,5 +9,6 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv6zk -mtune=arm1176jzf-s
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/sabrelite/build.conf
+++ b/templates/arm/sabrelite/build.conf
@@ -8,5 +8,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g -mno-unaligned-access
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/sk_imx6q/build.conf
+++ b/templates/arm/sk_imx6q/build.conf
@@ -9,5 +9,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g -mno-unaligned-access
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/test/units/build.conf
+++ b/templates/arm/test/units/build.conf
@@ -7,7 +7,7 @@ CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g
 CFLAGS += -march=armv5te -mtune=arm926ej-s
-
+CFLAGS += -mapcs-frame
 CFLAGS += -mfpu=vfp -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/templates/arm/var_som_mx6/build.conf
+++ b/templates/arm/var_som_mx6/build.conf
@@ -9,5 +9,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g -mno-unaligned-access
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g

--- a/templates/arm/vexpress-a9/build.conf
+++ b/templates/arm/vexpress-a9/build.conf
@@ -11,5 +11,6 @@ CROSS_COMPILE = arm-none-eabi-
 CFLAGS += -O0 -g
 CFLAGS += -march=armv7-a -mtune=cortex-a9
 CFLAGS += -mfloat-abi=softfp -mfpu=neon
+CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g


### PR DESCRIPTION
`-mapcs-frame` gcc option is used to make ARM stack frame in ACPS format, so we can do backtrace. It requires a bit of additional memory per each frame. So, I updated some of "big" ARM tempaletes so backtrace should work out of the box.