### PR TITLE
Fix pjsip templates

### DIFF
--- a/platform/pjsip/templates/stm32f746g-discovery/mods.conf
+++ b/platform/pjsip/templates/stm32f746g-discovery/mods.conf
@@ -44,7 +44,7 @@ configuration conf {
 	include embox.net.skbuff_data(amount_skb_data=16,data_size=1300)
 	include embox.net.sock_noxattr
 	include embox.net.af_inet(amount_inet_sock=10)
-	include embox.compat.posix.net.getaddrinfo(addrinfo_pool_size=4)
+	include embox.compat.posix.net.getaddrinfo(addrinfo_pool_size=8)
 	@Runlevel(2) include embox.net.core(amount_interface=2)
 	@Runlevel(2) include embox.net.socket
 	@Runlevel(2) include embox.net.dev(netdev_quantity=2)

--- a/platform/pjsip/templates/stm32f769i-discovery/mods.conf
+++ b/platform/pjsip/templates/stm32f769i-discovery/mods.conf
@@ -45,7 +45,7 @@ configuration conf {
 	include embox.net.skbuff_data(amount_skb_data=16,data_size=1300)
 	include embox.net.sock_noxattr
 	include embox.net.af_inet(amount_inet_sock=10)
-	include embox.compat.posix.net.getaddrinfo(addrinfo_pool_size=4)
+	include embox.compat.posix.net.getaddrinfo(addrinfo_pool_size=8)
 	@Runlevel(2) include embox.net.core(amount_interface=2)
 	@Runlevel(2) include embox.net.socket
 	@Runlevel(2) include embox.net.dev(netdev_quantity=2)

--- a/src/compat/posix/net/Net.my
+++ b/src/compat/posix/net/Net.my
@@ -26,6 +26,8 @@ static module gai_strerror {
 }
 
 static module getaddrinfo {
+	option number log_level = 1
+
 	option number addrinfo_pool_size = 10
 
 	source "getaddrinfo.c"

--- a/src/compat/posix/net/getaddrinfo.c
+++ b/src/compat/posix/net/getaddrinfo.c
@@ -14,6 +14,7 @@
 #include <sys/socket.h>
 #include <errno.h>
 #include <net/util/servent.h>
+#include <util/log.h>
 
 #include <mem/misc/pool.h>
 
@@ -146,6 +147,7 @@ static int ai_make(int family, int socktype, int protocol,
 	ait = pool_alloc(&addrinfo_tuple_pool);
 	if (ait == NULL) {
 		SET_ERRNO(ENOMEM);
+		log_error("addrinfo alloc: no mem");
 		return EAI_SYSTEM;
 	}
 


### PR DESCRIPTION
It was broken when trying to resolve sip.linphone.org even in previously working revisions in master. Maybe it's due to linphone changed something in their servers, I don't know for sure. But this fix helps.