### PR TITLE
(templates) Replace sh-style comments with C-style comments

### DIFF
--- a/platform/efm32zg_sk3200/templates/debug/build.conf
+++ b/platform/efm32zg_sk3200/templates/debug/build.conf
@@ -5,7 +5,7 @@ PLATFORM = efm32zg_sk3200
 
 ARCH = arm
 
-# Path to GCC ARM Embedded (https://launchpad.net/gcc-arm-embedded)
+/* Path to GCC ARM Embedded (https://launchpad.net/gcc-arm-embedded) */
 CROSS_COMPILE = /opt/gcc-arm-none-eabi-4_8-2013q4/bin/arm-none-eabi-
 
 CFLAGS += -Os -g -DNDEBUG

--- a/platform/gpio_http_admin/templates/stm32f4_discovery/build.conf
+++ b/platform/gpio_http_admin/templates/stm32f4_discovery/build.conf
@@ -11,7 +11,7 @@ CFLAGS += -O0 -g
 CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -ffreestanding
 
 /* Switch between FPU and non-FPU modes */
-#CFLAGS += -msoft-float
+/* CFLAGS += -msoft-float */
 CFLAGS += -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/platform/nuklear/templates/arm_qemu/build.conf
+++ b/platform/nuklear/templates/arm_qemu/build.conf
@@ -11,11 +11,4 @@ CFLAGS += -mapcs-frame
 
 LDFLAGS += -N -g
 
-#if 0
-CXXFLAGS += -fno-rtti -O0 -g -Wno-error=c++14-compat
-CXXFLAGS += -fno-exceptions
-CXXFLAGS += -fno-threadsafe-statics -mcpu=arm926ej-s -march=armv5te
-CXXFLAGS += -mapcs-frame
-#endif
-
 SYMBOLS_WITH_FILENAME ?= 0

--- a/platform/pjsip/templates/stm32f746g-discovery/build.conf
+++ b/platform/pjsip/templates/stm32f746g-discovery/build.conf
@@ -12,7 +12,7 @@ CFLAGS += -ffreestanding -Wno-array-bounds
 CFLAGS += -mtune=cortex-m7 -march=armv7e-m
 
 /* Switch between FPU and non-FPU modes */
-#CFLAGS += -msoft-float
+/* CFLAGS += -msoft-float */
 CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/platform/pjsip/templates/stm32f769i-discovery/build.conf
+++ b/platform/pjsip/templates/stm32f769i-discovery/build.conf
@@ -12,7 +12,7 @@ CFLAGS += -ffreestanding -Wno-array-bounds
 CFLAGS += -mtune=cortex-m7 -march=armv7e-m
 
 /* Switch between FPU and non-FPU modes */
-#CFLAGS += -msoft-float
+/* CFLAGS += -msoft-float */
 CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/templates/arm/qt-stm32f7discovery/build.conf
+++ b/templates/arm/qt-stm32f7discovery/build.conf
@@ -14,7 +14,7 @@ CFLAGS += -ffreestanding
 CFLAGS += -mcpu=cortex-m7
 
 /* Switch between FPU and non-FPU modes */
-#CFLAGS += -msoft-float
+/* CFLAGS += -msoft-float */
 CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 CXXFLAGS += -Os -g
@@ -24,7 +24,7 @@ CXXFLAGS += -fno-rtti
 CXXFLAGS += -fno-exceptions
 CXXFLAGS += -mcpu=cortex-m7
 
-#CXXFLAGS += -msoft-float
+/* CXXFLAGS += -msoft-float */
 CXXFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32f4-discovery-clang/build.conf
+++ b/templates/arm/stm32f4-discovery-clang/build.conf
@@ -1,8 +1,8 @@
 COMPILER=clang
 
-# to see which target clang supports:
-# sudo update-alternatives --install /usr/bin/llc llc /usr/lib/llvm-3.9/bin/llc 20
-# llc -march=arm -mattr=help
+/* to see which target clang supports:
+   sudo update-alternatives --install /usr/bin/llc llc /usr/lib/llvm-3.9/bin/llc 20
+   llc -march=arm -mattr=help */
 
 TARGET = embox
 
@@ -25,15 +25,15 @@ endif
 
 LDFLAGS += -N -g
 
-# happens in stm32_flash_cube.c
+/* happens in stm32_flash_cube.c */
 override CFLAGS += -Wno-unused-const-variable
-# in ping.c
+/* in ping.c */
 override CFLAGS += -Wno-gnu-variable-sized-type-not-at-end
-# icmpv4.c
+/* icmpv4.c */
 override CFLAGS += -Wno-varargs
-# src/drivers/tty/serial/ttys_processing.c and maybe many others
+/* src/drivers/tty/serial/ttys_processing.c and maybe many others */
 override CFLAGS += -Wno-unused-function
-# src/lib/crypt/b64.c
+/* src/lib/crypt/b64.c */
 override CFLAGS += -Wno-tautological-constant-out-of-range-compare
-# build/extbld/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash_ex.c
+/* build/extbld/third_party/bsp/stmf4cube/core/STM32Cube_FW_F4_V1.13.0/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash_ex.c */
 override CFLAGS += -Wno-parentheses-equality

--- a/templates/arm/stm32f4-discovery/build.conf
+++ b/templates/arm/stm32f4-discovery/build.conf
@@ -11,7 +11,7 @@ CFLAGS += -O0 -g
 CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -ffreestanding
 
 /* Switch between FPU and non-FPU modes */
-#CFLAGS += -msoft-float
+/* CFLAGS += -msoft-float */
 CFLAGS += -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32f746g-discovery/build.conf
+++ b/templates/arm/stm32f746g-discovery/build.conf
@@ -14,7 +14,7 @@ CFLAGS += -ffreestanding
 CFLAGS += -mcpu=cortex-m7
 
 /* Switch between FPU and non-FPU modes */
-#CFLAGS += -msoft-float
+/* CFLAGS += -msoft-float */
 CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
 
 LDFLAGS += -N -g

--- a/templates/arm/stm32f769i-discovery/build.conf
+++ b/templates/arm/stm32f769i-discovery/build.conf
@@ -15,6 +15,6 @@ CFLAGS += -mcpu=cortex-m7
 
 /* Switch between FPU and non-FPU modes */
 CFLAGS += -msoft-float -mfloat-abi=soft
-#CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard
+/*CFLAGS += -mfpu=fpv5-sp-d16 -mfloat-abi=hard */
 
 LDFLAGS += -N -g

--- a/templates/e2k/monocube/build.conf
+++ b/templates/e2k/monocube/build.conf
@@ -4,7 +4,7 @@ ARCH = e2k
 
 COMPILER=lcc
 
-#sudo apt-get install lib32z1
+/* sudo apt-get install lib32z1 */
 CROSS_COMPILE = e2k-linux-
 
 CFLAGS += -mcpu=elbrus-v2


### PR DESCRIPTION
*.conf files are parsed by C preprocessor (i.e. in
scripts/qemu/auto_qemu), so shell-style comments may break it