### PR TITLE
templates: Add fat driver to imx6/iwave

### DIFF
--- a/templates/arm/iwave_imx6/mods.config
+++ b/templates/arm/iwave_imx6/mods.config
@@ -58,6 +58,7 @@ configuration conf {
 
 	include embox.fs.driver.initfs_dvfs
 	include embox.fs.driver.devfs_dvfs
+	include embox.fs.driver.fat_dvfs
 	@Runlevel(2) include embox.fs.rootfs_dvfs
 
 	include embox.test.kernel.timer_test
@@ -81,7 +82,13 @@ configuration conf {
 
 	include embox.cmd.fs.cat
 	include embox.cmd.fs.ls
+	include embox.cmd.fs.cd
 	include embox.cmd.fs.dd
+	include embox.cmd.fs.mkdir
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.mount
+	include embox.cmd.fs.umount
 
 	include embox.cmd.net.ifconfig
 	include embox.cmd.net.httpd


### PR DESCRIPTION
Add vfat (tested with EHCI).

```
root@embox:/#lsblk                                                              
Block devices:
  ID |  NAME          |    SIZE    | TYPE
   0 |    sda         | 16055795200 | disk
root@embox:/#mkdir -v /mnt
root@embox:/#mount -t vfat /dev/sda /mnt                                        
root@embox:/#ls /mnt                                                            
 /mnt/my.txt
 /mnt/1.txt
root@embox:/#cat /mnt/1.txt                                                     
Hello embox! Test 123 456 Bye!
```