### PR TITLE
ci: Disable ping xip.io tests

### DIFF
--- a/scripts/expect/ping.exp
+++ b/scripts/expect/ping.exp
@@ -22,12 +22,13 @@ TEST_CASE_TARGET {Embox should ping peer host by IP} {
 	return 0
 }
 
-
+TEST_CASE_DECLARE_FIXME {
 TEST_CASE_TARGET {Embox should ping by DNS name} {
 	send "ping -c 4 $::env(PEER_HOST_IP).xip.io\r"
 	test_assert_regexp_equal "4 packets transmitted, 4 received, \\+0 errors, 0% packet loss"
 
 	return 0
+}
 }
 
 TEST_CASE_HOST {Embox should reply after ping flooding} {

--- a/templates/x86/test/net/start_script.inc
+++ b/templates/x86/test/net/start_script.inc
@@ -16,7 +16,9 @@
 
 "ping 10.0.2.10",
 "ping 192.168.128.128",
-"ping 192.168.128.128.xip.io",
+/* FIXME Fails too often.
+ * "ping 192.168.128.128.xip.io",
+ */
 "httpd &",
 "telnetd &",
 "service dropbear -F",


### PR DESCRIPTION
`ping 192.168.128.128.xip.io` fails too often for both expect tests and start_script:
https://github.com/embox/embox/runs/505471758#step:10:266 (start_script)
https://github.com/embox/embox/runs/505907968#step:10:208 (expect)

Because of too many re-launches and questions we are disabling the test. The issue is here - https://github.com/embox/embox/issues/1865