### PR TITLE
Fix usb mouse

### DIFF
--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -353,9 +353,9 @@ if [ $graphic_n -gt 0 ]; then
 				graphic_lines="-nographic"
 			else
 				if [ $graphic_model = "pl110" ]; then
-					graphic_lines="-serial stdio"
+					graphic_lines="-serial mon:stdio"
 				else
-					graphic_lines="-vga $graphic_model -serial stdio"
+					graphic_lines="-vga $graphic_model -serial mon:stdio"
 				fi
 				break
 			fi

--- a/src/drivers/usb/class/Mybuild
+++ b/src/drivers/usb/class/Mybuild
@@ -2,6 +2,8 @@
 package embox.driver.usb.class
 
 module hid {
+	option number log_level = 1
+
 	source "usb_class_hid.c"
 	source "usb_hid.c"
 

--- a/src/drivers/usb/class/usb_class_hid.c
+++ b/src/drivers/usb/class/usb_class_hid.c
@@ -6,82 +6,45 @@
  * @date    16.10.2013
  */
 
-#include <mem/misc/pool.h>
-#include <kernel/printk.h>
-#include <kernel/panic.h>
 #include <embox/unit.h>
+#include <mem/misc/pool.h>
 #include <drivers/usb/usb_hid.h>
 #include <drivers/usb/usb_driver.h>
 
 EMBOX_UNIT_INIT(usb_hid_init);
 
-POOL_DEF(hid_getconfs, struct usb_hid_getconf, USB_HID_MAX_GETCONFS);
 POOL_DEF(hid_classes, struct usb_class_hid, USB_HID_MAX_DEVS);
 
-static void usb_class_hid_get_conf_hnd(struct usb_request *req, void *arg) {
-	struct usb_dev *dev = req->endp->dev;
-	struct usb_class_hid *hid = usb2hiddata(dev);
+static int usb_hid_probe(struct usb_dev *dev) {
+	struct usb_class_hid *hid;
 
-	usb_dev_generic_fill_iface(dev, &hid->getconf->interface_desc);
-	usb_dev_generic_fill_endps(dev, hid->getconf->endp_descs);
+	assert(dev);
 
-	pool_free(&hid_getconfs, hid->getconf);
-	hid->getconf = NULL;
+	hid = pool_alloc(&hid_classes);
+	if (!hid) {
+		return -1;
+	}
+	dev->driver_data = hid;
 
-	usb_class_start_handle(dev);
-
-	usb_driver_handle(req->endp->dev);
+	return usb_hid_found(dev);
 }
 
-static void *usb_class_hid_alloc(struct usb_class *cls, struct usb_dev *dev) {
-	return pool_alloc(&hid_classes);
+static void usb_hid_disconnect(struct usb_dev *dev, void *data) {
+	/* TODO */
 }
 
-static void usb_class_hid_free(struct usb_class *cls, struct usb_dev *dev, void *spec) {
-	pool_free(&hid_classes, spec);
-}
+static struct usb_device_id usb_hid_id_table[] = {
+	{USB_CLASS_HID, 0xffff, 0xffff},
+	{ },
+};
 
-static int usb_class_hid_get_conf(struct usb_class *cls, struct usb_dev *dev) {
-	struct usb_class_hid *hid = usb2hiddata(dev);
-
-	hid->getconf = pool_alloc(&hid_getconfs);
-
-	usb_endp_control(dev->endpoints[0], cls->get_conf_hnd, NULL,
-		USB_DEV_REQ_TYPE_RD
-			| USB_DEV_REQ_TYPE_STD
-			| USB_DEV_REQ_TYPE_DEV,
-		USB_DEV_REQ_GET_DESC,
-		USB_DESC_TYPE_CONFIG << 8,
-		dev->c_config,
-		sizeof(struct usb_desc_configuration)
-			+ sizeof(struct usb_desc_interface)
-			+ sizeof(struct usb_desc_hid)
-			+ (dev->endp_n - 1) * sizeof(struct usb_desc_endpoint),
-		hid->getconf);
-
-	return 0;
-}
-
-static void usb_class_hid_handle(struct usb_class *cls, struct usb_dev *dev) {
-	usb_hid_found(dev);
-}
-
-static void usb_class_hid_release(struct usb_class *cls, struct usb_dev *dev) {
-
-	/* can't release, do nothing */
-}
-
-static struct usb_class usb_class_hid = {
-	.usb_class = USB_CLASS_HID,
-	.class_alloc = usb_class_hid_alloc,
-	.class_free = usb_class_hid_free,
-	.get_conf = usb_class_hid_get_conf,
-	.get_conf_hnd = usb_class_hid_get_conf_hnd,
-	.class_handle = usb_class_hid_handle,
-	.class_release = usb_class_hid_release ,
+static struct usb_driver usb_driver_hid = {
+	.name = "hid",
+	.probe = usb_hid_probe,
+	.disconnect = usb_hid_disconnect,
+	.id_table = usb_hid_id_table,
 };
 
 static int usb_hid_init(void) {
-
-	return usb_class_register(&usb_class_hid);
+	return usb_driver_register(&usb_driver_hid);
 }

--- a/src/drivers/usb/class/usb_hid.c
+++ b/src/drivers/usb/class/usb_hid.c
@@ -105,7 +105,7 @@ static const struct input_dev_ops usb_hid_input_ops = {
 
 static void usb_hid_indev_init(struct input_dev *indev) {
 
-	indev->name = "usb_hid";
+	indev->name = "usb-mouse";
 	indev->type = INPUT_DEV_MOUSE;
 	indev->ops = &usb_hid_input_ops;
 	indev->irq = 0;

--- a/src/drivers/usb/class/usb_hid.c
+++ b/src/drivers/usb/class/usb_hid.c
@@ -7,7 +7,9 @@
  */
 #include <errno.h>
 #include <string.h>
+#include <stdbool.h>
 #include <util/member.h>
+#include <util/log.h>
 #include <mem/misc/pool.h>
 #include <drivers/usb/usb_hid.h>
 #include <drivers/usb/usb.h>
@@ -42,7 +44,7 @@ static int usb_hid_event_get(struct input_dev *dev, struct input_event *ev) {
 #endif
 
 	ev->value = ((int16_t) hindev->input_data[1]) << 16
-		| (0xffff & ((int16_t) hindev->input_data[2]));
+		| (0xffff & ((int16_t) -hindev->input_data[2]));
 
 	return 0;
 }
@@ -112,11 +114,14 @@ static void usb_hid_indev_init(struct input_dev *indev) {
 int usb_hid_found(struct usb_dev *dev) {
 	struct usb_class_hid *hid = usb2hiddata(dev);
 	struct usb_hid_indev *hindev;
+	int ret;
 
-	usb_dev_use_inc(dev);
+	/* FIXME */
+	/* usb_dev_use_inc(dev); */
 
 	hindev = pool_alloc(&usb_hid_indevs);
 	if (!hindev) {
+		log_error("alloc failed");
 		return -ENOMEM;
 	}
 
@@ -126,5 +131,11 @@ int usb_hid_found(struct usb_dev *dev) {
 
 	usb_hid_indev_init(&hindev->input_dev);
 
-	return input_dev_register(&hindev->input_dev);
+	ret = input_dev_register(&hindev->input_dev);
+	if (!ret) {
+		log_error("input device registration failed");
+		return ret;
+	}
+
+	return 0;
 }

--- a/src/drivers/usb/class/usb_mass_storage.c
+++ b/src/drivers/usb/class/usb_mass_storage.c
@@ -177,7 +177,7 @@ static struct usb_device_id usb_ms_id_table[] = {
 	{ },
 };
 
-struct usb_driver usb_driver_ms = {
+static struct usb_driver usb_driver_ms = {
 	.name = "mass_storage",
 	.probe = usb_ms_probe,
 	.disconnect = usb_ms_disconnect,

--- a/src/drivers/usb/hc/ohci_pci.c
+++ b/src/drivers/usb/hc/ohci_pci.c
@@ -601,11 +601,11 @@ static irq_return_t ohci_irq(unsigned int irq_nr, void *data) {
 		} while ((td = next_td));
 
 		OHCI_WRITE(ohcd, &ohcd->base->hc_intstat, OHCI_INTERRUPT_DONE_QUEUE);
-	}
 
-	if (!usb_queue_empty(&ohcd->req_queue)) {
-		req = usb_link2req(usb_queue_first(&ohcd->req_queue));
-		ohci_request_do(req);
+		if (!usb_queue_empty(&ohcd->req_queue)) {
+			req = usb_link2req(usb_queue_first(&ohcd->req_queue));
+			ohci_request_do(req);
+		}
 	}
 
 	return IRQ_HANDLED;

--- a/src/include/drivers/usb/usb_hid.h
+++ b/src/include/drivers/usb/usb_hid.h
@@ -10,7 +10,6 @@
 #define DRIVERS_USB_HID_H_
 
 #define USB_HID_MAX_DEVS         2
-#define USB_HID_MAX_GETCONFS     2
 
 #define USB_CLASS_HID 		 3
 
@@ -35,20 +34,12 @@ struct usb_desc_hid {
 	uint16_t w_descriptor_len;
 } __attribute__((packed));
 
-struct usb_hid_getconf {
-	struct usb_desc_configuration config_desc;
-	struct usb_desc_interface interface_desc;
-	struct usb_desc_hid hid_desc;
-	struct usb_desc_endpoint endp_descs[USB_DEV_MAX_ENDP];
-} __attribute__((packed));
-
 struct usb_class_hid {
-	struct usb_hid_getconf *getconf;
 	struct input_dev *indev;
 };
 
 static inline struct usb_class_hid *usb2hiddata(struct usb_dev *dev) {
-	return dev->class_specific;
+	return dev->driver_data;
 }
 
 extern int usb_hid_found(struct usb_dev *dev);


### PR DESCRIPTION
* Fix usb mouse (compilation and functioning).
* (minor) auto_qemu: Multiplex stdio and qemu monitor when running in graphical mode, so you can use qemu monitor in console (like for -nographic mode).

You can verify usb mouse on OHCI in the following way:
* Add to `x86/qemu`:
```
    @Runlevel(1) include embox.arch.x86.boot.multiboot(video_mode_set=1, video_width=800, video_height=600, video_depth=16)
    @Runlevel(1) include embox.driver.video.bochs
    @Runlevel(1) include embox.driver.video.fb
    @Runlevel(1) include embox.driver.usb.class.hid
    @Runlevel(3) include embox.init.GraphicMode
    include embox.cmd.testing.mouse_fb_test
```
* Run `./scripts/qemu/auto_qemu -device usb-mouse`
* `mouse_fb_test usb-mouse`. Then go to qemu graphical window, press there and move your mouse.

On wiki - https://github.com/embox/embox/wiki/Using-USB-on-qemu#usb-mouse
