### PR TITLE
compat: posix: Implement mprotect()

### DIFF
--- a/src/compat/posix/sys/mman/Mybuild
+++ b/src/compat/posix/sys/mman/Mybuild
@@ -33,3 +33,9 @@ module mmap_stub extends mmap_api {
 	source "mmap_stub.c"
 	depends embox.fs.syslib.idesc_mmap_api
 }
+
+module mprotect {
+	source "mprotect.c"
+
+	depends mmap
+}

--- a/src/compat/posix/sys/mman/mprotect.c
+++ b/src/compat/posix/sys/mman/mprotect.c
@@ -1,0 +1,38 @@
+/**
+ * @file mprotect.c
+ * @brief Set protection of memory mapping
+ * @author Archit Checker <archit.checker5@gmail.com>
+ * @version
+ * @date 24.03.2020
+ */
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <sys/mman.h>
+#include <hal/mmu.h>
+#include <mem/vmem.h>
+#include <mem/mmap.h>
+#include <kernel/task/resource/mmap.h>
+
+int mprotect(void* addr, size_t len, int prot) {
+	int err;
+	struct emmap *emmap = task_self_resource_mmap();
+
+	if ((int) addr % VMEM_PAGE_SIZE != 0) {
+		err = EINVAL;
+		return SET_ERRNO(err);
+	}
+
+	prot &= PROT_READ | PROT_WRITE | PROT_EXEC;
+
+	if ((err = vmem_set_flags(emmap->ctx,
+				(mmu_vaddr_t) addr,
+				len,
+				prot))) {
+		return err;
+	}
+
+	return 0;
+
+}

--- a/src/tests/mem/Mybuild
+++ b/src/tests/mem/Mybuild
@@ -43,3 +43,9 @@ module mmap {
 	depends embox.kernel.task.resource.mmap_full
 	depends embox.compat.posix.sys.mman.mmap
 }
+
+module mprotect {
+	source "mprotect.c"
+
+	depends embox.compat.posix.sys.mman.mprotect
+}

--- a/src/tests/mem/mprotect.c
+++ b/src/tests/mem/mprotect.c
@@ -1,0 +1,42 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @date 10.4.2020
+ * @author Archit Checker <archit.checker5@gmail.com>
+ */
+
+#include <embox/test.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+EMBOX_TEST_SUITE("mprotect");
+
+TEST_CASE("mprotect an address not multiple of page-size") {
+	int result = mprotect((void *) 1, PAGE_SIZE(), PROT_READ);
+
+	test_assert_equal(result, -1);
+	test_assert_equal(errno, EINVAL);
+}
+
+TEST_CASE("set read protection") {
+	int *ptr = mmap(NULL, PAGE_SIZE(), PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
+	int result = mprotect(ptr, PAGE_SIZE(), PROT_READ);
+
+	munmap(ptr, PAGE_SIZE());
+
+	test_assert_equal(result, 0);
+}
+
+TEST_CASE("set write protection and write to memory") {
+	int *ptr = mmap(NULL, PAGE_SIZE(), PROT_READ, MAP_ANONYMOUS, -1, 0);
+	int result = mprotect(ptr, PAGE_SIZE(), PROT_READ | PROT_WRITE);
+
+	*ptr = 'x';
+
+	test_assert_equal(result, 0);
+	test_assert_equal(*ptr, 'x');
+
+	munmap(ptr, PAGE_SIZE());
+}


### PR DESCRIPTION
The standard posix routine `mprotect()` was not
implemented before. This commit implements
`mprotect()` and closes #1815.