### PR TITLE
Third-party: BSP: Port Embox to Nucleo-l476rg

### DIFF
--- a/src/drivers/serial/stm32_usart/hal_msp_l4.c
+++ b/src/drivers/serial/stm32_usart/hal_msp_l4.c
@@ -12,6 +12,8 @@
 void USART_TX_GPIO_CLK_ENABLE(void *usart_base) {
 	if (usart_base == USART1)
 		__HAL_RCC_GPIOB_CLK_ENABLE();
+	else if(usart_base == USART2)
+		__HAL_RCC_GPIOA_CLK_ENABLE();
 	else
 		/* Not supported */
 		assert(0);
@@ -20,6 +22,8 @@ void USART_TX_GPIO_CLK_ENABLE(void *usart_base) {
 void USART_RX_GPIO_CLK_ENABLE(void *usart_base) {
 	if (usart_base == USART1)
 		__HAL_RCC_GPIOB_CLK_ENABLE();
+	else if (usart_base == USART2)
+		__HAL_RCC_GPIOA_CLK_ENABLE();
 	else
 		/* Not supported */
 		assert(0);
@@ -28,6 +32,8 @@ void USART_RX_GPIO_CLK_ENABLE(void *usart_base) {
 void USART_CLK_ENABLE(void *usart_base) {
 	if (usart_base == USART1)
 		__HAL_RCC_USART1_CLK_ENABLE();
+	else if(usart_base == USART2)
+		__HAL_RCC_USART2_CLK_ENABLE();
 	else
 		/* Not supported */
 		assert(0);
@@ -36,6 +42,8 @@ void USART_CLK_ENABLE(void *usart_base) {
 uint16_t USART_RX_PIN(void *usart_base) {
 	if (usart_base == USART1)
 		return GPIO_PIN_7;
+	else if(usart_base == USART2)
+		return GPIO_PIN_3;
 	/* Not supported */
 	assert(0);
 	return 0;
@@ -44,6 +52,8 @@ uint16_t USART_RX_PIN(void *usart_base) {
 uint16_t USART_TX_PIN(void *usart_base) {
 	if (usart_base == USART1)
 		return GPIO_PIN_6;
+	else if(usart_base == USART2)
+		return GPIO_PIN_2;
 	/* Not supported */
 	assert(0);
 	return 0;
@@ -52,6 +62,8 @@ uint16_t USART_TX_PIN(void *usart_base) {
 uint8_t USART_TX_AF(void *usart_base) {
 	if (usart_base == USART1)
 		return GPIO_AF7_USART1;
+	else if(usart_base == USART2)
+		return GPIO_AF7_USART2;
 	/* Not supported */
 	assert(0);
 	return 0;
@@ -60,6 +72,8 @@ uint8_t USART_TX_AF(void *usart_base) {
 uint8_t USART_RX_AF(void *usart_base) {
 	if (usart_base == USART1)
 		return GPIO_AF7_USART1;
+	else if(usart_base == USART2)
+		return GPIO_AF7_USART2;
 	/* Not supported */
 	assert(0);
 	return 0;
@@ -68,6 +82,8 @@ uint8_t USART_RX_AF(void *usart_base) {
 GPIO_TypeDef *USART_RX_GPIO_PORT(void *usart_base) {
 	if (usart_base == USART1)
 		return GPIOB;
+	else if(usart_base == USART2)
+		return GPIOA;
 	/* Not supported */
 	assert(0);
 	return 0;
@@ -76,6 +92,8 @@ GPIO_TypeDef *USART_RX_GPIO_PORT(void *usart_base) {
 GPIO_TypeDef *USART_TX_GPIO_PORT(void *usart_base) {
 	if (usart_base ==  USART1)
 		return GPIOB;
+	else if(usart_base == USART2)
+		return GPIOA;
 	/* Not supported */
 	assert(0);
 	return 0;

--- a/src/drivers/serial/stm32_usart/stm32_usart_conf_l4.h
+++ b/src/drivers/serial/stm32_usart/stm32_usart_conf_l4.h
@@ -11,7 +11,6 @@
 #define USE_HAL_UART_REGISTER_CALLBACKS 0
 #define USE_HAL_USART_REGISTER_CALLBACKS 0
 
-#include <stm32l475xx.h>
 #include <stm32l4xx_hal_dma.h>
 #include <stm32l4xx_hal_gpio.h>
 #include <stm32l4xx_hal_rcc.h>

--- a/templates/arm/nucleo_l476rg/build.conf
+++ b/templates/arm/nucleo_l476rg/build.conf
@@ -1,0 +1,10 @@
+TARGET = embox
+
+PLATFORM = stm32l4
+
+ARCH = arm
+
+CROSS_COMPILE = arm-none-eabi-
+
+CFLAGS += -O0 -g -DSTM32L476xx
+CFLAGS += -mthumb -mlittle-endian -march=armv7e-m -mtune=cortex-m4 -msoft-float -ffreestanding

--- a/templates/arm/nucleo_l476rg/lds.conf
+++ b/templates/arm/nucleo_l476rg/lds.conf
@@ -1,0 +1,13 @@
+/*
+ * Linkage configuration.
+ */
+
+/* region (origin, length) */
+ROM (0x08000000, 1M)
+RAM (0x20000000, 128K)
+
+/* section (region[, lma_region]) */
+text   (ROM)
+rodata (ROM)
+data   (RAM, ROM)
+bss    (RAM)

--- a/templates/arm/nucleo_l476rg/mods.conf
+++ b/templates/arm/nucleo_l476rg/mods.conf
@@ -1,0 +1,68 @@
+package genconfig
+
+configuration conf {
+	@Runlevel(0) include embox.arch.system(core_freq=144000000)
+	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
+	@Runlevel(0) include third_party.bsp.stml4cube.nucleo_l476rg.arch
+	include third_party.bsp.stml4cube.nucleo_l476rg.core
+	include embox.arch.arm.vfork
+
+	@Runlevel(0) include embox.kernel.stack(stack_size=4096,alignment=4)
+
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=32)
+	@Runlevel(1) include embox.driver.clock.cortexm_systick
+
+	@Runlevel(1) include embox.driver.serial.stm_usart_l4(baud_rate=115200, usartx=2)
+	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_l4")
+
+	/* Some fs stuff required to block_dev_test to be compiled */
+	include embox.fs.buffer_cache(bcache_size=8)
+	include embox.fs.driver.initfs_dvfs
+	include embox.fs.dvfs.core
+	include embox.fs.dvfs.core(inode_pool_size=8,file_pool_size=8,dentry_pool_size=8)
+
+	include embox.driver.serial.core_notty
+
+	include embox.kernel.task.multi
+	include embox.kernel.task.resource.idesc_table(idesc_table_size=6)
+
+	include embox.kernel.thread.thread_local_none
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.thread.signal_stub
+	include embox.kernel.timer.sleep_nosched
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	include embox.kernel.sched.sched
+	include embox.kernel.sched.idle_light
+	include embox.kernel.thread.signal_stub
+
+	include embox.kernel.lthread.lthread
+	include embox.kernel.thread.core(thread_pool_size=1)
+
+	/* tty requires */
+	include embox.kernel.thread.mutex
+	include embox.driver.tty.tty(rx_buff_sz=16, io_buff_sz=16)
+	include embox.driver.tty.task_breaking_disable
+
+	@Runlevel(2) include embox.cmd.shell
+	include embox.init.setup_tty_diag
+	@Runlevel(3) include embox.init.start_script(shell_name="diag_shell")
+
+	include embox.cmd.help
+	include embox.cmd.sys.version
+
+	include embox.kernel.critical
+	include embox.kernel.irq
+	include embox.mem.pool_adapter
+
+	include embox.util.LibUtil
+	include embox.framework.LibFramework
+	include embox.arch.arm.libarch
+	include embox.compat.libc.stdio.print(support_floating=0)
+	include embox.compat.libc.stdio.file_pool(file_quantity=4)
+	include embox.mem.heap_bm
+	include embox.mem.static_heap(heap_size=0x400)
+	include embox.mem.bitmask(page_size=64)
+
+	include embox.driver.char_dev_stub
+	include embox.fs.driver.devfs_stub
+}

--- a/templates/arm/nucleo_l476rg/start_script.inc
+++ b/templates/arm/nucleo_l476rg/start_script.inc
@@ -1,0 +1,3 @@
+/* Uncomment for flash device read/write testing */
+//"block_dev_test -l",
+//"block_dev_test stm32flash0",

--- a/third-party/bsp/stml4cube/nucleo_l476rg/Makefile
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/Makefile
@@ -1,0 +1,7 @@
+
+PKG_NAME := stm32cubel4
+
+PKG_SOURCES := https://github.com/STMicroelectronics/STM32CubeL4/archive/v1.14.0.zip
+PKG_MD5     := 4ecae18543a461335f2889eb2206dbf4
+
+include $(EXTBLD_LIB)

--- a/third-party/bsp/stml4cube/nucleo_l476rg/Mybuild
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/Mybuild
@@ -1,0 +1,100 @@
+package third_party.bsp.stml4cube.nucleo_l476rg
+
+@Build(stage=1,script="$(EXTERNAL_MAKE) download extract patch")
+@BuildArtifactPath(cppflags="-DSTM32L476xx -DUSE_RTOS=0 -I$(ROOT_DIR)/third-party/bsp/stml4cube/ -I$(ROOT_DIR)/third-party/bsp/stml4cube/nucleo_l476rg $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/,Drivers/STM32L4xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32L4xx/Include Drivers/CMSIS/Include Drivers/BSP/STM32L4-Discovery)")
+static module core extends third_party.bsp.st_bsp_api {
+
+	option number hse_freq_hz = 8000000 /* Nucleo_L476RG oscillator */
+
+	@Cflags("-Wno-unused")
+	@DefineMacro("STM32L476xx")
+	@DefineMacro("USE_RTOS=0")
+	@DefineMacro("USE_HAL_DRIVER")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Include")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH")
+	source
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_adc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_adc_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_can.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_cec.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_cortex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_crc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dac.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dac_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_dma.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_flash.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_flash_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_gpio.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_hrtim.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2c.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2c_ex.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_i2s.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_irda.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_iwdg.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_msp_template.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_nand.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_nor.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_opamp.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_opamp_ex.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pccard.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pwr.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pwr_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rcc_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rcc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_smartcard.c",
+		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_spi.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sram.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_uart.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_uart_ex.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_usart.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_wwdg.c",
+		//"STM32CubeL4-1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery.c",
+		//"STM32CubeL4-1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery_accelerometer.c",
+		//"STM32CubeL4-1.14.0/Drivers/BSP/STM32L4-Discovery/stm32l4_discovery_gyroscope.c"
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_fmc.c"
+
+		@IncludeExport(path="")
+		source "stm32l4xx_hal_conf.h"
+}
+
+@Build(stage=1,script="true")
+@BuildDepends(core)
+static module nucleo_l476rg_bsp extends third_party.bsp.stml4cube.stm32l4_bsp {
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/BSP/Components/l3gd20")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/BSP/Components/lsm303dlhc")
+	@AddPrefix("^BUILD/extbld/third_party/bsp/stml4cube/nucleo_l476rg/core")
+	source "STM32CubeL4-1.14.0/Drivers/BSP/Components/l3gd20/l3gd20.c",
+		"STM32CubeL4-1.14.0/Drivers/BSP/Components/lsm303dlhc/lsm303dlhc.c"
+}
+
+@Build(stage=1,script="true")
+@BuildDepends(core)
+static module system_init extends third_party.bsp.stml4cube.system_init {
+	@DefineMacro("STM32L476xx")
+	@DefineMacro("USE_RTOS=0")
+	@DefineMacro("USE_HAL_DRIVER")
+	@DefineMacro("USE_STM32L4XX_NUCLEO_64")
+	@DefineMacro("USE_STDPERIPH_DRIVER")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Include")
+	@AddPrefix("^BUILD/extbld/third_party/bsp/stml4cube/nucleo_l476rg/core")
+	source "./STM32CubeL4-1.14.0/Projects/NUCLEO-L476RG/Templates/Src/system_stm32l4xx.c"
+}
+
+@Build(stage=1,script="true")
+@BuildDepends(core)
+module arch extends embox.arch.arch {
+	source "arch.c"
+
+	depends system_init
+}

--- a/third-party/bsp/stml4cube/nucleo_l476rg/arch.c
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/arch.c
@@ -1,0 +1,103 @@
+/**
+ * @file arch.c
+ * @brief Based on arch.c for STM32L4Cube
+ * @author Puranjay Mohan <puranjay12@gmail.com>
+ * @version
+ * @date 18.06.2020
+ */
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <hal/arch.h>
+#include <hal/clock.h>
+#include <hal/ipl.h>
+
+#include <system_stm32l4xx.h>
+#include <stm32l4xx_hal.h>
+
+#include <framework/mod/options.h>
+#include <module/embox/arch/system.h>
+
+static void SystemClock_Config(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* MSI is enabled after System reset, activate PLL with MSI as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
+  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
+  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
+  RCC_OscInitStruct.PLL.PLLM = 1;
+  RCC_OscInitStruct.PLL.PLLN = 40;
+  RCC_OscInitStruct.PLL.PLLR = 2;
+  RCC_OscInitStruct.PLL.PLLP = 7;
+  RCC_OscInitStruct.PLL.PLLQ = 4;
+  if(HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+  {
+    /* Initialization Error */
+    while(1);
+  }
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+     clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  if(HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK)
+  {
+    /* Initialization Error */
+    while(1);
+  }
+}
+
+extern void nvic_table_fill_stubs(void);
+
+void arch_init(void) {
+	ipl_t ipl = ipl_save();
+
+	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 144000000);
+
+	SystemInit();
+	HAL_Init();
+
+	nvic_table_fill_stubs();
+
+	SystemClock_Config();
+
+	ipl_restore(ipl);
+}
+
+void arch_idle(void) {
+
+}
+
+void arch_shutdown(arch_shutdown_mode_t mode) {
+	switch (mode) {
+	case ARCH_SHUTDOWN_MODE_HALT:
+	case ARCH_SHUTDOWN_MODE_REBOOT:
+	case ARCH_SHUTDOWN_MODE_ABORT:
+	default:
+		//HAL_NVIC_SystemReset();
+		break;
+	}
+
+	/* NOTREACHED */
+	while(1) {
+
+	}
+}
+
+
+HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority) {
+	return HAL_OK;
+}
+
+uint32_t HAL_GetTick(void) {
+	return clock_sys_ticks();
+}

--- a/third-party/bsp/stml4cube/nucleo_l476rg/stm32l4xx_hal_conf.h
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/stm32l4xx_hal_conf.h
@@ -1,0 +1,322 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_hal_conf.h
+  * @author  MCD Application Team
+  * @version V1.4.0
+  * @date    13-November-2015
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32l4xx_HAL_CONF_H
+#define __STM32l4xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include <stdint.h>
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+//#define HAL_ADC_MODULE_ENABLED
+//#define HAL_CAN_MODULE_ENABLED
+//#define HAL_CEC_MODULE_ENABLED
+//#define HAL_COMP_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+//#define HAL_CRC_MODULE_ENABLED
+//#define HAL_DAC_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+//#define HAL_HRTIM_MODULE_ENABLED
+//#define HAL_I2C_MODULE_ENABLED
+//#define HAL_I2S_MODULE_ENABLED
+//#define HAL_IRDA_MODULE_ENABLED
+//#define HAL_IWDG_MODULE_ENABLED
+//#define HAL_OPAMP_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+//#define HAL_RTC_MODULE_ENABLED
+//#define HAL_SDADC_MODULE_ENABLED
+//#define HAL_SMARTCARD_MODULE_ENABLED
+//#define HAL_SPI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+//#define HAL_TSC_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+//#define HAL_WWDG_MODULE_ENABLED
+
+#define USE_HAL_TIM_REGISTER_CALLBACKS 0
+#define USE_HAL_USART_REGISTER_CALLBACKS 0
+#define USE_HAL_UART_REGISTER_CALLBACKS 0
+/* ########################## HSE/HSI Values adaptation ##################### */
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+/**
+  * @brief In the following line adjust the External High Speed oscillator (HSE) Startup
+  *        Timeout value
+  */
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)8000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief In the following line adjust the Internal High Speed oscillator (HSI) Startup
+  *        Timeout value
+  */
+#if !defined  (HSI_STARTUP_TIMEOUT)
+ #define HSI_STARTUP_TIMEOUT   ((uint32_t)5000) /*!< Time out for HSI start up */
+#endif /* HSI_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE  ((uint32_t)40000)
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */
+
+/**
+  * @brief Time out for LSE start up value in ms.
+  */
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source
+  *        frequency, this source is inserted directly through I2S_CKIN pad.
+  *        - External clock generated through external PLL component on EVAL 303 (based on MCO or crystal)
+  *        - External clock not generated on EVAL 373
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define  VDD_VALUE                    ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)(1<<__NVIC_PRIO_BITS) - 1)   /*!< tick interrupt priority (lowest by default) */
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              1
+#define  INSTRUCTION_CACHE_ENABLE     0
+#define  DATA_CACHE_ENABLE            0
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/*#define USE_FULL_ASSERT    1*/
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+ #include "stm32l4xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+ #include "stm32l4xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32l4xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+ #include "stm32l4xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+ #include "stm32l4xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CAN_MODULE_ENABLED
+ #include "stm32l4xx_hal_can.h"
+#endif /* HAL_CAN_MODULE_ENABLED */
+
+#ifdef HAL_CEC_MODULE_ENABLED
+ #include "stm32l4xx_hal_cec.h"
+#endif /* HAL_CEC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+ #include "stm32l4xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+ #include "stm32l4xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+ #include "stm32l4xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+ #include "stm32l4xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_HRTIM_MODULE_ENABLED
+ #include "stm32l4xx_hal_hrtim.h"
+#endif /* HAL_HRTIM_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32l4xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32l4xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32l4xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32l4xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_OPAMP_MODULE_ENABLED
+ #include "stm32l4xx_hal_opamp.h"
+#endif /* HAL_OPAMP_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32l4xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32l4xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SDADC_MODULE_ENABLED
+ #include "stm32l4xx_hal_sdadc.h"
+#endif /* HAL_SDADC_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32l4xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32l4xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32l4xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_TSC_MODULE_ENABLED
+ #include "stm32l4xx_hal_tsc.h"
+#endif /* HAL_TSC_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32l4xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32l4xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32l4xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+/* Some declaraions to avoid compilation errors */
+extern void HAL_PWR_EnableBkUpAccess(void);
+extern void HAL_PWR_DisableBkUpAccess(void);
+uint32_t HAL_PWREx_GetVoltageRange(void);
+
+#define EXTERNAL_SAI1_CLOCK_VALUE 48000U
+#define EXTERNAL_SAI2_CLOCK_VALUE    48000U /*!< Value of the SAI2 External clock source in Hz*/
+#define MSI_VALUE    4000000U /*!< Value of the Internal oscillator in Hz*/
+
+#define PWR_REGULATOR_VOLTAGE_SCALE1        PWR_CR1_VOS_0           /*!< Voltage scaling range 1 normal mode */
+#define PWR_REGULATOR_VOLTAGE_SCALE2        PWR_CR1_VOS_1           /*!< Voltage scaling range 2             */
+
+#endif /* __STM32L4xx_HAL_CONF_H */


### PR DESCRIPTION
Add the BSP and template for the ST's Nucleo-l476rg Board.
This closes #2034
It builds correctly but I have to test it on the board.

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>