### PR TITLE
Solved Incorrect Output of More Command On a Short File

### DIFF
--- a/src/cmds/fs/more.c
+++ b/src/cmds/fs/more.c
@@ -28,29 +28,31 @@ static void screen(FILE *fp) {
 		columns = MAX_SCREEN_WIDTH - 1;
 	}
 	lines = std->endy - std->begy;
-	endwin();
+	//endwin();
 
 	while (1) {
 		for (x = 0; x < lines - 1; x++) {
 
 			for (y = 0; y < columns; y++) {
-				buff[y] = getc(fp);
-				switch ((int) buff[y]) {
-				case EOF:
+				if(fread(&buff[y],1,1,fp)==1){
+					switch ((int) buff[y]) {
+						case '\n':
+							/*	End of the line, filling the rest of buffer */
+							memset(buff + y, ' ', columns - y);
+							y = columns;
+							break;
+						case '\t':
+							/*	Perform tab instert	*/
+							memset(buff + y, ' ', TAB_SIZE);
+							y += TAB_SIZE - 1;
+							break;
+					}
+				}
+				else{
 					for (i = 0; i < y; i++) {
 						printf("%c", buff[i]);
 					}
 					return;
-				case '\n':
-					/*	End of the line, filling the rest of buffer */
-					memset(buff + y, ' ', columns - y);
-					y = columns;
-					break;
-				case '\t':
-					/*	Perform tab instert	*/
-					memset(buff + y, ' ', TAB_SIZE);
-					y += TAB_SIZE - 1;
-					break;
 				}
 			}
 			/*	In case if we got out of the actual line size	*/

--- a/src/compat/posix/curses/curses.c
+++ b/src/compat/posix/curses/curses.c
@@ -109,7 +109,7 @@ static SCREEN * newterm(char *type, FILE *outfile, FILE *infile) {
 	screen.out = outfile;
 	screen.in = infile;
 	window_init(&screen.std_win, 0, 0, LINES, COLS, NULL, &screen.std_buff[0][0]);
-	memset(&screen.std_buff[0][0], ' ', sizeof screen.std_buff);
+	memset(&screen.std_buff[0][0],0, sizeof screen.std_buff);
 	window_init(&screen.cur_win, 0, 0, LINES, COLS, NULL, &screen.cur_buff[0][0]);
 	memset(&screen.cur_buff[0][0], 0, sizeof screen.cur_buff);
 	screen.curses_mode = true;


### PR DESCRIPTION
Removed endwin() call before the display of file contents.
Modified code to properly detect EOF of the given file.