### PR TITLE
Fix pjsip sha256 registration failure

### DIFF
--- a/platform/pjsip/templates/x86-qemu/mods.config
+++ b/platform/pjsip/templates/x86-qemu/mods.config
@@ -89,7 +89,8 @@ configuration conf {
 
 	@Runlevel(2) include embox.cmd.sh.tish(prompt="%u@%h:%w%$", rich_prompt_support=1, builtin_commands="exit logout cd export mount umount")
 	//@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
-	include embox.init.system_start_service
+	include embox.init.system_start_service(log_level=3, tty_dev="ttyS0")
+	include embox.cmd.service
 
 	include embox.cmd.service
 	include embox.cmd.net.arp
@@ -179,7 +180,11 @@ configuration conf {
 
 	include third_party.pjproject.pjsua
 	include third_party.pjproject.simpleua
-	include platform.pjsip.cmd.simple_pjsua_imported
+
+	include platform.pjsip.cmd.simple_pjsua_imported(
+		sip_domain="server",
+		sip_user="username",
+		sip_passwd="password")
 
 	//include embox.driver.audio.es1370
 

--- a/third-party/pjproject/Makefile
+++ b/third-party/pjproject/Makefile
@@ -11,7 +11,8 @@ PKG_PATCHES := pjproject.patch \
 	simpleua_default_loglevel.patch \
 	mutex_loglevel_increase.patch \
 	kmalloc.patch \
-	srtp.patch
+	srtp.patch \
+	sha256_error_fix.patch
 
 ifeq ($(PJSIP_ENABLE_CXX),false)
 PKG_PATCHES	+= pjsua2_disable.patch

--- a/third-party/pjproject/sha256_error_fix.patch
+++ b/third-party/pjproject/sha256_error_fix.patch
@@ -1,0 +1,20 @@
+diff -aur pjproject-2.2.1/pjsip/src/pjsip/sip_auth_client.c ../build/extbld/third_party/pjproject/core_cxx/pjproject-2.2.1/pjsip/src/pjsip/sip_auth_client.c
+--- pjproject-2.2.1/pjsip/src/pjsip/sip_auth_client.c	2014-02-04 14:13:56.000000000 +0400
++++ ../build/extbld/third_party/pjproject/core_cxx/pjproject-2.2.1/pjsip/src/pjsip/sip_auth_client.c	2020-04-28 19:01:31.698744140 +0300
+@@ -1150,8 +1150,14 @@
+ 	 */
+ 	status = process_auth( tdata->pool, hchal, tdata->msg->line.req.uri,
+ 			       tdata, sess, cached_auth, &hauth);
+-	if (status != PJ_SUCCESS)
+-	    return status;
++	if (status != PJ_SUCCESS) {
++		/*
++		 * https://stackoverflow.com/questions/60683714/pjsip-application-fails-to-register-the-account-with-invalid-unsupported-digest
++		 */
++		PJ_LOG(4,(THIS_FILE, "Moving to the next header"));
++		hdr = hdr->next;
++		continue;
++	}
+ 
+ 	/* Add to the message. */
+ 	pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)hauth);


### PR DESCRIPTION
Fix the problem of SIP account registration with sha256.

```
CSeq: 40584 REGISTER
Server: Flexisip/2.0.0-beta-57-gc9f98e9 (sofia-sip-nta/2.0)
WWW-Authenticate: Digest realm="sip.linphone.org", nonce="fsZS4gAAAAAMuwl4AAAt4vD7FUEAAAAA", opaque="+GNywA==", algorithm=SHA-256, qop="auth"
WWW-Authenticate: Digest realm="sip.linphone.org", nonce="fsZS4gAAAAAMuwl4AAAt4vD7FUEAAAAA", opaque="+GNywA==", algorithm=MD5, qop="auth"
Content-Length: 0

--end msg--
00:00:03.412    pjsua_acc.c  ....IP address change detected for account 0 (10.0.2.16:5060 --> 91.108.30.188:50580). Updating registration (using method 4)
00:00:03.414 sip_auth_clien  ...Unsupported digest algorithm "SHA-256"
00:00:03.415    pjsua_acc.c  ....SIP registration error: Invalid/unsupported digest algorithm (PJSIP_EINVALIDALGORITHM) [status=171102]
```

The problem is not only ours, described on StackOverflow, and looks like a pjsip bug - https://stackoverflow.com/questions/60683714/pjsip-application-fails-to-register-the-account-with-invalid-unsupported-digest.