### PR TITLE
Drivers: serial: stm32: stm32l4 UART Config

### DIFF
--- a/src/drivers/serial/stm32_usart/stm32_usart_conf_l4.h
+++ b/src/drivers/serial/stm32_usart/stm32_usart_conf_l4.h
@@ -25,7 +25,7 @@
 #define MODOPS_USARTX OPTION_GET(NUMBER, usartx)
 
 #define USART1_IRQ    \
-	OPTION_MODULE_GET(embox__driver__serial__stm_usart_f3, NUMBER, usart1_irq)
+	OPTION_MODULE_GET(embox__driver__serial__stm_usart_l4, NUMBER, usart1_irq)
 static_assert(USART1_IRQ == USART1_IRQn);
 
 #if MODOPS_USARTX == 1


### PR DESCRIPTION
Solves the typo made in #2033 where f3 module was imported by mistake.
here correct module for l4 is included and it solved build errors.

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>