### PR TITLE
systimer lthread call only if required

### DIFF
--- a/platform/efm32zg_sk3200/templates/debug/mods.config
+++ b/platform/efm32zg_sk3200/templates/debug/mods.config
@@ -31,7 +31,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.sched.timing.none
 
 	@Runlevel(2) include embox.kernel.timer.sys_timer(timer_quantity=2)
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.kernel_time
 	@Runlevel(2) include embox.kernel.timer.itimer(itimer_quantity=2)
 

--- a/platform/mesa/templates/integratorcp/mods.config
+++ b/platform/mesa/templates/integratorcp/mods.config
@@ -39,7 +39,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core(thread_pool_size=32, thread_stack_size=1048576)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/mesa/templates/mesa_x86_osmesa/mods.config
+++ b/platform/mesa/templates/mesa_x86_osmesa/mods.config
@@ -119,7 +119,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/nuklear/templates/arm_qemu/mods.config
+++ b/platform/nuklear/templates/arm_qemu/mods.config
@@ -39,7 +39,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core(thread_pool_size=32, thread_stack_size=1048576)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/nuklear/templates/x86_qemu/mods.config
+++ b/platform/nuklear/templates/x86_qemu/mods.config
@@ -115,7 +115,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/opencv/templates/arm-qemu/mods.config
+++ b/platform/opencv/templates/arm-qemu/mods.config
@@ -48,7 +48,7 @@ configuration conf {
 				thread_pool_size=16, thread_stack_size=1048576)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/pjsip/templates/x86-qemu/mods.config
