### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: make confload-test/buildgen
-      - run: make buildgen
+      - run: make -j $(nproc) buildgen
       - name: compress
         run: |
           mkdir mk-cache
@@ -60,5 +60,5 @@ jobs:
         if: matrix.template == 'x86/test/fs'
       - run: ./scripts/continuous/prepare.sh ${{matrix.template}}
       - run: make confload-${{matrix.template}}
-      - run: make
+      - run: make -j $(nproc)
       - run: ./scripts/continuous/run.sh ${{matrix.template}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on: [push]
+
+jobs:
+  # does Mybuilds processing and provides mk/.cache to other jobs
+  buildgen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: make confload-test/buildgen
+      - run: make buildgen
+      - name: compress
+        run: |
+          mkdir mk-cache
+          tar zcf mk-cache/archive.tar.gz mk/.cache
+      - uses: actions/upload-artifact@v1
+        with:
+          name: mk-cache
+          path: mk-cache
+
+  ci:
+    needs: buildgen
+    runs-on: ubuntu-16.04 # Embox NFS write test fails with ubuntu 18.04: "RPC: Can't decode result"
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+          - aarch64/qemu
+          - arm/qemu
+          - arm/stm32f4-discovery
+          - x86/qemu
+          - x86/smp
+          - x86/user_apps
+          - x86/qt-app
+          - x86/test/lang
+          - x86/test/net
+          - x86/test/fs
+          - x86/test/units
+          - x86/test/packetdrill
+          - x86/test/qt-vnc
+          - sparc/qemu
+          - mips/qemu
+          - ppc/qemu
+          - microblaze/qemu
+          - usermode86/debug
+    container:
+      image: embox/emdocker-test
+      options: --privileged -v /:/host
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: mk-cache
+      - name: unpack mk-cache
+        run: |
+          tar zxf mk-cache/archive.tar.gz
+          scripts/continuous/touch-mk-cache.sh
+      - run: chroot /host modprobe nfsd
+        if: matrix.template == 'x86/test/fs'
+      - run: ./scripts/continuous/prepare.sh ${{matrix.template}}
+      - run: make confload-${{matrix.template}}
+      - run: make
+      - run: ./scripts/continuous/run.sh ${{matrix.template}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ before_script:
 script:
   - set -e # make this script fail as soon as any individual command fail
   - . ./scripts/docker/docker_rc.sh
+  - run dr ./scripts/continuous/prepare.sh "$TEMPLATE"
   - dr make confload-"$TEMPLATE"
   - run dr ./scripts/continuous/build.sh
   - run dr ./scripts/continuous/run.sh "$TEMPLATE"

--- a/scripts/continuous/build.sh
+++ b/scripts/continuous/build.sh
@@ -15,7 +15,7 @@ function bell() {
 bell &
 bell_pid=$!
 
-make &> build.log
+make -j $(nproc) &> build.log
 RETVAL=$?
 tail -c 3M build.log
 

--- a/scripts/continuous/fs/img-manage.sh
+++ b/scripts/continuous/fs/img-manage.sh
@@ -98,7 +98,7 @@ check_dir() {
 	src=$1
 	dst=$2
 
-	diff -q -r --exclude=".*" $src $dst
+	diff -u -r --exclude=".*" $src $dst
 	ret=$?
 	return $ret
 }

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -93,10 +93,6 @@ test_end() {
 	fi
 }
 
-determ_dns() {
-	cat /etc/resolv.conf | sed -n 's/nameserver[\ \t]\+//p' | head -n 1 | sed 's/\(127\..\..\..\|localhost\)/$HOST_DNS_IP/'
-}
-
 tap_up() {
 	sudo /sbin/ip tuntap add mode tap tap0
 	sudo /sbin/ifconfig tap0 10.0.2.10 dstaddr 10.0.2.0 netmask 255.255.255.0 down
@@ -120,7 +116,7 @@ tap_down() {
 	sudo /sbin/ip tuntap del mode tap tap0
 }
 
-sed -i "s/CONTINIOUS_RUN_DNS_SERVER/$(determ_dns)/" conf/mods.config
+# FIXME The block can be removed, See discussion to #1703
 cp index.html conf/rootfs/index.html
 make >/dev/null 2>/dev/null
 

--- a/scripts/continuous/net/run.sh
+++ b/scripts/continuous/net/run.sh
@@ -130,6 +130,9 @@ tap_down() {
 	sudo /sbin/ip tuntap del mode tap tap0
 }
 
+sudo /etc/init.d/ntp restart
+sudo inetd
+
 # FIXME The block can be removed, See discussion to #1703
 cp index.html conf/rootfs/index.html
 make >/dev/null 2>/dev/null

--- a/scripts/continuous/prepare.sh
+++ b/scripts/continuous/prepare.sh
@@ -4,7 +4,7 @@ target=${1//\//__}
 
 x86__test__net() {
 	make confload-x86/test/ping-target
-	make
+	make -j $(nproc)
 	cp build/base/bin/embox ./ping-target
 }
 

--- a/scripts/continuous/prepare.sh
+++ b/scripts/continuous/prepare.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+target=${1//\//__}
+
+x86__test__net() {
+	make confload-x86/test/ping-target
+	make
+	cp build/base/bin/embox ./ping-target
+}
+
+if ! [ $target ] || ! type -t $target > /dev/null; then
+	echo nothing to prepare for \"$1\"
+	exit 0
+fi
+$target "$@"

--- a/scripts/continuous/touch-mk-cache.sh
+++ b/scripts/continuous/touch-mk-cache.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+C=./mk/.cache
+
+touch $C/mk/*
+find  $C/mybuild/files | xargs touch
+touch $C/mybuild/myfiles-model.mk
+touch $C/mybuild/myfiles-list.mk
+

--- a/scripts/expect/ping.exp
+++ b/scripts/expect/ping.exp
@@ -6,7 +6,7 @@ namespace import autotest::*
 
 TEST_SUITE_SETUP
 
-TEST_CASE_TARGET {Embox should ping host} {
+TEST_CASE_TARGET {Embox should ping host by IP} {
 	variable host_ip
 
 	send "ping -c 4 $host_ip\r"
@@ -15,10 +15,16 @@ TEST_CASE_TARGET {Embox should ping host} {
 	return 0
 }
 
-TEST_CASE_TARGET {Embox should ping google.com} {
-	variable host_ip
+TEST_CASE_TARGET {Embox should ping peer host by IP} {
+	send "ping -c 4 $::env(PEER_HOST_IP)\r"
+	test_assert_regexp_equal "4 packets transmitted, 4 received, \\+0 errors, 0% packet loss"
 
-	send "ping -c 4 google.com\r"
+	return 0
+}
+
+
+TEST_CASE_TARGET {Embox should ping by DNS name} {
+	send "ping -c 4 $::env(PEER_HOST_IP).xip.io\r"
 	test_assert_regexp_equal "4 packets transmitted, 4 received, \\+0 errors, 0% packet loss"
 
 	return 0

--- a/src/cmds/shell/Mybuild
+++ b/src/cmds/shell/Mybuild
@@ -1,7 +1,7 @@
 package embox.cmd.sh
 
 module shell_registry {
-	option number input_buff_sz = 80
+	option number input_buff_sz = 128
 	source "shell.c"
 
 	@IncludeExport(path="cmd")

--- a/templates/test/buildgen/build.conf
+++ b/templates/test/buildgen/build.conf
@@ -1,0 +1,5 @@
+TARGET = buildgen
+ARCH = dummy
+
+CFLAGS +=
+LDFLAGS +=

--- a/templates/test/buildgen/lds.conf
+++ b/templates/test/buildgen/lds.conf
@@ -1,0 +1,8 @@
+/* region (origin, length) */
+RAM (0x00100000, 256M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/templates/test/buildgen/mods.config
+++ b/templates/test/buildgen/mods.config
@@ -1,0 +1,4 @@
+package genconfig
+
+configuration conf {
+}

--- a/templates/x86/test/net/mods.config
+++ b/templates/x86/test/net/mods.config
@@ -126,7 +126,7 @@ configuration conf {
 	include embox.compat.posix.proc.vfork_stop_parent
 
 
-	include embox.net.lib.dns_fixed(nameserver="CONTINIOUS_RUN_DNS_SERVER")
+	include embox.net.lib.dns_fixed(nameserver="8.8.8.8")
 	include embox.demo.website
 	include embox.cmd.service
 }

--- a/templates/x86/test/net/start_script.inc
+++ b/templates/x86/test/net/start_script.inc
@@ -15,8 +15,8 @@
 "route",
 
 "ping 10.0.2.10",
-"ping 8.8.8.8",
-"ping google.com",
+"ping 192.168.128.128",
+"ping 192.168.128.128.xip.io",
 "httpd &",
 "telnetd &",
 "service dropbear -F",

--- a/templates/x86/test/ping-target/build.conf
+++ b/templates/x86/test/ping-target/build.conf
@@ -1,0 +1,9 @@
+TARGET = embox
+ARCH = usermode86
+
+CFLAGS += -O0 -g -fno-stack-protector
+CFLAGS += -nostdinc -m32
+
+LDFLAGS += -g -m elf_i386
+FINAL_LINK_WITH_CC = 1
+FINAL_LDFLAGS = -g -m32 -ldl

--- a/templates/x86/test/ping-target/lds.conf
+++ b/templates/x86/test/ping-target/lds.conf
@@ -1,0 +1,8 @@
+/* region (origin, length) */
+RAM (0x0, 32M) /* whole goes to the phymem */
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/templates/x86/test/ping-target/mods.config
+++ b/templates/x86/test/ping-target/mods.config
@@ -1,0 +1,142 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.usermode86.host
+	include embox.arch.usermode86.locore
+	include embox.arch.usermode86.ipl
+	include embox.arch.usermode86.context
+	include embox.compat.posix.proc.exec_stub
+	include embox.compat.posix.proc.vfork_stub
+
+	include embox.driver.diag.usermode
+	include embox.driver.interrupt.usermode
+	include embox.driver.clock.usermode
+	include embox.driver.net.usermode
+
+	include embox.driver.block_dev
+
+	include embox.driver.diag(impl="embox__driver__diag__usermode")
+	@Runlevel(2) include embox.fs.node(fnode_quantity=1024)
+	@Runlevel(2) include embox.fs.driver.fat
+	@Runlevel(2) include embox.fs.driver.cdfs
+	@Runlevel(2) include embox.fs.driver.initfs
+	@Runlevel(2) include embox.fs.driver.nfs
+	@Runlevel(2) include embox.fs.driver.ramfs
+	@Runlevel(2) include embox.fs.rootfs
+
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+	@Runlevel(1) include embox.kernel.thread.core(thread_pool_size=512, thread_stack_size=0x4000)
+	include embox.kernel.thread.signal.sigstate
+	include embox.kernel.thread.signal.siginfoq
+
+	include embox.kernel.timer.sys_timer(timer_quantity=512) // each sleep thread requires a timer
+
+	@Runlevel(2) include embox.cmd.sh.tish(prompt="%u@%h:%w%$", rich_prompt_support=1, builtin_commands="exit logout cd export mount umount")
+	@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=0)
+	include embox.cmd.net.arp
+	include embox.cmd.net.netstat
+	include embox.cmd.net.arping
+	include embox.cmd.net.rarping
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.ping
+	include embox.cmd.net.iptables
+	include embox.cmd.net.route
+	include embox.cmd.net.ftp
+	include embox.cmd.net.sftp
+	include embox.cmd.net.tftp
+	include embox.cmd.net.snmpd
+	include embox.cmd.net.ntpdate
+	include embox.cmd.net.bootpc
+	include embox.cmd.net.httpd
+	include embox.cmd.net.telnetd
+	include embox.cmd.net.nslookup
+	include embox.cmd.net.getmail
+	include embox.cmd.net.sendmail
+	include embox.cmd.net.speedtest
+
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.cd
+	include embox.cmd.fs.pwd
+	include embox.cmd.fs.ls
+	include embox.cmd.fs.rm
+	include embox.cmd.fs.mkfs
+	include embox.cmd.fs.mount
+	include embox.cmd.fs.more
+	include embox.cmd.fs.umount
+	include embox.cmd.fs.stat
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.mkdir
+	include embox.cmd.fs.cp
+	include embox.cmd.fs.mv
+
+	// include embox.cmd.cpuinfo
+
+
+	include embox.cmd.help
+	include embox.cmd.man
+
+	include embox.cmd.sys.uname
+	include embox.cmd.sys.env
+	include embox.cmd.sys.export
+	include embox.cmd.sys.version
+	include embox.cmd.sys.shutdown
+	include embox.cmd.msleep
+
+	include embox.cmd.lsmod
+	include embox.cmd.test
+
+	include embox.cmd.trace_blocks
+	include embox.cmd.trace_points
+	include embox.cmd.mem
+	include embox.cmd.wmem
+
+	include embox.cmd.proc.nice
+	include embox.cmd.proc.renice
+
+	include embox.cmd.proc.thread
+	include embox.cmd.proc.top
+
+
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=4000)
+	@Runlevel(2) include embox.net.skbuff_data(amount_skb_data=4000,data_size=1514,data_align=1,data_padto=1,ip_align=false)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.tcp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.tcp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.net_entry
+	@Runlevel(2) include embox.test.net.socket_test(family=2,type=1,proto=0) /* AF_INET, SOCK_STREAM, default */
+	@Runlevel(2) include embox.test.net.inet_socket_test(type=1,proto=0) /* SOCK_STREAM, default */
+	@Runlevel(2) include embox.test.net.inet_dgram_socket_test(proto=0) /* default */
+	@Runlevel(2) include embox.test.net.inet_stream_socket_test(proto=0) /* default */
+
+	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
+
+	@Runlevel(2) include embox.mem.pool_adapter
+	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(2) include embox.mem.bitmask
+	@Runlevel(2) include embox.mem.static_heap(heap_size=134217728)
+	@Runlevel(2) include embox.mem.heap_bm(heap_size=67108864)
+
+
+	@Runlevel(2) include embox.util.LibUtil
+	@Runlevel(2) include embox.framework.LibFramework
+	@Runlevel(2) include embox.compat.libc.all
+	include embox.compat.libc.math_openlibm
+
+	include embox.demo.website
+}

--- a/templates/x86/test/ping-target/rootfs/hosts
+++ b/templates/x86/test/ping-target/rootfs/hosts
@@ -1,0 +1,11 @@
+#
+# hosts         This file describes a number of hostname-to-address
+#               mappings for the TCP/IP subsystem
+# Syntax:
+#
+# IP-Address  Full-Qualified-Hostname  Short-Hostname
+#
+
+127.0.0.1       localhost
+10.0.2.16       embox.example.org embox
+

--- a/templates/x86/test/ping-target/start_script.inc
+++ b/templates/x86/test/ping-target/start_script.inc
@@ -1,0 +1,8 @@
+"msleep 100",
+/* Setup loopback interface */
+"ifconfig lo 127.0.0.1 netmask 255.0.0.0 up",
+"route add 127.0.0.0 netmask 255.0.0.0 lo",
+/* Setup eth0 interface */
+"ifconfig eth0 192.168.128.128 netmask 255.255.255.0 hw ether AA:BB:CC:DD:EE:03 up",
+"route add 192.168.128.0  netmask 255.255.255.0 eth0",
+"route add default gw 192.168.128.1 eth0",


### PR DESCRIPTION
New Actions infrastructure can be used for CI
* flexible: multiple workflows and triggers, can provide
  * long tests are started nightly
  * shorter tests are started on PR/push
* 20 concurrent workers are provided by default

This PR adds Actions and makes a few changes to improve for CI cycle time. 
There are some thoughts on nightly/on-push a the bottom.

Travis before: 28:46 (https://travis-ci.org/embox/embox/builds/659590134)
Travis after: 25:30 (https://travis-ci.org/AntonKozlov/embox/builds/659745090)
Actions: 14:45 (https://github.com/AntonKozlov/embox/actions/runs/51646799)
(There is some time distribution, numbers are illustrative)

CI run organized in buildgen and actual test jobs. Buildgen only creates `mk/.cache` to avoid each test to do all Mybuilds parsing.
* this should improve test time if concurrent workers number is smaller than number of tests (now it's not: 18 tests vs 20 workers)
* but test jobs are are blocked by buildgen. If you want to compute critical path time, it's buildgen (1:07) + x86/test/qt-vnc (13:10)

Although tests can be splitted between nightly and onpush sets, this PR doesn't do this, all of them are started on each push. One reason is that I'm not sure which ones to move to nightly, the other is that I started to think nightly tests are redundant.
I think, there are no benefits of nightly/on-push compared to all-on-push policy. With the first one, when push tests states I can merge, I do and only after some time I'm notified nightly tests failed or passed. Same effect as with all-on-push, if I stop looking on results when short tests have passed. 
Nightly/on-push and all-on-push policies are equivalent, but with the latter one I can decide how many tests performed by the time of clicking merge button. You may merge in hurry with no tests finished and you can wait a bit (or got distracted) and get many/all of them finished.