### PR TITLE
Microblaze partially fix (working without mmu)

### DIFF
--- a/src/drivers/serial/xuartlite/Mybuild
+++ b/src/drivers/serial/xuartlite/Mybuild
@@ -6,5 +6,7 @@ module xuartlite extends embox.driver.diag.diag_api {
 	option number xuartlite_base
 	option number irq_num
 
+	depends core
+	depends diag
 	depends embox.driver.periph_memory
 }

--- a/templates/microblaze/qemu/mods.config
+++ b/templates/microblaze/qemu/mods.config
@@ -25,8 +25,11 @@ configuration conf {
 
 	include embox.driver.block_dev
 
-	@Runlevel(0) include embox.arch.microblaze.mmu
-	@Runlevel(0) include embox.arch.microblaze.mmuinfo
+	/* FIXME See https://github.com/embox/embox/issues/2011 */
+	//@Runlevel(0) include embox.arch.microblaze.mmu
+	//@Runlevel(0) include embox.arch.microblaze.mmuinfo
+	//include embox.cmd.mmuinfo
+	//include embox.cmd.hw.mmutrans
 
 	//@Runlevel(2) include embox.lib.debug.whereami
 	@Runlevel(2) include embox.profiler.tracing
@@ -160,8 +163,6 @@ configuration conf {
 	include embox.cmd.proc.thread
 	include embox.cmd.proc.top
 
-	include embox.cmd.mmuinfo
-	include embox.cmd.hw.mmutrans
 	include embox.cmd.mem
 
 	@Runlevel(2) include embox.net.core

--- a/templates/microblaze/qemu/mods.config
+++ b/templates/microblaze/qemu/mods.config
@@ -17,7 +17,7 @@ configuration conf {
 	@Runlevel(0) include embox.kernel.stack(stack_size=0x10000)
 
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__xuartlite")
-	@Runlevel(1) include embox.driver.serial.xuartlite(xuartlite_base=0x84000000, irq_num=2)
+	@Runlevel(1) include embox.driver.serial.xuartlite(xuartlite_base=0x84000000, irq_num=3)
 	@Runlevel(1) include embox.driver.interrupt.mb_intc(mbintc_base=0x81800000)
 	@Runlevel(1) include embox.driver.clock.mb_timer(mbtimer_base=0x83c00000, irq_num=0)
 	@Runlevel(2) include embox.driver.net.xemaclite(xemaclite_base=0x81000000, irq_num=1)


### PR DESCRIPTION
* Fix xilinix uart implementation to be an uart, not just diag
* Add ipl locks to head timer strategy

This issue  closes partially https://github.com/embox/embox/issues/2011 - now telnet (and network) works well, but only with mmu disabled.