### PR TITLE
x86: kernel: acpi: Change break to return in function

### DIFF
--- a/src/arch/x86/kernel/acpi_shutdown.c
+++ b/src/arch/x86/kernel/acpi_shutdown.c
@@ -16,7 +16,7 @@ void acpi_shutdown(void) {
 	status = AcpiEnterSleepStatePrep(ACPI_STATE_S5);
 	if (ACPI_FAILURE(status)) {
 		printk("ERROR: Unable to prepare to enter the soft off system state\n");
-		break;
+		return;
 	}
 
 	status = AcpiEnterSleepState(ACPI_STATE_S5);


### PR DESCRIPTION
Replace the break statement to return statement in the acpi_shutdown
fuction.

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>