### PR TITLE
fs: Fix odd error codes during write access to initfs

### DIFF
--- a/src/fs/driver/initfs/initfs_dvfs.c
+++ b/src/fs/driver/initfs/initfs_dvfs.c
@@ -99,6 +99,10 @@ static int initfs_fill_inode(struct inode *node, char *cpio,
 	return 0;
 }
 
+static int initfs_create(struct inode *i_new, struct inode *i_dir, int mode) {
+	return -EACCES;
+}
+
 static struct inode *initfs_lookup(char const *name, struct inode const *dir) {
 	extern char _initfs_start;
 	char *cpio = &_initfs_start;
@@ -192,6 +196,7 @@ struct super_block_operations initfs_sbops = {
 };
 
 struct inode_operations initfs_iops = {
+	.create   = initfs_create,
 	.lookup   = initfs_lookup,
 	.iterate  = initfs_iterate,
 };

--- a/src/fs/driver/initfs/initfs_fops.c
+++ b/src/fs/driver/initfs/initfs_fops.c
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <string.h>
+#include <errno.h>
 
 #include <fs/file_operation.h>
 #include <fs/file_desc.h>
@@ -42,7 +43,12 @@ static int initfs_ioctl(struct file_desc *desc, int request, void *data) {
 	return 0;
 }
 
+static size_t initfs_write(struct file_desc *desc, void *buf, size_t size) {
+	return -EACCES;
+}
+
 struct file_operations initfs_fops = {
 	.read  = initfs_read,
+	.write = initfs_write,
 	.ioctl = initfs_ioctl,
 };

--- a/src/fs/driver/initfs/initfs_oldfs.c
+++ b/src/fs/driver/initfs/initfs_oldfs.c
@@ -80,10 +80,15 @@ static int initfs_mount(struct super_block *sb, struct inode *dest) {
 	return 0;
 }
 
+static int initfs_create_node(struct inode *parent_node, struct inode *node) {
+	return -EACCES;
+}
+
 extern struct file_operations initfs_fops;
 
 static struct fsop_desc initfs_fsop = {
 	.mount = initfs_mount,
+	.create_node = initfs_create_node,
 };
 
 static struct fs_driver initfs_driver = {


### PR DESCRIPTION
Fixed weird error codes when try write or create in initfs
`mkdir /tmp_dir`
or
`touch /tmp_file`

