### PR TITLE
cmd: Add blockdev command utlity

### DIFF
--- a/src/cmds/Blockdev.my
+++ b/src/cmds/Blockdev.my
@@ -1,0 +1,21 @@
+package embox.cmd
+
+@AutoCmd
+@Cmd(name = "blockdev",
+	help = "blockdev shows the device blocks information",
+	man = '''
+		NAME
+			blockdev - block devices information
+		SYNOPSIS
+			blockdev displays block devices related information, like the block size
+			of the specified block or the report of the block devices present, in terms
+			of block size and total size.
+		AUTHOR
+			Adityar Rayala
+	''')
+module blockdev {
+	source "blockdev.c"
+	@NoRuntime depends embox.framework.cmd
+	@NoRuntime depends embox.compat.libc.stdio.printf
+	depends embox.driver.block_dev
+}

--- a/src/cmds/blockdev.c
+++ b/src/cmds/blockdev.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ *
+ * @date 20.02.23
+ * @author Adityar Rayala
+ */
+
+#include<stdio.h>
+#include<string.h>
+#include <drivers/block_dev.h>
+
+static void print_usage(void) {
+    printf("Usage:\nblockdev command devices\n");
+    printf("blockdev --report [devices]\n");
+    printf("Options:\n");
+    printf(" %-15s print report for specified (or all) devices.\n", "--report");
+    printf("Available Commands:\n");
+    printf(" %-15s get size in 512-byte sectors.\n", "--getbsz");
+}
+
+static inline struct block_dev* chk_dev_avail(char* dev_name) {
+	struct block_dev *bdev;
+
+	bdev = block_dev_find(dev_name);
+	if (!bdev) {
+		printf("Block device \"%s\" not found.\n", dev_name);
+		return 0;
+	}
+
+	return bdev;
+}
+static inline void print_device_info(int count, struct block_dev *bdev) {
+	printf("| %-3d | %-15s | %-15d | %-20lld |\n", count, bdev->name, bdev->block_size, bdev->size);
+}
+
+int main(int argc, char **argv) {
+    struct block_dev **bdevs, *bdev;
+	int count = 0;
+
+    if (argc < 2) {
+        print_usage();
+        return 0;
+    }
+
+	if (!strcmp(argv[1], "--getbsz")) {
+			if (argc < 3) {
+				printf("blockdev: No device specified\n");
+			}
+			else{
+				bdev = chk_dev_avail(argv[2]);
+				if (bdev) {
+					printf("%d\n", bdev->block_size);
+				}
+			}
+	}
+	else if (!strcmp(argv[1], "--report")) {
+		printf("------------------------------------------------------------------\n");
+		printf("| %-3s | %-15s | %-15s | %-20s |\n", "ID", "Device Name", "BSZ", "Size");
+		printf("------------------------------------------------------------------\n");
+		bdevs = get_bdev_tab();
+		if (bdevs == NULL) {
+			return 0;
+		}
+		if (argc >= 3) {
+			bdev = chk_dev_avail(argv[2]);
+			if (bdev) {
+				print_device_info(count,bdev);
+				printf("------------------------------------------------------------------\n");
+			}
+		}
+		else {
+			int i;
+			for (i = 0; i < MAX_BDEV_QUANTITY; i++) {
+				if (bdevs[i]) {
+					print_device_info(count,bdevs[i]);
+					count++;
+				}
+			}
+			printf("------------------------------------------------------------------\n");
+		}
+	}
+}


### PR DESCRIPTION
Current implementation of blockdev command lets us view the blocksize of a specified blockdevice. It also gives a report of the blocksize and total size of the overall block devices or a specified device

Rebased #1706 