### PR TITLE
Fix microblaze build

### DIFF
--- a/mk/extbld/toolchain.mk
+++ b/mk/extbld/toolchain.mk
@@ -21,7 +21,12 @@ EMBOX_IMPORTED_LDFLAGS += -T $(_empty_lds_hack)
 endif
 
 EMBOX_IMPORTED_LDFLAGS_FULL  =
+LD_DISABLE_RELAXATION ?= n
+ifeq (n,$(LD_DISABLE_RELAXATION))
 EMBOX_IMPORTED_LDFLAGS_FULL += -Wl,--relax
+else
+EMBOX_IMPORTED_LDFLAGS_FULL += -Wl,--no-relax
+endif
 EMBOX_IMPORTED_LDFLAGS_FULL += -Wl,-T,$(abspath $(OBJ_DIR))/mk/image.lds
 EMBOX_IMPORTED_LDFLAGS_FULL += -Wl,--defsym=__symbol_table=0,--defsym=__symbol_table_size=0
 EMBOX_IMPORTED_LDFLAGS_FULL += $(abspath $(OBJ_DIR))/embox.o

--- a/mk/image3.mk
+++ b/mk/image3.mk
@@ -65,6 +65,13 @@ else
 ld_scripts_flag = $(if $(strip $1),-T $1)
 endif
 
+LD_DISABLE_RELAXATION ?= n
+ifeq (n,$(LD_DISABLE_RELAXATION))
+relax = --relax
+else
+relax = --no-relax
+endif
+
 # This must be expanded in a secondary expansion context.
 # NOTE: must be the last one in a list of prerequisites (contains order-only)
 common_prereqs = mk/image2.mk mk/flags.mk $(MKGEN_DIR)/build.mk \
@@ -152,7 +159,7 @@ $(image_relocatable_o): $(image_lds) $(embox_o) $$(common_prereqs)
 	-o $@
 
 $(image_nosymbols_o): $(image_lds) $(embox_o) $$(common_prereqs)
-	$(CC) -Wl,--relax \
+	$(CC) -Wl,$(relax) \
 	$(embox_o) \
 	$(FINAL_LDFLAGS) \
 	-Wl,--defsym=__symbol_table=0 \
@@ -162,7 +169,7 @@ $(image_nosymbols_o): $(image_lds) $(embox_o) $$(common_prereqs)
 	-o $@
 
 $(image_pass1_o): $(image_lds) $(embox_o) $(symbols_pass1_a) $$(common_prereqs)
-	$(CC) -Wl,--relax \
+	$(CC) -Wl,$(relax) \
 	$(embox_o) \
 	$(FINAL_LDFLAGS) \
 	$(symbols_pass1_a) \
@@ -171,7 +178,7 @@ $(image_pass1_o): $(image_lds) $(embox_o) $(symbols_pass1_a) $$(common_prereqs)
 	-o $@
 
 $(IMAGE): $(image_lds) $(embox_o) $(symbols_pass2_a) $$(common_prereqs)
-	$(CC) -Wl,--relax \
+	$(CC) -Wl,$(relax) \
 	$(embox_o) \
 	$(FINAL_LDFLAGS) \
 	$(symbols_pass2_a) \
@@ -190,7 +197,7 @@ $(image_relocatable_o): $(image_lds) $(embox_o) $$(common_prereqs)
 	-o $@
 
 $(image_nosymbols_o): $(image_lds) $(embox_o) $$(common_prereqs)
-	$(LD) --relax $(ldflags) \
+	$(LD) $(relax) $(ldflags) \
 	-T $(image_lds) \
 	$(embox_o) \
 	--defsym=__symbol_table=0 \
@@ -199,7 +206,7 @@ $(image_nosymbols_o): $(image_lds) $(embox_o) $$(common_prereqs)
 	-o $@
 
 $(image_pass1_o): $(image_lds) $(embox_o) $(symbols_pass1_a) $$(common_prereqs)
-	$(LD) --relax $(ldflags) \
+	$(LD) $(relax) $(ldflags) \
 	-T $(image_lds) \
 	$(embox_o) \
 	$(symbols_pass1_a) \
