### PR TITLE
Fix pthread_kill

### DIFF
--- a/src/compat/posix/include/pthread.h
+++ b/src/compat/posix/include/pthread.h
@@ -153,6 +153,8 @@ extern int   pthread_join(pthread_t, void **);
 extern int   pthread_key_create(pthread_key_t *, void (*)(void *));
 extern int   pthread_key_delete(pthread_key_t);
 
+extern int   pthread_kill(pthread_t thread, int sig);
+
 extern int   pthread_mutex_destroy(pthread_mutex_t *);
 //extern int   pthread_mutex_getprioceiling(const pthread_mutex_t *, int *);
 extern int   pthread_mutex_init(pthread_mutex_t *, const pthread_mutexattr_t *);

--- a/src/compat/posix/proc/signal.c
+++ b/src/compat/posix/proc/signal.c
@@ -111,6 +111,12 @@ int pthread_kill(pthread_t thread, int sig) {
 
 	assert(thread);
 
+	struct thread *t = (struct thread *)thread;
+	if (t->state & TS_EXITED)
+		return ESRCH;
+	if (!sig)
+		return 0;
+
 	sigstate = &thread->sigstate;
 	err = sigstate_send(sigstate, sig, NULL);
 	if (err)


### PR DESCRIPTION
#1808 
pthread_kill is  fixed. @anton-bondarev 
This commit is the modification in signal.c and pthread.h for the fix.
I think unit tests should be based on this.