### PR TITLE
Usb ccid (host mode)

### DIFF
--- a/scripts/qemu/auto_qemu_with_usb_ccid
+++ b/scripts/qemu/auto_qemu_with_usb_ccid
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# libnss3-dev, libnss3-tools, libcacard-dev packages are required
+# to run properly
+
+FAKE_SMARTCARD="fake_smartcard.img"
+
+if [ -d $FAKE_SMARTCARD ]; then
+	echo "$FAKE_SMARTCARD found."
+else
+	echo "$FAKE_SMARTCARD not found. A new one will be created now..."
+
+	# It's taken from QEMU's docs/ccid.txt
+	mkdir $FAKE_SMARTCARD
+	cd $FAKE_SMARTCARD
+	certutil -N -d sql:$PWD
+	certutil -S -d sql:$PWD -s "CN=Fake Smart Card CA" -x -t TC,TC,TC -n fake-smartcard-ca
+	certutil -S -d sql:$PWD -t ,, -s "CN=John Doe" -n id-cert -c fake-smartcard-ca
+	certutil -S -d sql:$PWD -t ,, -s "CN=John Doe (signing)" --nsCertType smime -n signing-cert -c fake-smartcard-ca
+	certutil -S -d sql:$PWD -t ,, -s "CN=John Doe (encryption)" --nsCertType sslClient -n encryption-cert -c fake-smartcard-ca
+	cd -
+fi
+
+./scripts/qemu/auto_qemu \
+	-device usb-ccid \
+	-device ccid-card-emulated,backend=certificates,db=sql:$FAKE_SMARTCARD,cert1=id-cert,cert2=signing-cert,cert3=encryption-cert \
+	$@

--- a/src/cmds/hardware/ccid/Mybuild
+++ b/src/cmds/hardware/ccid/Mybuild
@@ -1,0 +1,21 @@
+package embox.cmd.hw
+
+@AutoCmd
+@Cmd(name = "ccid_cmd",
+	man = '''
+	NAME
+       ccid_cmd - list Smart Cards, show ATR's and executes commands
+    SYNOPSIS
+       ccid_cmd [ -h ] <usb bus> <usb dev>
+    DESCRIPTION
+	OPTIONS
+			-h
+				Shows usage
+	AUTHORS
+			Alexander Kalmuk
+	''')
+module ccid_cmd {
+	source "ccid_cmd.c"
+
+	@NoRuntime depends embox.driver.usb.core
+}

