### PR TITLE
x86: kernel: ACPI: Fix build error

### DIFF
--- a/src/arch/x86/kernel/Mybuild
+++ b/src/arch/x86/kernel/Mybuild
@@ -53,9 +53,11 @@ module arch extends embox.arch.arch {
 @DefaultImpl(noacpi_shutdown)
 abstract module shutdown {}
 
+@BuildDepends(third_party.lib.acpica)
 module acpi_shutdown extends shutdown {
+	@IncludePath("$(THIRDPARTY_DIR)/lib/acpica")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/lib/acpica/acpica-unix-20150204/source/include/")
 	source "acpi_shutdown.c"
-
 	depends third_party.lib.acpica
 	depends embox.lib.Printk
 }


### PR DESCRIPTION
Add the includes which are required for the successful build
of ACPI. This solves #1799 

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>