### PR TITLE
templates: x86: Add httpd quick start config

### DIFF
--- a/templates/x86/unikernel/build.conf
+++ b/templates/x86/unikernel/build.conf
@@ -1,0 +1,10 @@
+TARGET = embox
+ARCH = x86
+
+// For MAC OS X
+//CROSS_COMPILE = i386-elf-
+
+CFLAGS += -O3 -gdwarf-2
+CFLAGS += -nostdinc -m32 -march=i386 -fno-stack-protector -Wno-array-bounds
+
+LDFLAGS += -m elf_i386

--- a/templates/x86/unikernel/lds.conf
+++ b/templates/x86/unikernel/lds.conf
@@ -1,0 +1,8 @@
+/* region (origin, length) */
+RAM (0x00100000, 256M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/templates/x86/unikernel/mods.conf
+++ b/templates/x86/unikernel/mods.conf
@@ -1,0 +1,183 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.x86.kernel.arch
+	include embox.arch.x86.kernel.locore
+	include embox.arch.x86.kernel.context
+	include embox.arch.x86.kernel.interrupt
+
+	include embox.arch.x86.vfork
+	include embox.arch.x86.stackframe
+	include embox.arch.x86.libarch
+
+	@Runlevel(2) include embox.driver.interrupt.i8259
+	@Runlevel(2) include embox.driver.clock.pit
+
+	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
+	@Runlevel(2) include embox.driver.diag(impl="embox__driver__serial__i8250")
+
+	@Runlevel(2) include embox.driver.virtual.null
+	@Runlevel(2) include embox.driver.virtual.zero
+
+	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(2) include embox.driver.net.virtio
+
+	@Runlevel(2) include embox.lib.debug.whereami
+
+	@Runlevel(0) include embox.mem.phymem
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.list_timer
+	@Runlevel(2) include embox.kernel.time.timekeeper
+	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)
+	include embox.kernel.stack(stack_size=0x20000)
+	include embox.kernel.sched.strategy.priority_based
+	include embox.kernel.thread.signal.sigstate
+	include embox.kernel.thread.signal.siginfoq
+	include embox.kernel.task.resource.env(env_str_len=64)
+
+	include embox.mem.pool_adapter
+	@Runlevel(2) include embox.mem.static_heap(heap_size=0x8000000)
+	include embox.mem.heap_bm(heap_size=0x4000000)
+	include embox.mem.bitmask
+
+/* for old fs comment dvfs part */
+	@Runlevel(2) include embox.fs.node(fnode_quantity=1024)
+	@Runlevel(2) include embox.fs.rootfs
+	@Runlevel(2) include embox.fs.driver.initfs
+	@Runlevel(2) include embox.fs.driver.ramfs
+	@Runlevel(2) include embox.fs.driver.ext2
+	@Runlevel(2) include embox.fs.driver.fat
+	@Runlevel(2) include embox.fs.driver.nfs
+	include embox.fs.driver.devfs_old
+
+/* for dvfs comment old fs part */
+/*
+	@Runlevel(2) include embox.fs.dvfs.core
+	@Runlevel(2) include embox.fs.driver.fat_dvfs
+	@Runlevel(2) include embox.fs.driver.initfs_dvfs
+	@Runlevel(2) include embox.fs.rootfs_dvfs
+	include embox.compat.posix.fs.all_dvfs
+	include embox.compat.posix.fs.ftruncate_dvfs
+	include embox.compat.posix.fs.file_dvfs
+	include embox.compat.posix.fs.lseek_dvfs
+	include embox.compat.libc.stdio.rename_dvfs
+	include embox.fs.driver.devfs_dvfs
+*/
+
+	@Runlevel(2) include embox.cmd.sh.tish(
+				prompt="%u@%h:%w%$", rich_prompt_support=1,
+				builtin_commands="exit logout cd export mount umount")
+	include embox.init.system_start_service(log_level=3, tty_dev="ttyS0")
+	include embox.cmd.service
+
+	include embox.cmd.net.arp
+	include embox.cmd.net.netstat
+	include embox.cmd.net.arping
+	include embox.cmd.net.rarping
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.ping
+	include embox.cmd.net.iptables
+	include embox.cmd.net.route
+	include embox.cmd.net.ftp
+	include embox.cmd.net.sftp
+	include embox.cmd.net.tftp
+	include embox.cmd.net.snmpd
+	include embox.cmd.net.ntpdate
+	include embox.cmd.net.telnetd
+	include embox.cmd.net.nslookup
+	include embox.cmd.net.getmail
+	include embox.cmd.net.sendmail
+	include embox.cmd.net.httpd(use_real_cmd=true, use_parallel_cgi=false)
+	include embox.cmd.net.httpd_cgi
+	include embox.service.http_admin
+	include embox.demo.website
+	include embox.cmd.net.netmanager
+
+	include embox.cmd.wc
+	include embox.cmd.head
+
+	include embox.cmd.fs.dd
+	include embox.cmd.fs.md5sum
+	include embox.cmd.fs.uniq
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.cd
+	include embox.cmd.fs.pwd
+	include embox.cmd.fs.ls
+	include embox.cmd.fs.du
+	include embox.cmd.fs.rm
+	include embox.cmd.fs.mkfs
+	include embox.cmd.fs.mount
+	include embox.cmd.fs.more
+	include embox.cmd.fs.umount
+	include embox.cmd.fs.stat
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.mkdir
+	include embox.cmd.fs.cp
+	include embox.cmd.fs.mv
+
+	include embox.cmd.help
+	include embox.cmd.man
+
+	include embox.cmd.sys.uname
+	include embox.cmd.sys.env
+	include embox.cmd.sys.export
+	include embox.cmd.sys.version
+	include embox.cmd.sys.date
+	include embox.cmd.sys.shutdown
+
+	include embox.cmd.lsmod
+	include embox.cmd.test
+
+	include embox.cmd.proc.nice
+	include embox.cmd.proc.renice
+
+	include embox.cmd.proc.thread
+	include embox.cmd.proc.top
+
+	include embox.cmd.mem
+
+	include embox.cmd.hw.lsblk
+
+	include embox.cmd.cpuinfo
+
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=4000)
+	@Runlevel(2) include embox.net.skbuff_data(
+				amount_skb_data=4000, data_size=1514,
+				data_align=1, data_padto=1,ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(
+				amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.tcp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.tcp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.net_entry
+	/* AF_INET, SOCK_STREAM, default */
+
+	include embox.compat.libc.all
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.libc.math_builtins
+	include embox.compat.posix.pthread_key
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.fs.rewinddir_stub
+
+	include embox.compat.atomic.pseudo_atomic
+
+	include embox.util.LibUtil
+	include embox.framework.LibFramework
+}

--- a/templates/x86/unikernel/rootfs/network
+++ b/templates/x86/unikernel/rootfs/network
@@ -1,0 +1,9 @@
+iface eth0 inet static
+	address 10.0.2.16
+	netmask 255.255.255.0
+	gateway 10.0.2.10
+	hwaddress aa:bb:cc:dd:ee:02
+
+iface lo inet static
+	address 127.0.0.1
+	netmask 255.0.0.0

--- a/templates/x86/unikernel/system_start.inc
+++ b/templates/x86/unikernel/system_start.inc
@@ -1,0 +1,6 @@
+"export PWD=/",
+"export HOME=/",
+// "mkdir -v /bin",
+// "mount -t binfs / /bin",
+"netmanager",
+"httpd",


### PR DESCRIPTION
Config based on x86/qemu, optimized for httpd launch
Add -O3 to build.conf
Remove unnecessary commands from system_start.inc
Remove tests and unnecessary mods:
driver.ide, profiler.tracing, arch.x86.mmu, driver.usb.*