--- a/src/cmds/hardware/ccid/ccid_cmd.c
+++ b/src/cmds/hardware/ccid/ccid_cmd.c
@@ -1,0 +1,227 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    10.06.2020
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <drivers/usb/usb.h>
+#include <drivers/usb/class/ccid.h>
+
+/* Global counter for all CCID requests. */
+static int b_seq;
+
+static void print_usage(void) {
+	printf("Usage: ccid_cmd [-h] <usb bus> <usb device>\n");
+	printf("\t[-h]      - print this help\n");
+	printf("\n\t Example:\n");
+	printf("\t    ccid_cmd 0 1: Works with CCID device on bus 0, addr 1.\n");
+}
+
+static void ccid_cmd_show_atr(struct usb_dev *udev) {
+	struct ccid_msg_hdr_icc_power_on *pwr_on_hdr;
+	struct ccid_msg_hdr *hdr;
+	uint8_t buf[64];
+	uint8_t msg_hdr_buf[CCID_MSG_HEADER_SIZE];
+	int i;
+
+	pwr_on_hdr = (struct ccid_msg_hdr_icc_power_on *) msg_hdr_buf;
+
+	pwr_on_hdr->hdr.b_message_type = CCID_MESSAGE_TYPE_PC_to_RDR_IccPowerOn;
+	pwr_on_hdr->hdr.dw_length = 0;
+	pwr_on_hdr->hdr.b_slot = 0;
+	pwr_on_hdr->hdr.b_seq = b_seq++;
+	pwr_on_hdr->b_power_select = 0; /* automatic voltage selection */
+
+	ccid_handle_msg(udev, pwr_on_hdr, buf, sizeof buf);
+
+	hdr = (struct ccid_msg_hdr *) buf;
+	assert(hdr->b_message_type == CCID_MESSAGE_TYPE_RDR_to_PC_DataBlock);
+
+	printf("ATR: ");
+	for (i = 0; i < hdr->dw_length; i++) {
+		printf("%02x ", buf[CCID_MSG_HEADER_SIZE + i]);
+	}
+	printf("\n");
+}
+
+static int ccid_cmd_card_status(struct usb_dev *udev) {
+	struct ccid_msg_hdr *hdr;
+	struct ccid_msg_hdr_bulk_in *bulk_in_hdr;
+	uint8_t buf[64];
+	uint8_t msg_hdr_buf[CCID_MSG_HEADER_SIZE];
+
+	hdr = (struct ccid_msg_hdr *) msg_hdr_buf;
+
+	hdr->b_message_type = CCID_MESSAGE_TYPE_PC_to_RDR_GetSlotStatus;
+	hdr->dw_length = 0;
+	hdr->b_slot = 0;
+	hdr->b_seq = b_seq++;
+
+	ccid_handle_msg(udev, hdr, buf, sizeof buf);
+
+	bulk_in_hdr = (struct ccid_msg_hdr_bulk_in *) buf;
+	assert(bulk_in_hdr->hdr.b_message_type == CCID_MESSAGE_TYPE_RDR_to_PC_SlotStatus);
+
+	return bulk_in_hdr->b_status & CCID_SLOT_STATUS_MASK;
+}
+
+static int ccid_cmd_card_cmd(struct usb_dev *udev, uint8_t *cmd,
+		int len) {
+	struct ccid_msg_hdr *hdr;
+	struct ccid_msg_hdr_bulk_in *bulk_in_hdr;
+	uint8_t buf[CCID_MSG_HEADER_SIZE];
+	uint8_t *msg_hdr_buf, *data;
+	int i;
+
+	msg_hdr_buf = malloc(CCID_MSG_HEADER_SIZE + len);
+	if (!msg_hdr_buf) {
+		goto out_err;
+	}
+
+	hdr = (struct ccid_msg_hdr *) msg_hdr_buf;
+
+	hdr->b_message_type = CCID_MESSAGE_TYPE_PC_to_RDR_XfrBlock;
+	hdr->dw_length = len;
+	hdr->b_slot = 0;
+	hdr->b_seq = b_seq++;
+	memcpy(msg_hdr_buf + CCID_MSG_HEADER_SIZE, cmd, len);
+
+	ccid_handle_msg(udev, hdr, buf, CCID_MSG_HEADER_SIZE);
+
+	bulk_in_hdr = (struct ccid_msg_hdr_bulk_in *) buf;
+	assert(bulk_in_hdr->hdr.b_message_type == CCID_MESSAGE_TYPE_RDR_to_PC_DataBlock);
+
+	data = malloc(bulk_in_hdr->hdr.dw_length);
+	if (!data) {
+		goto out_err_free_msg;
+	}
+
+	/* Now read the reset of data replied. */
+	ccid_read_msg_data(udev, data, bulk_in_hdr->hdr.dw_length);
+
+	printf("Reply: ");
+	for (i = 0; i < bulk_in_hdr->hdr.dw_length; i++) {
+		printf("0x%02x ", data[i]);
+	}
+	printf("\n");
+
+	free(msg_hdr_buf);
+	free(data);
+
+	return 0;
+
+out_err_free_msg:
+	free(msg_hdr_buf);
+out_err:
+	fprintf(stderr, "ccid_cmd_card_cmd failed\n");
+	return -1;
+}
+
+static void handle_ccid_commands(struct usb_dev *udev) {
+	int card_status;
+
+	printf("\n");
+
+	/* Card status */
+	card_status = ccid_cmd_card_status(udev);
+	switch (card_status) {
+	case CCID_SLOT_STATUS_ACTIVE:
+		printf("Card status (slot 0): Inserted\n");
+		break;
+	case CCID_SLOT_STATUS_INACTIVE:
+		printf("Card status (slot 0): Inserted, but inactive (probably not powered)\n");
+		return;
+	case CCID_SLOT_STATUS_NOT_PRESENT:
+		printf("Card status (slot 0): No present\n");
+		return;
+	}
+
+	/* ATR */
+	ccid_cmd_show_atr(udev);
+
+	/* Process user entered commands */
+	printf("\nYou can enter command bytes, press enter to send it to smart card:\n"
+		   "  For example:\n"
+		   "    C0 20 00 00 03 31 32 33 - If you want to input PIN \"123\"\n"
+		   "                              (\"C0 20 00 00\" - cmd, 03 - len, \"31 32 33\" - your PIN) \n"
+	);
+
+	while (1) {
+		char user_input[64];
+		uint8_t cmd_buf[64];
+		int cmd_len;
+		char *str;
+
+		cmd_len = 0;
+
+		fgets(user_input, 64, stdin);
+		str = strtok(user_input, " ");
+		while (str != NULL) {
+			unsigned int c;
+
+			sscanf(str, "%x", &c);
+			cmd_buf[cmd_len++] = c;
+			str = strtok(NULL, " ");
+		}
+
+		ccid_cmd_card_cmd(udev, cmd_buf, cmd_len);
+	}
+}
+
+int main(int argc, char **argv) {
+	struct usb_dev *usb_dev = NULL;
+	int opt, ret;
+	int bus, addr;
+
+	while (-1 != (opt = getopt(argc, argv, "h"))) {
+		switch (opt) {
+		case '?':
+		case 'h':
+		default:
+			print_usage();
+			return 0;
+		}
+	}
+
+	if (argc < 3) {
+		print_usage();
+		return 0;
+	}
+
+	ret = sscanf(argv[argc - 2], "%d", &bus);
+	if (ret < 0) {
+		fprintf(stderr, "Bad usb bus number\n");
+		print_usage();
+		return -1;
+	}
+	ret = sscanf(argv[argc - 1], "%d", &addr);
+	if (ret < 0) {
+		fprintf(stderr, "Bad usb device number\n");
+		print_usage();
+		return -1;
+	}
+
+	while ((usb_dev = usb_dev_iterate(usb_dev))) {
+		if ((usb_dev->bus_idx != bus) || (usb_dev->addr != addr)) {
+			continue;
+		}
+
+		/* Make sure it's CCID device */
+		if (usb_dev->iface_desc[0]
+			&& (usb_dev->iface_desc[0]->b_interface_class == USB_CLASS_CCID)) {
+			handle_ccid_commands(usb_dev);
+			return 0;
+		}
+	}
+
+	fprintf(stderr, "No CCID device found: bus=%d, addr=%d\n", bus, addr);
+
+	return -1;
+}

