### PR TITLE
execv: fix execv returns 0 and doesn't set errno

### DIFF
--- a/src/cmds/sys/env.c
+++ b/src/cmds/sys/env.c
@@ -68,8 +68,7 @@ int main(int argc, char *argv[]) {
 	/* difference from posix: execv return 0 and does not set errno on errors */
 	if (optind < argc) {
 		execv(argv[optind], argv+optind);
-		printf("env: execv: No such command '%s'\n", argv[optind]);
-		return -ENOENT;
+		return -errno;
 	}
 	
 	if (environ)


### PR DESCRIPTION
Closes #1335:
Behaves like execv in posix: returns -1 on failure and sets errno to the value of error that occurred. Seems to have fixed #1334, but does not seem to have helped #1702.