### PR TITLE
Add tests for strupr() and strlwr()

### DIFF
--- a/src/tests/stdlib/Mybuild
+++ b/src/tests/stdlib/Mybuild
@@ -93,4 +93,18 @@ module strcmp_test {
 
 	depends embox.compat.libc.str
 	depends embox.framework.LibFramework
+}		
+
+module strlwr_test {
+	source "strlwr.c"
+
+	depends embox.compat.libc.stdlib.core
+	depends embox.framework.LibFramework
+}
+
+module strupr_test {
+	source "strupr.c"
+
+	depends embox.compat.libc.stdlib.core
+	depends embox.framework.LibFramework
 }

--- a/src/tests/stdlib/strlwr.c
+++ b/src/tests/stdlib/strlwr.c
@@ -1,0 +1,39 @@
+/**
+ * @file
+ *
+ * @date Mar 21, 2020
+ * @author: Faisal Riyaz
+ */
+
+#include <string.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("test suit for strlwr()");
+
+TEST_CASE("strlwr with uppercase string") {
+	char str[] = "STRING";
+
+	test_assert_zero(strcmp("string", strlwr(str)));	
+}
+
+TEST_CASE("strlwr with mixed string") {
+	char str1[] = "ABC string 123";
+	char str2[] = "ABCdefGH";	
+
+	test_assert_zero(strcmp("abc string 123", strlwr(str1)));
+	test_assert_zero(strcmp("abcdefgh", strlwr(str2)));
+}
+
+TEST_CASE("checking strlwr result with differnt string") {
+	char str[] = "STRING";
+
+	test_assert_not_zero(strcmp("abcdef", strlwr(str)));
+	test_assert_not_zero(strcmp("STriNG", strlwr(str)));
+}
+
+TEST_CASE("checking strlwr result with string of differnt length") {
+	char str[] = "STRING";
+
+	test_assert_not_zero(strcmp("strin", strlwr(str)));
+	test_assert_not_zero(strcmp("stringg", strlwr(str)));	
+}

--- a/src/tests/stdlib/strupr.c
+++ b/src/tests/stdlib/strupr.c
@@ -1,0 +1,39 @@
+/**
+ * @file
+ *
+ * @date Mar 21, 2020
+ * @author: Faisal Riyaz
+ */
+
+#include <string.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("test suit for strupr()");
+
+TEST_CASE("strupr with lowercase string") {
+	char str[] = "string";
+
+	test_assert_zero(strcmp("STRING", strupr(str)));
+}
+
+TEST_CASE("strupr with mixed string") {
+	char str1[] = "ABC string 123";
+	char str2[] = "abcDEFgh";
+
+	test_assert_zero(strcmp("ABC STRING 123", strupr(str1)));
+	test_assert_zero(strcmp("ABCDEFGH", strupr(str2)));	
+}
+
+TEST_CASE("checking strupr result with differnt string") {
+	char str[] = "string";
+
+	test_assert_not_zero(strcmp("ABCDEF", strupr(str)));
+	test_assert_not_zero(strcmp("STriNG", strupr(str)));
+}
+
+TEST_CASE("checking strupr result with differnt length") {
+	char str[] = "string";
+
+	test_assert_not_zero(strcmp("STRIN", strupr(str)));
+	test_assert_not_zero(strcmp("STRINGG", strupr(str)));	
+}

--- a/templates/x86/test/units/mods.config
+++ b/templates/x86/test/units/mods.config
@@ -79,6 +79,8 @@ configuration conf {
 	@Runlevel(1) include embox.test.stdlib.mblen_test
 	@Runlevel(1) include embox.test.stdlib.ffs_test
 	@Runlevel(1) include embox.test.stdlib.strcmp_test
+	@Runlevel(1) include embox.test.stdlib.strlwr_test	
+	@Runlevel(1) include embox.test.stdlib.strupr_test
 	@Runlevel(1) include embox.test.posix.environ_test
 	@Runlevel(1) include embox.test.posix.timerfd_test
 	@Runlevel(1) include embox.test.posix.fork.test_fork_static


### PR DESCRIPTION
Fixes #1849.
Added test cases for strlwr() and strupr() functions.