### PR TITLE
cortex-m: Remove nvic_table_fill_stubs from all platforms

### DIFF
--- a/src/drivers/interrupt/cortexm/cortexm_nvic.c
+++ b/src/drivers/interrupt/cortexm/cortexm_nvic.c
@@ -38,20 +38,6 @@ extern void *trap_table_end;
 
 extern void arm_m_irq_entry(void);
 
-static void hnd_stub(void) {
-	/* It's just a stub. DO NOTHING */
-}
-
-/* TODO Should be removed at all. */
-void nvic_table_fill_stubs(void) {
-	int i;
-
-	for (i = 0; i < EXCEPTION_TABLE_SZ; i++) {
-		exception_table[i] = ((int) hnd_stub) | 1;
-	}
-	REG_STORE(SCB_VTOR, SCB_VTOR_IN_RAM | (int) exception_table);
-}
-
 static int nvic_init(void) {
 	ipl_t ipl;
 	int i;
@@ -83,10 +69,6 @@ void nvic_irq_handle(void) {
 	critical_leave(CRITICAL_IRQ_HANDLER);
 }
 #else /* STATIC_IRQ_EXTENTION */
-void nvic_table_fill_stubs(void) {
-
-}
-
 static int nvic_init(void) {
 	return 0;
 }

--- a/third-party/bsp/stmf3cube/arch.c
+++ b/third-party/bsp/stmf3cube/arch.c
@@ -49,8 +49,6 @@ static void SystemClock_Config(void)
   }
 }
 
-extern void nvic_table_fill_stubs(void);
-
 void arch_init(void) {
 	ipl_t ipl = ipl_save();
 
@@ -58,8 +56,6 @@ void arch_init(void) {
 
 	SystemInit();
 	HAL_Init();
-
-	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 

--- a/third-party/bsp/stmf4cube/nucleo_f429zi/arch.c
+++ b/third-party/bsp/stmf4cube/nucleo_f429zi/arch.c
@@ -67,13 +67,11 @@ static void SystemClock_Config(void)
    // Error_Handler();
   }
 }
-extern void nvic_table_fill_stubs(void);
+
 void arch_init(void) {
 
 	SystemInit();
 	HAL_Init();
-
-	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 }

--- a/third-party/bsp/stmf4cube/stm32f4_discovery/arch.c
+++ b/third-party/bsp/stmf4cube/stm32f4_discovery/arch.c
@@ -68,15 +68,11 @@ static void SystemClock_Config(void)
   }
 }
 
-extern void nvic_table_fill_stubs(void);
-
 void arch_init(void) {
 	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 144000000);
 
 	SystemInit();
 	HAL_Init();
-
-	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 }

--- a/third-party/bsp/stmf7cube/arch.c
+++ b/third-party/bsp/stmf7cube/arch.c
@@ -69,8 +69,6 @@ static void SystemClock_Config(void)
   }
 }
 
-extern void nvic_table_fill_stubs(void);
-
 void arch_init(void) {
 	ipl_t ipl = ipl_save();
 
@@ -78,8 +76,6 @@ void arch_init(void) {
 
 	SystemInit();
 	HAL_Init();
-
-	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 

--- a/third-party/bsp/stml4cube/nucleo_l476rg/arch.c
+++ b/third-party/bsp/stml4cube/nucleo_l476rg/arch.c
@@ -56,8 +56,6 @@ static void SystemClock_Config(void)
   }
 }
 
-extern void nvic_table_fill_stubs(void);
-
 void arch_init(void) {
 	ipl_t ipl = ipl_save();
 
@@ -65,8 +63,6 @@ void arch_init(void) {
 
 	SystemInit();
 	HAL_Init();
-
-	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 

--- a/third-party/bsp/stml4cube/stm32l4_discovery/arch.c
+++ b/third-party/bsp/stml4cube/stm32l4_discovery/arch.c
@@ -56,8 +56,6 @@ static void SystemClock_Config(void)
   }
 }
 
-extern void nvic_table_fill_stubs(void);
-
 void arch_init(void) {
 	ipl_t ipl = ipl_save();
 
@@ -65,8 +63,6 @@ void arch_init(void) {
 
 	SystemInit();
 	HAL_Init();
-
-	nvic_table_fill_stubs();
 
 	SystemClock_Config();
 


### PR DESCRIPTION
It seems to be useless now.