### PR TITLE
Loadable apps fix

### DIFF
--- a/mk/script/loadable-build.mk
+++ b/mk/script/loadable-build.mk
@@ -1,5 +1,5 @@
 
-L_CFLAGS = -nostdlib -emain -fpie -N
+L_CFLAGS = -nostdlib -emain -fpie -static
 
 $(LOADABLE_DIR)/$(DST) : | $(LOADABLE_DIR)
 $(LOADABLE_DIR)/$(DST) : $(SRC)


### PR DESCRIPTION
This fixes `x86/test/units` build (some tests do fail, however).
Details are described in #1827, but I'm copying it here for the sake of clarity:

This -N flag breaks compilation of simple programs (as `src/cmds/load_app/hello.c`)
```
> cat main.c
int main() { return 0; }
> gcc main.c -N -nostdlib
/usr/bin/ld: warning: cannot find entry symbol _start; defaulting to 0000000000400241
/usr/bin/ld: a.out: error: PHDR segment not covered by LOAD segment
collect2: error: ld returned 1 exit status
```
Tested it with GCC 9 and GCC 6, same error message. I don't know if it's a GCC bug or not, but `gcc main.c -static -nostdlib` compiles well.

So I suggest to replace `-N` with `-static` (or even just get rid of this, because `-static` is used in `mk/flags.mk:251:override LDFLAGS  = -static -nostdlib`).