### PR TITLE
cmds: Fix hardware/ide getopt().

### DIFF
--- a/src/cmds/hardware/ide.c
+++ b/src/cmds/hardware/ide.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
 	int opt;
 
 	getopt_init();
-	while (-1 != (opt = getopt(argc - 1, argv, "ah"))) {
+	while (-1 != (opt = getopt(argc, argv, "ah"))) {
 		switch(opt) {
 		case 'a':
 			break;


### PR DESCRIPTION
I had written a patch fixing the main issue with cmds/hw/ide which had to do with printing the name of the device and not working on either dvfs nor oldfs(and coredumping).
the main issue was apparently fixed by 6bbb6c13e160c52b968347e5f6be8f4930fa1971.
This is what remains of that patch, fixing getopt(), which was missing the first argument. 