### PR TITLE
Mouse and keyboard tests

### DIFF
--- a/platform/mesa/templates/mesa_x86_osmesa/mods.config
+++ b/platform/mesa/templates/mesa_x86_osmesa/mods.config
@@ -23,7 +23,7 @@ configuration conf {
 	/* XXX, NOTE: mouse should be loaded first. Include keyboard, then mouse
 	   results in mouse, then keyboard initialization order */
 	//@Runlevel(1) include embox.driver.input.keyboard.keyboard(register_in_vt=0)
-	//@Runlevel(1) include embox.driver.input.mouse.PsMouse
+	//@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 
 	@Runlevel(2) include embox.driver.virtual.null
 	@Runlevel(2) include embox.driver.virtual.zero

--- a/platform/mesa/templates/mesa_x86_osmesa/mods.config
+++ b/platform/mesa/templates/mesa_x86_osmesa/mods.config
@@ -20,8 +20,6 @@ configuration conf {
 	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
 	@Runlevel(2) include embox.driver.net.loopback
 
-	/* XXX, NOTE: mouse should be loaded first. Include keyboard, then mouse
-	   results in mouse, then keyboard initialization order */
 	//@Runlevel(1) include embox.driver.input.keyboard.keyboard(register_in_vt=0)
 	//@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 

--- a/platform/quake3/templates/qemu/mods.config
+++ b/platform/quake3/templates/qemu/mods.config
@@ -22,7 +22,7 @@ configuration conf {
 	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
 	@Runlevel(2) include embox.driver.net.loopback
 
-	@Runlevel(1) include embox.driver.input.mouse.PsMouse
+	@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 
 	@Runlevel(2) include embox.driver.tty.tty
 	@Runlevel(2) include embox.driver.tty.vterm

--- a/src/cmds/testing/keyboard_test/Mybuild
+++ b/src/cmds/testing/keyboard_test/Mybuild
@@ -1,0 +1,20 @@
+package embox.cmd.testing
+
+@AutoCmd
+@Cmd(name = "keyboard_test",
+	help = "Prints keyboards events to serial port",
+	man = '''
+		NAME
+			keyboard_test - Prints keyboards events to serial port
+		SYNOPSIS
+			keyboard_test <keyboard>
+		DESCRIPTION
+			keyboard_test - Prints keyboards events to serial port
+		AUTHORS
+			Alexander Kalmuk
+	''')
+module keyboard_test {
+	source "keyboard_test.c"
+
+	depends embox.driver.input.core
+}

--- a/src/cmds/testing/keyboard_test/keyboard_test.c
+++ b/src/cmds/testing/keyboard_test/keyboard_test.c
@@ -1,0 +1,77 @@
+/**
+ * @file
+ * @brief Keyboard test - prints keyboards events to serial port
+ *
+ * @date 08.04.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <drivers/input/input_dev.h>
+#include <drivers/keyboard.h>
+#include <drivers/input/keymap.h>
+
+static int event_nr;
+
+static int keyboard_handle(struct input_dev *kbd) {
+	struct input_event ev;
+	unsigned char code[4];
+
+	while (0 <= input_dev_event(kbd, &ev)) {
+		printf("event (id=%d, type=0x%x, value=0x%x)\n",
+			event_nr++, ev.type, ev.value);
+		printf("Key %s\n", ev.type & KEY_PRESSED ? "pressed" : "released");
+		if (1 == keymap_to_ascii(&ev, code)) {
+			if (isprint(code[0])) {
+				printf("Code = %c\n", code[0]);
+			}
+		}
+		printf("\n");
+	}
+
+	return 0;
+}
+
+static void print_usage(const char *cmd) {
+	printf("Usage: %s [-h] <keyboard>\n", cmd);
+}
+
+int main(int argc, char **argv) {
+	int opt;
+	struct input_dev *kbd;
+
+	if (argc < 2) {
+		print_usage(argv[0]);
+		return 0;
+	}
+
+	while (-1 != (opt = getopt(argc, argv, "h"))) {
+		switch (opt) {
+		case 'h':
+			print_usage(argv[0]);
+			/* FALLTHROUGH */
+		default:
+			return 0;
+		}
+	}
+
+	event_nr = 0;
+
+	if (!(kbd = input_dev_lookup(argv[argc - 1]))) {
+		fprintf(stderr, "Cannot find keyboard \"%s\"\n", argv[argc - 1]);
+		return -1;
+	}
+
+	if (0 > input_dev_open(kbd, keyboard_handle)) {
+		fprintf(stderr, "Failed open keyboard input device\n");
+		return -1;
+	}
+
+	/* Testing for infinite time. */
+	while (1) {
+	}
+
+	return 0;
+}

