### PR TITLE
modified: templates/riscv/qemu-sifive-u/mods.config 

### DIFF
--- a/templates/riscv/qemu-sifive-u/mods.config
+++ b/templates/riscv/qemu-sifive-u/mods.config
@@ -1,7 +1,7 @@
 package genconfig
 
 configuration conf {
-	include embox.arch.system(core_freq=100000000)
+	include embox.arch.system(core_freq=10000000)
 	include embox.arch.riscv.kernel.boot
 	include embox.arch.riscv.kernel.arch
 	include embox.arch.riscv.kernel.locore


### PR DESCRIPTION
Close #1791 
include embox.arch.system(core_freq=10000000)
Then, the riscv clock works correctly.