### PR TITLE
modified: riscv_clk.c and qemu-sifive-u/mods.config

### DIFF
--- a/src/drivers/clock/Mybuild
+++ b/src/drivers/clock/Mybuild
@@ -79,6 +79,7 @@ module riscv_clk extends embox.arch.clock {
 
 	option number base_mtime=0x200bff8
 	option number base_mtimecmp=0x2004000
+	option number rtc_freq=1000000
 }
 
 module lapic_timer extends embox.arch.clock {

--- a/src/drivers/clock/riscv_clk.c
+++ b/src/drivers/clock/riscv_clk.c
@@ -18,8 +18,9 @@
 
 #include <embox/unit.h>
 
-#define HZ 1000
-#define COUNT_OFFSET (SYS_CLOCK / HZ)
+#define HZ 100
+#define COUNT_OFFSET (RTC_CLOCK / HZ)
+#define RTC_CLOCK    OPTION_GET(NUMBER, rtc_freq)
 #define MTIME        OPTION_GET(NUMBER, base_mtime)
 #define MTIMECMP     OPTION_GET(NUMBER, base_mtimecmp)
 

--- a/templates/riscv/qemu-sifive-u/mods.config
+++ b/templates/riscv/qemu-sifive-u/mods.config
@@ -1,7 +1,7 @@
 package genconfig
 
 configuration conf {
-	include embox.arch.system(core_freq=100000000)
+	include embox.arch.system(core_freq=1000000000)
 	include embox.arch.riscv.kernel.boot
 	include embox.arch.riscv.kernel.arch
 	include embox.arch.riscv.kernel.locore
@@ -13,7 +13,7 @@ configuration conf {
 	include embox.driver.diag(impl="embox__driver__serial__sifive_uart")
 
 	include embox.driver.interrupt.riscv_intc
-	include embox.driver.clock.riscv_clk(base_mtime=0x200bff8, base_mtimecmp=0x2004000)
+	include embox.driver.clock.riscv_clk(base_mtime=0x200bff8, base_mtimecmp=0x2004000, rtc_freq=1000000)
 
 	/* Tell printf() do not support floating point */
 	include embox.compat.libc.stdio.print(support_floating=0)


### PR DESCRIPTION
The recommended frequency of sifive coreclk is 1.0 GHz.
`include embox.arch.system(core_freq=1000000000)`
 `#define HZ 100000`
then the clock works correctly