### PR TITLE
Drivers: SPI: Add support for STM32L4

### DIFF
--- a/src/drivers/gpio/stm32/Mybuild
+++ b/src/drivers/gpio/stm32/Mybuild
@@ -22,6 +22,11 @@ module stm32_gpio_f4 extends api {
 module stm32_gpio_l4 extends api {
 	option number log_level = 0
 	option number gpio_chip_id = 0
+	option number exti0_irq = 6
+	option number exti1_irq = 7
+	option number exti2_irq = 8
+	option number exti3_irq = 9
+	option number exti4_irq = 10
 
 	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
 	source "stm32_gpio_conf_l4.h"

--- a/src/drivers/spi/stm32/Mybuild
+++ b/src/drivers/spi/stm32/Mybuild
@@ -16,6 +16,20 @@ module stm32_f4_cube extends stm32 {
 	depends third_party.bsp.st_bsp_api
 }
 
+@BuildDepends(third_party.bsp.st_bsp_api)
+module stm32_l4_cube extends stm32 {
+	option number log_level=1
+
+	@IncludeExport(path="drivers/spi", target_name="stm32_spi_conf.h")
+	source "spi_conf_l4.h"
+
+	source "stm32.c"
+
+	depends embox.driver.spi.core
+	depends embox.driver.gpio.api
+	depends third_party.bsp.st_bsp_api
+}
+
 @BuildDepends(stm32)
 module stm32_spi1 {
 	option number log_level=1

--- a/src/drivers/spi/stm32/spi_conf_l4.h
+++ b/src/drivers/spi/stm32/spi_conf_l4.h
@@ -1,0 +1,88 @@
+/**
+ * @file spi_conf_f4.h
+ * @brief
+ * @author Puranjay Mohan <puranjay12@gmail.com>
+ * @version
+ * @date 23.06.2020
+ */
+
+#ifndef SRC_DRIVERS_STM32_SPI_CONF_L4_H_
+#define SRC_DRIVERS_STM32_SPI_CONF_L4_H_
+
+#if defined(STM32L475xx)
+#include "stm32l475e_iot01.h"
+#elif defined (STM32L476xx)
+#include "stm32l4xx_nucleo.h"
+#else
+#error Unsupported platform
+#endif
+#include <drivers/gpio/gpio.h>
+
+#if defined(STM32L476xx)
+/* SPI1 */
+#define SPI1_SCK_PIN               GPIO_PIN_5
+#define SPI1_SCK_GPIO_PORT         GPIOA
+#define SPI1_SCK_AF                GPIO_AF5_SPI1
+#define SPI1_MISO_PIN              GPIO_PIN_6
+#define SPI1_MISO_GPIO_PORT        GPIOA
+#define SPI1_MISO_AF               GPIO_AF5_SPI1
+#define SPI1_MOSI_PIN              GPIO_PIN_7
+#define SPI1_MOSI_GPIO_PORT        GPIOA
+#define SPI1_MOSI_AF               GPIO_AF5_SPI1
+#define SPI1_NSS_GPIO_PORT         GPIOA
+#define SPI1_NSS_PIN               GPIO_PIN_4
+
+static inline void spi1_enable_gpio_clocks(void) {
+	__HAL_RCC_GPIOA_CLK_ENABLE();
+}
+
+#elif defined (STM32L475xx)
+/* SPI1 */
+#define SPI1_SCK_PIN               GPIO_PIN_5
+#define SPI1_SCK_GPIO_PORT         GPIOA
+#define SPI1_SCK_AF                GPIO_AF5_SPI1
+#define SPI1_MISO_PIN              GPIO_PIN_6
+#define SPI1_MISO_GPIO_PORT        GPIOA
+#define SPI1_MISO_AF               GPIO_AF5_SPI1
+#define SPI1_MOSI_PIN              GPIO_PIN_7
+#define SPI1_MOSI_GPIO_PORT        GPIOA
+#define SPI1_MOSI_AF               GPIO_AF5_SPI1
+
+#define SPI1_NSS_GPIO_PORT         GPIOA
+#define SPI1_NSS_PIN               GPIO_PIN_15
+
+static inline void spi1_enable_gpio_clocks(void) {
+	__HAL_RCC_GPIOA_CLK_ENABLE();
+}
+
+#endif
+
+#if defined(STM32L476xx)
+/* SPI2 */
+#define SPI2_SCK_PIN               GPIO_PIN_10
+#define SPI2_SCK_GPIO_PORT         GPIOB
+#define SPI2_SCK_AF                GPIO_AF5_SPI2
+#define SPI2_MISO_PIN              GPIO_PIN_14
+#define SPI2_MISO_GPIO_PORT        GPIOB
+#define SPI2_MISO_AF               GPIO_AF5_SPI2
+#define SPI2_MOSI_PIN              GPIO_PIN_15
+#define SPI2_MOSI_GPIO_PORT        GPIOB
+#define SPI2_MOSI_AF               GPIO_AF5_SPI2
+#define SPI2_NSS_GPIO_PORT         GPIOB
+#define SPI2_NSS_PIN               GPIO_PIN_12
+
+static inline void spi2_enable_gpio_clocks(void) {
+	__HAL_RCC_GPIOB_CLK_ENABLE();
+}
+
+#endif
+
+static inline void spi1_enable_spi_clocks(void) {
+	__HAL_RCC_SPI1_CLK_ENABLE();
+}
+
+static inline void spi2_enable_spi_clocks(void) {
+	__HAL_RCC_SPI2_CLK_ENABLE();
+}
+
+#endif /* SRC_DRIVERS_STM32_SPI_CONF_L4_H_ */

--- a/src/drivers/spi/stm32/stm32_spi.h
+++ b/src/drivers/spi/stm32/stm32_spi.h
@@ -14,6 +14,10 @@
 #include "stm32f4_discovery.h"
 #elif defined (STM32F429xx)
 #include "stm32f4xx_nucleo_144.h"
+#elif defined (STM32L476xx)
+#include "stm32l4xx_nucleo.h"
+#elif defined (STM32L475xx)
+#include "stm32l475e_iot01.h"
 #else
 #error Unsupported platform
 #endif

--- a/src/drivers/spi/stm32/stm32_spi1.c
+++ b/src/drivers/spi/stm32/stm32_spi1.c
@@ -15,6 +15,9 @@
 #if defined(STM32F407xx)
 #include <framework/mod/options.h>
 #include <config/third_party/bsp/stmf4cube/stm32f4_discovery/arch.h>
+#elif defined(STM32L476xx)
+#include <framework/mod/options.h>
+#include <config/third_party/bsp/stml4cube/nucleo_l476rg/arch.h>
 #endif
 
 #include "stm32_spi.h"

--- a/templates/arm/nucleo_l476rg/mods.conf
+++ b/templates/arm/nucleo_l476rg/mods.conf
@@ -24,6 +24,11 @@ configuration conf {
 	include embox.driver.serial.core_notty
 	include embox.driver.gpio.stm32_gpio_l4
 
+	include embox.driver.spi.core
+	include embox.driver.spi.stm32_l4_cube(log_level=0)
+	include embox.driver.spi.stm32_spi1(log_level=0) /* Note: SPI1 overlaps some USART2 pins */
+	// include embox.driver.spi.stm32_spi2(log_level=0) /* Note: SPI2 overlaps some Ethernet pins */
+
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=6)
 

--- a/third-party/bsp/stml4cube/nucleo_l476rg/Mybuild
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/Mybuild
@@ -1,7 +1,7 @@
 package third_party.bsp.stml4cube.nucleo_l476rg
 
 @Build(stage=1,script="$(EXTERNAL_MAKE) download extract patch")
-@BuildArtifactPath(cppflags="-DSTM32L476xx -DUSE_RTOS=0 -I$(ROOT_DIR)/third-party/bsp/stml4cube/ -I$(ROOT_DIR)/third-party/bsp/stml4cube/nucleo_l476rg $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/,Drivers/STM32L4xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32L4xx/Include Drivers/CMSIS/Include Drivers/BSP/STM32L4-Discovery)")
+@BuildArtifactPath(cppflags="-DSTM32L476xx -DUSE_RTOS=0 -I$(ROOT_DIR)/third-party/bsp/stml4cube/ -I$(ROOT_DIR)/third-party/bsp/stml4cube/nucleo_l476rg $(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/,Drivers/STM32L4xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32L4xx/Include Drivers/CMSIS/Include Drivers/BSP/STM32L4xx_Nucleo)")
 static module core extends third_party.bsp.st_bsp_api {
 
 	option number hse_freq_hz = 8000000 /* Nucleo_L476RG oscillator */
@@ -49,7 +49,7 @@ static module core extends third_party.bsp.st_bsp_api {
 		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc.c",
 		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_rtc_ex.c",
 		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_smartcard.c",
-		//"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_spi.c",
+		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_spi.c",
 		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sram.c",
 		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim.c",
 		"STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_tim_ex.c",
@@ -69,11 +69,9 @@ static module core extends third_party.bsp.st_bsp_api {
 @Build(stage=1,script="true")
 @BuildDepends(core)
 static module nucleo_l476rg_bsp extends third_party.bsp.stml4cube.stm32l4_bsp {
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/BSP/Components/l3gd20")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/BSP/Components/lsm303dlhc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/BSP/STM32L4xx_Nucleo")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stml4cube/nucleo_l476rg/core")
-	source "STM32CubeL4-1.14.0/Drivers/BSP/Components/l3gd20/l3gd20.c",
-		"STM32CubeL4-1.14.0/Drivers/BSP/Components/lsm303dlhc/lsm303dlhc.c"
+	source "STM32CubeL4-1.14.0/Drivers/BSP/STM32L4xx_Nucleo/stm32l4xx_nucleo.c"
 }
 
 @Build(stage=1,script="true")
@@ -82,7 +80,7 @@ static module system_init extends third_party.bsp.stml4cube.system_init {
 	@DefineMacro("STM32L476xx")
 	@DefineMacro("USE_RTOS=0")
 	@DefineMacro("USE_HAL_DRIVER")
-	@DefineMacro("USE_STM32L4XX_NUCLEO_64")
+	@DefineMacro("USE_STM32L4XX_NUCLEO")
 	@DefineMacro("USE_STDPERIPH_DRIVER")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/STM32L4xx_HAL_Driver/Inc")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stml4cube/nucleo_l476rg/core/STM32CubeL4-1.14.0/Drivers/CMSIS/Device/ST/STM32L4xx/Include")

--- a/third-party/bsp/stml4cube/nucleo_l476rg/stm32l4xx_hal_conf.h
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/stm32l4xx_hal_conf.h
@@ -74,7 +74,7 @@
 //#define HAL_RTC_MODULE_ENABLED
 //#define HAL_SDADC_MODULE_ENABLED
 //#define HAL_SMARTCARD_MODULE_ENABLED
-//#define HAL_SPI_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
 #define HAL_TIM_MODULE_ENABLED
 //#define HAL_TSC_MODULE_ENABLED
 #define HAL_UART_MODULE_ENABLED
@@ -84,6 +84,9 @@
 #define USE_HAL_TIM_REGISTER_CALLBACKS 0
 #define USE_HAL_USART_REGISTER_CALLBACKS 0
 #define USE_HAL_UART_REGISTER_CALLBACKS 0
+#define USE_HAL_SPI_REGISTER_CALLBACKS 0
+#define USE_SPI_CRC	1U
+
 /* ########################## HSE/HSI Values adaptation ##################### */
 /**
   * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.


### PR DESCRIPTION
Add configuration files for STM32L4 related to SPI
Make changes in HAL configurations to add SPI support
Change some other files for different reasons.

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>