### PR TITLE
Fix DumbFS driver

### DIFF
--- a/templates/arm/stm32_dvfs/mods.config
+++ b/templates/arm/stm32_dvfs/mods.config
@@ -92,7 +92,7 @@ configuration conf {
 
 	/* XXX block_size MUST be the same as sector_size for stm32 flash */
 	include embox.fs.driver.dfs(block_size=0x4000,pages_max=0x10000)
-	include embox.fs.driver.initfs_dvfs
+	include embox.fs.driver.initfs_dvfs(file_quantity=32)
 	include embox.fs.driver.devfs_dvfs
 	@Runlevel(2) include embox.fs.rootfs_dvfs(fstype="initfs")
 

--- a/templates/arm/stm32_modbus/mods.config
+++ b/templates/arm/stm32_modbus/mods.config
@@ -12,7 +12,7 @@ configuration conf {
 	include embox.fs.dvfs.core(inode_pool_size=24,file_pool_size=20,dentry_pool_size=24)
 
 	include embox.fs.driver.dfs(block_size=0x4000,pages_max=0x10000)
-	include embox.fs.driver.initfs_dvfs
+	include embox.fs.driver.initfs_dvfs(file_quantity=16)
 	include embox.fs.rootfs_dvfs(fstype="initfs")
 	include embox.compat.posix.fs.all_dvfs
 
@@ -43,7 +43,7 @@ configuration conf {
 	include embox.net.udp_sock
 	include embox.kernel.sched.sched
 	include embox.kernel.sched.idle_light
-	include embox.kernel.thread.signal.siginfoq(pool_sz=0)
+	include embox.kernel.thread.signal.siginfoq
 
 	include embox.kernel.lthread.lthread
 	include embox.kernel.thread.core(thread_pool_size=3,thread_stack_size=6600)
@@ -67,6 +67,8 @@ configuration conf {
 	include embox.cmd.net.httpd_cgi
 	include embox.cmd.net.bootpc
 	include embox.cmd.fs.ls
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.dd
 	include embox.cmd.fs.mount
 	include stm32f4_iocontrol.http_admin
 	include stm32f4_iocontrol.cmd.flash_settings


### PR DESCRIPTION
Now `stm32_modbus` templates works and saves config to flash device.