### PR TITLE
Toggle led through Lua UDP server on stm32f7-disco

### DIFF
--- a/src/cmds/hardware/pin/pin.c
+++ b/src/cmds/hardware/pin/pin.c
@@ -25,28 +25,27 @@ static void print_usage(void) {
 		"    pin GPIOA 12 blink  -- Toggle pin number 12 at GPIOA\n");
 }
 
-static int gpio_by_name(char *name) {
-	if (!strncmp("GPIO", name, 4) || !strncmp("gpio", name, 4)) {
-		name += 4;
-	}
+static int gpio_by_name(const char *name) {
+	int id = -1;
 
-	if (strlen(name) == 0) {
+	if (strncmp("GPIO", name, 4) && strncmp("gpio", name, 4)) {
 		return -1;
 	}
-
-	switch (name[0]) {
-	case '0': case 'a': case 'A': return GPIO_PORT_A;
-	case '1': case 'b': case 'B': return GPIO_PORT_B;
-	case '2': case 'c': case 'C': return GPIO_PORT_C;
-	case '3': case 'd': case 'D': return GPIO_PORT_D;
-	case '4': case 'e': case 'E': return GPIO_PORT_E;
-	case '5': case 'f': case 'F': return GPIO_PORT_F;
-	default:
-		fprintf(stderr, "Can't convert character '%c' to GPIO. Error.",
-			name[0]);
+	name += 4;
+	if (!strlen(name)) {
+		return -1;
 	}
-
-	return -1;
+	if (toupper(name[0]) >= 'A' && toupper(name[0]) <= 'Z') {
+		if (strlen(name) > 1) {
+			return -1;
+		}
+		id = toupper(name[0]) - 'A';
+	} else {
+		if (1 != sscanf(name, "%d", &id)) {
+			return -1;
+		}
+	}
+	return id;
 }
 
 int main(int argc, char **argv) {
@@ -73,11 +72,12 @@ int main(int argc, char **argv) {
 	}
 	opt = 1;
 
-	gpio = gpio_by_name(argv[opt++]);
+	gpio = gpio_by_name(argv[opt]);
 	if (gpio == -1) {
-		fprintf(stderr, "Can't extract GPIO.\n");
+		fprintf(stderr, "Unknown GPIO: %s\n", argv[opt]);
 		return 0;
 	}
+	opt++;
 
 	if (!sscanf(argv[opt++], "%d", &arg)) {
 		fprintf(stderr, "Pin is not specified.\n");

--- a/src/drivers/gpio/gpio.h
+++ b/src/drivers/gpio/gpio.h
@@ -89,6 +89,11 @@ typedef volatile unsigned long gpio_mask_t;
 #define GPIO_PORT_D 3
 #define GPIO_PORT_E 4
 #define GPIO_PORT_F 5
+#define GPIO_PORT_G 6
+#define GPIO_PORT_H 7
+#define GPIO_PORT_I 8
+#define GPIO_PORT_J 9
+#define GPIO_PORT_K 10
 
 #define GPIO_PIN_LOW  0
 #define GPIO_PIN_HIGH 1

--- a/src/drivers/gpio/stm32/Mybuild
+++ b/src/drivers/gpio/stm32/Mybuild
@@ -26,3 +26,16 @@ module stm32_gpio_f3 extends api {
 
 	depends embox.driver.gpio.core
 }
+
+@BuildDepends(third_party.bsp.stmf7cube.core)
+module stm32_gpio_f7 extends api {
+	option number log_level = 0
+	option number gpio_chip_id = 0
+
+	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
+	source "stm32_gpio_conf_f7.h"
+
+	source "stm32_gpio_cube.c"
+
+	depends embox.driver.gpio.core
+}

--- a/src/drivers/gpio/stm32/stm32_gpio_conf_f3.h
+++ b/src/drivers/gpio/stm32/stm32_gpio_conf_f3.h
@@ -11,6 +11,22 @@
 
 #include "stm32f3xx_hal.h"
 #include "stm32f3xx_hal_gpio.h"
-#include "stm32f3_discovery.h"
 
-#endif
+#define STM32_GPIO_PORTS_COUNT 6
+
+static GPIO_TypeDef *stm32_gpio_ports[STM32_GPIO_PORTS_COUNT] = {
+	GPIOA, GPIOB, GPIOC, GPIOD, GPIOE, GPIOF
+};
+
+static void stm32_gpio_clk_enable(void *gpio_base) {
+	switch ((int) gpio_base) {
+	case (int) GPIOA: __HAL_RCC_GPIOA_CLK_ENABLE(); break;
+	case (int) GPIOB: __HAL_RCC_GPIOB_CLK_ENABLE(); break;
+	case (int) GPIOC: __HAL_RCC_GPIOC_CLK_ENABLE(); break;
+	case (int) GPIOD: __HAL_RCC_GPIOD_CLK_ENABLE(); break;
+	case (int) GPIOE: __HAL_RCC_GPIOE_CLK_ENABLE(); break;
+	case (int) GPIOF: __HAL_RCC_GPIOF_CLK_ENABLE(); break;
+	}
+}
+
+#endif /* SRC_DRIVERS_GPIO_STM32_USART_STM32_USART_CONF_F3_H_ */

--- a/src/drivers/gpio/stm32/stm32_gpio_conf_f4.h
+++ b/src/drivers/gpio/stm32/stm32_gpio_conf_f4.h
@@ -11,6 +11,24 @@
 
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_gpio.h"
-#include "stm32f4_discovery.h"
 
-#endif
+#define STM32_GPIO_PORTS_COUNT 8
+
+static GPIO_TypeDef *stm32_gpio_ports[STM32_GPIO_PORTS_COUNT] = {
+	GPIOA, GPIOB, GPIOC, GPIOD, GPIOE, GPIOF, GPIOG, GPIOH
+};
+
+static void stm32_gpio_clk_enable(void *gpio_base) {
+	switch ((int) gpio_base) {
+	case (int) GPIOA: __HAL_RCC_GPIOA_CLK_ENABLE(); break;
+	case (int) GPIOB: __HAL_RCC_GPIOB_CLK_ENABLE(); break;
+	case (int) GPIOC: __HAL_RCC_GPIOC_CLK_ENABLE(); break;
+	case (int) GPIOD: __HAL_RCC_GPIOD_CLK_ENABLE(); break;
+	case (int) GPIOE: __HAL_RCC_GPIOE_CLK_ENABLE(); break;
+	case (int) GPIOF: __HAL_RCC_GPIOF_CLK_ENABLE(); break;
+	case (int) GPIOG: __HAL_RCC_GPIOG_CLK_ENABLE(); break;
+	case (int) GPIOH: __HAL_RCC_GPIOH_CLK_ENABLE(); break;
+	}
+}
+
+#endif /* SRC_DRIVERS_GPIO_STM32_USART_STM32_USART_CONF_F4_H_ */

--- a/src/drivers/gpio/stm32/stm32_gpio_conf_f7.h
+++ b/src/drivers/gpio/stm32/stm32_gpio_conf_f7.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ *
+ * @date 31.03.2020
+ * @author Alexander Kalmuk
+ */
+
+#ifndef SRC_DRIVERS_GPIO_STM32_USART_STM32_USART_CONF_F7_H_
+#define SRC_DRIVERS_GPIO_STM32_USART_STM32_USART_CONF_F7_H_
+
+#include "stm32f7xx_hal.h"
+#include "stm32f7xx_hal_gpio.h"
+
+#define STM32_GPIO_PORTS_COUNT 11
+
+static GPIO_TypeDef *stm32_gpio_ports[STM32_GPIO_PORTS_COUNT] = {
+	GPIOA, GPIOB, GPIOC, GPIOD, GPIOE, GPIOF, GPIOG, GPIOH,
+	GPIOI, GPIOJ, GPIOK
+};
+
+static void stm32_gpio_clk_enable(void *gpio_base) {
+	switch ((int) gpio_base) {
+	case (int) GPIOA: __HAL_RCC_GPIOA_CLK_ENABLE(); break;
+	case (int) GPIOB: __HAL_RCC_GPIOB_CLK_ENABLE(); break;
+	case (int) GPIOC: __HAL_RCC_GPIOC_CLK_ENABLE(); break;
+	case (int) GPIOD: __HAL_RCC_GPIOD_CLK_ENABLE(); break;
+	case (int) GPIOE: __HAL_RCC_GPIOE_CLK_ENABLE(); break;
+	case (int) GPIOF: __HAL_RCC_GPIOF_CLK_ENABLE(); break;
+	case (int) GPIOG: __HAL_RCC_GPIOG_CLK_ENABLE(); break;
+	case (int) GPIOH: __HAL_RCC_GPIOH_CLK_ENABLE(); break;
+	case (int) GPIOI: __HAL_RCC_GPIOI_CLK_ENABLE(); break;
+	case (int) GPIOJ: __HAL_RCC_GPIOJ_CLK_ENABLE(); break;
+	case (int) GPIOK: __HAL_RCC_GPIOK_CLK_ENABLE(); break;
+	}
+}
+
+#endif /* SRC_DRIVERS_GPIO_STM32_USART_STM32_USART_CONF_F7_H_ */

--- a/src/drivers/gpio/stm32/stm32_gpio_cube.c
+++ b/src/drivers/gpio/stm32/stm32_gpio_cube.c
@@ -17,35 +17,13 @@
 
 #define STM32_GPIO_CHIP_ID OPTION_GET(NUMBER,gpio_chip_id)
 
-#define STM32_GPIO_PORTS_COUNT 6
 #define EXTI_LINES_CNT 4
 
 #define EXTI0_IRQ (EXTI0_IRQn + 16)
 
 EMBOX_UNIT_INIT(stm32_gpio_init);
 
-static GPIO_TypeDef *stm32_gpio_ports[STM32_GPIO_PORTS_COUNT] = {
-	GPIOA, GPIOB, GPIOC, GPIOD, GPIOE, GPIOF
-};
-
 static struct gpio_chip stm32_gpio_chip;
-
-static void stm32_gpio_clk_enable(void *gpio_base) {
-	if (gpio_base == GPIOA)
-		__HAL_RCC_GPIOA_CLK_ENABLE();
-	else if (gpio_base == GPIOB)
-		__HAL_RCC_GPIOB_CLK_ENABLE();
-	else if (gpio_base == GPIOC)
-		__HAL_RCC_GPIOC_CLK_ENABLE();
-	else if (gpio_base == GPIOD)
-		__HAL_RCC_GPIOD_CLK_ENABLE();
-	else if (gpio_base == GPIOE)
-		__HAL_RCC_GPIOE_CLK_ENABLE();
-	else if (gpio_base == GPIOF)
-		__HAL_RCC_GPIOF_CLK_ENABLE();
-	else
-		assert(0);
-}
 
 static int stm32_gpio_setup_mode(unsigned char port, gpio_mask_t pins,
 		int mode) {

--- a/templates/arm/stm32f746g-discovery-lua/mods.config
+++ b/templates/arm/stm32f746g-discovery-lua/mods.config
@@ -26,6 +26,8 @@ configuration conf {
 	//@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=115200, usartx=6)
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
 
+	include embox.driver.gpio.stm32_gpio_f7
+
 	@Runlevel(2) include embox.driver.net.stm32f7cube_eth
 	@Runlevel(2) include embox.driver.net.loopback
 
@@ -66,6 +68,7 @@ configuration conf {
 	include embox.init.system_start_service(log_level=3, tty_dev="ttyS0")
 
 	include embox.cmd.mem
+	include embox.cmd.fs.echo
 	include embox.cmd.fs.ls
 	include embox.cmd.fs.cat
 	include embox.cmd.fs.mount
@@ -74,6 +77,7 @@ configuration conf {
 	include embox.cmd.net.route
 	include embox.cmd.net.ping
 	include embox.cmd.net.telnetd
+	include embox.cmd.hardware.pin
 
 	include third_party.cmd.lua(luasocket_support=true)
 	include third_party.lib.luasocket

--- a/third-party/lua/lib/luasocket/Mybuild
+++ b/third-party/lua/lib/luasocket/Mybuild
@@ -8,7 +8,8 @@ static module luasocket {
 
 	@InitFS
 	source "loadrobots.lua",
-		"http_request.lua"
+		"http_request.lua",
+		"udp_server.lua"
 
 	@NoRuntime depends embox.compat.posix.net.All
 	@NoRuntime depends embox.kernel.task.resource.errno

--- a/third-party/lua/lib/luasocket/udp_server.lua
+++ b/third-party/lua/lib/luasocket/udp_server.lua
@@ -1,0 +1,11 @@
+local socket = require("socket")
+
+port = arg[1] or 1027
+udp = assert(socket.udp())
+assert(udp:setsockname('*', port))
+print("Lua UDP server started on port " .. port .. "...")
+while 1 do
+	cmd, ip, port = assert(udp:receivefrom())
+	print("Execute '" .. cmd .. "' from " .. ip .. ":" .. port)
+	os.execute(cmd)
+end


### PR DESCRIPTION
* Add a very simple Lua example of how to toggle LEDs over the network.
* Split config for stm32 gpios because different boards have different gpio count.


On Linux:
```
$ lua5.3 echoclnt.lua 192.168.0.128 1027
Using remote host '192.168.0.128' and port 1027...
pin gpioi 1 toggle
pin gpioi 1 toggle

```

On Embox:
```
embox>lua udp_server.lua                                                        
Lua UDP server started on port 1027...
Execute 'pin gpioi 1 toggle' from 192.168.0.102:34300
Execute 'pin gpioi 1 toggle' from 192.168.0.102:34300
```