### PR TITLE
char_dev_stub: Unify interfaces with char_dev

### DIFF
--- a/src/drivers/char/char_dev_stub.h
+++ b/src/drivers/char/char_dev_stub.h
@@ -12,8 +12,7 @@
 #include <stddef.h>
 #include <fs/idesc.h>
 
-struct idesc;
-struct dev_module;
+#define MAX_CDEV_QUANTITY 0
 
 #ifdef __GNUC__
 	/* Avoid warning for unused parameters with ((unused)) attribute */
@@ -27,6 +26,9 @@ struct dev_module;
 	#define CHAR_DEV_DEF(chname, open_fn, close_fn, idesc_op, priv)
 #endif /* __GNUC__ */
 
+struct dev_module;
+
+struct idesc;
 struct idesc_dev {
 	struct idesc idesc;
 	void *dev;
@@ -35,7 +37,6 @@ struct idesc_dev {
 extern int char_dev_init_all(void);
 extern int char_dev_register(const struct dev_module *cdev);
 extern int char_dev_idesc_fstat(struct idesc *idesc, void *buff);
-extern int cdev_idesc_alloc(struct dev_module *cdev);
 extern struct idesc *char_dev_idesc_create(struct dev_module *cdev);
 
 static inline struct dev_module *idesc_to_dev_module(struct idesc *desc) {


### PR DESCRIPTION
* Add MAX_CDEV_QUANTITY macro
* Remove cdev_idesc_alloc() declaration