### PR TITLE
cmds: Fix tish memory leak

### DIFF
--- a/src/cmds/shell/tish.c
+++ b/src/cmds/shell/tish.c
@@ -32,6 +32,8 @@
 #include <framework/cmd/api.h>
 #include <embox/unit.h>
 
+#include <mem/sysmalloc.h>
+
 #include <kernel/task.h>
 #include <kernel/task/resource/module_ptr.h>
 
@@ -384,7 +386,8 @@ static void tish_run(void) {
 
 		tish_collect_bg_childs();
 
-		free(line);
+		/* TODO now linenoise use sysalloc for memory allocation */
+		sysfree(line);
 	}
 }
 


### PR DESCRIPTION
Now readline use sysalloc instead of malloc so it's required use sysfree