### PR TITLE
tests: stdlib: Add unit tests for strpbrk()

### DIFF
--- a/src/tests/stdlib/Mybuild
+++ b/src/tests/stdlib/Mybuild
@@ -164,3 +164,10 @@ module strchrnul_test {
 	depends embox.compat.libc.str
 	depends embox.framework.LibFramework
 }
+
+module strpbrk_test {
+	source "strpbrk.c"
+
+	depends embox.compat.libc.str
+	depends embox.framework.LibFramework
+}

--- a/src/tests/stdlib/strpbrk.c
+++ b/src/tests/stdlib/strpbrk.c
@@ -1,0 +1,45 @@
+/**
+ * @file
+ * @brief Tests for strpbrk().
+ *
+ * @date Mar 30, 2020
+ * @author: Neeraj Adhikari
+ */
+
+#include <string.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("strpbrk test suite");
+
+TEST_CASE("strpbrk with empty strings") {
+	char nonempty[] = "test";
+	char empty[] = "";
+
+	test_assert_null(strpbrk(nonempty, empty));
+	test_assert_null(strpbrk(empty, nonempty));
+	test_assert_null(strpbrk(empty, empty));
+}
+
+TEST_CASE("strpbrk with printable strings") {
+	char embox[] = "EMBOXembox";
+	char vowels_lower[] = "aeiou";
+	char digits[] = "0123456789";
+	char symbols[] = "~!@#$%^&*()_+?><:}{\"'";
+	char nine[] = "9";
+	char hash[] = "#";
+
+	test_assert_equal(strpbrk(embox, embox), embox);
+	test_assert_equal(strpbrk(embox, vowels_lower), embox + 5);
+	test_assert_equal(strpbrk(vowels_lower, embox), vowels_lower + 1);
+	test_assert_equal(strpbrk(digits, nine), digits + 9);
+	test_assert_null(strpbrk(symbols, nine));
+	test_assert_equal(strpbrk(symbols, hash), symbols + 3);
+}
+
+TEST_CASE("strpbrk with non-printable data") {
+	char data[] = {0xCA, 0xFE, 0xBA, 0xBE, 0x00};
+	char key[] = {0xBA, 0x00};
+
+	test_assert_equal(strpbrk(data, key), data + 2);
+	test_assert_equal(strpbrk(key, data), key);
+}

--- a/src/tests/stdlib/strpbrk.c
+++ b/src/tests/stdlib/strpbrk.c
@@ -37,8 +37,8 @@ TEST_CASE("strpbrk with printable strings") {
 }
 
 TEST_CASE("strpbrk with non-printable data") {
-	char data[] = {0xCA, 0xFE, 0xBA, 0xBE, 0x00};
-	char key[] = {0xBA, 0x00};
+	char data[] = "\xCA\xFE\xBA\xBE";
+	char key[] = "\xBA";
 
 	test_assert_equal(strpbrk(data, key), data + 2);
 	test_assert_equal(strpbrk(key, data), key);

--- a/templates/x86/test/units/mods.config
+++ b/templates/x86/test/units/mods.config
@@ -84,6 +84,7 @@ configuration conf {
 	@Runlevel(1) include embox.test.stdlib.strcmp_test
 	@Runlevel(1) include embox.test.stdlib.strlwr_test	
 	@Runlevel(1) include embox.test.stdlib.strcasestr_test	
+	@Runlevel(1) include embox.test.stdlib.strpbrk_test
 	@Runlevel(1) include embox.test.stdlib.strstr_test	
 	@Runlevel(1) include embox.test.stdlib.strupr_test
 	@Runlevel(1) include embox.test.stdlib.strcpy_test	


### PR DESCRIPTION
This fixes #1848.