--- a/src/cmds/testing/mouse_fb_test/Mybuild
+++ b/src/cmds/testing/mouse_fb_test/Mybuild
@@ -1,0 +1,21 @@
+package embox.cmd.testing
+
+@AutoCmd
+@Cmd(name = "mouse_fb_test",
+	help = "Demo application which draws mouse current pos into framebuffer",
+	man = '''
+		NAME
+			mouse_fb_test - Draws mouse into framebuffer
+		SYNOPSIS
+			mouse_fb_test <mouse>
+		DESCRIPTION
+			mouse_fb_test - Draws mouse into framebuffer
+		AUTHORS
+			Alexander Kalmuk
+	''')
+module mouse_fb_test {
+	source "mouse_fb_test.c"
+
+	depends embox.driver.input.core
+	depends embox.driver.video.fb
+}

--- a/src/cmds/testing/mouse_fb_test/mouse_fb_test.c
+++ b/src/cmds/testing/mouse_fb_test/mouse_fb_test.c
@@ -1,0 +1,140 @@
+/**
+ * @file
+ * @brief Mouse test - draws mouse, print position and other events
+ *
+ * @date 08.04.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <drivers/input/input_dev.h>
+#include <drivers/video/fb.h>
+
+#define CURSOR_HEIGHT 12
+#define CURSOR_WIDTH  6
+
+static int16_t mouse_x, mouse_y;
+static struct fb_info *fb;
+
+static uint32_t color_convert(uint32_t in) {
+	uint32_t out;
+	pix_fmt_convert(&in, &out, 1, RGB888, fb->var.fmt);
+	return out;
+}
+
+static int init_fb(void) {
+	struct fb_fillrect rect;
+
+	fb = fb_lookup(0);
+
+	if (!fb) {
+		fprintf(stderr, "Cannot open framebuffer\n");
+		return -1;
+	}
+
+	rect.dx = rect.dy = 0;
+	rect.width = fb->var.xres;
+	rect.height = fb->var.yres;
+	rect.color = color_convert(0xffffff);
+	rect.rop = ROP_COPY;
+
+	fb_fillrect(fb, &rect);
+
+	return 0;
+}
+
+static int normalize_coord(int x, int a, int b) {
+	if (x < a) {
+		return a;
+	} else if (x > b - 1) {
+		return b - 1;
+	} else {
+		return x;
+	}
+}
+
+static void draw_cursor(int x, int y, int color) {
+	struct fb_fillrect rect;
+
+	rect.dx = x - CURSOR_WIDTH / 2;
+	rect.dy = y - CURSOR_HEIGHT / 2;
+	rect.width = CURSOR_WIDTH;
+	rect.height = CURSOR_HEIGHT;
+	rect.color = color_convert(color);
+	rect.rop = ROP_COPY;
+
+	fb_fillrect(fb, &rect);
+}
+
+static int mouse_handle(struct input_dev *mouse) {
+	struct input_event ev;
+
+	while (0 <= input_dev_event(mouse, &ev)) {
+		if ((ev.type & 0x7) == 0) { /* Mouse move */
+			draw_cursor(mouse_x, mouse_y, 0xffffff);
+
+			mouse_x += (ev.value >> 16) & 0xffff;
+			mouse_y -= ev.value & 0xffff;
+
+			mouse_x = normalize_coord(mouse_x, CURSOR_WIDTH,
+				fb->var.xres - CURSOR_WIDTH);
+			mouse_y = normalize_coord(mouse_y, CURSOR_HEIGHT,
+				fb->var.yres - CURSOR_HEIGHT);
+
+			draw_cursor(mouse_x, mouse_y, 0x000000);
+
+			printf("pos = (%d, %d)\n", mouse_x, mouse_y);
+		} else {
+			printf("event (type=%d, value=%d)\n", ev.type, ev.value);
+		}
+	}
+
+	return 0;
+}
+
+static void print_usage(const char *cmd) {
+	printf("Usage: %s [-h] <mouse>\n", cmd);
+}
+
+int main(int argc, char **argv) {
+	int opt;
+	struct input_dev *mouse;
+
+	if (argc < 2) {
+		print_usage(argv[0]);
+		return 0;
+	}
+
+	while (-1 != (opt = getopt(argc, argv, "h"))) {
+		switch (opt) {
+		case 'h':
+			print_usage(argv[0]);
+			/* FALLTHROUGH */
+		default:
+			return 0;
+		}
+	}
+
+	if (!(mouse = input_dev_lookup(argv[argc - 1]))) {
+		fprintf(stderr, "Cannot find mouse \"%s\"\n", argv[argc - 1]);
+		return -1;
+	}
+
+	if (0 > input_dev_open(mouse, mouse_handle)) {
+		fprintf(stderr, "Failed open mouse input device\n");
+		return -1;
+	}
+
+	if (0 > init_fb()) {
+		fprintf(stderr, "Framebuffer color filling error\n");
+		input_dev_close(mouse);
+		return -1;
+	}
+
+	/* Testing for infinite time. */
+	while (1) {
+	}
+
+	return 0;
+}

