### PR TITLE
Usb gadget cdc ethernet

### DIFF
--- a/src/drivers/usb/gadget/ecm/Mybuild
+++ b/src/drivers/usb/gadget/ecm/Mybuild
@@ -1,0 +1,21 @@
+package embox.driver.usb.gadget
+
+module f_ecm {
+	option number log_level = 1
+
+	source "f_ecm.c"
+	source "ecm_net_card.c"
+
+	depends embox.net.skbuff
+	depends embox.net.l2.ethernet
+	depends embox.net.dev
+	depends embox.net.core
+}
+
+module ecm_gadget {
+	option number log_level = 1
+
+	source "ecm_gadget.c"
+
+	depends f_ecm
+}

--- a/src/drivers/usb/gadget/ecm/ecm_gadget.c
+++ b/src/drivers/usb/gadget/ecm/ecm_gadget.c
@@ -1,0 +1,76 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    25.06.2020
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <util/log.h>
+#include <util/array.h>
+#include <embox/unit.h>
+
+#include <drivers/usb/usb_defines.h>
+#include <drivers/usb/gadget/udc.h>
+#include <drivers/usb/gadget/gadget.h>
+
+#include "ecm_gadget.h"
+
+EMBOX_UNIT_INIT(ecm_gadget_init);
+
+#define ECM_VID    0xdead
+#define ECM_PID    0xbeaf
+
+static struct usb_gadget ecm_gadget = {
+	.device_desc = {
+		.b_length               = sizeof(struct usb_desc_device),
+		.b_desc_type            = USB_DESC_TYPE_DEV,
+		.bcd_usb                = 0x0200,
+		.b_dev_class            = 0, /* Each interface specifies it’s own class code */
+		.b_dev_subclass         = 0,
+		.b_dev_protocol         = 0,
+		.b_max_packet_size      = 8,
+		.id_vendor              = ECM_VID,
+		.id_product             = ECM_PID,
+		.bcd_device             = 0,
+		.i_manufacter           = ECM_STR_MANUFACTURER,
+		.i_product              = ECM_STR_PRODUCT,
+		.i_serial_number        = ECM_STR_SERIALNUMBER,
+		.b_num_configurations   = 1,
+	},
+	.config_desc = {
+		.b_length                = sizeof(struct  usb_desc_configuration),
+		.b_desc_type             = USB_DESC_TYPE_CONFIG,
+		.w_total_length          = 0, /* DYNAMIC */
+		.b_num_interfaces        = 0, /* DYNAMIC */
+		.b_configuration_value   = 1,
+		.i_configuration         = ECM_STR_CONFIGURATION,
+		.bm_attributes           = USB_CFG_ATT_ONE | USB_CFG_ATT_SELFPOWER |
+		                           USB_CFG_ATT_WAKEUP,
+		.b_max_power             = 0x30,
+	},
+	.strings = {
+		[ECM_STR_MANUFACTURER]      = "Embox",
+		[ECM_STR_PRODUCT]           = "Embox USB CDC-ECM",
+		[ECM_STR_SERIALNUMBER]      = "0123456789",
+		[ECM_STR_CONFIGURATION]     = "ECM",
+		[ECM_STR_CONTROL_INTERFACE] = "ECM Control Interface",
+		[ECM_STR_DATA_INTERFACE]    = "ECM Data Interface",
+		[ECM_STR_ETHADDR]           = "aabbccddee00",
+	},
+};
+
+static int ecm_gadget_init(void) {
+	usb_gadget_register(&ecm_gadget);
+
+	if (usb_gadget_add_function(&ecm_gadget, "ecm") != 0) {
+		log_error("ecm interface insertion failed");
+		return -1;
+	}
+
+	usb_gadget_udc_start(ecm_gadget.ep0.udc);
+
+	return 0;
+}

--- a/src/drivers/usb/gadget/ecm/ecm_gadget.h
+++ b/src/drivers/usb/gadget/ecm/ecm_gadget.h
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    22.07.2020
+ */
+
+#ifndef DRIVERS_USB_ECM_GADGET_H_
+#define DRIVERS_USB_ECM_GADGET_H_
+
+#define ECM_STR_MANUFACTURER        1
+#define ECM_STR_PRODUCT             2
+#define ECM_STR_SERIALNUMBER        3
+#define ECM_STR_CONFIGURATION       4
+#define ECM_STR_CONTROL_INTERFACE   5
+#define ECM_STR_DATA_INTERFACE      6
+#define ECM_STR_ETHADDR             7
+
+#endif /* DRIVERS_USB_ECM_GADGET_H_ */

