### PR TITLE
third-party: openlibm: add 'mips' in the patch file

### DIFF
--- a/third-party/lib/openlibm/patch.txt
+++ b/third-party/lib/openlibm/patch.txt
@@ -87,7 +87,7 @@ diff -aur openlibm-0.7.0/src/Make.files ../../../../../../tmp/openlibm/src/Make.
  	s_catanl.c s_csinl.c s_cacosl.c s_cexpl.c s_csinhl.c s_ccoshl.c \
  	s_clogl.c s_ctanhl.c s_ccosl.c s_cbrtl.c
  endif
-+ifneq ($(filter $(ARCH),arm),)
++ifneq ($(filter $(ARCH),arm mips),)
 +$(CUR_SRCS) += s_roundl.c
 +endif
 +


### PR DESCRIPTION
Fix the build error related to roundl() function by adding
mips to the list of architectures in patch file of openlibm.
Solves #1886  
Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>