--- a/src/drivers/input/i8042/Mybuild
+++ b/src/drivers/input/i8042/Mybuild
@@ -1,0 +1,5 @@
+package embox.driver.input
+
+module i8042 {
+	source "i8042.c"
+}

--- a/src/drivers/input/i8042/i8042.c
+++ b/src/drivers/input/i8042/i8042.c
@@ -1,0 +1,58 @@
+/*
+ * @file
+ *
+ * @date   10.04.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <embox/unit.h>
+#include <drivers/i8042.h>
+
+EMBOX_UNIT_INIT(i8042_init);
+
+int i8042_read_mode(void) {
+	i8042_wait_write();
+	outb(I8042_CMD_READ_MODE, I8042_CMD_PORT);
+	i8042_wait_read();
+	return inb(I8042_DATA_PORT);
+}
+
+void i8042_write_mode(uint8_t val) {
+	i8042_wait_write();
+	outb(I8042_CMD_WRITE_MODE, I8042_CMD_PORT);
+	i8042_wait_write();
+	outb(val, I8042_DATA_PORT);
+}
+
+void i8042_write_aux(uint8_t val) {
+	i8042_wait_write();
+	outb(I8042_CMD_WRITE_MOUSE, I8042_CMD_PORT);
+	i8042_wait_write();
+	outb(val, I8042_DATA_PORT);
+}
+
+static int i8042_init(void) {
+	uint8_t mode;
+
+	/* Disable mouse */
+	i8042_write_aux(I8042_AUX_DISABLE_DEV);
+	outb(I8042_AUX_DISABLE_DEV, I8042_CMD_PORT);
+
+	/* Disable keyboard. */
+	i8042_wait_write();
+	outb(I8042_CMD_PORT_DIS, I8042_CMD_PORT);
+	i8042_wait_write();
+	outb(I8042_KBD_RESET_DISABLE, I8042_DATA_PORT);
+
+	/* Disable mouse and keyboard interrupts. */
+	mode = i8042_read_mode();
+	mode &= ~(I8042_MODE_INTERRUPT | I8042_MODE_MOUSE_INT);
+	i8042_write_mode(mode);
+
+	/* Flush keyboard and mouse FIFOs (to clear interrupts if any). */
+	while (inb(I8042_STS_PORT) & I8042_STS_OBF) {
+		inb(I8042_DATA_PORT);
+	}
+
+	return 0;
+}

