### PR TITLE
usb: Do not disable hub ports power

### DIFF
--- a/src/drivers/usb/usb_hub.c
+++ b/src/drivers/usb/usb_hub.c
@@ -382,11 +382,6 @@ static int usb_hub_probe(struct usb_dev *dev) {
 	}
 
 	for (i = 0; i < hub->port_n; i++) {
-		usb_hub_clear_port_feature(hub, i, USB_PORT_FEATURE_POWER);
-	}
-	usleep(100 * 1000);
-
-	for (i = 0; i < hub->port_n; i++) {
 		usb_hub_set_port_feature(hub, i, USB_PORT_FEATURE_POWER);
 	}
 	usleep(100 * 1000);


### PR DESCRIPTION
Generally, power disable is not required when scanning USB ports. Also, it fixes OHCI hubs using in Qemu (`./scripts/qemu/auto_qemu_with_usb_hub` on x86/qemu)