--- a/src/cmds/hardware/lsusb/lsusb.c
+++ b/src/cmds/hardware/lsusb/lsusb.c
@@ -67,6 +67,13 @@ static void show_usb_desc_device(struct usb_dev *usb_dev) {
 }
 
 static void show_usb_desc_interface(struct usb_dev *usb_dev) {
+	if (!usb_dev->iface_desc[0]) {
+		printf(" Interface Descriptor:\n"
+			   "   No interfaces\n"
+		);
+		return;
+	}
+
 	printf(" Interface Descriptor:\n"
 			"   b_length             %5u\n"
 			"   b_desc_type          %5u\n"
@@ -92,7 +99,10 @@ static void show_usb_desc_configuration(struct usb_dev *usb_dev) {
 	struct usb_desc_configuration *config = \
 				(struct usb_desc_configuration *) usb_dev->config_buf;
 	
-	if(!config) {
+	if (!config) {
+		printf(" Configuration Descriptor:\n"
+			   "   No configurations\n\n"
+		);
 		return;
 	}
 

--- a/src/drivers/usb/class/ccid/Mybuild
+++ b/src/drivers/usb/class/ccid/Mybuild
@@ -1,0 +1,13 @@
+package embox.driver.usb.class
+
+module ccid {
+	option number log_level=1
+	option number ccid_max_devs=2
+
+	@IncludeExport(path="drivers/usb/class")
+	source "ccid.h"
+
+	source "ccid.c"
+
+	depends embox.driver.usb.core
+}

--- a/src/drivers/usb/class/ccid/ccid.c
+++ b/src/drivers/usb/class/ccid/ccid.c
@@ -1,0 +1,153 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    10.06.2020
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <mem/misc/pool.h>
+#include <embox/unit.h>
+#include <drivers/usb/usb_driver.h>
+#include <drivers/usb/usb.h>
+#include <util/log.h>
+
+#include <drivers/usb/class/ccid.h>
+
+#define CCID_MAX_DEVS  OPTION_GET(NUMBER, ccid_max_devs)
+
+#define CCID_BULK_TIMEOUT   1000
+
+struct ccid {
+	struct usb_dev *usb_dev;
+	char ep_bulk_in;  /* Mandatory EP */
+	char ep_bulk_out; /* Mandatory EP */
+	char ep_intr;     /* Optional EP */
+};
+
+EMBOX_UNIT_INIT(ccid_init);
+
+POOL_DEF(ccid_classes, struct ccid, CCID_MAX_DEVS);
+
+static int ccid_do_handle_msg(struct ccid *ccid,
+		const void *out, int out_cnt, void *in, int in_cnt) {
+	int res;
+
+	res = usb_endp_bulk_wait(ccid->usb_dev->endpoints[ccid->ep_bulk_out],
+			(void *) out, out_cnt, CCID_BULK_TIMEOUT);
+	if (res < 0) {
+		goto out_err;
+	}
+
+	res = usb_endp_bulk_wait(ccid->usb_dev->endpoints[ccid->ep_bulk_in],
+			in, in_cnt, CCID_BULK_TIMEOUT);
+	if (res < 0) {
+		goto out_err;
+	}
+
+	return 0;
+
+out_err:
+	log_error("failed");
+	return res;
+}
+
+int ccid_handle_msg(struct usb_dev *udev, const void *out,
+		void *in, int in_cnt) {
+	struct ccid_msg_hdr *ccid_hdr = (struct ccid_msg_hdr *) out;
+	struct ccid *ccid = (struct ccid *) udev->driver_data;
+	int res = 0;
+
+	switch (ccid_hdr->b_message_type) {
+	case CCID_MESSAGE_TYPE_PC_to_RDR_IccPowerOn:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_GetSlotStatus:
+		res = ccid_do_handle_msg(ccid, out, CCID_MSG_HEADER_SIZE,
+				in, in_cnt);
+		break;
+	case CCID_MESSAGE_TYPE_PC_to_RDR_XfrBlock:
+		res = ccid_do_handle_msg(ccid, out,
+				CCID_MSG_HEADER_SIZE + ccid_hdr->dw_length,
+			    in, in_cnt);
+		break;
+	case CCID_MESSAGE_TYPE_PC_to_RDR_IccPowerOff:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_GetParameters:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_ResetParameters:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_SetParameters:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_Escape:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_IccClock:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_T0APDU:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_Secure:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_Mechanical:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_Abort:
+	case CCID_MESSAGE_TYPE_PC_to_RDR_SetDataRateAndClockFrequency:
+	default:
+		log_error("Unsupported request 0x%02x\n", ccid_hdr->b_message_type);
+		res = -1;
+		break;
+	}
+
+	return res;
+}
+
+int ccid_read_msg_data(struct usb_dev *udev, void *in, int in_cnt) {
+	struct ccid *ccid = (struct ccid *) udev->driver_data;
+
+	return usb_endp_bulk_wait(udev->endpoints[ccid->ep_bulk_in],
+			in, in_cnt, CCID_BULK_TIMEOUT);
+}
+
+static int ccid_probe(struct usb_dev *udev) {
+	struct ccid *ccid;
+	int i;
+
+	assert(udev);
+
+	ccid = pool_alloc(&ccid_classes);
+	if (!ccid) {
+		return -1;
+	}
+	ccid->usb_dev = udev;
+	udev->driver_data = ccid;
+
+	/* Interrupt endpoint is currenly unsupported. */
+	ccid->ep_intr = -1;
+
+	for (i = 1; i < udev->endp_n; i++) {
+		struct usb_endp *endp = udev->endpoints[i];
+
+		if (endp->type == USB_COMM_BULK) {
+			if (endp->direction == USB_DIRECTION_IN) {
+				ccid->ep_bulk_in = i;
+			}
+			if (endp->direction == USB_DIRECTION_OUT) {
+				ccid->ep_bulk_out = i;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static void ccid_disconnect(struct usb_dev *dev, void *data) {
+}
+
+static struct usb_device_id ccid_id_table[] = {
+	{USB_CLASS_CCID, 0xffff, 0xffff},
+	{ },
+};
+
+static struct usb_driver ccid_driver = {
+	.name = "ccid",
+	.probe = ccid_probe,
+	.disconnect = ccid_disconnect,
+	.id_table = ccid_id_table,
+};
+
+static int ccid_init(void) {
+	return usb_driver_register(&ccid_driver);
+}

--- a/src/drivers/usb/class/ccid/ccid.h
+++ b/src/drivers/usb/class/ccid/ccid.h
@@ -1,0 +1,88 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    10.06.2020
+ */
+
+#ifndef USB_CLASS_CCID_H_
+#define USB_CLASS_CCID_H_
+
+#include <drivers/usb/usb.h>
+
+#define USB_CLASS_CCID     11
+
+/*
+ * BULK_OUT messages from PC to Reader
+ * Defined in CCID Rev 1.1 6.1 (page 26)
+ */
+#define CCID_MESSAGE_TYPE_PC_to_RDR_IccPowerOn              0x62
+#define CCID_MESSAGE_TYPE_PC_to_RDR_IccPowerOff             0x63
+#define CCID_MESSAGE_TYPE_PC_to_RDR_GetSlotStatus           0x65
+#define CCID_MESSAGE_TYPE_PC_to_RDR_XfrBlock                0x6f
+#define CCID_MESSAGE_TYPE_PC_to_RDR_GetParameters           0x6c
+#define CCID_MESSAGE_TYPE_PC_to_RDR_ResetParameters         0x6d
+#define CCID_MESSAGE_TYPE_PC_to_RDR_SetParameters           0x61
+#define CCID_MESSAGE_TYPE_PC_to_RDR_Escape                  0x6b
+#define CCID_MESSAGE_TYPE_PC_to_RDR_IccClock                0x6e
+#define CCID_MESSAGE_TYPE_PC_to_RDR_T0APDU                  0x6a
+#define CCID_MESSAGE_TYPE_PC_to_RDR_Secure                  0x69
+#define CCID_MESSAGE_TYPE_PC_to_RDR_Mechanical              0x71
+#define CCID_MESSAGE_TYPE_PC_to_RDR_Abort                   0x72
+#define CCID_MESSAGE_TYPE_PC_to_RDR_SetDataRateAndClockFrequency 0x73
+
+/*
+ * BULK_IN messages from Reader to PC
+ * Defined in CCID Rev 1.1 6.2 (page 48)
+ */
+#define CCID_MESSAGE_TYPE_RDR_to_PC_DataBlock               0x80
+#define CCID_MESSAGE_TYPE_RDR_to_PC_SlotStatus              0x81
+#define CCID_MESSAGE_TYPE_RDR_to_PC_Parameters              0x82
+#define CCID_MESSAGE_TYPE_RDR_to_PC_Escape                  0x83
+#define CCID_MESSAGE_TYPE_RDR_to_PC_DataRateAndClockFrequency 0x84
+
+/* Slot Status (6.2.6) */
+#define CCID_SLOT_STATUS_ACTIVE           0
+#define CCID_SLOT_STATUS_INACTIVE         1
+#define CCID_SLOT_STATUS_NOT_PRESENT      2
+
+#define CCID_SLOT_STATUS_MASK             0x3
+
+/* 6 CCID Messages */
+#define CCID_MSG_HEADER_SIZE              10
+
+struct ccid_msg_hdr {
+	uint8_t b_message_type;
+	uint32_t dw_length;
+	uint8_t b_slot;
+	uint8_t b_seq;
+} __attribute__((packed));
+
+struct ccid_msg_hdr_bulk_in {
+	struct ccid_msg_hdr hdr;
+	uint8_t b_status;
+	uint8_t b_error;
+} __attribute__((packed));
+
+struct ccid_msg_hdr_icc_power_on {
+	struct ccid_msg_hdr hdr;
+	uint8_t b_power_select;
+	uint16_t ab_rfu;
+} __attribute__((packed));
+
+/* Sends msg and receives reply */
+extern int ccid_handle_msg(struct usb_dev *udev, const void *out,
+		void *in, int in_cnt);
+
+/* Read the rest (data) of the message, if not all bytes were read with
+ * ccid_handle_msg(). For example, you can use ccid_handle_msg()
+ * to send CCID_MESSAGE_TYPE_PC_to_RDR_XfrBlock and get only
+ * message header of the reply (that is, in_cnt = CCID_MSG_HEADER_SIZE
+ * for ccid_handle_msg()).
+ * Then you read an actual data size (ccid_msg_hdr.dw_length) from
+ * the received header and call ccid_read_msg_data() to read
+ * the rest of the message. */
+extern int ccid_read_msg_data(struct usb_dev *udev, void *in, int in_cnt);
+
+#endif /* USB_CLASS_CCID_H_ */

--- a/templates/x86/qemu/mods.conf
+++ b/templates/x86/qemu/mods.conf
@@ -27,6 +27,7 @@ configuration conf {
 	@Runlevel(1) include embox.driver.ide
 
 	@Runlevel(1) include embox.driver.usb.class.mass_storage
+	@Runlevel(1) include embox.driver.usb.class.ccid(log_level=4)
 	@Runlevel(2) include embox.driver.usb.hc.ohci_pci
 
 	@Runlevel(2) include embox.lib.debug.whereami
@@ -173,6 +174,7 @@ configuration conf {
 	include embox.cmd.hw.lsusb
 	include embox.cmd.hw.lsblk
 	include embox.cmd.hw.partition
+	include embox.cmd.hw.ccid_cmd
 
 	include embox.cmd.cpuinfo
 


### PR DESCRIPTION
* Add CCID (host mode only).
* Add ccid_cmd to get smart card status, get ATR, and send raw command.

You can launch `./scripts/qemu/auto_qemu_with_usb_ccid` and use `ccid_cmd` to verify ccid.