--- a/src/drivers/input/keyboard/Mybuild
+++ b/src/drivers/input/keyboard/Mybuild
@@ -13,6 +13,7 @@ module keyboard {
 	depends kbd_defs
 	depends embox.driver.input.core
 	depends embox.driver.tty.vterm
+	depends embox.driver.input.i8042
 }
 
 module keymap {

--- a/src/drivers/input/keyboard/keyboard.c
+++ b/src/drivers/input/keyboard/keyboard.c
@@ -132,6 +132,9 @@ static int keyboard_start(struct input_dev *indev) {
 
 	keyboard_send_cmd(I8042_CMD_PORT_EN);
 
+	i8042_wait_write();
+	outb(I8042_KBD_RESET_ENABLE, I8042_DATA_PORT);
+
 	kbd_state = 0;
 
 	return 0;

--- a/src/drivers/input/keyboard/keyboard.c
+++ b/src/drivers/input/keyboard/keyboard.c
@@ -13,6 +13,7 @@
 #include <drivers/input/keymap.h>
 #include <drivers/input/input_dev.h>
 
+#include <kernel/irq.h>
 #include <embox/unit.h>
 #include <drivers/diag.h>
 #include <drivers/tty.h>
@@ -55,88 +56,99 @@ static void kbd_key_serv_press(int state, int flag) {
 
 static int keyboard_get_input_event(struct input_dev *dev, struct input_event *event) {
 	uint8_t scan_code, status;
-	int flag = 0;
+	int ret = 0, flag = 0;
 
-	event->type = event->value = 0;
+	irq_lock();
+	{
+		event->type = event->value = 0;
 
-	status = keyboard_read_stat();
+		status = keyboard_read_stat();
 
-	if (!(status & I8042_STS_OBF)) {
-		return -EAGAIN;
+		if (!(status & I8042_STS_OBF)) {
+			ret = -EAGAIN;
+			goto out;
+		}
+
+		scan_code = inb(I8042_DATA_PORT);
+
+		if (scan_code == KEYBOARD_SCAN_CODE_EXT) {
+			ret = -EAGAIN;
+			goto out;
+		}
+
+		if (status & I8042_STS_AUXOBF) {
+			ret = -EAGAIN;
+			goto out;
+		}
+
+		if (scan_code & 0x80) {
+			/* key unpressed */
+			event->type &= ~KEY_PRESSED;
+		} else {
+			/* key pressed */
+			event->type |= KEY_PRESSED;
+		}
+		scan_code &= 0x7F;
+
+		switch(scan_code) {
+		case KEYBOARD_SCAN_CODE_CTRL:
+			flag = CTRL_PRESSED;
+			break;
+		case KEYBOARD_SCAN_CODE_ALT:
+			flag = ALT_PRESSED;
+			break;
+		case KEYBOARD_SCAN_CODE_SHIFT:
+			flag = SHIFT_PRESSED;
+			break;
+		case KEYBOARD_SCAN_CODE_CAPS:
+			flag = CAPS_PRESSED;
+			break;
+		}
+		kbd_key_serv_press(event->type, flag);
+
+		event->value = kbd_state | scan_code;
 	}
-
-	scan_code = inb(I8042_DATA_PORT);
-
-	if (scan_code == KEYBOARD_SCAN_CODE_EXT) {
-		return -EAGAIN;
-	}
-
-	if (status & I8042_STS_AUXOBF) {
-		return -EAGAIN;
-	}
-
-	if (scan_code & 0x80) {
-		/* key unpressed */
-		event->type &= ~KEY_PRESSED;
-	} else {
-		/* key pressed */
-		event->type |= KEY_PRESSED;
-	}
-	scan_code &= 0x7F;
-
-	switch(scan_code) {
-	case KEYBOARD_SCAN_CODE_CTRL:
-		flag = CTRL_PRESSED;
-		break;
-	case KEYBOARD_SCAN_CODE_ALT:
-		flag = ALT_PRESSED;
-		break;
-	case KEYBOARD_SCAN_CODE_SHIFT:
-		flag = SHIFT_PRESSED;
-		break;
-	case KEYBOARD_SCAN_CODE_CAPS:
-		flag = CAPS_PRESSED;
-		break;
-	}
-	kbd_key_serv_press(event->type, flag);
-
-	event->value = kbd_state | scan_code;
-
-	return 0;
+out:
+	irq_unlock();
+	return ret;
 }
 
 static int keyboard_start(struct input_dev *indev) {
 	uint8_t mode;
 
-	/* If 0x64 returns 0xff, then we have no keyboard
-	 * controller */
-	if (inb(0x64) == 0xFF) {
-		return 0;
+	irq_lock();
+	{
+		/* If 0x64 returns 0xff, then we have no keyboard
+		 * controller */
+		if (inb(0x64) == 0xFF) {
+			goto out;
+		}
+
+		keyboard_send_cmd(I8042_CMD_PORT_DIS);
+
+		while (keyboard_havechar()) inb(I8042_DATA_PORT);
+
+		/* Read the current mode */
+		mode = keyboard_get_mode();
+		/* Turn on scancode translate mode so that we can
+		 use the scancode set 1 tables */
+		mode |= I8042_MODE_XLATE;
+		/* Enable keyboard. */
+		mode &= ~I8042_MODE_DISABLE;
+		/* Enable interrupt */
+		mode |= I8042_MODE_INTERRUPT;
+		/* Write the new mode */
+		keyboard_set_mode(mode);
+
+		keyboard_send_cmd(I8042_CMD_PORT_EN);
+
+		i8042_wait_write();
+		outb(I8042_KBD_RESET_ENABLE, I8042_DATA_PORT);
+
+		kbd_state = 0;
 	}
-
-	keyboard_send_cmd(I8042_CMD_PORT_DIS);
-
-	while (keyboard_havechar()) inb(I8042_DATA_PORT);
-
-	/* Read the current mode */
-	mode = keyboard_get_mode();
-	/* Turn on scancode translate mode so that we can
-	 use the scancode set 1 tables */
-	mode |= I8042_MODE_XLATE;
-	/* Enable keyboard. */
-	mode &= ~I8042_MODE_DISABLE;
-	/* Enable interrupt */
-	mode |= I8042_MODE_INTERRUPT;
-	/* Write the new mode */
-	keyboard_set_mode(mode);
-
-	keyboard_send_cmd(I8042_CMD_PORT_EN);
-
-	i8042_wait_write();
-	outb(I8042_KBD_RESET_ENABLE, I8042_DATA_PORT);
-
-	kbd_state = 0;
-
+out:
+	irq_unlock();
 	return 0;
 }
 
@@ -156,10 +168,30 @@ static struct input_dev kbd_dev = {
 		.ops = &kbd_input_ops,
 		.name = "keyboard",
 		.type = INPUT_DEV_KBD,
-		.irq = 1,
 };
 
+static irq_return_t ps_kbd_irq_hnd(unsigned int irq_nr, void *data) {
+	struct input_dev *dev = (struct input_dev *) data;
+
+	if (!dev->event_cb) {
+		/* Input device is not opened, so just get rid of ths event. */
+		struct input_event ev;
+		keyboard_get_input_event(dev, &ev);
+	} else {
+		input_dev_input(dev);
+	}
+
+	return IRQ_HANDLED;
+}
+
 static int keyboard_init(void) {
+	int res;
+
+	res = irq_attach(I8042_KBD_IRQ, ps_kbd_irq_hnd, 0,
+					 &kbd_dev, "ps keyboard");
+	if (res < 0) {
+		return res;
+	}
 
 	keyboard_start(NULL);
 

--- a/src/drivers/input/mouse/Mybuild
+++ b/src/drivers/input/mouse/Mybuild
@@ -1,6 +1,6 @@
 package embox.driver.input.mouse
 
-module PsMouse {
+module ps_mouse {
 	source "ps_mouse.c"
 	depends embox.driver.input.core
 }

--- a/src/drivers/input/mouse/Mybuild
+++ b/src/drivers/input/mouse/Mybuild
@@ -2,5 +2,7 @@ package embox.driver.input.mouse
 
 module ps_mouse {
 	source "ps_mouse.c"
+
 	depends embox.driver.input.core
+	depends embox.driver.input.i8042
 }

--- a/src/drivers/input/mouse/ps_mouse.c
+++ b/src/drivers/input/mouse/ps_mouse.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <embox/unit.h>
 #include <drivers/input/input_dev.h>
+#include <kernel/irq.h>
 
 #include <drivers/i8042.h>
 
@@ -29,52 +30,63 @@ struct ps2_mouse_indev {
 
 //http://lists.gnu.org/archive/html/qemu-devel/2004-11/msg00082.html
 static int ps_mouse_get_input_event(struct input_dev *dev, struct input_event *ev) {
-	unsigned char data;
+	uint8_t data;
+	int ret = 0;
 
-	data = inb(I8042_STS_PORT);
+	irq_lock();
+	{
+		data = inb(I8042_STS_PORT);
 
-	if ((data & (I8042_STS_AUXOBF | I8042_STS_OBF))
-			!= (I8042_STS_AUXOBF | I8042_STS_OBF)) {
-		/* this is keyboard scan code */
-		return -EAGAIN;
+		if ((data & (I8042_STS_AUXOBF | I8042_STS_OBF))
+				!= (I8042_STS_AUXOBF | I8042_STS_OBF)) {
+			/* this is keyboard scan code */
+			ret = -EAGAIN;
+			goto out;
+		}
+
+		data = inb(I8042_DATA_PORT);
+		if (data == MOUSE_ACK) {
+			ret = -EAGAIN;
+			goto out;
+		}
+
+		ev->type = data;
+
+		data = inb(I8042_DATA_PORT);
+		ev->value = ((ev->type & MSTAT_XSIGN ? 0xff00 : 0) | data) << 16;
+		data = inb(I8042_DATA_PORT);
+		ev->value |= (ev->type & MSTAT_YSIGN ? 0xff00 : 0) | data;
+
+		ev->type  &= MSTAT_BUTMASK;
 	}
-
-	data = inb(I8042_DATA_PORT);
-	if (data == MOUSE_ACK) {
-		return -EAGAIN;
-	}
-
-	ev->type = data;
-
-	data = inb(I8042_DATA_PORT);
-	ev->value = ((ev->type & MSTAT_XSIGN ? 0xff00 : 0) | data) << 16;
-	data = inb(I8042_DATA_PORT);
-	ev->value |= (ev->type & MSTAT_YSIGN ? 0xff00 : 0) | data;
-
-	ev->type  &= MSTAT_BUTMASK;
-
-	return 0;
+out:
+	irq_unlock();
+	return ret;
 }
 
 static int ps_mouse_start(struct input_dev *dev) {
-	unsigned char mode;
+	uint8_t mode;
 
-	mode = i8042_read_mode();
-	mode |= I8042_MODE_XLATE | I8042_MODE_SYS | I8042_MODE_MOUSE_INT;
-	mode &= ~I8042_MODE_DISABLE_MOUSE;
-	i8042_write_mode(mode);
+	irq_lock();
+	{
+		mode = i8042_read_mode();
+		mode |= I8042_MODE_XLATE | I8042_MODE_SYS | I8042_MODE_MOUSE_INT;
+		mode &= ~I8042_MODE_DISABLE_MOUSE;
+		i8042_write_mode(mode);
 
-	i8042_wait_write();
-	outb(I8042_CMD_MOUSE_ENABLE, I8042_CMD_PORT);
+		i8042_wait_write();
+		outb(I8042_CMD_MOUSE_ENABLE, I8042_CMD_PORT);
 
-	i8042_write_aux(I8042_AUX_SET_SAMPLE);
-	i8042_write_aux(100); /* 100 samples/sec */
+		i8042_write_aux(I8042_AUX_SET_SAMPLE);
+		i8042_write_aux(100); /* 100 samples/sec */
 
-	i8042_write_aux(I8042_AUX_SET_RES);
-	i8042_write_aux(3); /* 8 counts per mm */
-	i8042_write_aux(I8042_AUX_SET_SCALE21);
+		i8042_write_aux(I8042_AUX_SET_RES);
+		i8042_write_aux(3); /* 8 counts per mm */
+		i8042_write_aux(I8042_AUX_SET_SCALE21);
 
-	i8042_write_aux(I8042_AUX_ENABLE_DEV);
+		i8042_write_aux(I8042_AUX_ENABLE_DEV);
+	}
+	irq_unlock();
 
 	return 0;
 }
@@ -96,11 +108,32 @@ static struct ps2_mouse_indev mouse_dev = {
 		.ops = &ps_mouse_input_ops,
 		.name = "mouse",
 		.type = INPUT_DEV_MOUSE,
-		.irq = 12,
 	},
 };
 
+static irq_return_t ps_mouse_irq_hnd(unsigned int irq_nr, void *data) {
+	struct input_dev *dev = (struct input_dev *) data;
+
+	if (!dev->event_cb) {
+		/* Input device is not opened, so just get rid of ths event. */
+		struct input_event ev;
+		ps_mouse_get_input_event(dev, &ev);
+	} else {
+		input_dev_input(dev);
+	}
+
+	return IRQ_HANDLED;
+}
+
 static int ps_mouse_init(void) {
+	int res;
+
+	res = irq_attach(I8042_MOUSE_IRQ, ps_mouse_irq_hnd, 0,
+					 &mouse_dev.input_dev, "ps mouse");
+	if (res < 0) {
+		return res;
+	}
+
 	ps_mouse_start(NULL);
 
 	return input_dev_register(&mouse_dev.input_dev);

--- a/src/drivers/video/fb.c
+++ b/src/drivers/video/fb.c
@@ -429,6 +429,7 @@ static void fb_default_copyarea(struct fb_info *info, const struct fb_copyarea *
 }
 
 static uint32_t pixel_to_pat(uint32_t bpp, uint32_t pixel) {
+	pixel &= ~((uint32_t )-1 << bpp);
 	return bpp == 1 ? 0xffffffffUL * pixel
 			: bpp == 2 ? 0x55555555UL * pixel
 			: bpp == 4 ? 0x11111111UL * pixel

--- a/src/include/drivers/i8042.h
+++ b/src/include/drivers/i8042.h
@@ -11,28 +11,67 @@
 
 #include <asm/io.h>
 
-#define  I8042_CMD_PORT        0x64
-#define  I8042_STS_PORT        0x64
-#define  I8042_DATA_PORT       0x60
+/* I/O ports */
+#define  I8042_CMD_PORT           0x64
+#define  I8042_STS_PORT           0x64
+#define  I8042_DATA_PORT          0x60
 
-#define  I8042_CMD_READ_MODE   0x20
-#define  I8042_CMD_WRITE_MODE  0x60
-#define  I8042_CMD_PORT_DIS    0xAD
-#define  I8042_CMD_PORT_EN     0xAE
+/* Controller Commands */
+#define  I8042_CMD_READ_MODE      0x20
+#define  I8042_CMD_WRITE_MODE     0x60
+#define  I8042_CMD_MOUSE_DISABLE  0xA7
+#define  I8042_CMD_MOUSE_ENABLE   0xA8
+#define  I8042_CMD_PORT_DIS       0xAD
+#define  I8042_CMD_PORT_EN        0xAE
+#define  I8042_CMD_WRITE_MOUSE    0xD4
 
-#define  I8042_MODE_XLATE      0x40
-#define  I8042_MODE_DISABLE    0x10
-#define  I8042_MODE_INTERRUPT  0x01
+/* Controller Status */
+#define I8042_STS_PERR            0x80
+#define I8042_STS_TMO             0x40
+#define I8042_STS_AUXOBF          0x20
+#define I8042_STS_INH             0x10
+#define I8042_STS_SYS             0x04
+#define I8042_STS_IBF             0x02
+#define I8042_STS_OBF             0x01
 
+/* Controller Mode Register Bits */
+#define I8042_MODE_INTERRUPT      0x01
+#define I8042_MODE_MOUSE_INT      0x02
+#define I8042_MODE_SYS            0x04
+#define I8042_MODE_NO_KEYLOCK     0x08
+#define I8042_MODE_DISABLE        0x10
+#define I8042_MODE_DISABLE_MOUSE  0x20
+#define I8042_MODE_XLATE          0x40
+#define I8042_MODE_RFU            0x80
 
-/* Status */
-#define I8042_STS_PERR      0x80    /* Parity error */
-#define I8042_STS_TMO       0x40    /* Timeout */
-#define I8042_STS_AUXOBF    0x20    /* Mouse OBF */
-#define I8042_STS_INH       0x10    /* 0: inhibit  1: no-inhibit */
-#define I8042_STS_SYS       0x04    /* 0: power up  1:Init comp */
-#define I8042_STS_IBF       0x02    /* Input (to kbd) buffer full */
-#define I8042_STS_OBF       0x01    /* Output (from kbd) buffer full */
+/* Mouse Commands */
+#define I8042_AUX_SET_SCALE11     0xE6
+#define I8042_AUX_SET_SCALE21     0xE7
+#define I8042_AUX_SET_RES         0xE8
+#define I8042_AUX_GET_SCALE       0xE9
+#define I8042_AUX_SET_STREAM      0xEA
+#define I8042_AUX_POLL            0xEB
+#define I8042_AUX_RESET_WRAP      0xEC
+#define I8042_AUX_SET_WRAP        0xEE
+#define I8042_AUX_SET_REMOTE      0xF0
+#define I8042_AUX_GET_TYPE        0xF2
+#define I8042_AUX_SET_SAMPLE      0xF3
+#define I8042_AUX_ENABLE_DEV      0xF4
+#define I8042_AUX_DISABLE_DEV     0xF5
+#define I8042_AUX_SET_DEFAULT     0xF6
+#define I8042_AUX_RESET           0xFF
+#define I8042_AUX_ACK             0xFA
+
+/* Keyboard Commands */
+#define I8042_KBD_SET_LEDS        0xED
+#define I8042_KBD_ECHO            0xEE
+#define I8042_KBD_SCANCODE        0xF0
+#define I8042_KBD_GET_ID          0xF2
+#define I8042_KBD_SET_RATE        0xF3
+#define I8042_KBD_ENABLE          0xF4
+#define I8042_KBD_RESET_DISABLE   0xF5
+#define I8042_KBD_RESET_ENABLE    0xF6
+#define I8042_KBD_RESET           0xFF
 
 #define keyboard_read_stat() \
 	inb(I8042_STS_PORT)
@@ -41,7 +80,13 @@
 	do {} while (0 == ((status = inb(I8042_STS_PORT)) & I8042_STS_OBF))
 #define keyboard_wait_write(status) \
 	do {} while (0 != ((status = inb(I8042_STS_PORT)) & I8042_STS_IBF))
-#define kmc_wait_ibe()	while (inb(I8042_STS_PORT) & I8042_STS_IBF)
+
+#define i8042_wait_write() while (inb(I8042_STS_PORT) & I8042_STS_IBF)
+#define i8042_wait_read() while (~inb(I8042_STS_PORT) & I8042_STS_OBF)
+
+extern int i8042_read_mode(void);
+extern void i8042_write_mode(uint8_t val);
+extern void i8042_write_aux(uint8_t val);
 
 static inline int keyboard_havechar(void) {
 	unsigned char c = inb(I8042_STS_PORT);

--- a/src/include/drivers/i8042.h
+++ b/src/include/drivers/i8042.h
@@ -73,6 +73,9 @@
 #define I8042_KBD_RESET_ENABLE    0xF6
 #define I8042_KBD_RESET           0xFF
 
+#define I8042_KBD_IRQ   1
+#define I8042_MOUSE_IRQ 12
+
 #define keyboard_read_stat() \
 	inb(I8042_STS_PORT)
 

--- a/templates/x86/qt-app/mods.config
+++ b/templates/x86/qt-app/mods.config
@@ -23,7 +23,7 @@ configuration conf {
 	/* XXX, NOTE: mouse should be loaded first. Include keyboard, then mouse
 	   results in mouse, then keyboard initialization order */
 	@Runlevel(1) include embox.driver.input.keyboard.keyboard(register_in_vt=0)
-	@Runlevel(1) include embox.driver.input.mouse.PsMouse
+	@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 
 	@Runlevel(2) include embox.driver.virtual.null
 	@Runlevel(2) include embox.driver.virtual.zero

--- a/templates/x86/qt-app/mods.config
+++ b/templates/x86/qt-app/mods.config
@@ -20,8 +20,6 @@ configuration conf {
 	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
 	@Runlevel(2) include embox.driver.net.loopback
 
-	/* XXX, NOTE: mouse should be loaded first. Include keyboard, then mouse
-	   results in mouse, then keyboard initialization order */
 	@Runlevel(1) include embox.driver.input.keyboard.keyboard(register_in_vt=0)
 	@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 

--- a/templates/x86/qt-fb/mods.config
+++ b/templates/x86/qt-fb/mods.config
@@ -23,7 +23,7 @@ configuration conf {
 	/* XXX, NOTE: mouse should be loaded first. Include keyboard, then mouse
 	   results in mouse, then keyboard initialization order */
 	@Runlevel(1) include embox.driver.input.keyboard.keyboard(register_in_vt=0)
-	@Runlevel(1) include embox.driver.input.mouse.PsMouse
+	@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 
 	@Runlevel(2) include embox.driver.virtual.null
 	@Runlevel(2) include embox.driver.virtual.zero

--- a/templates/x86/qt-fb/mods.config
+++ b/templates/x86/qt-fb/mods.config
@@ -20,8 +20,6 @@ configuration conf {
 	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
 	@Runlevel(2) include embox.driver.net.loopback
 
-	/* XXX, NOTE: mouse should be loaded first. Include keyboard, then mouse
-	   results in mouse, then keyboard initialization order */
 	@Runlevel(1) include embox.driver.input.keyboard.keyboard(register_in_vt=0)
 	@Runlevel(1) include embox.driver.input.mouse.ps_mouse
 

--- a/templates/x86/qt-vnc/mods.config
+++ b/templates/x86/qt-vnc/mods.config
@@ -30,7 +30,7 @@ configuration conf {
 	@Runlevel(2) include embox.mem.bitmask
 
 
-	@Runlevel(2) include embox.driver.input.mouse.PsMouse
+	@Runlevel(2) include embox.driver.input.mouse.ps_mouse
 	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
 	//@Runlevel(2) include embox.driver.input.keyboard.keyboard
 	//@Runlevel(2) include embox.driver.console.vc.vc


### PR DESCRIPTION
* Add mouse and keyboard simple tests.
* Fix PS/2 mouse
* Fix PS/2 mouse and PS/2 keyboard race condition and initialization order - now it doesn't matter in which order you included these modules in the config, moreover you can include only mouse or only keyboard.

To verify how these tests work, include the following modules in `x86/qemu`:

```
    @Runlevel(1) include embox.arch.x86.boot.multiboot(video_mode_set=1, video_width=800, video_height=600, video_depth=16)
    @Runlevel(1) include embox.driver.video.bochs
    @Runlevel(1) include embox.driver.video.fb
    @Runlevel(2) include embox.driver.input.keyboard.keyboard
    @Runlevel(2) include embox.driver.input.mouse.ps_mouse
    @Runlevel(3) include embox.init.GraphicMode
    include embox.cmd.testing.mouse_fb_test
    include embox.cmd.testing.keyboard_test
```

Then you can run only mouse test:
```
root@embox:/# mouse_fb_test mouse
```
or keyboard:
```
root@embox:/# keyboard_test keyboard
```
or both:
```
root@embox:/# mouse_fb_test mouse &
root@embox:/# keyboard_test keyboard &
```

Press on QEMU graphical window after running the tests and move your mouse or press keyboard keys.