### PR TITLE
x86/lib: cmds: Extend `cpuinfo` command output

### DIFF
--- a/src/arch/x86/lib/cpu_performance/cpu_info.h
+++ b/src/arch/x86/lib/cpu_performance/cpu_info.h
@@ -3,7 +3,11 @@
 
 struct cpu_info {
 	char vendor_id[13];
-	unsigned int freq;
+	unsigned int base_freq;
+	unsigned int max_freq;
+	unsigned int FPU;
+	unsigned int SSE;
+	unsigned int MMX;
 };
 
 extern uint64_t get_cpu_counter(void);

--- a/src/cmds/cpuinfo.c
+++ b/src/cmds/cpuinfo.c
@@ -13,6 +13,11 @@
 int main(int argc, char **argv) {
 	struct cpu_info *info = get_cpu_info();
 	printf("CPU Vendor ID:              %s\n", info->vendor_id);
+	printf("CPU Base Frequency (MHz):   %u\n", info->base_freq);
+	printf("CPU Max Frequency (MHz):    %u\n", info->max_freq);
+	printf("CPU FPU Support:            %s\n", info->FPU == 1 ? "true" : "false");
+	printf("CPU MMX Support:            %s\n", info->MMX == 1 ? "true" : "false");
+	printf("CPU SSE Support:            %s\n", info->SSE == 1 ? "true" : "false");
 	printf("Current time stamp counter: %llu\n", get_cpu_counter());
 	return 0;
 }


### PR DESCRIPTION
The cpuinfo command now displays base and max frequency along with FPU,
MMX, and SSE as mentioned in issue #1758.