@@ -222,7 +229,7 @@ $(GEN_DIR)/md5sums1.c $(GEN_DIR)/md5sums2.c: $$(source)
 	done
 
 $(image_nocksum): $(image_lds) $(embox_o) $(md5sums1) $(symbols_pass2_a) $$(common_prereqs)
-	$(LD) --relax $(ldflags) \
+	$(LD) $(relax) $(ldflags) \
 	-T $(image_lds) \
 	$(embox_o) \
 	$(md5sums1) \
@@ -231,7 +238,7 @@ $(image_nocksum): $(image_lds) $(embox_o) $(md5sums1) $(symbols_pass2_a) $$(comm
 	-o $@
 
 $(IMAGE): $(image_lds) $(embox_o) $(md5sums2) $(symbols_pass2_a) $$(common_prereqs)
-	$(LD) --relax $(ldflags) \
+	$(LD) $(relax) $(ldflags) \
 	-T $(image_lds) \
 	$(embox_o) \
 	$(md5sums2) \

--- a/src/arch/microblaze/kernel/traps_core.c
+++ b/src/arch/microblaze/kernel/traps_core.c
@@ -35,13 +35,13 @@ static inline void traps_status_restore(uint32_t *status) {
 void traps_save_env(traps_env_t *env) {
 	if (NULL != old_env) {
 		env->base_addr = 0; /*always 0*/
-		memcpy(&(&cur_env)->hw_traps, hwtrap_handler,
-				ARRAY_SIZE(&(&cur_env)->hw_traps));
-		memcpy(&(&cur_env)->soft_traps, sotftrap_handler,
-				ARRAY_SIZE(&(&cur_env)->soft_traps));
+		memcpy(cur_env.hw_traps, hwtrap_handler,
+				ARRAY_SIZE(cur_env.hw_traps));
+		memcpy(cur_env.soft_traps, sotftrap_handler,
+				ARRAY_SIZE(cur_env.soft_traps));
 		old_env = &cur_env;
 	}
-	(&cur_env)->status = msr_get_value();
+	cur_env.status = msr_get_value();
 	memcpy(env, old_env, sizeof(*env));
 }
 

--- a/templates/microblaze/debug/build.conf
+++ b/templates/microblaze/debug/build.conf
@@ -9,3 +9,4 @@ CFLAGS += -O0 -g
 CFLAGS += -ffixed-r31 -mno-xl-soft-mul
 
 LD_SINGLE_T_OPTION = y
+LD_DISABLE_RELAXATION = y

--- a/templates/microblaze/petalogix/build.conf
+++ b/templates/microblaze/petalogix/build.conf
@@ -9,3 +9,4 @@ CFLAGS += -O0 -g
 CFLAGS += -ffixed-r31 -mno-xl-soft-mul
 
 LD_SINGLE_T_OPTION = y
+LD_DISABLE_RELAXATION = y

--- a/templates/microblaze/qemu/build.conf
+++ b/templates/microblaze/qemu/build.conf
@@ -8,3 +8,4 @@ CFLAGS += -O0 -g
 CFLAGS += -ffixed-r31 -mno-xl-soft-mul
 
 LD_SINGLE_T_OPTION = y
+LD_DISABLE_RELAXATION = y

--- a/templates/microblaze/test/units/build.conf
+++ b/templates/microblaze/test/units/build.conf
@@ -9,3 +9,4 @@ CFLAGS += -O0 -g
 CFLAGS += -ffixed-r31 -mno-xl-soft-mul
 
 LD_SINGLE_T_OPTION = y
+LD_DISABLE_RELAXATION = y


### PR DESCRIPTION
Fixes https://github.com/embox/embox/issues/1919.
Fix microblaze/qemu build by disabling linker relaxation (`--relax` option) for MicroBlaze only. The issue is here - https://github.com/embox/embox/issues/1929. Linker relaxation is a kind of target-specific optimization, so it seems to be safe to do not perform it for MicroBlaze.