### PR TITLE
Use actions/cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,24 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  # does Mybuilds processing and provides mk/.cache to other jobs
-  buildgen:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - run: make confload-test/buildgen
-      - run: make -j $(nproc) buildgen
-      - name: compress
-        run: |
-          mkdir mk-cache
-          tar zcf mk-cache/archive.tar.gz mk/.cache
-      - uses: actions/upload-artifact@v1
-        with:
-          name: mk-cache
-          path: mk-cache
-
   ci:
-    needs: buildgen
     runs-on: ubuntu-16.04 # Embox NFS write test fails with ubuntu 18.04: "RPC: Can't decode result"
     strategy:
       fail-fast: false
@@ -49,13 +32,12 @@ jobs:
       options: --privileged -v /:/host
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/download-artifact@v1
+      - uses: actions/cache@v2
         with:
-          name: mk-cache
-      - name: unpack mk-cache
-        run: |
-          tar zxf mk-cache/archive.tar.gz
-          scripts/continuous/touch-mk-cache.sh
+          path: |
+            mk/.cache
+          key: mybuild-${{ hashFiles('**/Mybuild') }}-${{ hashFiles('**/*.my') }}
+      - run: scripts/continuous/touch-mk-cache.sh
       - run: chroot /host modprobe nfsd
         if: matrix.template == 'x86/test/fs'
       - run: ./scripts/continuous/prepare.sh ${{matrix.template}}

--- a/scripts/continuous/touch-mk-cache.sh
+++ b/scripts/continuous/touch-mk-cache.sh
@@ -6,4 +6,4 @@ touch $C/mk/*
 find  $C/mybuild/files | xargs touch
 touch $C/mybuild/myfiles-model.mk
 touch $C/mybuild/myfiles-list.mk
-
+exit 0


### PR DESCRIPTION
In CI, Mybuild cache is prepared at the start and then distributed to testing jobs by using Actions Artifact.

There is actions/cache that is intended to cache data between runs and jobs, allows to eliminate the cache building and save time

A run from master: https://github.com/embox/embox/actions/runs/132366028

A run with actions/cache: https://github.com/embox/embox/actions/runs/133189816 (after the Mybuild cache was preparied)
* fast templates start on ~1.5 min earlier and do not take longer; first results appears after ~2min
* same for slow templates, overall run time is reduced to 14min

Downside is that earlier Mybuilds are parsed to create a cache, so cache always matched Mybilds. With this, cache is searched by hashing Mybuilds, so it's possible to get wrong cache for a set of Mybuilds. Caching algorithm desribed in https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#hashfiles