### PR TITLE
Scsi simplify the logic

### DIFF
--- a/src/drivers/scsi/scsi.c
+++ b/src/drivers/scsi/scsi.c
@@ -12,32 +12,26 @@
 
 #include <drivers/usb/usb.h>
 #include <drivers/usb/class/usb_mass_storage.h>
-
 #include <drivers/scsi.h>
 
-#include <kernel/panic.h>
-
 #include <util/log.h>
+
+#define SCSI_CMD_MAX_LEN 16
 
 static inline struct usb_mass *scsi2mass(struct scsi_dev *dev) {
 	return member_cast_out(dev, struct usb_mass, scsi_dev);
 }
 
-static const struct scsi_dev_state scsi_state_test_unit;
-static const struct scsi_dev_state scsi_state_inquiry;
-static const struct scsi_dev_state scsi_state_capacity10;
-static const struct scsi_dev_state scsi_state_sense;
-
-int scsi_cmd(struct scsi_dev *sdev, void *cmd, size_t cmd_len, void *data, size_t data_len) {
+static int scsi_cmd(struct scsi_dev *sdev, void *cmd, size_t cmd_len,
+		void *data, size_t data_len) {
 	struct usb_mass *mass = scsi2mass(sdev);
 	struct scsi_cmd *scmd = cmd;
-	enum usb_direction usb_dir = USB_DIRECTION_IN;
-	int ret;
+	enum usb_direction usb_dir;
 
 	if (!sdev->attached) {
 		return -ENODEV;
 	}
-	if(scmd->scmd_opcode == SCSI_CMD_OPCODE_WRITE10) {
+	if (scmd->scmd_opcode == SCSI_CMD_OPCODE_WRITE10) {
 		usb_dir = USB_DIRECTION_OUT;
 	} else {
 		usb_dir = USB_DIRECTION_IN;
@@ -46,19 +40,15 @@ int scsi_cmd(struct scsi_dev *sdev, void *cmd, size_t cmd_len, void *data, size_
 	log_debug("opc (0x%x) cmd_len(%d), usb_dir(%d), data_len(%d)",
 		    scmd->scmd_opcode, cmd_len, usb_dir, data_len);
 	
-	ret = usb_ms_transfer(mass->usb_dev, cmd, cmd_len, usb_dir, data, data_len);
-	scsi_request_done(sdev, ret);
-
-	return ret;
+	return usb_ms_transfer(mass->usb_dev, cmd, cmd_len, usb_dir, data, data_len);
 }
 
-#define SCSI_CMD_LEN 16
 int scsi_do_cmd(struct scsi_dev *dev, struct scsi_cmd *cmd) {
-	uint8_t scmd[SCSI_CMD_LEN];
+	uint8_t scmd[SCSI_CMD_MAX_LEN];
 
 	log_debug("opcode 0x%x, len %d", cmd->scmd_opcode, cmd->scmd_len);
 
-	assert(cmd->scmd_len <= SCSI_CMD_LEN);
+	assert(cmd->scmd_len <= SCSI_CMD_MAX_LEN);
 	memset(scmd + 1, 0, cmd->scmd_len - 1);
 	scmd[0] = cmd->scmd_opcode;
 
@@ -67,6 +57,98 @@ int scsi_do_cmd(struct scsi_dev *dev, struct scsi_cmd *cmd) {
 	}
 
 	return scsi_cmd(dev, scmd, cmd->scmd_len, cmd->scmd_obuf, cmd->scmd_olen);
+}
+
+static int scsi_send_inquiry(struct scsi_dev *dev) {
+	struct scsi_cmd cmd = scsi_cmd_template_inquiry;
+	struct scsi_data_inquiry *data;
+
+	cmd.scmd_obuf = dev->scsi_data_scratchpad;
+	cmd.scmd_olen = USB_SCSI_SCRATCHPAD_LEN;
+	if (scsi_do_cmd(dev, &cmd) < 0) {
+		return -1;
+	}
+
+	data = (struct scsi_data_inquiry *) dev->scsi_data_scratchpad;
+	if ((data->dinq_devtype & SCSI_INQIRY_DEVTYPE_MASK)
+			!= SCSI_INQIRY_DEVTYPE_BLK) {
+		return -1;
+	}
+	return 0;
+}
+
+static int scsi_send_test_unit(struct scsi_dev *dev) {
+	struct scsi_cmd cmd = scsi_cmd_template_test_unit;
+
+	cmd.scmd_olen = 0;
+	return scsi_do_cmd(dev, &cmd);
+}
+
+static int scsi_send_sense(struct scsi_dev *dev) {
+	struct scsi_cmd cmd = scsi_cmd_template_sense;
+	struct scsi_data_sense *data;
+	uint8_t acode;
+
+	cmd.scmd_obuf = dev->scsi_data_scratchpad;
+	cmd.scmd_olen = sizeof(struct scsi_data_sense);
+	if (scsi_do_cmd(dev, &cmd) < 0) {
+		return -1;
+	}
+
+	data = (struct scsi_data_sense *) dev->scsi_data_scratchpad;
+	acode = data->dsns_additional_code;
+	if (!(acode == 0x28 || acode == 0x29)) {
+		log_error("Don't know how to recover unknown error %x", acode);
+		return -1;
+	}
+	return 0;
+}
+
+static int scsi_send_capacity10(struct scsi_dev *dev) {
+	struct scsi_cmd cmd = scsi_cmd_template_cap10;
+	struct scsi_data_cap10 *data;
+
+	cmd.scmd_obuf = dev->scsi_data_scratchpad;
+	cmd.scmd_olen = sizeof(struct scsi_data_cap10);
+	if (scsi_do_cmd(dev, &cmd) < 0) {
+		return -1;
+	}
+
+	data = (struct scsi_data_cap10 *) dev->scsi_data_scratchpad;
+	dev->blk_size = be32toh(data->dc10_blklen);
+	dev->blk_n = be32toh(data->dc10_lba);
+	return 0;
+}
+
+int scsi_dev_attached(struct scsi_dev *dev) {
+	int ret;
+	int test_unit_retries = 3;
+
+	dev->attached = 1;
+
+	if (scsi_send_inquiry(dev)) {
+		log_debug("INQUIRY failed");
+		return -1;
+	}
+
+	/* FIXME This logic derived from the previos variant,
+	 * but when we should issue sense? */
+	while ((ret = scsi_send_test_unit(dev)) && test_unit_retries--) {
+		scsi_send_sense(dev);
+	}
+	if (ret) {
+		log_debug("TEST UNIT failed");
+		return -1;
+	}
+
+	if (scsi_send_capacity10(dev)) {
+		log_debug("CAPACITY10 failed");
+		return -1;
+	}
+
+	scsi_disk_found(dev);
+
+	return 0;
 }
 
 static void scsi_fixup_inquiry(void *buf, struct scsi_dev *dev,
@@ -140,169 +222,6 @@ const struct scsi_cmd scsi_cmd_template_write10 = {
 	.scmd_fixup = scsi_fixup_write10,
 };
 
-int scsi_dev_init(struct scsi_dev *dev) {
-	dev->in_cmd = 0;
-
-	return 0;
-}
-
-static const char *scsi_state_to_str(const struct scsi_dev_state *state) {
-	if (state == NULL) {
-		return "start";
-	}
-	if ((intptr_t)state == (intptr_t)&scsi_state_inquiry) {
-		return "inquiry";
-	}
-	if ((intptr_t)state == (intptr_t)&scsi_state_capacity10) {
-		return "capacity10";
-	}
-	if ((intptr_t)state == (intptr_t)&scsi_state_sense) {
-		return "sense";
-	}
-	if ((intptr_t)state == (intptr_t)&scsi_state_test_unit) {
-		return "test unit";
-	}
-
-	return "user defined";
-}
-
-void scsi_state_transit(struct scsi_dev *dev,
-		const struct scsi_dev_state *to) {
-	const struct scsi_dev_state *from = dev->state;
-	const char *from_str;
-	const char *to_str;
-
-	from_str = scsi_state_to_str(from);
-	to_str = scsi_state_to_str(to);
-	log_debug("dev=%p (%s->%s)", dev, from_str, to_str);
-
-	if (from && from->sds_leave) {
-		from->sds_leave(dev);
-	}
-
-	dev->state = to;
-
-	if (to->sds_enter) {
-		to->sds_enter(dev);
-	}
-}
-
-static void scsi_inquiry_enter(struct scsi_dev *dev) {
-	struct scsi_cmd cmd = scsi_cmd_template_inquiry;
-
-	cmd.scmd_obuf = dev->scsi_data_scratchpad;
-	cmd.scmd_olen = USB_SCSI_SCRATCHPAD_LEN;
-
-	scsi_do_cmd(dev, &cmd);
-}
-
-static void scsi_inquiry_input(struct scsi_dev *dev, int res) {
-	struct scsi_data_inquiry *data;
-
-	assert(res == 0);
-
-	data = (struct scsi_data_inquiry *) dev->scsi_data_scratchpad;
-	if ((data->dinq_devtype & SCSI_INQIRY_DEVTYPE_MASK)
-			!= SCSI_INQIRY_DEVTYPE_BLK) {
-		return;
-	}
-
-	scsi_state_transit(dev, &scsi_state_test_unit);
-}
-
-static const struct scsi_dev_state scsi_state_inquiry = {
-	.sds_enter = scsi_inquiry_enter,
-	.sds_input = scsi_inquiry_input,
-};
-
-static void scsi_capacity10_enter(struct scsi_dev *dev) {
-	struct scsi_cmd cmd = scsi_cmd_template_cap10;
-
-	cmd.scmd_obuf = dev->scsi_data_scratchpad;
-	cmd.scmd_olen = sizeof(struct scsi_data_cap10);
-
-	log_debug("");
-
-	scsi_do_cmd(dev, &cmd);
-}
-
-static void scsi_capacity10_input(struct scsi_dev *dev, int res) {
-	struct scsi_data_cap10 *data;
-
-	log_debug("res %d", res);
-
-	if (res < 0) {
-		scsi_dev_recover(dev);
-		return;
-	}
-
-	data = (struct scsi_data_cap10 *) dev->scsi_data_scratchpad;
-	dev->blk_size = be32toh(data->dc10_blklen);
-	dev->blk_n = be32toh(data->dc10_lba);
-
-	scsi_disk_found(dev);
-}
-
-static const struct scsi_dev_state scsi_state_capacity10 = {
-	.sds_enter = scsi_capacity10_enter,
-	.sds_input = scsi_capacity10_input,
-};
-
-
-static void scsi_sense_enter(struct scsi_dev *dev) {
-	struct scsi_cmd cmd = scsi_cmd_template_sense;
-
-	cmd.scmd_obuf = dev->scsi_data_scratchpad;
-	cmd.scmd_olen = sizeof(struct scsi_data_sense);
-
-	log_debug("");
-
-	scsi_do_cmd(dev, &cmd);
-}
-
-static void scsi_sense_input(struct scsi_dev *dev, int res) {
-	struct scsi_data_sense *data;
-	uint8_t acode;
-
-	assert(res == 0);
-
-	data = (struct scsi_data_sense *) dev->scsi_data_scratchpad;
-	acode = data->dsns_additional_code;
-	if (!(acode == 0x28 || acode == 0x29)) {
-		panic("Don't know how to recover unknown error %x", acode);
-	}
-
-	/* 0x28 and 0x29 are just required attention, seems that can go on */
-
-	scsi_state_transit(dev, &scsi_state_test_unit);
-}
-
-static const struct scsi_dev_state scsi_state_sense = {
-	.sds_enter = scsi_sense_enter,
-	.sds_input = scsi_sense_input,
-};
-
-static void scsi_test_unit_enter(struct scsi_dev *dev) {
-	struct scsi_cmd cmd = scsi_cmd_template_test_unit;
-
-	cmd.scmd_olen = 0;
-
-	scsi_do_cmd(dev, &cmd);
-}
-
-static void scsi_test_unit_input(struct scsi_dev *dev, int res) {
-	if (res) {
-		scsi_state_transit(dev, &scsi_state_sense);
-	} else {
-		scsi_state_transit(dev, &scsi_state_capacity10);
-	}
-}
-
-static const struct scsi_dev_state scsi_state_test_unit = {
-	.sds_enter = scsi_test_unit_enter,
-	.sds_input = scsi_test_unit_input,
-};
-
 static void scsi_dev_try_release(struct scsi_dev *dev) {
 	//struct usb_dev *udev = scsi2mass(dev)->usb_dev;
 
@@ -312,36 +231,12 @@ static void scsi_dev_try_release(struct scsi_dev *dev) {
 	}
 }
 
-void scsi_dev_recover(struct scsi_dev *dev) {
-
-	assertf(dev->holded_state == NULL, "Can't recover recovering procedure");
-
-	dev->holded_state = dev->state;
-
-	scsi_state_transit(dev, &scsi_state_sense);
-}
-
-void scsi_dev_attached(struct scsi_dev *dev) {
-
-	dev->attached = 1;
-
-	dev->state = dev->holded_state = NULL;
-	scsi_state_transit(dev, &scsi_state_inquiry);
-}
-
 void scsi_dev_detached(struct scsi_dev *dev) {
 
 	dev->attached = 0;
 
 	scsi_disk_lost(dev);
 	scsi_dev_try_release(dev);
-}
-
-void scsi_request_done(struct scsi_dev *dev, int res) {
-	log_debug("state=%s res=%d", scsi_state_to_str(dev->state), res);
-	if (dev->state && dev->state->sds_input) {
-		dev->state->sds_input(dev, res);
-	}
 }
 
 void scsi_dev_use_inc(struct scsi_dev *dev) {

--- a/src/drivers/scsi/scsi.h
+++ b/src/drivers/scsi/scsi.h
@@ -17,17 +17,9 @@
 
 struct scsi_dev;
 
-struct scsi_dev_state {
-	void (*sds_enter)(struct scsi_dev *sdev);
-	void (*sds_input)(struct scsi_dev *sdev, int req_status);
-	void (*sds_leave)(struct scsi_dev *sdev);
-};
-
 #define USB_SCSI_SCRATCHPAD_LEN 36
 struct scsi_dev {
 	int idx;
-	const struct scsi_dev_state *state;
-	const struct scsi_dev_state *holded_state;
 
 	uint8_t scsi_data_scratchpad[USB_SCSI_SCRATCHPAD_LEN];
 
@@ -36,9 +28,6 @@ struct scsi_dev {
 
 	struct block_dev *bdev;
 	struct mutex m;
-	struct waitq wq;
-	char in_cmd;
-	char cmd_complete;
 	char attached;
 	unsigned int use_count;
 };
@@ -53,8 +42,6 @@ struct scsi_cmd {
 
 	size_t  scmd_lba;
 };
-
-
 
 #define SCSI_CMD_OPCODE_TEST_UNIT 0x00
 struct scsi_cmd_test_unit {
@@ -180,25 +167,19 @@ struct scsi_cmd_write10 {
 	uint8_t  sw10_control;
 } __attribute__((packed));
 
+extern const struct scsi_cmd scsi_cmd_template_test_unit;
 extern const struct scsi_cmd scsi_cmd_template_inquiry;
 extern const struct scsi_cmd scsi_cmd_template_cap10;
 extern const struct scsi_cmd scsi_cmd_template_sense;
 extern const struct scsi_cmd scsi_cmd_template_read10;
 extern const struct scsi_cmd scsi_cmd_template_write10;
 
-int scsi_dev_init(struct scsi_dev *dev);
-void scsi_dev_attached(struct scsi_dev *dev);
-void scsi_dev_detached(struct scsi_dev *dev);
-void scsi_request_done(struct scsi_dev *dev, int res);
-void scsi_dev_wake(struct scsi_dev *dev, int res);
-void scsi_disk_bdev_try_unbind(struct scsi_dev *sdev);
-
-int scsi_do_cmd(struct scsi_dev *dev, struct scsi_cmd *cmd);
-
-void scsi_dev_recover(struct scsi_dev *dev);
-void scsi_state_transit(struct scsi_dev *dev, const struct scsi_dev_state *to);
-void scsi_dev_use_inc(struct scsi_dev *dev);
-void scsi_dev_use_dec(struct scsi_dev *dev);
+extern int scsi_dev_attached(struct scsi_dev *dev);
+extern void scsi_dev_detached(struct scsi_dev *dev);
+extern void scsi_disk_bdev_try_unbind(struct scsi_dev *sdev);
+extern int scsi_do_cmd(struct scsi_dev *dev, struct scsi_cmd *cmd);
+extern void scsi_dev_use_inc(struct scsi_dev *dev);
+extern void scsi_dev_use_dec(struct scsi_dev *dev);
 
 extern void scsi_disk_found(struct scsi_dev *dev);
 extern void scsi_disk_lost(struct scsi_dev *dev);

--- a/src/drivers/usb/class/usb_mass_storage.c
+++ b/src/drivers/usb/class/usb_mass_storage.c
@@ -143,7 +143,6 @@ static void usb_mass_start(struct usb_dev *dev) {
 	}
 	log_debug("mass(blkin = %d, blkout = %d, maxlun=%d)", mass->blkin, mass->blkout, mass->maxlun);
 
-	scsi_dev_init(&mass->scsi_dev);
 	scsi_dev_attached(&mass->scsi_dev);
 }
 


### PR DESCRIPTION
The goal of this PR is just to simplify SCSI logic.

* Remove scsi per-command states. While the idea to have scsi state machine is undoubtedly good, introducing a state for each scsi command looks overcomplicated and creates additional troubles to debug and add new states. I would like to refer here to Linux `include/scsi/scsi_device.h`:

```
enum scsi_device_state {
    SDEV_CREATED = 1,   /* device created but not added to sysfs
                 * Only internal commands allowed (for inq) */
    SDEV_RUNNING,       /* device properly configured
                 * All commands allowed */
    SDEV_CANCEL,        /* beginning to delete device
***
};
```

You can see here a state machine, but not for each scsi command. In Embox there are two states only - attached and detached for now (I mean the flag `dev->attached`).

* Make mass storage to handle errors during the probe(), so here we check if scsi failed.

* (possible downgrade, minor) I removed scsi_disk_recover, since it already seems to be broken now in master, and I even have no idea how we can test it. Alternatively, I'd suggest deferring disk recovering to the future, when we would understand how to deal with it.

I verified the changes on `x86/qemu` with both OHCI and EHCI with `scripts/qemu/auto_qemu_with_usb_storage`, and with `arm/iwave_imx6` making `dd` on the flash drive inserted.