### PR TITLE
Stm32f7 touchscreen

### DIFF
--- a/src/cmds/hardware/input/Mybuild
+++ b/src/cmds/hardware/input/Mybuild
@@ -2,18 +2,15 @@ package embox.cmd.hw
 
 @AutoCmd
 @Cmd(name = "input",
+	help = "Show input devices list",
 	man = '''
-	NAME
-       input - list input devices
-    SYNOPSIS
-       input [ options ]
-    DESCRIPTION
-	OPTIONS
-			-h
-				Shows usage
-	SEE ALSO
-			input
-	AUTHORS
+		NAME
+			input - Show input devices list
+		SYNOPSIS
+			input [-h]
+		DESCRIPTION
+			input - Show input devices list
+		AUTHORS
 			Alexander Kalmuk
 	''')
 module input {

--- a/src/cmds/hardware/input/input.c
+++ b/src/cmds/hardware/input/input.c
@@ -22,6 +22,8 @@ static char *type_to_str(enum input_dev_type type) {
 		return "mouse";
 	case INPUT_DEV_APB:
 		return "apb";
+	case INPUT_DEV_TOUCHSCREEN:
+		return "touchscreen";
 	default:
 		return "unknown";
 	}

--- a/src/cmds/testing/input/touchscreen/Mybuild
+++ b/src/cmds/testing/input/touchscreen/Mybuild
@@ -1,0 +1,22 @@
+package embox.cmd.testing.input
+
+@AutoCmd
+@Cmd(name = "touchscreen_test",
+	help = "Demo application which tests touchscreen",
+	man = '''
+		NAME
+			touchscreen_test - Test for touchscreen
+		SYNOPSIS
+			touchscreen_test <touchscreen>
+		DESCRIPTION
+			touchscreen_test - Test for touchscreen
+		AUTHORS
+			Alexander Kalmuk
+	''')
+module touchscreen_test {
+	source "touchscreen_test.c"
+
+	depends embox.driver.input.core
+	depends embox.driver.input.touchscreen
+	depends embox.driver.video.fb
+}

--- a/src/cmds/testing/input/touchscreen/touchscreen_test.c
+++ b/src/cmds/testing/input/touchscreen/touchscreen_test.c
@@ -1,0 +1,186 @@
+/**
+ * @file
+ * @brief Touchscreen test - draws touches, print position and other events
+ *
+ * @date   15.04.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <drivers/input/input_dev.h>
+#include <drivers/input/touchscreen.h>
+#include <drivers/video/fb.h>
+
+/* Cursor is 12 x 12 */
+#define CURSOR_DEFAULT_SIZE 12
+
+static const int ts_cursor_color[2] = { 0x000000, 0xff0000 };
+static int16_t ts_x[2], ts_y[2];
+static uint16_t ts_cursor_size[2];
+static struct fb_info *fb;
+
+static uint32_t color_convert(uint32_t in) {
+	uint32_t out;
+	pix_fmt_convert(&in, &out, 1, RGB888, fb->var.fmt);
+	return out;
+}
+
+static int init_fb(void) {
+	struct fb_fillrect rect;
+
+	fb = fb_lookup(0);
+
+	if (!fb) {
+		fprintf(stderr, "Cannot open framebuffer\n");
+		return -1;
+	}
+
+	rect.dx = rect.dy = 0;
+	rect.width = fb->var.xres;
+	rect.height = fb->var.yres;
+	rect.color = color_convert(0xffffff);
+	rect.rop = ROP_COPY;
+
+	fb_fillrect(fb, &rect);
+
+	return 0;
+}
+
+static int normalize_coord(int x, int a, int b) {
+	if (x < a) {
+		return a;
+	} else if (x > b - 1) {
+		return b - 1;
+	} else {
+		return x;
+	}
+}
+
+static void draw_cursor(int i, int x, int y, int color) {
+	struct fb_fillrect rect;
+
+	rect.dx = x - (ts_cursor_size[i] + 1) / 2;
+	rect.dy = y - (ts_cursor_size[i] + 1) / 2;
+	rect.width = ts_cursor_size[i];
+	rect.height = ts_cursor_size[i];
+	rect.color = color_convert(color);
+	rect.rop = ROP_COPY;
+
+	fb_fillrect(fb, &rect);
+}
+
+static void handle_touch(int i, int x, int y, int pressure) {
+	/* Clear cursor */
+	draw_cursor(i, ts_x[i], ts_y[i], 0xffffff);
+
+	/* Update new area because of new pressure. */
+	ts_cursor_size[i] = pressure;
+
+	/* Update cursor */
+	ts_x[i] = normalize_coord(x, ts_cursor_size[i],
+		fb->var.xres - ts_cursor_size[i]);
+	ts_y[i] = normalize_coord(y, ts_cursor_size[i],
+		fb->var.yres - ts_cursor_size[i]);
+	draw_cursor(i, ts_x[i], ts_y[i], ts_cursor_color[i]);
+
+	printf("finger%d = (x=%d, y=%d)\n", i, ts_x[i], ts_y[i]);
+}
+
+static int ts_handle(struct input_dev *ts) {
+	struct input_event ev;
+	int type;
+	int pressure = CURSOR_DEFAULT_SIZE, new_x = 0, new_y = 0, touch = -1;
+
+	while (0 <= input_dev_event(ts, &ev)) {
+		type = ev.type & ~TS_EVENT_NEXT;
+
+		switch (type) {
+		case TS_TOUCH_1:
+			touch = 0;
+			new_x = (ev.value >> 16) & 0xffff;
+			new_y = ev.value & 0xffff;
+			break;
+		case TS_TOUCH_2:
+			touch = 1;
+			new_x = (ev.value >> 16) & 0xffff;
+			new_y = ev.value & 0xffff;
+			break;
+		case TS_TOUCH_1_RELEASED:
+			printf("Finger 0 released\n");
+			break;
+		case TS_TOUCH_2_RELEASED:
+			printf("Finger 1 released\n");
+			break;
+		case TS_TOUCH_PRESSURE:
+			printf("Pressure = %d\n", ev.value);
+			pressure = ev.value / 3;
+			break;
+		default:
+			printf("event (type=%d, value=%d)\n", ev.type, ev.value);
+			break;
+		}
+
+		if (ev.type & TS_EVENT_NEXT) {
+			continue;
+		}
+
+		if (touch != -1 && pressure) {
+			handle_touch(touch, new_x, new_y, pressure);
+		}
+		touch = -1;
+	}
+
+	return 0;
+}
+
+static void print_usage(const char *cmd) {
+	printf("Usage: %s [-h] <ts>\n", cmd);
+}
+
+int main(int argc, char **argv) {
+	int opt;
+	struct input_dev *ts;
+
+	if (argc < 2) {
+		print_usage(argv[0]);
+		return 0;
+	}
+
+	while (-1 != (opt = getopt(argc, argv, "h"))) {
+		switch (opt) {
+		case 'h':
+			print_usage(argv[0]);
+			/* FALLTHROUGH */
+		default:
+			return 0;
+		}
+	}
+
+	/* Set default cursor size. */
+	memset(ts_x, 0, sizeof ts_x);
+	memset(ts_y, 0, sizeof ts_y);
+	ts_cursor_size[0] = ts_cursor_size[1] = CURSOR_DEFAULT_SIZE;
+
+	if (!(ts = input_dev_lookup(argv[argc - 1]))) {
+		fprintf(stderr, "Cannot find touchscreen \"%s\"\n", argv[argc - 1]);
+		return -1;
+	}
+
+	if (0 > input_dev_open(ts, ts_handle)) {
+		fprintf(stderr, "Failed open ts input device\n");
+		return -1;
+	}
+
+	if (0 > init_fb()) {
+		fprintf(stderr, "Framebuffer color filling error\n");
+		input_dev_close(ts);
+		return -1;
+	}
+
+	/* Testing for infinite time. */
+	while (1) {
+	}
+
+	return 0;
+}

--- a/src/drivers/input/input_dev.h
+++ b/src/drivers/input/input_dev.h
@@ -26,6 +26,7 @@ enum input_dev_type {
 	INPUT_DEV_KBD,
 	INPUT_DEV_MOUSE,
 	INPUT_DEV_APB,
+	INPUT_DEV_TOUCHSCREEN,
 };
 
 struct input_event {

--- a/src/drivers/input/touchscreen/Mybuild
+++ b/src/drivers/input/touchscreen/Mybuild
@@ -1,0 +1,6 @@
+package embox.driver.input
+
+module touchscreen {
+	@IncludeExport(path="drivers/input")
+	source "touchscreen.h"
+}

--- a/src/drivers/input/touchscreen/stm32/Mybuild
+++ b/src/drivers/input/touchscreen/stm32/Mybuild
@@ -1,0 +1,33 @@
+package embox.driver.input.touchscreen
+
+@BuildDepends(third_party.bsp.stm32746g_cube.core)
+module stm32f746g_ts {
+	option number log_level = 1
+
+	@IncludeExport(path="drivers/input", target_name="stm32cube_ts.h")
+	source "stm32f746g_ts.h"
+
+	source "stm32_cube_touchscreen.c"
+
+	depends embox.driver.input.core
+	depends embox.driver.input.touchscreen
+
+	@NoRuntime depends third_party.bsp.stm32746g_cube.stm32f7_discovery_bsp
+	@NoRuntime depends third_party.bsp.stm32746g_cube.stm32f7_discovery_components
+}
+
+@BuildDepends(third_party.bsp.stm32f769i_cube.core)
+module stm32f769i_ts {
+	option number log_level = 1
+
+	@IncludeExport(path="drivers/input", target_name="stm32cube_ts.h")
+	source "stm32f769i_ts.h"
+
+	source "stm32_cube_touchscreen.c"
+
+	depends embox.driver.input.core
+	depends embox.driver.input.touchscreen
+
+	@NoRuntime depends third_party.bsp.stm32f769i_cube.stm32f7_discovery_bsp
+	@NoRuntime depends third_party.bsp.stm32f769i_cube.stm32f7_discovery_components
+}

--- a/src/drivers/input/touchscreen/stm32/stm32_cube_touchscreen.c
+++ b/src/drivers/input/touchscreen/stm32/stm32_cube_touchscreen.c
@@ -1,0 +1,141 @@
+/*
+ * @file
+ *
+ * @date 15.04.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <errno.h>
+#include <assert.h>
+#include <embox/unit.h>
+#include <util/log.h>
+#include <util/math.h>
+#include <kernel/irq.h>
+#include <drivers/input/input_dev.h>
+#include <drivers/input/touchscreen.h>
+#include <drivers/video/fb.h>
+
+#include <drivers/input/stm32cube_ts.h>
+
+EMBOX_UNIT_INIT(stm32_ts_init);
+
+struct stm32_ts_indev {
+	int touch_active[2];
+	struct input_dev input_dev;
+};
+
+static int stm32_ts_start(struct input_dev *dev) {
+	int ret;
+	struct fb_info *fb;
+
+	fb = fb_lookup(0);
+	if (!fb) {
+		log_error("fb_lookup failed");
+		return -1;
+	}
+
+	ret = BSP_TS_Init(fb->var.xres, fb->var.yres);
+	if (ret != TS_OK) {
+		log_error("BSP_TS_Init failed");
+		return -1;
+	}
+
+	BSP_TS_ITConfig();
+
+	return 0;
+}
+
+static void stm32_ts_poll(struct input_dev *dev) {
+	TS_StateTypeDef ts_state;
+	struct stm32_ts_indev *ts_dev = (struct stm32_ts_indev *) dev->data;
+	struct input_event ev;
+	int i;
+	/* Only two fingers supported at once on the screen. */
+	int touch[2] = {0, 0};
+
+	assert(dev && ts_dev);
+
+	BSP_TS_GetState(&ts_state);
+
+	for (i = 0; i < min(ts_state.touchDetected, 2); i++) {
+		ev.type = (TS_TOUCH_1 + i);
+#if (TS_MULTI_TOUCH_SUPPORTED == 1)
+		/* We will send touched area if multi touch is supported. */
+		ev.type |= TS_EVENT_NEXT;
+#endif
+		ev.value = (ts_state.touchX[i] << 16) | (ts_state.touchY[i] & 0xffff);
+		input_dev_report_event(dev, &ev);
+
+#if (TS_MULTI_TOUCH_SUPPORTED == 1)
+		ev.type = TS_TOUCH_PRESSURE;
+		ev.value = ts_state.touchWeight[i];
+		input_dev_report_event(dev, &ev);
+#endif
+
+		touch[i] = 1;
+	}
+
+	for (i = 0; i < 2; i++) {
+		if (touch[i]) {
+			ts_dev->touch_active[i] = 1;
+		} else {
+			if (ts_dev->touch_active[i]) {
+				ev.type = TS_TOUCH_1_RELEASED + i;
+				input_dev_report_event(dev, &ev);
+			}
+			ts_dev->touch_active[i] = 0;
+		}
+	}
+}
+
+static irq_return_t stm32_ts_irq_hnd(unsigned int irq_nr, void *data) {
+	struct input_dev *dev = (struct input_dev *) data;
+
+	stm32_ts_poll(dev);
+
+	__HAL_GPIO_EXTI_CLEAR_IT(STM32_TS_INT_PIN);
+
+	return IRQ_HANDLED;
+}
+
+static const struct input_dev_ops stm32_ts_input_ops = {
+	/* Nothing to do for now, TS started at module init and running forever. */
+};
+
+static struct stm32_ts_indev stm32_ts_dev = {
+	.input_dev = {
+		.ops = &stm32_ts_input_ops,
+		.name = "stm32-ts",
+		.type = INPUT_DEV_TOUCHSCREEN,
+	},
+};
+
+static int stm32_ts_init(void) {
+	int ret = 0;
+
+	ret = irq_attach(STM32_TS_IRQ, stm32_ts_irq_hnd, 0,
+					 &stm32_ts_dev.input_dev, "stm32 touchscreen");
+	if (ret != 0) {
+		log_error("irq_attach failed");
+		return ret;
+	}
+
+	ret = input_dev_register(&stm32_ts_dev.input_dev);
+	if (ret != 0) {
+		log_error("input_dev_register failed");
+		goto err_irq_detach;
+	}
+	stm32_ts_dev.input_dev.data = (void *) &stm32_ts_dev;
+
+	ret = stm32_ts_start(NULL);
+	if (ret != 0) {
+		log_error("stm32_ts_start failed");
+		goto err_irq_detach;
+	}
+
+	return 0;
+
+err_irq_detach:
+	irq_detach(STM32_TS_IRQ, &stm32_ts_dev.input_dev);
+	return ret;
+}

--- a/src/drivers/input/touchscreen/stm32/stm32f746g_ts.h
+++ b/src/drivers/input/touchscreen/stm32/stm32f746g_ts.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 26.04.20
+ * @author Alexander Kalmuk
+ */
+
+#ifndef DRIVERS_INPUT_TOUCHSCREEN_STM32_STM32F746G_TS__H_
+#define DRIVERS_INPUT_TOUCHSCREEN_STM32_STM32F746G_TS__H_
+
+#include "stm32746g_discovery_ts.h"
+
+#define STM32_TS_INT_PIN   TS_INT_PIN
+#define STM32_TS_IRQ       (TS_INT_EXTI_IRQn + 16)
+
+#endif /* DRIVERS_INPUT_TOUCHSCREEN_STM32_STM32F746G_TS__H_ */

--- a/src/drivers/input/touchscreen/stm32/stm32f769i_ts.h
+++ b/src/drivers/input/touchscreen/stm32/stm32f769i_ts.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 26.04.20
+ * @author Alexander Kalmuk
+ */
+
+#ifndef DRIVERS_INPUT_TOUCHSCREEN_STM32_STM32F769I_TS__H_
+#define DRIVERS_INPUT_TOUCHSCREEN_STM32_STM32F769I_TS__H_
+
+#include "stm32f769i_discovery_ts.h"
+
+#define STM32_TS_INT_PIN   TS_INT_PIN
+#define STM32_TS_IRQ       (TS_INT_EXTI_IRQn + 16)
+
+#endif /* DRIVERS_INPUT_TOUCHSCREEN_STM32_STM32F769I_TS__H_ */

--- a/src/drivers/input/touchscreen/touchscreen.h
+++ b/src/drivers/input/touchscreen/touchscreen.h
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 26.04.20
+ * @author Alexander Kalmuk
+ */
+
+#ifndef DRIVERS_INPUT_TOUCHSCREEN_TOUCHSCREEN_H_
+#define DRIVERS_INPUT_TOUCHSCREEN_TOUCHSCREEN_H_
+
+/* Touchscreen common event types */
+
+#define TS_TOUCH_1              1
+#define TS_TOUCH_2              2
+#define TS_TOUCH_1_RELEASED     3
+#define TS_TOUCH_2_RELEASED     4
+#define TS_TOUCH_PRESSURE       5
+
+/* TODO Should we move it to the common part input_dev.h? */
+#define TS_EVENT_NEXT           (1 << 31)
+
+#endif /* DRIVERS_INPUT_TOUCHSCREEN_TOUCHSCREEN_H_ */

--- a/templates/arm/stm32f746g-discovery/mods.config
+++ b/templates/arm/stm32f746g-discovery/mods.config
@@ -26,8 +26,15 @@ configuration conf {
 	//@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=115200, usartx=6)
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.flash.stm32f7_qspi
-	@Runlevel(2) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000)
+	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000)
 	@Runlevel(2) include embox.driver.sd.stm32f746g_discovery_sd
