### PR TITLE
Remove getopt_init

### DIFF
--- a/platform/mesa/cmds/gles/gles_example.c
+++ b/platform/mesa/cmds/gles/gles_example.c
@@ -225,7 +225,6 @@ int main(int argc, char **argv) {
 	GLenum type;
 	int opt, depth = -1;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "hasd:"))) {
 		switch(opt) {
 			case 'h':

--- a/platform/mesa/cmds/osdemo_fb/osdemo_fb.c
+++ b/platform/mesa/cmds/osdemo_fb/osdemo_fb.c
@@ -208,7 +208,6 @@ int main(int argc, char **argv) {
 
 	animated_scene = 1;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "hasd:"))) {
 		switch(opt) {
 			case 'h':

--- a/src/cmds/bootloader/boot.c
+++ b/src/cmds/bootloader/boot.c
@@ -91,7 +91,6 @@ int main(int argc, char **argv) {
 	unsigned int load_addr;
 	void (*entry_point)(void);
 	image_header_t *hdr;
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "f:a:h"))) {
 		switch(opt) {
 		case 'f':

--- a/src/cmds/bootloader/load.c
+++ b/src/cmds/bootloader/load.c
@@ -72,7 +72,6 @@ int main(int argc, char **argv) {
 	int opt;
 	int err;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "a:h"))) {
 		switch (opt) {
 		case 'a':

--- a/src/cmds/fs/mknod.c
+++ b/src/cmds/fs/mknod.c
@@ -18,7 +18,6 @@ int main(int argc, char **argv) {
 	int opt;
 	mode_t mode;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc - 1, argv, "h"))) {
 		switch (opt) {
 			case 'h': /* help message */

--- a/src/cmds/fs/rm.c
+++ b/src/cmds/fs/rm.c
@@ -18,7 +18,6 @@ static void print_usage(void) {
 int main(int argc, char **argv) {
 	const char *file_path;
 	int opt;
-	getopt_init();
 	while (-1 != (opt = getopt(argc - 1, argv, "frh"))) {
 		switch(opt) {
 		case 'f':

--- a/src/cmds/fs/touch.c
+++ b/src/cmds/fs/touch.c
@@ -21,7 +21,6 @@ int main(int argc, char **argv) {
 	char *point;
 	int fd;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc - 1, argv, "h"))) {
 		switch(opt) {
 		case 'h':

--- a/src/cmds/fs/xattr.c
+++ b/src/cmds/fs/xattr.c
@@ -212,7 +212,6 @@ int main(int argc, char **argv) {
 
 	xattr_cmd_op_flags = 0;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "lxcdhpw"))) {
 		switch (opt) {
 		case 'c':

--- a/src/cmds/hardware/clock.c
+++ b/src/cmds/hardware/clock.c
@@ -50,7 +50,6 @@ int main(int argc, char **argv) {
 		return -EINVAL;
 	}
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hi"))) {
 		printf("\n");

--- a/src/cmds/hardware/ide.c
+++ b/src/cmds/hardware/ide.c
@@ -51,7 +51,6 @@ static void print_drive (struct ide_tab *ide) {
 int main(int argc, char **argv) {
 	int opt;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "ah"))) {
 		switch(opt) {
 		case 'a':

--- a/src/cmds/hardware/input_test.c
+++ b/src/cmds/hardware/input_test.c
@@ -47,7 +47,6 @@ int main(int argc, char **argv) {
 	struct input_dev *indev;
 	int res;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "i:"))) {
 		switch(opt) {
 		case 'i':

--- a/src/cmds/hardware/lspnp.c
+++ b/src/cmds/hardware/lspnp.c
@@ -286,7 +286,6 @@ int main(int argc, char **argv) {
 	int dev_number = -1;
 	func_show_bus_t show_func = show_all;
 	int opt;
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "n:b:h"))) {
 		switch(opt) {
 		case 'h':

--- a/src/cmds/hardware/lssata.c
+++ b/src/cmds/hardware/lssata.c
@@ -171,7 +171,6 @@ int main(int argc, char **argv) {
 	struct lssata_cb cookie;
 
 	if (argc > 1) {
-		getopt_init();
 		while (-1 != (opt = getopt(argc, argv, "xdh"))) {
 			switch (opt) {
 			case 'x':

--- a/src/cmds/hardware/usb_test.c
+++ b/src/cmds/hardware/usb_test.c
@@ -63,7 +63,6 @@ int main(int argc, char **argv) {
 	struct usb_dev_desc *ddesc;
 	int opt, res;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "v:p:e:r:asw"))) {
 		switch(opt) {
 		case 'v':

--- a/src/cmds/hardware/vmem/wmem.c
+++ b/src/cmds/hardware/vmem/wmem.c
@@ -53,7 +53,6 @@ int main(int argc, char **argv) {
 	unsigned int value;
 	enum access_type at = MEM_AT_LONG;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "a:v:hlsc"))) {
 		switch (opt) {
 		case 'a':

--- a/src/cmds/help.c
+++ b/src/cmds/help.c
@@ -21,7 +21,6 @@ int main(int argc, char **argv) {
 	int opt, tab = 10;
 	char fmt[20];
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "h"))) {
 		switch (opt) {
 		case '?':

--- a/src/cmds/module/test.c
+++ b/src/cmds/module/test.c
@@ -55,7 +55,6 @@ int main(int argc, char **argv) {
 	/* TODO it must be agreed with shell maximum command length */
 	char test_name[100] = { 0 };
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "hn:t:i"))) {
 		switch (opt) {
 		case 'n':

--- a/src/cmds/mpstat.c
+++ b/src/cmds/mpstat.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv) {
 		return -EINVAL;
 	}
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "Ph"))) {
 		switch (opt) {

--- a/src/cmds/net/arp.c
+++ b/src/cmds/net/arp.c
@@ -58,7 +58,6 @@ int main(int argc, char **argv) {
 	unsigned char hwaddr[ETH_ALEN];
 	struct in_device *ifdev = NULL;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "hd:s:a:m:i:"))) {
 		switch (opt) {
 		case 'd':

--- a/src/cmds/net/arping.c
+++ b/src/cmds/net/arping.c
@@ -75,7 +75,6 @@ int main(int argc, char **argv) {
 	struct timeval t1, t2, sub_res;
 	int ret, microseconds, milliseconds;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "I:c:h"))) {
 		switch (opt) {
 		case 'I': /* get interface */

--- a/src/cmds/net/ntpd.c
+++ b/src/cmds/net/ntpd.c
@@ -184,7 +184,6 @@ int main(int argc, char **argv) {
 	};
 	int opt;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hS"))) {
 		switch(opt) {

--- a/src/cmds/net/ntpdate.c
+++ b/src/cmds/net/ntpdate.c
@@ -179,7 +179,6 @@ int main(int argc, char **argv) {
 
 	only_query = 0;
 	timeout = MODOPS_TIMEOUT;
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hqt:"))) {
 		switch (opt) {

--- a/src/cmds/net/ping.c
+++ b/src/cmds/net/ping.c
@@ -297,7 +297,6 @@ int main(int argc, char **argv) {
 	pinfo.timeout = DEFAULT_TIMEOUT;
 	pinfo.ttl = DEFAULT_TTL;
 
-	getopt_init();
 	/* while (-1 != (opt = getopt(argc, argv, "I:c:t:W:s:i:p:h"))) { */
 	/* Parse commandline options */
 	for (i_opt = 0; i_opt < argc - 1; i_opt++) {

--- a/src/cmds/net/pnet.c
+++ b/src/cmds/net/pnet.c
@@ -410,7 +410,6 @@ int main(int argc, char **argv) {
 	net_node_t node;
 	_rule_setter setter;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hgnt:d:p:r:s:a:l:"))) {
 		switch(opt) {

--- a/src/cmds/net/rarping.c
+++ b/src/cmds/net/rarping.c
@@ -75,7 +75,6 @@ int main(int argc, char **argv) {
 	char sha_str[] = "xx.xx.xx.xx.xx.xx", tha_str[] = "xx.xx.xx.xx.xx.xx";
 	char spa_str[] = "xxx.xxx.xxx.xxx", tpa_str[] = "xxx.xxx.xxx.xxx";
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "I:c:h"))) {
 		switch (opt) {
 		case 'I': /* get interface */

--- a/src/cmds/net/rlogin.c
+++ b/src/cmds/net/rlogin.c
@@ -244,7 +244,6 @@ int main(int argc, char **argv) {
 		return 0;
 	}
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "hl:"))) {
 		switch (opt) {
 		case 'h':

--- a/src/cmds/net/snmpd.c
+++ b/src/cmds/net/snmpd.c
@@ -58,7 +58,6 @@ int main(int argc, char **argv) {
 	char varbuf[MAX_PDU_LEN]; /* for received variables */
 	socklen_t sklen = sizeof addr;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "h"))) {
 		switch (opt) {

--- a/src/cmds/net/speedtest.c
+++ b/src/cmds/net/speedtest.c
@@ -71,7 +71,6 @@ int main(int argc, char *argv[]) {
 	memset(&in, 0, sizeof in);
 	in.sin_family = AF_INET;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "K:M:G:h"))) {
 		switch (opt) {
 		case '?':

--- a/src/cmds/net/tftp.c
+++ b/src/cmds/net/tftp.c
@@ -155,7 +155,6 @@ int main(int argc, char **argv) {
 
 	/* Initialize objects */
 	param_ascii = param_binary = param_get = param_put = 0;
-	getopt_init();
 
 	/* Get options */
 	while ((ret = getopt(argc, argv, "habgpm:")) != -1) {

--- a/src/cmds/proc/kill.c
+++ b/src/cmds/proc/kill.c
@@ -20,7 +20,6 @@ int main(int argc, char **argv) {
 	int opt, sig = SIGKILL;
 	int tid;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "s:"))) {
 		switch (opt) {

--- a/src/cmds/proc/ps.c
+++ b/src/cmds/proc/ps.c
@@ -36,7 +36,6 @@ int main(int argc, char **argv) {
 		return -EINVAL;
 	}
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "ah:"))) {
 		printf("\n");

--- a/src/cmds/proc/taskset.c
+++ b/src/cmds/proc/taskset.c
@@ -30,7 +30,6 @@ int main(int argc, char **argv) {
 		return -EINVAL;
 	}
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "ph"))) {
 		switch (opt) {

--- a/src/cmds/proc/thread.c
+++ b/src/cmds/proc/thread.c
@@ -105,7 +105,6 @@ int main(int argc, char **argv) {
 		return -EINVAL;
 	}
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hsk:"))) {
 		printf("\n");

--- a/src/cmds/profiler/coverage.c
+++ b/src/cmds/profiler/coverage.c
@@ -24,7 +24,6 @@ int main(int argc, char *argv[]) {
 	const unsigned long *cov_bitmap;
 	int opt, i, sym_n;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "o:h"))) {
 		switch (opt) {
 		case 'h':

--- a/src/cmds/profiler/sample.c
+++ b/src/cmds/profiler/sample.c
@@ -44,7 +44,6 @@ int main(int argc, char **argv) {
 
 	counters = get_counters();
 
-	getopt_init();
 
 	while ((c = getopt(argc, argv, "hsl:ti:")) != (char) -1) {
 		switch (c) {

--- a/src/cmds/profiler/tbprof.c
+++ b/src/cmds/profiler/tbprof.c
@@ -60,7 +60,6 @@ int main(int argc, char *argv[]) {
 	int c_argc = argc, opt, argnum = 1;
 	FILE *out = NULL;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "chn:ed"))) {
 		argnum++;

--- a/src/cmds/profiler/trace_blocks.c
+++ b/src/cmds/profiler/trace_blocks.c
@@ -166,7 +166,6 @@ int main(int argc, char **argv) {
 		return -EINVAL;
 	}
 
-	getopt_init();
 	filter[0] = 0;
 	while (-1 != (opt = getopt(argc, argv, "f:ehsi:d:a:n:"))) {
 		printf("\n");

--- a/src/cmds/profiler/trace_points.c
+++ b/src/cmds/profiler/trace_points.c
@@ -93,7 +93,6 @@ int main(int argc, char **argv) {
 		return 0;
 	}
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hsi:d:a:"))) {
 		printf("\n");

--- a/src/cmds/readelf.c
+++ b/src/cmds/readelf.c
@@ -506,7 +506,6 @@ int main(int argc, char **argv) {
 
 	elf_initialize_object(&elf);
 
-	getopt_init();
 	do {
 		cnt++;
 		opt = getopt(argc - 1, argv, "hHSlrs");

--- a/src/cmds/smac_adm.c
+++ b/src/cmds/smac_adm.c
@@ -89,7 +89,6 @@ int main(int argc, char *argv[]) {
 	} action = ACT_NONE;
 	int opt;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "S:GFPR:U:o:a:h"))) {
 		enum action act = ACT_NONE;
 

--- a/src/cmds/sys/date.c
+++ b/src/cmds/sys/date.c
@@ -126,7 +126,6 @@ static int show_fdate(char *fmt) {
 int main(int argc, char **argv) {
 	int opt;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "hs:"))) {
 		printf("\n");

--- a/src/cmds/sys/install.c
+++ b/src/cmds/sys/install.c
@@ -46,7 +46,6 @@ int main(int argc, char *argv[]) {
 	bool mount_manage = true;
 	bool mountpoint_manage = true;
 
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "mb:t:"))) {
 		switch(opt) {
 		case 'm':

--- a/src/cmds/sys/version.c
+++ b/src/cmds/sys/version.c
@@ -19,7 +19,6 @@ int main(int argc, char **argv) {
 	unsigned int rev = CONFIG_SVN_REV;
 #endif
 	int opt;
-	getopt_init();
 	while (-1 != (opt = getopt(argc, argv, "h"))) {
 		switch(opt) {
 		case 'h':

--- a/src/cmds/user/login.c
+++ b/src/cmds/user/login.c
@@ -258,7 +258,6 @@ int main(int argc, char **argv) {
 
 	if (argc != 1) {
 
-		getopt_init();
 
 		while (-1 != (opt = getopt(argc, argv, "pc:"))) {
 			switch(opt) {

--- a/src/cmds/user/su.c
+++ b/src/cmds/user/su.c
@@ -29,7 +29,6 @@ int main(int argc, char *argv[]) {
 	char *newargv[5];
 	int newargc;
 
-	getopt_init();
 
 	while (-1 != (opt = getopt(argc, argv, "c:"))) {
 		switch(opt) {

--- a/src/cmds/user/useradd.c
+++ b/src/cmds/user/useradd.c
@@ -139,7 +139,6 @@ int main(int argc, char **argv) {
 	int opt, count = 0, user_create = 1;
 
 	if (argc >= 1) {
-		getopt_init();
 		while (-1 != (opt = getopt(argc, argv, "d:s:p:c:g:Dh"))) {
 			count++;
 

--- a/src/cmds/user/userdel.c
+++ b/src/cmds/user/userdel.c
@@ -79,7 +79,6 @@ int main(int argc, char **argv) {
 	int opt;
 
 	if (argc >= 1) {
-		getopt_init();
 		while (-1 != (opt = getopt(argc, argv, "h"))) {
 
 			switch (opt) {

--- a/src/cmds/user/usermod.c
+++ b/src/cmds/user/usermod.c
@@ -93,7 +93,6 @@ int main(int argc, char **argv) {
 	int opt;
 
 	if (argc >= 1) {
-		getopt_init();
 		while (-1 != (opt = getopt(argc, argv, "d:s:p:c:g:l:h"))) {
 
 			switch (opt) {

--- a/src/compat/cxx/core/cxx_app_startup_shutdown.cpp
+++ b/src/compat/cxx/core/cxx_app_startup_shutdown.cpp
@@ -9,6 +9,7 @@
 #include "cxx_app_startup_termination.h"
 #include "cxxapp.hpp"
 #include <unistd.h>
+#include <util/getopt.h>
 
 int cxx_app_start(int argc, char **argv) {
 	int ret;

--- a/src/compat/posix/include/getopt.h
+++ b/src/compat/posix/include/getopt.h
@@ -18,9 +18,6 @@
  */
 extern int getopt(int argc, char *const argv[], const char *opts);
 
-/** setup optind and opterr */
-extern void getopt_init(void); /* TODO remove this */
-
 #define no_argument       0
 #define required_argument 1
 #define optional_argument 2

--- a/src/compat/posix/include/unistd.h
+++ b/src/compat/posix/include/unistd.h
@@ -245,7 +245,13 @@ static inline int access(const char *path, int amode) {
 }
 
 extern void swab(const void *bfrom, void *bto, ssize_t n);
-#include <getopt.h>
+
+extern int getopt(int argc, char *const argv[], const char *opts);
+
+extern char *optarg; /**< argument to optopt */
+extern int optind;   /**< last touched cmdline argument */
+extern int optopt;   /**< last returned option */
+extern int opterr;   /**< flag:error message on unrecognzed options */
 
 #ifndef environ
 /**

--- a/src/compat/posix/util/Util.my
+++ b/src/compat/posix/util/Util.my
@@ -14,6 +14,8 @@ module All {
 }
 
 static module getopt {
+	@IncludeExport(path="util")
+	source "getopt.h"
 	source "getopt.c"
 	source "getopt_long.c"
 

--- a/src/compat/posix/util/getopt.c
+++ b/src/compat/posix/util/getopt.c
@@ -19,6 +19,12 @@ char  *optarg = NULL;
 static int sp = 1;
 static int not_opt = 0;
 
+/**
+ * @param argc is the number of arguments on cmdline
+ * @param argv is the pointer to array of cmdline arguments
+ * @param opts is the string of all valid options
+ * each char case must be given; options taking an arg are followed by = ':'
+ */
 int getopt(int argc, char *const argv[], const char *opts) {
 	int c;
 	char *cp;

--- a/src/compat/posix/util/getopt.h
+++ b/src/compat/posix/util/getopt.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Erick Cafferata
+ * @date    15.03.2020
+ */
+
+#ifndef GETOPT_H_
+#define GETOPT_H_
+
+
+/** setup optind and opterr */
+extern void getopt_init(void);
+
+#endif /* GETOPT_H_ */
+

--- a/src/framework/cmd/core.c
+++ b/src/framework/cmd/core.c
@@ -15,10 +15,9 @@
 #include <string.h>
 
 #include <util/array.h>
+#include <util/getopt.h>
 
 ARRAY_SPREAD_DEF(const struct cmd * const, __cmd_registry);
-
-extern void getopt_init(void);
 
 int cmd_exec(const struct cmd *cmd, int argc, char **argv) {
 	int err;

--- a/src/fs/driver/ext3/ext3.c
+++ b/src/fs/driver/ext3/ext3.c
@@ -16,6 +16,7 @@
 
 #include <util/array.h>
 #include <util/err.h>
+#include <util/getopt.h>
 #include <embox/unit.h>
 #include <drivers/block_dev.h>
 #include <mem/objalloc.h>

--- a/src/fs/driver/ext4/ext4.c
+++ b/src/fs/driver/ext4/ext4.c
@@ -16,6 +16,7 @@
 
 #include <util/array.h>
 #include <util/err.h>
+#include <util/getopt.h>
 #include <embox/unit.h>
 #include <drivers/block_dev.h>
 #include <mem/misc/pool.h>

--- a/src/tests/posix/getopt_test.c
+++ b/src/tests/posix/getopt_test.c
@@ -10,6 +10,7 @@
 #include <embox/test.h>
 #include <util/array.h>
 #include <unistd.h>
+#include <util/getopt.h>
 
 EMBOX_TEST_SUITE("stdlib/getopt test");
 

--- a/third-party/e2fsprogs/mke2fs_cmd.c
+++ b/third-party/e2fsprogs/mke2fs_cmd.c
@@ -9,6 +9,7 @@
 #include <embox/cmd.h>
 #include <assert.h>
 #include <unistd.h>
+#include <util/getopt.h>
 
 EMBOX_CMD(exec);
 


### PR DESCRIPTION
getopt_init() is now being called from src/framework/cmd/core.c, by cmd_exec(), before the execution of any command, so executing getopt_init from the commands themselves is redundant.
This patch removes all the getopt_init() from src/cmds/ and fix some exception for getopt tests, fixing #1833 