### PR TITLE
Add lthread static definition

### DIFF
--- a/src/include/kernel/sched/affinity.h
+++ b/src/include/kernel/sched/affinity.h
@@ -16,4 +16,7 @@ extern int sched_affinity_check(struct affinity *a, int mask);
 extern void sched_affinity_set(struct affinity *a, int mask);
 extern int sched_affinity_get(struct affinity *a);
 
+#define SCHED_AFFINITY_INIT() \
+	__SCHED_AFFINITY_INIT()
+
 #endif /* AFFINITY_H_ */

--- a/src/include/kernel/sched/runq.h
+++ b/src/include/kernel/sched/runq.h
@@ -20,4 +20,7 @@ extern struct schedee *runq_extract(runq_t *queue);
 
 extern void runq_item_init(runq_item_t *runq_link);
 
+#define RUNQ_ITEM_INIT(item) \
+	__RUNQ_ITEM_INIT(item)
+
 #endif /* SCHED_RUNQ_H_ */

--- a/src/include/kernel/sched/sched_timing.h
+++ b/src/include/kernel/sched/sched_timing.h
@@ -18,4 +18,7 @@ extern clock_t sched_timing_get(struct schedee *s);
 extern void sched_timing_start(struct schedee *s);
 extern void sched_timing_stop(struct schedee *s);
 
+#define SCHED_TIMING_INIT() \
+	__SCHED_TIMING_INIT()
+
 #endif /* SCHED_TIMING_H_ */

--- a/src/include/kernel/sched/schedee_priority.h
+++ b/src/include/kernel/sched/schedee_priority.h
@@ -26,6 +26,8 @@
 #define SCHED_PRIORITY_HIGH \
 	(SCHED_PRIORITY_MAX + SCHED_PRIORITY_NORMAL) / 2
 
+#define SCHED_PRIORITY_INIT(prio_nr) \
+	__SCHED_PRIORITY_INIT(prio_nr)
 
 struct schedee;
 struct schedee_priority;

