### PR TITLE
qt: Fix Q_FOREACH for gcc >= 9

### DIFF
--- a/third-party/qt/Makefile
+++ b/third-party/qt/Makefile
@@ -7,8 +7,21 @@ PKG_SOURCES := http://download.qt-project.org/archive/qt/4.8/$(PKG_VER)/$(PKG_NA
 
 PKG_MD5     := d990ee66bf7ab0c785589776f35ba6ad
 
+#
+# NOTE: q_foreach_bug_g++9.txt patch is required because
+# QT 4 has a buggy Q_FOREACH() macro which breaks "for" loop
+# at incorrect place (outer loop). It is discussed here
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=44715,
+# and here
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90617
+#
+# QT 5 has a better version of Q_FOREACH(), so this patch
+# derives this improved version from QT 5 sources.
+#
+
 PKG_PATCHES := pkg_patch.txt \
-	patch_cortex_m7.txt
+	patch_cortex_m7.txt \
+	q_foreach_bug_g++9.txt
 
 include $(EXTBLD_LIB)
 

--- a/third-party/qt/q_foreach_bug_g++9.txt
+++ b/third-party/qt/q_foreach_bug_g++9.txt
@@ -1,0 +1,34 @@
+--- qt-everywhere-opensource-src-4.8.7/src/corelib/global/qglobal.h	2020-08-04 16:03:47.890697094 +0300
++++ ../build/extbld/third_party/qt/core/qt-everywhere-opensource-src-4.8.7/src/corelib/global/qglobal.h	2020-08-04 16:28:16.555747362 +0300
+@@ -2492,17 +2492,26 @@
+ template <typename T>
+ class QForeachContainer {
+ public:
+-    inline QForeachContainer(const T& t) : c(t), brk(0), i(c.begin()), e(c.end()) { }
++    inline QForeachContainer(const T& t) : c(t), control(1), i(c.begin()), e(c.end()) { }
+     const T c;
+-    int brk;
++    int control;
+     typename T::const_iterator i, e;
+ };
+ 
++// Explanation of the control word:
++//  - it's initialized to 1
++//  - that means both the inner and outer loops start
++//  - if there were no breaks, at the end of the inner loop, it's set to 0, which
++//    causes it to exit (the inner loop is run exactly once)
++//  - at the end of the outer loop, it's inverted, so it becomes 1 again, allowing
++//    the outer loop to continue executing
++//  - if there was a break inside the inner loop, it will exit with control still
++//    set to 1; in that case, the outer loop will invert it to 0 and will exit too
+ #define Q_FOREACH(variable, container)                                \
+ for (QForeachContainer<__typeof__(container)> _container_(container); \
+-     !_container_.brk && _container_.i != _container_.e;              \
+-     __extension__  ({ ++_container_.brk; ++_container_.i; }))                       \
+-    for (variable = *_container_.i;; __extension__ ({--_container_.brk; break;}))
++     _container_.control && _container_.i != _container_.e;         \
++     ++_container_.i, _container_.control ^= 1)                     \
++    for (variable = *_container_.i; _container_.control; _container_.control = 0)
+ 
+ #else
+ 


### PR DESCRIPTION
This PR fixes https://github.com/embox/embox/issues/1900 and fixes https://github.com/embox/embox/issues/2024

There is "buggy" `Q_FOREACH` in QT 4:

```cpp
#define Q_FOREACH(variable, container)                                \
for (QForeachContainer<__typeof__(container)> _container_(container); \
     !_container_.brk && _container_.i != _container_.e;              \
     __extension__  ({ ++_container_.brk; ++_container_.i; }))                       \
    for (variable = *_container_.i;; __extension__ ({--_container_.brk; break;}))
```

It's compiled and works in different ways for gcc 8 and gcc 9. The problem here is that in GCC 8 this `break` breaks only out from the inner loop, while in GCC >= 9 it breaks out of the outer loop.

It's discussed here https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90617 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=44715 .

Basing on the GCC thread discussion, I decided that it's better to avoid using such `break` in increment expression. In QT 5 developers removed this `break` from the inner loop and things seem to be fixed. So I derived this new `Q_FOREACH` version from QT 5.