### PR TITLE
Use lthread to handle USB requests

### DIFF
--- a/src/drivers/usb/Mybuild
+++ b/src/drivers/usb/Mybuild
@@ -5,11 +5,18 @@ module core {
 
 	source "usb_core.c",
 		"usb_queue.c",
-		"usb_hub.c",
 		"usb_config.c"
 
 	source "usb_driver.c"
 	depends embox.driver.char_dev
+}
+
+module hub {
+	option number log_level = 1
+
+	source "usb_hub.c"
+
+	depends core
 }
 
 module driver_example {

--- a/src/drivers/usb/Mybuild
+++ b/src/drivers/usb/Mybuild
@@ -2,6 +2,7 @@ package embox.driver.usb
 
 module core {
 	option number log_level = 1
+	option number usb_req_hnd_priority = 200
 
 	source "usb_core.c",
 		"usb_queue.c",

--- a/src/drivers/usb/hc/Mybuild
+++ b/src/drivers/usb/hc/Mybuild
@@ -7,6 +7,7 @@ module ohci_pci {
 	source "ohci_pci.c"
 
 	depends embox.driver.usb.core
+	depends embox.driver.usb.hub
 	depends embox.driver.pci
 }
 
@@ -23,6 +24,7 @@ module ehci_hcd {
 	source "ehci.h", "ehci_regs.h"
 
 	depends embox.driver.usb.core
+	depends embox.driver.usb.hub
 }
 
 module ehci_pci {
@@ -32,6 +34,7 @@ module ehci_pci {
 
 	depends ehci_hcd
 	depends embox.driver.usb.core
+	depends embox.driver.usb.hub
 	depends embox.driver.pci
 }
 
@@ -39,12 +42,14 @@ module ti81xx {
 	source "ti81xx.c"
 
 	depends embox.driver.usb.core
+	depends embox.driver.usb.hub
 }
 
 module usb_dwc {
 	source "usb_dwc.c", "usb_dwc.h"
 
 	depends embox.driver.usb.core
+	depends embox.driver.usb.hub
 	depends embox.kernel.thread.sync
 	depends embox.driver.power.bcm2835_power
 }

--- a/src/drivers/usb/hc/ehci.h
+++ b/src/drivers/usb/hc/ehci.h
@@ -10,7 +10,6 @@
 
 #include <drivers/usb/usb.h>
 #include <drivers/usb/ehci_regs.h>
-#include <util/dlist.h>
 
 /* type tag from {qh,itd,sitd,fstn}->hw_next */
 #define EHCI_Q_NEXT_TYPE(ehci, dma) ((dma) & 3 << 1)
@@ -66,7 +65,7 @@ struct ehci_qtd_hw {
 struct ehci_req {
 	struct usb_request *req;
 	struct ehci_qtd_hw *qtds_head;
-	struct dlist_head req_link;
+	struct usb_queue_link req_link;
 };
 
 /*
@@ -223,7 +222,7 @@ struct ehci_hcd {
 	/* async schedule support */
 	struct ehci_qh *async;
 
-	struct dlist_head req_list;
+	struct usb_queue req_queue;
 
 	/* periodic schedule support */
 	int periodic_size;

--- a/src/drivers/usb/hc/ehci_hcd.c
+++ b/src/drivers/usb/hc/ehci_hcd.c
@@ -281,7 +281,7 @@ static int echi_hcd_init(struct ehci_hcd *ehci_hcd) {
 	if ((ret = ehci_mem_init(ehci_hcd)) < 0)
 		return ret;
 
-	dlist_init(&ehci_hcd->req_list);
+	usb_queue_init(&ehci_hcd->req_queue);
 
 	/*
 	 * dedicate a qh for the async ring head, since we couldn't unlink
@@ -747,11 +747,11 @@ static int ehci_request(struct usb_request *req) {
 	ehci_req->req = req;
 	ehci_req->qtds_head = qtd_first;
 
-	if (dlist_empty(&ehci->req_list)) {
-		dlist_add_next(&ehci_req->req_link, &ehci->req_list);
+	if (usb_queue_empty(&ehci->req_queue)) {
+		usb_queue_add(&ehci->req_queue, &ehci_req->req_link);
 		ehci_submit_async(ehci, ehci_req);
 	} else {
-		dlist_add_next(&ehci_req->req_link, &ehci->req_list);
+		usb_queue_add(&ehci->req_queue, &ehci_req->req_link);
 	}
 
 	return 0;

--- a/src/drivers/usb/hc/ehci_mem.c
+++ b/src/drivers/usb/hc/ehci_mem.c
@@ -50,7 +50,7 @@ struct ehci_req *ehci_req_alloc(struct ehci_hcd *ehci) {
 	if (!ehci_req) {
 		return NULL;
 	}
-	dlist_head_init(&ehci_req->req_link);
+	usb_queue_link_init(&ehci_req->req_link);
 	return ehci_req;
 }
 

--- a/src/drivers/usb/hc/ohci.h
+++ b/src/drivers/usb/hc/ohci.h
@@ -129,7 +129,7 @@ struct ohci_hcd {
 	struct usb_hcd *hcd;
 	struct ohci_hcca *hcca;
 	struct ohci_reg *base;
-
+	struct usb_queue req_queue;
 };
 
 static inline struct usb_hcd *ohci2hcd(struct ohci_hcd *ohcd) {

--- a/src/drivers/usb/usb_config.c
+++ b/src/drivers/usb/usb_config.c
@@ -77,7 +77,6 @@ static struct usb_endp *usb_endp_alloc(struct usb_dev *dev, unsigned n,
 	ep->dev = dev;
 
 	usb_endp_fill_from_desc(ep, ep_desc);
-	usb_queue_init(&ep->req_queue);
 
 	dev->endpoints[n] = ep;
 

--- a/src/drivers/usb/usb_core.c
+++ b/src/drivers/usb/usb_core.c
@@ -92,10 +92,6 @@ static void usb_build_control_header(struct usb_request *req, uint8_t req_type,
 	rbuf[7] = count >> 8;
 }
 
-static inline struct usb_request *usb_link2req(struct usb_queue_link *ul) {
-	return member_cast_out(ul, struct usb_request, req_link);
-}
-
 static int usb_endp_request(struct usb_endp *endp, struct usb_request *req) {
 	struct usb_hcd *hcd;
 	struct usb_dev *dev = endp->dev;

--- a/src/include/drivers/usb/usb.h
+++ b/src/include/drivers/usb/usb.h
@@ -143,8 +143,6 @@ struct usb_endp {
 	unsigned short max_packet_size;
 	unsigned char interval;
 
-	struct usb_queue req_queue;
-
 	void *hci_specific;
 };
 

--- a/src/include/drivers/usb/usb.h
+++ b/src/include/drivers/usb/usb.h
@@ -210,6 +210,10 @@ static inline enum usb_comm_type usb_endp_type(struct usb_endp *endp) {
 	return endp->type;
 }
 
+static inline struct usb_request *usb_link2req(struct usb_queue_link *ul) {
+	return member_cast_out(ul, struct usb_request, req_link);
+}
+
 extern struct usb_hcd *usb_hcd_alloc(struct usb_hcd_ops *ops, void *args);
 
 extern void usb_hcd_free(struct usb_hcd *hcd);

--- a/src/include/drivers/usb/usb_queue.h
+++ b/src/include/drivers/usb/usb_queue.h
@@ -23,51 +23,18 @@ struct usb_queue_link {
 };
 
 static inline void usb_queue_init(struct usb_queue *q) {
-
 	dlist_init(&q->q);
 }
 
 static inline void usb_queue_link_init(struct usb_queue_link *l) {
-
 	dlist_head_init(&l->l);
 }
 
-struct usb_queue_link *usb_queue_last(struct usb_queue *q);
-
-struct usb_queue_link *usb_queue_peek(struct usb_queue *q);
-
-/**
- * @brief Add link to the tail of queue
- *
- * @param q
- * @param l
- *
- * @return true if queue was not empty
- * @return false if queue was empty and \a q is the first
- */
-int usb_queue_add(struct usb_queue *q, struct usb_queue_link *l);
-
-/**
- * @brief Pop current link form queue
- *
- * @param q
- * @param l
- *
- * @return true if queue is not empty
- * @return false if queue is not empty
- */
-int usb_queue_done(struct usb_queue *q, struct usb_queue_link *l);
-
-/**
- * @brief Remove link from queue
- *
- * @param q
- * @param l
- *
- * @return true if it was first link in queue
- * @return false in other case
- */
-int usb_queue_remove(struct usb_queue *q, struct usb_queue_link *l);
+extern int usb_queue_empty(struct usb_queue *q);
+extern struct usb_queue_link *usb_queue_last(struct usb_queue *q);
+extern struct usb_queue_link *usb_queue_first(struct usb_queue *q);
+extern void usb_queue_add(struct usb_queue *q, struct usb_queue_link *l);
+extern void usb_queue_del(struct usb_queue *q, struct usb_queue_link *l);
 
 #endif /* USB_QUEUE_H_ */
 


### PR DESCRIPTION
* Use lthreads to handle USB requests when they are completed.
* Refactor USB queue - now it has dlist interface but with irq_lock/unlock protection.
* Extract USB hub to a separate module.