--- a/src/drivers/usb/gadget/ecm/ecm_net_card.c
+++ b/src/drivers/usb/gadget/ecm/ecm_net_card.c
@@ -1,0 +1,116 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    22.07.2020
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <util/log.h>
+#include <arpa/inet.h>
+#include <net/l2/ethernet.h>
+#include <net/netdevice.h>
+#include <net/inetdevice.h>
+#include <net/skbuff.h>
+#include <net/l0/net_entry.h>
+#include <drivers/usb/usb_defines.h>
+#include <drivers/usb/usb_desc.h>
+#include <drivers/usb/gadget/udc.h>
+#include <drivers/usb/gadget/gadget.h>
+
+#define ECM_RX_BUF_SZ    1024
+
+static struct net_device *ecm_card_nic;
+
+static struct usb_gadget_ep *bulk_tx;
+static struct usb_gadget_ep *bulk_rx;
+
+static struct usb_gadget_request req_rx;
+static struct usb_gadget_request req_tx;
+
+static uint8_t ecm_rx_buf[ECM_RX_BUF_SZ];
+static size_t ecm_rx_len;
+
+static int ecm_card_xmit(struct net_device *dev, struct sk_buff *skb) {
+	memcpy(req_tx.buf, skb->mac.raw, skb->len);
+	req_tx.len = skb->len;
+
+	usb_gadget_ep_queue(bulk_tx, &req_tx);
+
+	skb_free(skb);
+
+	return 0;
+}
+
+/* TODO The packets should be assemblied on UDC level, not here at ECM. */
+static int ecm_rx_complete(struct usb_gadget_ep *ep,
+	                    struct usb_gadget_request *req) {
+	struct sk_buff *skb;
+
+	memcpy(ecm_rx_buf + ecm_rx_len, req->buf, req->actual_len);
+	ecm_rx_len += req->actual_len;
+
+	if (req->actual_len == ep->desc->w_max_packet_size) {
+		/* Packet is not completed yet. */
+		usb_gadget_ep_queue(ep, req);
+		return 0;
+	}
+
+	/* Packet is completed */
+
+	assert(ecm_rx_len <= sizeof req->buf);
+
+	skb = skb_alloc(ecm_rx_len);
+
+	if (!skb) {
+		log_error("skbuff allocation failed");
+	} else {
+		memcpy(skb->mac.raw, ecm_rx_buf, ecm_rx_len);
+		skb->dev = ecm_card_nic;
+		netif_rx(skb);
+	}
+
+	/* Wait for the next packet. */
+	ecm_rx_len = 0;
+
+	usb_gadget_ep_queue(ep, req);
+
+	return 0;
+}
+
+static int ecm_card_start(struct net_device *dev) {
+	return 0;
+}
+
+static int ecm_card_stop(struct net_device *dev) {
+	return 0;
+}
+
+static const struct net_driver ecm_card_drv_ops = {
+	.start       = ecm_card_start,
+	.stop        = ecm_card_stop,
+	.xmit        = ecm_card_xmit,
+};
+
+int ecm_card_init(struct usb_gadget_ep *tx, struct usb_gadget_ep *rx) {
+	bulk_tx = tx;
+	bulk_rx = rx;
+
+	req_rx.complete = ecm_rx_complete;
+	req_rx.len = sizeof req_rx.buf;
+	usb_gadget_ep_queue(bulk_rx, &req_rx);
+
+	req_tx.len = sizeof req_tx.buf;
+
+	if (NULL == (ecm_card_nic = etherdev_alloc(0))) {
+		return -ENOMEM;
+	}
+
+	ecm_card_nic->drv_ops = &ecm_card_drv_ops;
+
+	return inetdev_register_dev(ecm_card_nic);
+}

