### PR TITLE
Third-party: bsp: stml4cube: Update the download URL

### DIFF
--- a/third-party/bsp/stml4cube/Makefile
+++ b/third-party/bsp/stml4cube/Makefile
@@ -1,7 +1,7 @@
 
 PKG_NAME := stm32cubel4
 
-PKG_SOURCES := http://download.embox.rocks/en.$(PKG_NAME).zip
-PKG_MD5     := 6729ce70fcfb45741fb7732c8875b438
+PKG_SOURCES := https://github.com/STMicroelectronics/STM32CubeL4/archive/v1.14.0.zip
+PKG_MD5     := 4ecae18543a461335f2889eb2206dbf4
 
 include $(EXTBLD_LIB)

--- a/third-party/bsp/stml4cube/Mybuild
+++ b/third-party/bsp/stml4cube/Mybuild
@@ -1,7 +1,7 @@
 package third_party.bsp.stml4cube
 
 @Build(stage=1,script="$(EXTERNAL_MAKE) download extract patch")
-@BuildArtifactPath(cppflags="-DSTM32L475xx -DUSE_RTOS=0 -I$(ROOT_DIR)/third-party/bsp/stml4cube/ $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/,Drivers/STM32L4xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32L4xx/Include Drivers/CMSIS/Include Drivers/BSP/STM32L4-Discovery)")
+@BuildArtifactPath(cppflags="-DSTM32L475xx -DUSE_RTOS=0 -I$(ROOT_DIR)/third-party/bsp/stml4cube/ $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/,Drivers/STM32L4xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32L4xx/Include Drivers/CMSIS/Include Drivers/BSP/STM32L4-Discovery)")
 static module core extends third_party.bsp.st_bsp_api {
 
 	option number hse_freq_hz = 8000000 /* STM32l4Discovery oscillator */
@@ -10,57 +10,57 @@ static module core extends third_party.bsp.st_bsp_api {
 	@DefineMacro("STM32L475xx")
 	@DefineMacro("USE_RTOS=0")
 	@DefineMacro("USE_HAL_DRIVER")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/CMSIS/Include")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Include")
 	@AddPrefix("^BUILD/extbld/^MOD_PATH")
 	source
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_adc.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_adc_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_can.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_cec.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_cortex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_crc.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dac.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dac_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dma.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_flash.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_flash_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_gpio.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_hrtim.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2c.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2c_ex.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2s.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_irda.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_iwdg.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_msp_template.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_nand.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_nor.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_opamp.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_opamp_ex.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pccard.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pwr.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pwr_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rcc_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rcc.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_smartcard.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_spi.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sram.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_uart.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_uart_ex.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_usart.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_wwdg.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery_accelerometer.c",
-		//"STM32Cube_FW_L4_V1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery_gyroscope.c"
-		"STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_fmc.c"
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_adc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_adc_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_can.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_cec.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_cortex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_crc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dac.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dac_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dma.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_flash.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_flash_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_gpio.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_hrtim.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2c.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2c_ex.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2s.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_irda.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_iwdg.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_msp_template.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_nand.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_nor.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_opamp.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_opamp_ex.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pccard.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pwr.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pwr_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rcc_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rcc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_smartcard.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_spi.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sram.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_uart.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_uart_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_usart.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_wwdg.c",
+		//"STM32CubeL4-1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery.c",
+		//"STM32CubeL4-1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery_accelerometer.c",
+		//"STM32CubeL4-1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery_gyroscope.c"
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_fmc.c"
 
 		@IncludeExport(path="")
 		source "stm32l4xx_hal_conf.h"
@@ -69,11 +69,11 @@ static module core extends third_party.bsp.st_bsp_api {
 @Build(stage=1,script="true")
 @BuildDepends(core)
 static module stm32l4_discovery_bsp {
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/BSP/Components/l3gd20")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/BSP/Components/lsm303dlhc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/BSP/Components/l3gd20")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/BSP/Components/lsm303dlhc")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stml4cube/core")
-	source "STM32Cube_FW_L4_V1.14.0/Drivers/BSP/Components/l3gd20/l3gd20.c",
-		"STM32Cube_FW_L4_V1.14.0/Drivers/BSP/Components/lsm303dlhc/lsm303dlhc.c"
+	source "STM32CubeL4-1.14.0/Drivers/BSP/Components/l3gd20/l3gd20.c",
+		"STM32CubeL4-1.14.0/Drivers/BSP/Components/lsm303dlhc/lsm303dlhc.c"
 }
 
 @Build(stage=1,script="true")
@@ -82,11 +82,11 @@ static module system_init {
 	@DefineMacro("STM32L475xx")
 	@DefineMacro("USE_RTOS=0")
 	@DefineMacro("USE_STDPERIPH_DRIVER")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32Cube_FW_L4_V1.14.0/Drivers/CMSIS/Include")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Include")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stml4cube/core")
-	source "./STM32Cube_FW_L4_V1.14.0/Projects/B-L475E-IOT01A/Applications/WiFi/WiFi_HTTP_Server/Src/system_stm32l4xx.c"
+	source "./STM32CubeL4-1.14.0/Projects/B-L475E-IOT01A/Applications/WiFi/WiFi_HTTP_Server/Src/system_stm32l4xx.c"
 }
 
 


### PR DESCRIPTION
Change the download URL to
https://github.com/STMicroelectronics/STM32CubeL4/archive/v1.14.0.zip so
that the latest file can be downloaded.
Change paths in the Mybuild to solve build errors that occur due to the new version.
closes #2035
closes #2039  
Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>