### PR TITLE
pl011: Disable back FIFO mode

### DIFF
--- a/src/drivers/serial/pl011/pl011.c
+++ b/src/drivers/serial/pl011/pl011.c
@@ -75,10 +75,8 @@ static int pl011_setup(struct uart *dev, const struct uart_params *params) {
 
 	pl011_set_baudrate(dev);
 
-	/* Enable Rx and Tx fifos. */
-	REG_ORIN(UART_LCRH, UART_FEN);
 	/* Word len 8 bit. */
-	REG_ORIN(UART_LCRH, UART_WLEN_8BIT << UART_WLEN_SHIFT);
+	REG_STORE(UART_LCRH, UART_WLEN_8BIT << UART_WLEN_SHIFT);
 
 	/* Enable uart. */
 	REG_STORE(UART_CR, UART_UARTEN | UART_TXE | UART_RXE);


### PR DESCRIPTION
Fixes https://github.com/embox/embox/issues/1891

Occasionally I misunderstood what FIFO means, and enabled RX fifo which means to trigger RX irq only with trigger level (>= 2 incoming chars). So now I disabled fifo mode and irq happens per each incoming character.