### PR TITLE
cmd: testing: fix incorrect parsing of command line arguments

### DIFF
--- a/src/cmds/testing/block_dev/block_dev_test.c
+++ b/src/cmds/testing/block_dev/block_dev_test.c
@@ -462,7 +462,7 @@ int main(int argc, char **argv) {
 				print_block_devs();
 				return 0;
 			case 'i':
-				iters = strtol(argv[optind], NULL, 0);
+				iters = strtol(optarg, NULL, 0);
 				break;
 			case 'h':
 			default:


### PR DESCRIPTION
The implementation currently uses optind to get follow-on parameter
of an option, but the problem with this is when getopt is returned,
optind contains the index of the next argv argument for a subsequent
call to getopt(). This commit replaces it with optarg: when getopt
encounters an option it's follow-on parameter is found in optarg.

Fixes: #1725

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>