+
+	/* Touchscreen shares INT pin with SD detect. */
+	/*
+	include embox.cmd.hw.input
+	@Runlevel(2) include embox.driver.input.touchscreen.stm32f746g_ts
+	include embox.cmd.testing.input.touchscreen_test
+	*/
 
 	include embox.driver.flash.stm32f7cube(flash_size=0x18000)
 	include embox.driver.flash.flash_fs

--- a/templates/arm/stm32f769i-discovery/mods.config
+++ b/templates/arm/stm32f769i-discovery/mods.config
@@ -108,7 +108,14 @@ configuration conf {
 
 	include embox.cmd.testing.fb_direct_access
 
-	@Runlevel(2) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000)
+	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000)
+
+	/* Touchscreen shares INT pin with SD detect. */
+	/*
+	include embox.cmd.hw.input
+	@Runlevel(2) include embox.driver.input.touchscreen.stm32f769i_ts
+	include embox.cmd.testing.input.touchscreen_test
+	*/
 
 	@Runlevel(0) include third_party.bsp.stmf7cube.sdram(fmc_swap=true)
 	@Runlevel(0) include third_party.bsp.stm32f769i_cube.stm32f7_discovery_bsp

--- a/third-party/bsp/stmf7cube/stm32f769i/Mybuild
+++ b/third-party/bsp/stmf7cube/stm32f769i/Mybuild
@@ -126,6 +126,10 @@ static module stm32f7_discovery_components extends third_party.bsp.stmf7cube.stm
     @AddPrefix("^BUILD/extbld/third_party/bsp/stm32f769i_cube/core")
 	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ft5336/ft5336.c"
 
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stm32f769i_cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ft6x06")
+    @AddPrefix("^BUILD/extbld/third_party/bsp/stm32f769i_cube/core")
+	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/ft6x06/ft6x06.c"
+
     @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stm32f769i_cube/core/STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/wm8994")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stm32f769i_cube/core")
 	source "./STM32Cube_FW_F7_V1.5.0/Drivers/BSP/Components/wm8994/wm8994.c"


### PR DESCRIPTION
* Add touchscreen driver for STM32F7 (both f746g and f769i).
* Add testing command which handles touches (one or two fingers).

You can test it in the following way:

*
For STM32F746g add to `arm/stm32f746g-discovery`:
```
    include embox.cmd.hw.input
    @Runlevel(2) include embox.driver.input.touchscreen.stm32f746g_ts
    include embox.cmd.testing.input.touchscreen_test
```
For STM32F69I add to `arm/stm32f769i-discovery`:
```
    include embox.cmd.hw.input
    @Runlevel(2) include embox.driver.input.touchscreen.stm32f769i_ts
    include embox.cmd.testing.input.touchscreen_test
```
* In Embox:
```
embox> input                                                                     
        Name        Type
    stm32-ts touchscreen
embox> touchscreen_test stm32-ts
```

Expected behavior is black (first finger) and red (second finger if you touch) squares moving on the screen.