### PR TITLE
libs: Fix telnetd on stm32

### DIFF
--- a/third-party/lib/linenoise/linenoise.c
+++ b/third-party/lib/linenoise/linenoise.c
@@ -136,7 +136,7 @@ static char * sysstrdup(const char *s) {
 #endif /* __EMBOX__ */
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
-#define LINENOISE_MAX_LINE 4096
+#define LINENOISE_MAX_LINE 256
 static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;


### PR DESCRIPTION
Decrease LINENOISE_MAX_LINE macro, this array is allocated on stack