### PR TITLE
mk: makefile: Fix stack-size error on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,11 @@ export PS1 :=
 
 .PHONY : $(sort all $(MAKECMDGOALS))
 $(sort all $(MAKECMDGOALS)) :
+
+# To account for upper limit on stack size in Mac OS X
+ifneq ($(shell uname -s), Darwin) 
 	@ulimit -s 65536 && $(MAKE) -C $(dir $(lastword $(MAKEFILE_LIST))) -f mk/main.mk $@
+else
+	@ulimit -s $(shell ulimit -Hs) && $(MAKE) -C $(dir $(lastword $(MAKEFILE_LIST))) -f mk/main.mk $@
+endif
 


### PR DESCRIPTION
Added code to change the stack size on a Mac without raising any error.

Code first checks if it is being run on a Mac. If so, it finds the maximum stack size limit allowed by the hardware and sets it with ```ulimit -s STACK_SIZE_LIMIT```.

```STACK_SIZE_LIMIT```is provided by ```ulimit -Hs```.