--- a/src/drivers/usb/gadget/ecm/f_ecm.c
+++ b/src/drivers/usb/gadget/ecm/f_ecm.c
@@ -1,0 +1,223 @@
+/**
+ * @file
+ * @brief
+ *
+ * @author  Alexander Kalmuk
+ * @date    22.07.2020
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <embox/unit.h>
+#include <util/log.h>
+#include <net/l2/ethernet.h>
+#include <drivers/usb/usb_defines.h>
+#include <drivers/usb/usb_desc.h>
+#include <drivers/usb/gadget/udc.h>
+#include <drivers/usb/gadget/gadget.h>
+
+/* TODO Remove. It's only used for i_interface, iMACAddress, etc. defines. */
+#include "ecm_gadget.h"
+
+EMBOX_UNIT_INIT(ecm_init);
+
+/* TODO These defines should be moved to some CDC part. */
+#define USB_CDC_SUBCLASS_ETHERNET   0x06
+
+#define USB_CDC_HEADER_TYPE         0x00
+#define USB_CDC_UNION_TYPE          0x06
+#define USB_CDC_ETHERNET_TYPE       0x0f
+
+static int ecm_probe(struct usb_gadget *gadget);
+
+static struct usb_desc_endpoint int_ep_desc = {
+	.b_length            = sizeof (struct usb_desc_endpoint),
+	.b_desc_type         = USB_DESC_TYPE_ENDPOINT,
+	.bm_attributes       = USB_DESC_ENDP_TYPE_INTR,
+	.w_max_packet_size   = 16, /* 8 byte header + data */
+	.b_interval          = 1,
+};
+
+static struct usb_desc_endpoint bulk_ep_tx_desc = {
+	.b_length            = sizeof (struct usb_desc_endpoint),
+	.b_desc_type         = USB_DESC_TYPE_ENDPOINT,
+	.bm_attributes       = USB_DESC_ENDP_TYPE_BULK,
+	.w_max_packet_size   = 64,
+	.b_interval          = 0,
+};
+
+static struct usb_desc_endpoint bulk_ep_rx_desc = {
+	.b_length            = sizeof (struct usb_desc_endpoint),
+	.b_desc_type         = USB_DESC_TYPE_ENDPOINT,
+	.bm_attributes       = USB_DESC_ENDP_TYPE_BULK,
+	.w_max_packet_size   = 64,
+	.b_interval          = 0,
+};
+
+static struct usb_desc_interface ecm_control_intf_desc = {
+	.b_length                = sizeof(struct usb_desc_interface),
+	.b_desc_type             = USB_DESC_TYPE_INTERFACE,
+	.b_interface_number      = 0, /* DYNAMIC */
+	.b_alternate_setting     = 0,
+	.b_num_endpoints         = 1,
+	.b_interface_class       = USB_CLASS_COMM,
+	.b_interface_subclass    = USB_CDC_SUBCLASS_ETHERNET,
+	.b_interface_protocol    = 0,
+	.i_interface             = ECM_STR_CONTROL_INTERFACE,
+};
+
+static const uint8_t ecm_header_desc[] = {
+	0x05,                       /*  u8    bLength */
+	USB_DT_CS_INTERFACE,        /*  u8    bDescriptorType */
+	USB_CDC_HEADER_TYPE,        /*  u8    bDescriptorSubType */
+	0x10, 0x01,                 /*  le16  bcdCDC */
+};
+
+static const uint8_t ecm_union_desc[] = {
+	0x05,                       /*  u8    bLength */
+	USB_DT_CS_INTERFACE,        /*  u8    bDescriptorType */
+	USB_CDC_UNION_TYPE,         /*  u8    bDescriptorSubType */
+	0x00,                       /*  u8    bMasterInterface0 */
+	0x01,                       /*  u8    bSlaveInterface0 */
+};
+
+static const uint8_t ecm_eth_desc[] = {
+	0x0d,                       /*  u8    bLength */
+	USB_DT_CS_INTERFACE,        /*  u8    bDescriptorType */
+	USB_CDC_ETHERNET_TYPE,      /*  u8    bDescriptorSubType */
+	ECM_STR_ETHADDR,            /*  u8    iMACAddress */
+	0x00, 0x00, 0x00, 0x00,     /*  le32  bmEthernetStatistics */
+	ETH_FRAME_LEN & 0xff,
+	ETH_FRAME_LEN >> 8,         /*  le16  wMaxSegmentSize */
+	0x00, 0x00,                 /*  le16  wNumberMCFilters */
+	0x00,                       /*  u8    bNumberPowerFilters */
+};
+
+static struct usb_desc_interface ecm_data_intf_nop_desc = {
+	.b_length                = sizeof(struct usb_desc_interface),
+	.b_desc_type             = USB_DESC_TYPE_INTERFACE,
+	.b_interface_number      = 0, /* DYNAMIC */
+	.b_alternate_setting     = 0,
+	.b_num_endpoints         = 0,
+	.b_interface_class       = USB_CLASS_CDC_DATA,
+	.b_interface_subclass    = 0,
+	.b_interface_protocol    = 0,
+	.i_interface             = 0,
+};
+
+static struct usb_desc_interface ecm_data_intf_desc = {
+	.b_length                = sizeof(struct usb_desc_interface),
+	.b_desc_type             = USB_DESC_TYPE_INTERFACE,
+	.b_interface_number      = 0, /* DYNAMIC */
+	.b_alternate_setting     = 1,
+	.b_num_endpoints         = 2,
+	.b_interface_class       = USB_CLASS_CDC_DATA,
+	.b_interface_subclass    = 0,
+	.b_interface_protocol    = 0,
+	.i_interface             = ECM_STR_DATA_INTERFACE,
+};
+
+static const struct usb_desc_common_header *ecm_descs[] = {
+	/* Control interface */
+	(struct usb_desc_common_header *) &ecm_control_intf_desc,
+	(struct usb_desc_common_header *) &ecm_header_desc,
+	(struct usb_desc_common_header *) &ecm_union_desc,
+	(struct usb_desc_common_header *) &ecm_eth_desc,
+	(struct usb_desc_common_header *) &int_ep_desc,
+
+	/* Data interface alt 0 */
+	(struct usb_desc_common_header *) &ecm_data_intf_nop_desc,
+
+	/* Data interface alt 1 */
+	(struct usb_desc_common_header *) &ecm_data_intf_desc,
+	(struct usb_desc_common_header *) &bulk_ep_tx_desc,
+	(struct usb_desc_common_header *) &bulk_ep_rx_desc,
+	NULL,
+};
+
+static struct usb_gadget_ep intr = {
+	.dir = USB_DIR_IN,
+	.desc = &int_ep_desc,
+};
+
+static struct usb_gadget_ep bulk_tx = {
+	.dir = USB_DIR_IN,
+	.desc = &bulk_ep_tx_desc,
+};
+
+static struct usb_gadget_ep bulk_rx = {
+	.dir = USB_DIR_OUT,
+	.desc = &bulk_ep_rx_desc,
+};
+
+static int ecm_setup(struct usb_gadget_function *f,
+		const struct usb_control_header *ctrl, uint8_t *buffer) {
+	struct usb_gadget *gadget = f->gadget;
+	struct usb_gadget_request *req = &gadget->req;
+
+	if ((ctrl->bm_request_type & USB_REQ_TYPE_MASK) != USB_REQ_TYPE_STANDARD) {
+		log_error("Not a standard request");
+		return -1;
+	}
+
+	switch (ctrl->b_request) {
+	case USB_REQ_SET_INTERFACE:
+		/* Send zero-length reply */
+		req->len = 0;
+		usb_gadget_ep_queue(&gadget->ep0, req);
+		return 0;
+	default:
+		log_error("Not supported standard request");
+		break;
+	}
+
+	return -1;
+}
+
+extern int ecm_card_init(struct usb_gadget_ep *tx, struct usb_gadget_ep *rx);
+
+static int ecm_enumerate(struct usb_gadget_function *f) {
+	ecm_card_init(&bulk_tx, &bulk_rx);
+
+	usb_gadget_ep_enable(&bulk_tx);
+	usb_gadget_ep_enable(&bulk_rx);
+	usb_gadget_ep_enable(&intr);
+
+	return 0;
+}
+
+static struct usb_gadget_function ecm_func = {
+	.name = "ecm",
+	.descs = ecm_descs,
+	.probe = ecm_probe,
+	.setup = ecm_setup,
+	.enumerate = ecm_enumerate,
+};
+
+static int ecm_probe(struct usb_gadget *gadget) {
+	ecm_control_intf_desc.b_interface_number =
+		usb_gadget_add_interface(gadget, &ecm_func);
+
+	ecm_data_intf_nop_desc.b_interface_number =
+		usb_gadget_add_interface(gadget, &ecm_func);
+
+	ecm_data_intf_desc.b_interface_number =
+		ecm_data_intf_nop_desc.b_interface_number;
+
+	/* FIXME */
+	intr.udc    = gadget->ep0.udc;
+	bulk_tx.udc = gadget->ep0.udc;
+	bulk_rx.udc = gadget->ep0.udc;
+
+	usb_gadget_ep_configure(&bulk_tx);
+	usb_gadget_ep_configure(&bulk_rx);
+	usb_gadget_ep_configure(&intr);
+
+	return 0;
+}
+
+static int ecm_init(void) {
+	usb_gadget_register_function(&ecm_func);
+
+	return 0;
+}