+++ b/platform/pjsip/templates/x86-qemu/mods.config
@@ -52,7 +52,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=655536)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/quake3/templates/qemu/mods.config
+++ b/platform/quake3/templates/qemu/mods.config
@@ -117,7 +117,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/platform/stellaris/templates/lm3s811evb/mods.config
+++ b/platform/stellaris/templates/lm3s811evb/mods.config
@@ -24,7 +24,7 @@ configuration conf {
 	include embox.kernel.task.task_no_table
 
 	@Runlevel(1) include embox.kernel.timer.sys_timer(timer_quantity=2)
-	@Runlevel(1) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(1) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(1) include embox.kernel.timer.itimer(itimer_quantity=0)
 	include embox.kernel.timer.sleep_nosched

--- a/src/include/kernel/time/time.h
+++ b/src/include/kernel/time/time.h
@@ -87,7 +87,9 @@ static inline time64_t clock_to_ns(uint32_t hz, clock_t ticks) {
 
 static inline clock_t ns_to_clock(uint32_t hz, time64_t ns) {
 	assert(hz != 0);
-	return (ns * hz + NSEC_PER_SEC - 1) / NSEC_PER_SEC;
+	/* for example, 10001000 ns = 1 ms 1 usec, hz = 1000. Then,
+	 * there should be 3 clocks to guarantee 1 ms 1 usec fits the interval. */
+	return (ns * hz + NSEC_PER_SEC - 1) / NSEC_PER_SEC + 1;
 }
 
 static inline struct timespec cycles64_to_timespec(uint32_t hz, uint64_t cycles) {

--- a/src/include/kernel/time/timer.h
+++ b/src/include/kernel/time/timer.h
@@ -47,7 +47,8 @@ struct sys_timer {
 	struct dlist_head st_wait_link;
 
 	uint32_t   load;
-	uint32_t   cnt;
+	/* Clocks count at which timer should fire: cnt = current clocks() + load. */
+	clock_t    cnt;
 	sys_timer_handler_t handle;
 	void       *param;
 	unsigned int flags;

--- a/src/include/kernel/time/timer_strat.h
+++ b/src/include/kernel/time/timer_strat.h
@@ -11,11 +11,14 @@
 #define TIMER_STRAT_H_
 struct sys_timer;
 #include <module/embox/kernel/timer/strategy/api.h>
+#include <sys/types.h>
 
 /********
  * timer_strat
  */
-extern void timer_strat_sched(void);
+extern void timer_strat_sched(clock_t jiffies);
+
+extern bool timer_strat_need_sched(clock_t jiffies);
 
 extern void timer_strat_stop(struct sys_timer *ptimer);
 

--- a/src/kernel/time/timer/strategy/head_timer.c
+++ b/src/kernel/time/timer/strategy/head_timer.c
@@ -9,6 +9,7 @@
  */
 
 #include <kernel/time/timer.h>
+#include <hal/clock.h>
 
 static DLIST_DEFINE(sys_timers_list); /* list head to timers */
 
@@ -18,7 +19,7 @@ void timer_strat_start(struct sys_timer *tmr) {
 	dlist_head_init(&tmr->lnk);
 	timer_set_started(tmr);
 
-	tmr->cnt = tmr->load;
+	tmr->cnt = clock_sys_ticks() + tmr->load;
 
 	/* find first element that its time bigger than inserting @new_time */
 	dlist_foreach_entry(it_tmr, &sys_timers_list, lnk) {
@@ -51,33 +52,14 @@ void timer_strat_stop(struct sys_timer *ptimer) {
 	dlist_del(&ptimer->lnk);
 }
 
-static inline bool timers_need_schedule(void) {
+bool timer_strat_need_sched(clock_t jiffies) {
+	struct sys_timer *t;
+
 	if (dlist_empty(&sys_timers_list)) {
 		return false;
 	}
-
-	if (0 == --((sys_timer_t*)sys_timers_list.next)->cnt) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
-static inline void timers_schedule(void) {
-	struct sys_timer *timer;
-
-	dlist_foreach_entry(timer, &sys_timers_list, lnk) {
-		if (0 != timer->cnt) {
-			break;
-		}
-
-		timer_strat_stop(timer);
-		if (timer_is_periodic(timer)) {
-			timer_strat_start(timer);
-		}
-
-		timer->handle(timer, timer->param);
-	}
+	t = dlist_first_entry(&sys_timers_list, struct sys_timer, lnk);
+	return jiffies >= t->cnt;
 }
 
 /**
@@ -85,8 +67,20 @@ static inline void timers_schedule(void) {
  * and the counter of this timer is the zero then its initial value is assigned
  * to the counter and the function is executed.
  */
-void timer_strat_sched(void) {
-	if (timers_need_schedule()) {
-		timers_schedule();
+void timer_strat_sched(clock_t jiffies) {
+	struct sys_timer *timer;
+
+	dlist_foreach_entry(timer, &sys_timers_list, lnk) {
+		if (jiffies < timer->cnt) {
+			break;
+		}
+		jiffies -= timer->cnt;
+
+		timer_strat_stop(timer);
+		if (timer_is_periodic(timer)) {
+			timer_strat_start(timer);
+		}
+
+		timer->handle(timer, timer->param);
 	}
 }

--- a/src/kernel/time/timer/sys_timer.c
+++ b/src/kernel/time/timer/sys_timer.c
@@ -14,6 +14,7 @@
 #include <kernel/time/timer.h>
 #include <kernel/time/time.h>
 #include <kernel/sched/sched_lock.h>
+#include <hal/clock.h>
 
 POOL_DEF(timer_pool, sys_timer_t, OPTION_GET(NUMBER,timer_quantity));
 
@@ -34,12 +35,8 @@ void timer_start(struct sys_timer *tmr, clock_t jiffies) {
 
 	timer_stop(tmr);
 
-	if (timer_is_periodic(tmr)) {
-		tmr->load = jiffies;
-		tmr->cnt = tmr->load + 1;
-	} else {
-		tmr->cnt = tmr->load = jiffies + 1;
-	}
+	tmr->load = jiffies;
+	tmr->cnt = clock_sys_ticks() + tmr->load;
 
 	sched_lock();
 	{

--- a/templates/aarch64/qemu/mods.config
+++ b/templates/aarch64/qemu/mods.config
@@ -42,7 +42,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/arm/c++_demo/mods.config
+++ b/templates/arm/c++_demo/mods.config
@@ -38,7 +38,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/arm/da14680/mods.config
+++ b/templates/arm/da14680/mods.config
@@ -11,7 +11,7 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.armmlib.interrupt
 
 	@Runlevel(1) include embox.driver.interrupt.cortexm0_nvic
-	@Runlevel(2) include embox.driver.clock.cortexm_systick(systick_hz=100)
+	@Runlevel(2) include embox.driver.clock.cortexm_systick(systick_hz=1000)
 
 	include embox.kernel.irq_static_light
 	include embox.kernel.stack(stack_size=0x2000, alignment=8)

--- a/templates/arm/qemu/mods.config
+++ b/templates/arm/qemu/mods.config
@@ -43,7 +43,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/arm/qt-app/mods.config
+++ b/templates/arm/qt-app/mods.config
@@ -51,7 +51,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core(thread_pool_size=32, thread_stack_size=1048576)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/arm/qt-fb-small/mods.config
+++ b/templates/arm/qt-fb-small/mods.config
@@ -48,7 +48,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/arm/rpi1-model-b/mods.config
+++ b/templates/arm/rpi1-model-b/mods.config
@@ -37,7 +37,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/arm/sabrelite/mods.config
+++ b/templates/arm/sabrelite/mods.config
@@ -44,7 +44,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(stack_align=8, thread_stack_size=0x20000)

--- a/templates/arm/stm32_vl/mods.config
+++ b/templates/arm/stm32_vl/mods.config
@@ -20,7 +20,7 @@ configuration conf {
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=6)
 
 	@Runlevel(1) include embox.kernel.timer.sys_timer(timer_quantity=4)
-	@Runlevel(1) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(1) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(1) include embox.kernel.timer.itimer(itimer_quantity=4)
 

--- a/templates/arm/stm32_vl_light/mods.config
+++ b/templates/arm/stm32_vl_light/mods.config
@@ -25,7 +25,7 @@ configuration conf {
 	include embox.kernel.task.task_no_table
 
 	@Runlevel(1) include embox.kernel.timer.sys_timer(timer_quantity=2)
-	@Runlevel(1) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(1) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(1) include embox.kernel.timer.itimer(itimer_quantity=0)
 	include embox.kernel.timer.sleep_nosched

--- a/templates/arm/test/units/mods.config
+++ b/templates/arm/test/units/mods.config
@@ -59,7 +59,7 @@ configuration conf {
 				thread_pool_size=32, thread_stack_size=1048576)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/e2k/monocube/mods.config
+++ b/templates/e2k/monocube/mods.config
@@ -53,7 +53,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core(stack_align=4096, thread_stack_size=0x10000)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/microblaze/qemu/mods.config
+++ b/templates/microblaze/qemu/mods.config
@@ -38,7 +38,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/mips/c++_demo/mods.config
+++ b/templates/mips/c++_demo/mods.config
@@ -29,7 +29,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/mips/qemu/mods.config
+++ b/templates/mips/qemu/mods.config
@@ -32,7 +32,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/mips/test/units/mods.config
+++ b/templates/mips/test/units/mods.config
@@ -34,7 +34,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/mips64/qemu/mods.config
+++ b/templates/mips64/qemu/mods.config
@@ -36,7 +36,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/riscv/qemu-sifive-u/mods.config
+++ b/templates/riscv/qemu-sifive-u/mods.config
@@ -25,7 +25,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core

--- a/templates/sparc/c++_demo/mods.config
+++ b/templates/sparc/c++_demo/mods.config
@@ -35,7 +35,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/sparc/greth/mods.config
+++ b/templates/sparc/greth/mods.config
@@ -64,7 +64,7 @@ configuration conf {
 
 	@Runlevel(1) include embox.kernel.timer.sys_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.timer.sleep
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/sparc/qemu/mods.config
+++ b/templates/sparc/qemu/mods.config
@@ -36,7 +36,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/sparc/test/units/mods.config
+++ b/templates/sparc/test/units/mods.config
@@ -27,7 +27,7 @@ configuration conf {
 	@Runlevel(1) include embox.arch.sparc.kernel.interrupt
 	@Runlevel(1) include embox.kernel.timer.sys_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.timer.sleep
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/sparc/tsim/mods.config
+++ b/templates/sparc/tsim/mods.config
@@ -26,7 +26,7 @@ configuration conf {
 
 	@Runlevel(1) include embox.kernel.timer.sys_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.timer.sleep
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/usermode86/debug/mods.config
+++ b/templates/usermode86/debug/mods.config
@@ -150,7 +150,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/bifferboard/mods.config
+++ b/templates/x86/bifferboard/mods.config
@@ -63,7 +63,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/x86/c++_demo/mods.config
+++ b/templates/x86/c++_demo/mods.config
@@ -35,7 +35,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/x86/debug/mods.config
+++ b/templates/x86/debug/mods.config
@@ -19,7 +19,7 @@ configuration conf {
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/x86/qemu/mods.config
+++ b/templates/x86/qemu/mods.config
@@ -39,7 +39,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.task.multi
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)

--- a/templates/x86/qt-app/mods.config
+++ b/templates/x86/qt-app/mods.config
@@ -118,7 +118,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/qt-fb/mods.config
+++ b/templates/x86/qt-fb/mods.config
@@ -116,7 +116,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/qt-vnc/mods.config
+++ b/templates/x86/qt-vnc/mods.config
@@ -16,7 +16,7 @@ configuration conf {
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/x86/smp/mods.config
+++ b/templates/x86/smp/mods.config
@@ -16,7 +16,7 @@ configuration conf {
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based_smp
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/x86/studp/mods.config
+++ b/templates/x86/studp/mods.config
@@ -171,7 +171,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/test/lang/mods.config
+++ b/templates/x86/test/lang/mods.config
@@ -160,7 +160,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/test/net/mods.config
+++ b/templates/x86/test/net/mods.config
@@ -107,7 +107,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/test/packetdrill/mods.config
+++ b/templates/x86/test/packetdrill/mods.config
@@ -133,7 +133,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/test/ping-target/mods.config
+++ b/templates/x86/test/ping-target/mods.config
@@ -122,7 +122,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/test/qt-vnc/mods.config
+++ b/templates/x86/test/qt-vnc/mods.config
@@ -17,7 +17,7 @@ configuration conf {
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical

--- a/templates/x86/test/units/mods.config
+++ b/templates/x86/test/units/mods.config
@@ -48,7 +48,7 @@ configuration conf {
 	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x4000)
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/third_party/mods.config
+++ b/templates/x86/third_party/mods.config
@@ -150,7 +150,7 @@ configuration conf {
 
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical
 

--- a/templates/x86/user_apps/mods.config
+++ b/templates/x86/user_apps/mods.config
@@ -16,7 +16,7 @@ configuration conf {
 	@Runlevel(1) include embox.kernel.time.kernel_time
 	@Runlevel(2) include embox.kernel.sched.strategy.priority_based
 	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(2) include embox.kernel.time.timekeeper
 	@Runlevel(2) include embox.kernel.irq
 	@Runlevel(2) include embox.kernel.critical


### PR DESCRIPTION
Verify in the interrupt context whether timer scheduling is actually required, so now we do not call lthread on every hardware timer tick.