### PR TITLE
templates: Fix input_test path

### DIFF
--- a/templates/arm/ti816x-qt/mods.config
+++ b/templates/arm/ti816x-qt/mods.config
@@ -41,7 +41,7 @@ configuration conf {
 	include embox.cmd.help
 	include embox.cmd.mem
 	include embox.cmd.wmem
-	include embox.cmd.input_test
+	include embox.cmd.testing.input.input_test
 
 	include embox.cmd.sys.date
 	include embox.cmd.sys.export

--- a/templates/arm/ti816x/mods.config
+++ b/templates/arm/ti816x/mods.config
@@ -48,7 +48,7 @@ configuration conf {
 	@Runlevel(2) include embox.cmd.lspci
 	include embox.cmd.mem
 	include embox.cmd.wmem
-	include embox.cmd.input_test
+	include embox.cmd.testing.input.input_test
 
 	include embox.cmd.sys.date
 	include embox.cmd.sys.export


### PR DESCRIPTION
Fix after c4a96afe5cd7699dd3535534138e34272148b5ad