### PR TITLE
Fix riscv64 interrupt

### DIFF
--- a/src/arch/riscv64/kernel/entry.S
+++ b/src/arch/riscv64/kernel/entry.S
@@ -15,6 +15,12 @@
 trap_handler:
 	SAVE_ALL
 
+	csrr    t6, mcause
+	srli    t6, t6, 63
+	beqz    t6, riscv64_exception_handler
+	mv      a0, sp
+	jal     riscv64_interrupt_handler
+
 	RESTORE_ALL
 	mret
 

--- a/src/arch/riscv64/kernel/interrupt.c
+++ b/src/arch/riscv64/kernel/interrupt.c
@@ -18,11 +18,11 @@
 
 #include <embox/unit.h>
 
-EMBOX_UNIT_INIT(riscv_interrupt_init);
+EMBOX_UNIT_INIT(riscv64_interrupt_init);
 
-#define CLEAN_IRQ_BIT (~(1 << 31))
+#define CLEAN_IRQ_BIT (~(1L << 63))
 
-void riscv_interrupt_handler(pt_regs_t *regs) {
+void riscv64_interrupt_handler(pt_regs_t *regs) {
 	assert(!critical_inside(CRITICAL_IRQ_LOCK));
 
 	critical_enter(CRITICAL_IRQ_HANDLER);
@@ -41,7 +41,7 @@ void riscv_interrupt_handler(pt_regs_t *regs) {
 	critical_dispatch_pending();
 }
 
-static int riscv_interrupt_init(void) {
+static int riscv64_interrupt_init(void) {
 	enable_interrupts();
 	return 0;
 }


### PR DESCRIPTION
Fix #2064.

I thought timer initialization was not working but it was wrong.

In my previous PR(#2053), trap handler does not call interrupt handler.
So, a timer interrupt occurs after timer initialization cannot be handled and stuck(and "done" was not printed well).