--- a/src/include/util/priolist.h
+++ b/src/include/util/priolist.h
@@ -38,13 +38,13 @@ struct priolist_link {
 
 #define PRIOLIST_INIT(list) \
 	{                                               \
-		.node_list = DLIST_INIT((list)->node_list), \
+		.node_list = DLIST_INIT((list).node_list), \
 	}
 
 #define PRIOLIST_LINK_INIT(link) \
 	{                                               \
-		.node_link = DLIST_INIT((link)->node_link), \
-		.prio_link = DLIST_INIT((link)->prio_link), \
+		.node_link = DLIST_INIT((link).node_link), \
+		.prio_link = DLIST_INIT((link).prio_link), \
 	}
 
 static inline void priolist_init(struct priolist *list) {

--- a/src/kernel/lthread/lthread.c
+++ b/src/kernel/lthread/lthread.c
@@ -26,7 +26,7 @@ int __lthread_is_disabled(struct lthread *lt) {
 }
 
 /** locks: IPL, sched. lthread->run must be atomic. */
-static struct schedee *lthread_process(struct schedee *prev,
+struct schedee *lthread_process(struct schedee *prev,
 		struct schedee *next) {
 	struct lthread *lt = mcast_out(next, struct lthread, schedee);
 

--- a/src/kernel/lthread/lthread.h
+++ b/src/kernel/lthread/lthread.h
@@ -131,4 +131,23 @@ static inline void *lthread_resume(struct lthread *lt, void *initial_lbl) {
 	return initial_lbl + lt->label_offset;
 }
 
+extern struct schedee *lthread_process(struct schedee *prev,
+		struct schedee *next);
+
+#define LTHREAD_DEF(_lth, _run, _prio) \
+	struct lthread _lth = { \
+		.run = _run, \
+		.schedee = { \
+			.runq_link = RUNQ_ITEM_INIT(_lth.schedee.runq_link), \
+			.lock = SPIN_UNLOCKED, \
+			.process = lthread_process, \
+			.ready = false, \
+			.active = false, \
+			.waiting = true, \
+			.affinity = SCHED_AFFINITY_INIT(), \
+			.priority = SCHED_PRIORITY_INIT(_prio), \
+			.sched_timing = SCHED_TIMING_INIT(), \
+		} \
+	}
+
 #endif /* _KERNEL_LTHREAD_H_ */

--- a/src/kernel/sched/affinity/none.h
+++ b/src/kernel/sched/affinity/none.h
@@ -24,4 +24,7 @@ static inline void sched_affinity_init(struct affinity *a) { }
 /* TODO none affinity shouldn't have set method */
 static inline void sched_affinity_set(struct affinity *a, int mask) { }
 
+#define __SCHED_AFFINITY_INIT() \
+	{ }
+
 #endif /* AFFINITY_NONE_H_ */

--- a/src/kernel/sched/affinity/smp.c
+++ b/src/kernel/sched/affinity/smp.c
@@ -7,9 +7,6 @@
 
 #include <kernel/sched/affinity.h>
 
-/** Default schedee affinity mask */
-#define SCHEDEE_AFFINITY_NONE         ((unsigned int)-1)
-
 int sched_affinity_check(struct affinity *a, int mask) {
 	return !!(a->mask & mask);
 }

--- a/src/kernel/sched/affinity/smp.h
+++ b/src/kernel/sched/affinity/smp.h
@@ -12,4 +12,10 @@ struct affinity {
 	int mask;
 };
 
+/** Default schedee affinity mask */
+#define SCHEDEE_AFFINITY_NONE         ((unsigned int)-1)
+
+#define __SCHED_AFFINITY_INIT() \
+	{ .mask = SCHEDEE_AFFINITY_NONE }
+
 #endif /* SMP_AFFINITY_H_ */

--- a/src/kernel/sched/priority/inherit.h
+++ b/src/kernel/sched/priority/inherit.h
@@ -14,4 +14,7 @@ struct schedee_priority {
 	short current_priority;   /**< Current schedee scheduling priority. */
 };
 
+#define __SCHED_PRIORITY_INIT(prio) \
+	{ .base_priority = prio, .current_priority = prio }
+
 #endif /* SCHED_PRIORITY_INHERIT_H_ */

--- a/src/kernel/sched/priority/none.h
+++ b/src/kernel/sched/priority/none.h
@@ -16,6 +16,9 @@ struct schedee_priority {
 	EMPTY_STRUCT_BODY
 };
 
+#define __SCHED_PRIORITY_INIT(prio) \
+	{ }
+
 typedef struct schedee_priority __schedee_priority_t;
 
 static inline int schedee_priority_set(struct schedee *s, int new_priority) {

--- a/src/kernel/sched/strategy/runq/list.c
+++ b/src/kernel/sched/strategy/runq/list.c
@@ -8,6 +8,7 @@
 
 #include <util/dlist.h>
 
+#include <kernel/sched.h>
 #include <kernel/sched/sched_strategy.h>
 
 struct schedee;

--- a/src/kernel/sched/strategy/runq/list.h
+++ b/src/kernel/sched/strategy/runq/list.h
@@ -11,9 +11,11 @@
 
 #include <util/dlist.h>
 
-
 typedef struct dlist_head runq_item_t;
 
 typedef struct dlist_head runq_t;
+
+#define __RUNQ_ITEM_INIT(item) \
+	DLIST_INIT(item)
 
 #endif /* KERNEL_THREAD_QUEUE_LIST_H_ */

--- a/src/kernel/sched/strategy/runq/list_array.h
+++ b/src/kernel/sched/strategy/runq/list_array.h
@@ -13,7 +13,6 @@
 
 #include <kernel/sched/schedee_priority.h>
 
-
 struct runq_queue {
 	struct dlist_head list[SCHED_PRIORITY_TOTAL];
 };
@@ -21,5 +20,8 @@ struct runq_queue {
 typedef struct dlist_head runq_item_t;
 
 typedef struct runq_queue runq_t;
+
+#define __RUNQ_ITEM_INIT(item) \
+	DLIST_INIT(item)
 
 #endif /* KERNEL_THREAD_QUEUE_PRIOQ2_H_ */

--- a/src/kernel/sched/strategy/runq/prioq.h
+++ b/src/kernel/sched/strategy/runq/prioq.h
@@ -14,4 +14,7 @@
 typedef struct priolist      runq_t;
 typedef struct priolist_link runq_item_t;
 
+#define __RUNQ_ITEM_INIT(item) \
+	PRIOLIST_LINK_INIT(item)
+
 #endif /* KERNEL_THREAD_QUEUE_PRIOQ_H_ */

--- a/src/kernel/sched/timing/none.h
+++ b/src/kernel/sched/timing/none.h
@@ -19,6 +19,9 @@ struct sched_timing {
 	EMPTY_STRUCT_BODY
 };
 
+#define __SCHED_TIMING_INIT() \
+	{ }
+
 static inline void sched_timing_init(struct schedee *t) { }
 
 static inline clock_t sched_timing_get(struct schedee *t) {

--- a/src/kernel/sched/timing/running_time.h
+++ b/src/kernel/sched/timing/running_time.h
@@ -15,4 +15,7 @@ struct sched_timing {
 	clock_t            last_sync;     /**< Last recalculation of running time.*/
 };
 
+#define __SCHED_TIMING_INIT() \
+	{ .running_time = 0, .last_sync = 0 }
+
 #endif /* SCHED_RUNNING_TIME_H_ */


### PR DESCRIPTION
Add `LTHREAD_DEF` macro, which declares lthread at compile time. Fix net_enrty as an example.

An example:

```
static LTHREAD_DEF(netif_rx_irq_handler, netif_rx_action, NETIF_RX_HND_PRIORITY);
```