--- a/src/drivers/usb/gadget/gadget.c
+++ b/src/drivers/usb/gadget/gadget.c
@@ -181,13 +181,18 @@ void usb_gadget_register_function(struct usb_gadget_function *func) {
 
 int usb_gadget_add_function(struct usb_gadget *gadget,
 	                         const char *func_name) {
+	int res;
 	struct usb_gadget_function *func;
 
 	/* Check each hub for event occured. */
 	dlist_foreach_entry(func, &usb_gadget_func_list, link) {
 		if (!strcmp(func->name, func_name)) {
 			assert(func->probe);
-			return func->probe(gadget);
+			res = func->probe(gadget);
+			if (!res) {
+				func->gadget = gadget;
+			}
+			return res;
 		}
 	}
 	return -1; /* func not found */

--- a/src/drivers/usb/gadget/gadget.h
+++ b/src/drivers/usb/gadget/gadget.h
@@ -50,6 +50,8 @@ struct usb_gadget_function {
 	const struct usb_desc_common_header **descs;
 	const char *name;
 
+	struct usb_gadget *gadget;
+
 	struct dlist_head link;
 
 	int (*probe)(struct usb_gadget *);

--- a/src/include/drivers/usb/usb_defines.h
+++ b/src/include/drivers/usb/usb_defines.h
@@ -45,7 +45,33 @@
 #define USB_PORT_STAT_OVERCURRENT   0x0008
 #define USB_PORT_STAT_RESET         0x0010
 
-#define USB_CLASS_HUB  0x9
+/*
+ * Descriptor types ... USB 2.0 spec table 9.5
+ */
+#define USB_DT_DEVICE               0x01
+#define USB_DT_CONFIG               0x02
+#define USB_DT_STRING               0x03
+#define USB_DT_INTERFACE            0x04
+#define USB_DT_ENDPOINT             0x05
+#define USB_DT_DEVICE_QUALIFIER     0x06
+#define USB_DT_OTHER_SPEED_CONFIG   0x07
+#define USB_DT_INTERFACE_POWER      0x08
+
+/* Conventional codes for class-specific descriptors.  The convention is
+ * defined in the USB "Common Class" Spec (3.11).  Individual class specs
+ * are authoritative for their usage, not the "common class" writeup.
+ */
+#define USB_DT_CS_DEVICE        (USB_REQ_TYPE_CLASS | USB_DT_DEVICE)
+#define USB_DT_CS_CONFIG        (USB_REQ_TYPE_CLASS | USB_DT_CONFIG)
+#define USB_DT_CS_STRING        (USB_REQ_TYPE_CLASS | USB_DT_STRING)
+#define USB_DT_CS_INTERFACE     (USB_REQ_TYPE_CLASS | USB_DT_INTERFACE)
+#define USB_DT_CS_ENDPOINT      (USB_REQ_TYPE_CLASS | USB_DT_ENDPOINT)
+
+/* USB classes */
+#define USB_CLASS_COMM       0x02
+#define USB_CLASS_HUB        0x09
+#define USB_CLASS_CDC_DATA   0x0a
+
 #define USB_DT_HUB     (USB_REQ_TYPE_CLASS | USB_CLASS_HUB)
 
 /* Hub request types */


### PR DESCRIPTION
Add CDC-ECM (usbnet) function and gadget example:

```
@Runlevel(2) include embox.driver.usb.gadget.ecm_gadget
```

Tested only with `arm/da14695`. Also, there is a number of drawbacks labeled with TODOs, FIXMEs..