### PR TITLE
Refactor stdio

### DIFF
--- a/src/cmds/net/ftp.c
+++ b/src/cmds/net/ftp.c
@@ -328,7 +328,7 @@ static int flush_file_to_socket(FILE *file, int sock, char *buff, size_t buff_sz
 
 	while (1) {
 		readed = fread(buff, 1, buff_sz, file);
-		if (readed < 0) {
+		if (ferror(file) || readed < 0) {
 			fprintf(stderr, "Can't read data from file.\n");
 			return FTP_RET_ERROR;
 		}

--- a/src/cmds/net/tftp.c
+++ b/src/cmds/net/tftp.c
@@ -53,9 +53,9 @@ static int read_file(FILE *fp, char *buff, size_t buff_sz, size_t *out_bytes) {
 	int ret;
 
 	ret = fread(buff, 1, buff_sz, fp);
-	if (ret < 0) {
+	if (ferror(fp) || ret < 0) {
 		fprintf(stderr, "Can't read data from file\n");
-		return -errno;
+		return -1;
 	}
 
 	*out_bytes = (size_t)ret;

--- a/src/compat/libc/include/stdio.h
+++ b/src/compat/libc/include/stdio.h
@@ -76,9 +76,6 @@ extern int getchar(void);
 
 extern int ungetc(int c, FILE *stream);
 
-/* ungetc() for stdin */
-int ungetchar(int ch);
-
 extern void perror(const char *s);
 
 /**

--- a/src/compat/libc/stdio/fopen.c
+++ b/src/compat/libc/stdio/fopen.c
@@ -15,25 +15,48 @@
 #include "file_struct.h"
 
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 
-#define DEFAULT_MODE 0666
+#define DEFAULT_MODE (S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH) /* 0666 */
 
 extern FILE *stdio_file_alloc(int fd);
 
 static int mode2flag(const char *mode) {
-	int flags = 0;
+	int oflags, omode, loop;
 
-	if (strchr(mode, 'r') && strchr(mode, 'w')) {
-		flags |= O_RDWR | O_TRUNC | O_CREAT;
-	} else if (strchr(mode, 'w')) {
-		flags |= O_WRONLY | O_TRUNC | O_CREAT;
+	switch (*mode++) {
+	case 'r':
+		omode = O_RDONLY;
+		oflags = 0;
+		break;
+	case 'w':
+		omode = O_WRONLY;
+		oflags = O_CREAT|O_TRUNC;
+		break;
+	case 'a':
+		omode = O_WRONLY;
+		oflags = O_CREAT|O_APPEND;
+		break;
+	default: /*illegal mode */
+		SET_ERRNO(EINVAL);
+		return -1;
 	}
 
-	if (strchr(mode, 'a')) {
-		flags |= O_APPEND | O_CREAT | O_RDWR;
-	}
-
-	return flags;
+	do {
+		loop = 1;
+		switch (*mode++) {
+		case 'b':
+			/* ignore 'b' (binary) */
+			break;
+		case '+':
+			omode = O_RDWR;
+			break;
+		default:
+			loop = 0;
+			break;
+		}
+	} while (loop);
+	return omode | oflags;
 }
 
 FILE *fopen(const char *path, const char *mode) {
@@ -41,7 +64,9 @@ FILE *fopen(const char *path, const char *mode) {
 	FILE *file = NULL;
 	int flags = 0;
 
-	flags = mode2flag(mode);
+	if((flags = mode2flag(mode)) < 0 ) {
+		return NULL;
+	}
 
 	if ((fd = open(path, flags, DEFAULT_MODE)) < 0) {
 		/* That's sad, but open sets errno, no need to alter */
@@ -84,7 +109,9 @@ FILE *freopen(const char *path, const char *mode, FILE *file) {
 		return NULL;
 	}
 
-	flags = mode2flag(mode);
+	if((flags = mode2flag(mode)) < 0 ) {
+		return NULL;
+	}
 
 	if ((fd = open(path, flags, DEFAULT_MODE)) < 0) {
 		/* That's sad, but open sets errno, no need to alter */

--- a/src/compat/libc/stdio/fopen.c
+++ b/src/compat/libc/stdio/fopen.c
@@ -106,6 +106,7 @@ FILE *freopen(const char *path, const char *mode, FILE *file) {
 	int old_fd;
 
 	if (NULL == path || NULL == file) {
+		SET_ERRNO(EINVAL);
 		return NULL;
 	}
 
@@ -121,6 +122,7 @@ FILE *freopen(const char *path, const char *mode, FILE *file) {
 
 	dup2(fd, old_fd);
 	file->flags = flags;
+	clearerr(file); /* redundant but just-in-case */
 
 	close(fd);
 

--- a/src/compat/libc/stdio/fseek.c
+++ b/src/compat/libc/stdio/fseek.c
@@ -32,6 +32,9 @@ int fseek(FILE *file, long int offset, int origin) {
 		return -1;
 	}
 
+	/* undo ungetc() and clear EOF flag */
+	file->has_ungetc = 0;
+	file->flags &= ~IO_EOF_;
 	return 0;
 }
 
@@ -83,9 +86,14 @@ int fsetpos(FILE *stream, const fpos_t *pos) {
 		return -1;
 	}
 
+	/* undo ungetc() and clear EOF flag */
+	stream->has_ungetc = 0;
+	stream->flags &= ~IO_EOF_;
 	return 0;
 }
 
 void rewind(FILE *file) {
-	fseek(file, 0L, SEEK_SET);
+	if (!fseek(file, 0L, SEEK_SET)) {
+		clearerr(file);
+	}
 }

--- a/src/compat/libc/stdio/rename_dvfs.c
+++ b/src/compat/libc/stdio/rename_dvfs.c
@@ -96,7 +96,7 @@ int rename(const char *src_name, const char *dst_name) {
 
 		while (pos < from->d_inode->length) {
 			err = fread(buf, sizeof(buf[0]), FS_BUFFER_SZ, in);
-			if (err < 0) {
+			if (err <= 0 && ferror(in)) {
 				goto err_out;
 			}
 

--- a/src/compat/libc/stdio/scanf.c
+++ b/src/compat/libc/stdio/scanf.c
@@ -63,7 +63,7 @@ static void unscanchar(const char **str, int ch, int *pc_ptr) {
 	} else if ((uintptr_t) str == 1) {
 		ungetc(ch, file);
 	} else {
-		ungetchar(ch);
+		ungetc(ch, stdin);
 	}
 }
 

--- a/src/compat/libc/stdio/ungetc.c
+++ b/src/compat/libc/stdio/ungetc.c
@@ -24,7 +24,3 @@ int ungetc(int ch, FILE *file) {
 	return ch;
 }
 
-int ungetchar(int ch) {
-	return ungetc(ch, stdin);
-}
-

--- a/src/compat/libc/stdio/ungetc.c
+++ b/src/compat/libc/stdio/ungetc.c
@@ -14,10 +14,13 @@
 int ungetc(int ch, FILE *file) {
 	if (NULL == file) {
 		SET_ERRNO(EBADF);
-		return -1;
+		return EOF;
 	}
-	file->ungetc = (char) ch;
-	file->has_ungetc = 1;
+	if (EOF != ch) {
+		file->ungetc = (char) ch;
+		file->has_ungetc = 1;
+		file->flags &= ~IO_EOF_;
+	}
 	return ch;
 }
 

--- a/src/net/lib/dns/dns_file.c
+++ b/src/net/lib/dns/dns_file.c
@@ -32,7 +32,7 @@ char *dns_set_nameserver(char *nameserver) {
 	char buf[0x40];
 	char *res;
 
-	file = fopen(RESOLV_FILE, "rw");
+	file = fopen(RESOLV_FILE, "w+");
 	if (file == NULL) {
 		return err_ptr(errno);
 	}

--- a/src/pnet/node/timer.c
+++ b/src/pnet/node/timer.c
@@ -61,7 +61,7 @@ PNET_NODE_DEF("timer", {
 });
 
 static int init(void) {
-	results = fopen("/tmp/pnet_total", "rw");
+	results = fopen("/tmp/pnet_total", "w+");
 	return (NULL == results);
 }
 


### PR DESCRIPTION
I've been finding some issue with a few functions in stdio.h. Theses patches contain:
- fopen(): change mode parsing so it's complaint with POSIX. (also changes the two files which used the more carefree mode notation.
- fread(): A big issue triggered when has_ungetc is set, caused:
  - useless calls to read() with size=0 (read(file->fd,buf,0).
 -  the previous addition of F_EOF setup in 93ad52283 to break and set F_EOF always.
 So fread() was refactored, to fix the previous issues and to return a 'short item count (or zero)' when error occurs, as POSIX states. (also adapted the few files which assumed the non-POSIX behavior).
- Clear F_EOF and F_ERR flags in all the corresponding functions. (along with some small fixes in the same functions).
- remove non-POSIX ungetchar(): It's basically unused, except by scanf(). 