### PR TITLE
posix: semaphore: Add an adaptive layer to get POSIX semaphore value

### DIFF
--- a/src/compat/posix/semaphore.c
+++ b/src/compat/posix/semaphore.c
@@ -22,7 +22,9 @@ int sem_destroy(sem_t *sem) {
 }
 
 int sem_getvalue(sem_t *restrict sem, int *restrict sval) {
-	return semaphore_getvalue(sem, sval);
+	int ret = semaphore_getvalue(sem, sval);
+	*sval = sem->max_value - *sval;
+	return ret;
 }
 
 int sem_post(sem_t *sem) {


### PR DESCRIPTION
POSIX semaphore value begins from its max available value, `sem_post()` decrements it and `sem_wait()` decrements it. The kernel semaphore module does in contrary.

Temporally resolve #1750 