### PR TITLE
Boards configs

### DIFF
--- a/board_config/nucleo_f429zi.conf.h
+++ b/board_config/nucleo_f429zi.conf.h
@@ -21,6 +21,25 @@ struct uart_conf uarts[] = {
 		},
 		.baudrate = 115200,
 	},
+	[3] = {
+		.status = ENABLED,
+		.name = "USART3",
+		.dev = {
+			.irqs = {
+				VAL("", 39),
+			},
+			.pins = {
+				PIN("TX", PD, PIN_8, AF7),
+				PIN("RX", PD, PIN_9, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOD),
+				VAL("RX",   CLK_GPIOD),
+				VAL("UART", CLK_USART3),
+			}
+		},
+		.baudrate = 115200,
+	},
 	[6] = {
 		.status = ENABLED,
 		.name = "USART6",

--- a/board_config/nucleo_l476rg.conf.h
+++ b/board_config/nucleo_l476rg.conf.h
@@ -1,0 +1,43 @@
+#include <gen_board_conf.h>
+#include <stm32.h>
+
+struct uart_conf uarts[] = {
+	[1] = {
+		.status = DISABLED,
+		.name = "USART1",
+		.dev = {
+			.irqs = {
+				VAL("", 37),
+			},
+			.pins = {
+				PIN("TX", PB, PIN_6, AF7),
+				PIN("RX", PB, PIN_7, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOB),
+				VAL("RX",   CLK_GPIOB),
+				VAL("UART", CLK_USART1),
+			}
+		},
+		.baudrate = 115200,
+	},
+	[2] = {
+		.status = DISABLED,
+		.name = "USART2",
+		.dev = {
+			.irqs = {
+				VAL("", 38),
+			},
+			.pins = {
+				PIN("TX", PA, PIN_2, AF7),
+				PIN("RX", PA, PIN_3, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOA),
+				VAL("RX",   CLK_GPIOA),
+				VAL("UART", CLK_USART2),
+			}
+		},
+		.baudrate = 115200,
+	},
+};

--- a/board_config/stm32f3discovery.conf.h
+++ b/board_config/stm32f3discovery.conf.h
@@ -2,6 +2,25 @@
 #include <stm32.h>
 
 struct uart_conf uarts[] = {
+	[1] = {
+		.status = DISABLED,
+		.name = "USART1",
+		.dev = {
+			.irqs = {
+				VAL("", 37),
+			},
+			.pins = {
+				PIN("TX", PC, PIN_4, AF7),
+				PIN("RX", PC, PIN_5, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOC),
+				VAL("RX",   CLK_GPIOC),
+				VAL("UART", CLK_USART1),
+			}
+		},
+		.baudrate = 115200,
+	},
 	[2] = {
 		.status = DISABLED,
 		.name = "USART2",
@@ -21,20 +40,20 @@ struct uart_conf uarts[] = {
 		},
 		.baudrate = 115200,
 	},
-	[6] = {
-		.status = ENABLED,
-		.name = "USART6",
+	[3] = {
+		.status = DISABLED,
+		.name = "USART3",
 		.dev = {
 			.irqs = {
 				VAL("", 71),
 			},
 			.pins = {
-				PIN("TX", PC, PIN_6, AF8),
-				PIN("RX", PC, PIN_7, AF8),
+				PIN("TX", PC, PIN_10, AF8),
+				PIN("RX", PC, PIN_10, AF8),
 			},
 			.clocks = {
-				VAL("TX",   CLK_GPIOC),
-				VAL("RX",   CLK_GPIOC),
+				VAL("TX",   CLK_GPIOB),
+				VAL("RX",   CLK_GPIOB),
 				VAL("UART", CLK_USART6),
 			}
 		},

--- a/board_config/stm32f4discovery.conf.h
+++ b/board_config/stm32f4discovery.conf.h
@@ -1,0 +1,43 @@
+#include <gen_board_conf.h>
+#include <stm32.h>
+
+struct uart_conf uarts[] = {
+	[2] = {
+		.status = DISABLED,
+		.name = "USART2",
+		.dev = {
+			.irqs = {
+				VAL("", 38),
+			},
+			.pins = {
+				PIN("TX", PA, PIN_2, AF7),
+				PIN("RX", PA, PIN_3, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOA),
+				VAL("RX",   CLK_GPIOA),
+				VAL("UART", CLK_USART2),
+			}
+		},
+		.baudrate = 115200,
+	},
+	[6] = {
+		.status = ENABLED,
+		.name = "USART6",
+		.dev = {
+			.irqs = {
+				VAL("", 71),
+			},
+			.pins = {
+				PIN("TX", PC, PIN_6, AF8),
+				PIN("RX", PC, PIN_7, AF8),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOC),
+				VAL("RX",   CLK_GPIOC),
+				VAL("UART", CLK_USART6),
+			}
+		},
+		.baudrate = 115200,
+	},
+};

--- a/board_config/stm32f746g_discovery.conf.h
+++ b/board_config/stm32f746g_discovery.conf.h
@@ -2,6 +2,25 @@
 #include <stm32.h>
 
 struct uart_conf uarts[] = {
+	[1] = {
+		.status = DISABLED,
+		.name = "USART1",
+		.dev = {
+			.irqs = {
+				VAL("", 37),
+			},
+			.pins = {
+				PIN("TX", PA, PIN_9, AF7),
+				PIN("RX", PB, PIN_7, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOA),
+				VAL("RX",   CLK_GPIOB),
+				VAL("UART", CLK_USART1),
+			}
+		},
+		.baudrate = 115200,
+	},
 	[2] = {
 		.status = DISABLED,
 		.name = "USART2",

--- a/board_config/stm32f769i_discovery.conf.h
+++ b/board_config/stm32f769i_discovery.conf.h
@@ -2,6 +2,25 @@
 #include <stm32.h>
 
 struct uart_conf uarts[] = {
+	[1] = {
+		.status = DISABLED,
+		.name = "USART1",
+		.dev = {
+			.irqs = {
+				VAL("", 37),
+			},
+			.pins = {
+				PIN("TX", PA, PIN_9, AF7),
+				PIN("RX", PA, PIN_10, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOA),
+				VAL("RX",   CLK_GPIOA),
+				VAL("UART", CLK_USART1),
+			}
+		},
+		.baudrate = 115200,
+	},
 	[2] = {
 		.status = DISABLED,
 		.name = "USART2",
@@ -43,3 +62,4 @@ struct uart_conf uarts[] = {
 };
 
 EXPORT_CONFIG(UART(uarts))
+

--- a/board_config/stm32l4discovery.conf.h
+++ b/board_config/stm32l4discovery.conf.h
@@ -1,0 +1,45 @@
+#include <gen_board_conf.h>
+#include <stm32.h>
+
+struct uart_conf uarts[] = {
+	[1] = {
+		.status = DISABLED,
+		.name = "USART1",
+		.dev = {
+			.irqs = {
+				VAL("", 37),
+			},
+			.pins = {
+				PIN("TX", PB, PIN_6, AF7),
+				PIN("RX", PB, PIN_7, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOB),
+				VAL("RX",   CLK_GPIOB),
+				VAL("UART", CLK_USART1),
+			}
+		},
+		.baudrate = 115200,
+	},
+	[2] = {
+		.status = DISABLED,
+		.name = "USART2",
+		.dev = {
+			.irqs = {
+				VAL("", 38),
+			},
+			.pins = {
+				PIN("TX", PA, PIN_2, AF7),
+				PIN("RX", PA, PIN_3, AF7),
+			},
+			.clocks = {
+				VAL("TX",   CLK_GPIOA),
+				VAL("RX",   CLK_GPIOA),
+				VAL("UART", CLK_USART2),
+			}
+		},
+		.baudrate = 115200,
+	},
+};
+
+EXPORT_CONFIG(UART(uarts))

--- a/mk/board_conf/board-conf-gen.mk
+++ b/mk/board_conf/board-conf-gen.mk
@@ -1,0 +1,15 @@
+
+HOSTCC  = cc
+
+BOARD_CONF_DIR := board_config/
+BOARD_CONF := $(CONF_DIR)/board.conf.h
+BOARD_CONF_GEN_DIR := $(ROOT_DIR)/mk/board_conf
+board_config_h := $(SRCGEN_DIR)/include/config/board_config.h
+GEN_EXE := $(BUILD_DIR)/gen_board_conf
+
+all:
+ifneq ($(wildcard $(BOARD_CONF)),)
+	$(HOSTCC) -I $(CONF_DIR) -I $(BOARD_CONF_DIR) -I $(BOARD_CONF_GEN_DIR) \
+		-o $(GEN_EXE) $(BOARD_CONF_GEN_DIR)/gen_board_conf.c
+	$(GEN_EXE) > $(board_config_h)
+endif

--- a/mk/board_conf/gen_board_conf.c
+++ b/mk/board_conf/gen_board_conf.c
@@ -1,0 +1,139 @@
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "gen_board_conf.h"
+
+/* It's conf/board.conf.h */
+#include <board.conf.h>
+
+static int gen_dev_enabled(const char *dev_name) {
+	char buf[128];
+	char def[64];
+
+	sprintf(def, "#define CONF_%s_ENABLED", dev_name);
+	sprintf(buf, "%-50s %d", def, 1);
+	printf("%s\n", buf);
+}
+
+static int gen_field_int(const char *dev_name,
+		const char *prop_name, const struct field_int *f) {
+	char buf[128];
+	char def[64];
+
+	if (!f->name) {
+		return -1;
+	}
+
+	if (!strcmp(f->name, "")) {
+		sprintf(def, "#define CONF_%s_%s",
+			dev_name, prop_name);
+	} else {
+		sprintf(def, "#define CONF_%s_%s_%s",
+			dev_name, prop_name, f->name);
+	}
+	sprintf(buf, "%-50s %s", def, f->val);
+	printf("%s\n", buf);
+
+	return 0;
+}
+
+static int gen_field_func(const char *dev_name,
+		const char *prop_name, const struct field_int *f) {
+	char buf[128];
+	char def[64];
+
+	if (!f->name) {
+		return -1;
+	}
+
+	if (!strcmp(f->name, "")) {
+		sprintf(def, "#define CONF_%s_%s()",
+			dev_name, prop_name);
+	} else {
+		sprintf(def, "#define CONF_%s_%s_%s()",
+			dev_name, prop_name, f->name);
+	}
+	sprintf(buf, "%-50s %s", def, f->val);
+	printf("%s\n", buf);
+
+	return 0;
+}
+
+static int gen_field_pin(const char *dev_name,
+		const char *prop_name, const struct field_pin *f) {
+	char buf[128];
+	char def[64];
+
+	if (!f->name) {
+		return -1;
+	}
+
+	sprintf(def, "#define CONF_%s_%s_%s_PORT",
+		dev_name, prop_name, f->name);
+	sprintf(buf, "%-50s %s", def, f->port);
+	printf("%s\n", buf);
+
+	sprintf(def, "#define CONF_%s_%s_%s_NR",
+		dev_name, prop_name, f->name);
+	sprintf(buf, "%-50s %s", def, f->n);
+	printf("%s\n", buf);
+
+	sprintf(def, "#define CONF_%s_%s_%s_AF",
+		dev_name, prop_name, f->name);
+	sprintf(buf, "%-50s %s", def, f->af);
+	printf("%s\n", buf);
+
+	return 0;
+}
+
+int main() {
+	int i, j;
+	struct conf_item *uart_conf = &board_config[UART_IDX];
+	const struct uart_conf *uart;
+
+	config();
+
+	printf("#ifndef BOARD_CONFIG_H_\n");
+	printf("#define BOARD_CONFIG_H_\n\n");
+
+	for (i = 0; i < uart_conf->array_size; i++) {
+		uart = &((const struct uart_conf *) uart_conf->ptr)[i];;
+
+		if (uart->status != ENABLED) {
+			continue;
+		}
+
+		gen_dev_enabled(uart->name);
+
+		for (j = 0; j < ARRAY_SIZE(uart->dev.irqs); j++) {
+			if (gen_field_int(uart->name,
+					"IRQ", &uart->dev.irqs[j]) != 0) {
+				break;
+			}
+		}
+
+		for (j = 0; j < ARRAY_SIZE(uart->dev.pins); j++) {
+			if (gen_field_pin(uart->name,
+					"PIN", &uart->dev.pins[j]) != 0) {
+				break;
+			}
+		}
+
+		for (j = 0; j < ARRAY_SIZE(uart->dev.clocks); j++) {
+			if (gen_field_func(uart->name,
+					"CLK_ENABLE", &uart->dev.clocks[j]) != 0) {
+				break;
+			}
+		}
+
+		printf("\n");
+	}
+
+	printf("#endif /* BOARD_CONFIG_H_ */\n");
+
+	return 0;
+}

--- a/mk/board_conf/gen_board_conf.h
+++ b/mk/board_conf/gen_board_conf.h
@@ -1,0 +1,111 @@
+#ifndef GEN_BOARD_CONF_H_
+#define GEN_BOARD_CONF_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+struct field_int {
+	const char *name;
+	const char *val;
+};
+
+struct field_reg_map {
+	const char *name;
+	const char *baseaddr;
+	const char *len;
+};
+
+struct field_pin {
+	const char *name;
+	const char *port;
+	const char *n;
+	const char *af;
+};
+
+struct device_conf {
+	struct field_reg_map regs[16];
+	struct field_int irqs[16];
+	struct field_pin pins[64];
+	struct field_int clocks[16];
+};
+
+struct uart_conf {
+	int status;
+	const char *name;
+	struct device_conf dev;
+	unsigned int baudrate;
+};
+
+struct spi_conf {
+	int status;
+	const char *name;
+	struct device_conf dev;
+	struct field_pin cs[64];
+};
+
+struct i2c_conf {
+	int status;
+	const char *name;
+	struct device_conf dev;
+};
+
+struct eth_conf {
+	int status;
+	const char *name;
+	struct device_conf dev;
+};
+
+struct conf_item {
+	void *ptr;
+	unsigned array_size;
+};
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+#define UART_IDX    0
+#define SPI_IDX     1
+#define I2C_IDX     2
+#define MAX_IDX     3
+
+#define EXPORT_CONFIG(...) \
+	struct conf_item board_config[MAX_IDX] = { \
+		__VA_ARGS__ \
+	};
+
+#define UART(uarts) \
+	[UART_IDX] = { \
+		(void *) &(uarts)[0], \
+		ARRAY_SIZE(uarts), \
+	}
+
+#define SPI(spis) \
+	[SPI_IDX] = { \
+		(void *) &(spis)[0], \
+		ARRAY_SIZE(spis), \
+	}
+
+#define I2C(i2cs) \
+	[I2C_IDX] = { \
+		(void *) &(i2cs)[0], \
+		ARRAY_SIZE(i2cs), \
+	}
+
+#define CONFIG   void config()
+
+#define DISABLED   0
+#define ENABLED    1
+
+#define MACRO_STRING(...) __MACRO_STRING(__VA_ARGS__)
+#define __MACRO_STRING(...) # __VA_ARGS__
+
+#define VAL(_name, _n) \
+	{ .name = _name, .val = MACRO_STRING(_n) }
+
+#define REGMAP(_name, _addr, _len) \
+	{ .name = _name, .baseaddr = MACRO_STRING(_addr), .len = MACRO_STRING(_len) }
+
+#define PIN(_name, _gpio, _n, _af) \
+	{ .name = _name, .port = MACRO_STRING(_gpio), .n = MACRO_STRING(_n), \
+		.af = MACRO_STRING(_af) }
+
+#endif /* GEN_BOARD_CONF_H_ */

--- a/mk/board_conf/stm32.h
+++ b/mk/board_conf/stm32.h
@@ -1,0 +1,67 @@
+#ifndef STM32_H_
+#define STM32_H_
+
+#define PA     GPIOA
+#define PB     GPIOB
+#define PC     GPIOC
+#define PD     GPIOD
+#define PE     GPIOE
+#define PF     GPIOF
+#define PG     GPIOG
+#define PH     GPIOH
+#define PI     GPIOI
+#define PJ     GPIOJ
+#define PK     GPIOK
+
+#define PIN_1   GPIO_PIN_1
+#define PIN_2   GPIO_PIN_2
+#define PIN_3   GPIO_PIN_3
+#define PIN_4   GPIO_PIN_4
+#define PIN_5   GPIO_PIN_5
+#define PIN_6   GPIO_PIN_6
+#define PIN_7   GPIO_PIN_7
+#define PIN_8   GPIO_PIN_8
+#define PIN_9   GPIO_PIN_9
+#define PIN_10  GPIO_PIN_10
+#define PIN_11  GPIO_PIN_11
+#define PIN_12  GPIO_PIN_12
+#define PIN_13  GPIO_PIN_13
+#define PIN_14  GPIO_PIN_14
+#define PIN_15  GPIO_PIN_15
+
+#define AF0    0x0
+#define AF1    0x1
+#define AF2    0x2
+#define AF3    0x3
+#define AF4    0x4
+#define AF5    0x5
+#define AF6    0x6
+#define AF7    0x7
+#define AF8    0x8
+#define AF9    0x9
+#define AF10   0xa
+#define AF11   0xb
+#define AF12   0xc
+#define AF13   0xd
+#define AF14   0xe
+#define AF15   0xf
+
+#define CLK_GPIOA     __HAL_RCC_GPIOA_CLK_ENABLE()
+#define CLK_GPIOB     __HAL_RCC_GPIOB_CLK_ENABLE()
+#define CLK_GPIOC     __HAL_RCC_GPIOC_CLK_ENABLE()
+#define CLK_GPIOD     __HAL_RCC_GPIOD_CLK_ENABLE()
+#define CLK_GPIOE     __HAL_RCC_GPIOE_CLK_ENABLE()
+#define CLK_GPIOF     __HAL_RCC_GPIOF_CLK_ENABLE()
+#define CLK_GPIOG     __HAL_RCC_GPIOG_CLK_ENABLE()
+#define CLK_GPIOI     __HAL_RCC_GPIOI_CLK_ENABLE()
+#define CLK_GPIOJ     __HAL_RCC_GPIOJ_CLK_ENABLE()
+#define CLK_GPIOK     __HAL_RCC_GPIOK_CLK_ENABLE()
+
+#define CLK_USART1    __HAL_RCC_USART1_CLK_ENABLE()
+#define CLK_USART2    __HAL_RCC_USART2_CLK_ENABLE()
+#define CLK_USART3    __HAL_RCC_USART3_CLK_ENABLE()
+#define CLK_USART4    __HAL_RCC_USART4_CLK_ENABLE()
+#define CLK_USART5    __HAL_RCC_USART5_CLK_ENABLE()
+#define CLK_USART6    __HAL_RCC_USART6_CLK_ENABLE()
+
+#endif /* STM32_H_ */

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -17,6 +17,7 @@ build_gen_ts := $(BUILD_DIR)/build-gen.timestamp
 
 build : $(build_gen_ts)
 	@$(MAKE) -f mk/script/build/oldconf-gen.mk MAKEFILES=''
+	@$(MAKE) -f mk/board_conf/board-conf-gen.mk MAKEFILES=''
 	@$(MAKE) -f mk/script/incinst.mk
 	@$(MAKE) -f mk/extbld/toolchain.mk MAKEFILES=''
 	@$(MAKE) -f mk/extbld.mk MAKEFILES='' __extbld-1

--- a/platform/gpio_http_admin/templates/stm32f4_discovery/board.conf.h
+++ b/platform/gpio_http_admin/templates/stm32f4_discovery/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32f4discovery.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[6].status = ENABLED;
+}

--- a/platform/nuklear/templates/stm32f746g-discovery/board.conf.h
+++ b/platform/nuklear/templates/stm32f746g-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/nuklear/templates/stm32f746g-discovery/build.conf
+++ b/platform/nuklear/templates/stm32f746g-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM =
+PLATFORM = stm32f746g_discovery
 
 ARCH = arm
 

--- a/platform/nuklear/templates/stm32f769i-discovery/board.conf.h
+++ b/platform/nuklear/templates/stm32f769i-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f769i_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/nuklear/templates/stm32f769i-discovery/build.conf
+++ b/platform/nuklear/templates/stm32f769i-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f7
+PLATFORM = stm32f769g_discovery
 
 ARCH = arm
 

--- a/platform/opencv/templates/stm32f746g-discovery/board.conf.h
+++ b/platform/opencv/templates/stm32f746g-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/opencv/templates/stm32f746g-discovery/build.conf
+++ b/platform/opencv/templates/stm32f746g-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM =
+PLATFORM = stm32f746g_discovery
 
 ARCH = arm
 

--- a/platform/opencv/templates/stm32f769i-discovery/board.conf.h
+++ b/platform/opencv/templates/stm32f769i-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f769i_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/opencv/templates/stm32f769i-discovery/build.conf
+++ b/platform/opencv/templates/stm32f769i-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM =
+PLATFORM = stm32f796_discovery
 
 ARCH = arm
 

--- a/platform/pjsip/templates/stm32f746g-discovery/board.conf.h
+++ b/platform/pjsip/templates/stm32f746g-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/pjsip/templates/stm32f746g-discovery/build.conf
+++ b/platform/pjsip/templates/stm32f746g-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f7
+PLATFORM = stm32f7466g_discovery
 
 ARCH = arm
 

--- a/platform/pjsip/templates/stm32f769i-discovery/board.conf.h
+++ b/platform/pjsip/templates/stm32f769i-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f769i_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/pjsip/templates/stm32f769i-discovery/build.conf
+++ b/platform/pjsip/templates/stm32f769i-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f7
+PLATFORM = stm32f769g_discovery
 
 ARCH = arm
 

--- a/platform/stm32f3_agents/templates/feather/board.conf.h
+++ b/platform/stm32f3_agents/templates/feather/board.conf.h
@@ -1,0 +1,5 @@
+#include <stm32f3discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+}

--- a/platform/stm32f3_agents/templates/feather/build.conf
+++ b/platform/stm32f3_agents/templates/feather/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f4
+PLATFORM = stm32f3_discovery
 
 ARCH = arm
 

--- a/platform/stm32f3_sensors/templates/car/board.conf.h
+++ b/platform/stm32f3_sensors/templates/car/board.conf.h
@@ -1,0 +1,5 @@
+#include <stm32f3discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = DISABLED;
+}

--- a/platform/stm32f3_sensors/templates/car/build.conf
+++ b/platform/stm32f3_sensors/templates/car/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f4
+PLATFORM = stm32f3_discovery
 
 ARCH = arm
 

--- a/platform/stm32f4_cnc/templates/debug/board.conf.h
+++ b/platform/stm32f4_cnc/templates/debug/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32f4discovery.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[6].status = ENABLED;
+}

--- a/platform/stm32f7/templates/stm32f7_discovery/board.conf.h
+++ b/platform/stm32f7/templates/stm32f7_discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/platform/stm32f7/templates/stm32f7_discovery/build.conf
+++ b/platform/stm32f7/templates/stm32f7_discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM =
+PLATFORM = stm23f746g_discovery
 
 ARCH = arm
 

--- a/src/drivers/serial/stm32_usart/stm32_usart_conf_f3.h
+++ b/src/drivers/serial/stm32_usart/stm32_usart_conf_f3.h
@@ -57,37 +57,6 @@ static_assert(USART3_IRQ == USART3_IRQn);
 
 #endif
 
-#define STM32_USART1_ENABLED             1
-#define USART1_RX_GPIO_CLK_ENABLE()      __GPIOC_CLK_ENABLE()
-#define USART1_TX_GPIO_CLK_ENABLE()      __GPIOC_CLK_ENABLE()
-#define USART1_TX_PIN                    GPIO_PIN_4
-#define USART1_TX_GPIO_PORT              GPIOC
-#define USART1_TX_AF                     GPIO_AF7_USART1
-#define USART1_RX_PIN                    GPIO_PIN_5
-#define USART1_RX_GPIO_PORT              GPIOC
-#define USART1_RX_AF                     GPIO_AF7_USART1
-
-#define STM32_USART2_ENABLED             1
-#define USART2_RX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
-#define USART2_TX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
-#define USART2_TX_PIN                    GPIO_PIN_2
-#define USART2_TX_GPIO_PORT              GPIOA
-#define USART2_TX_AF                     GPIO_AF7_USART2
-#define USART2_RX_PIN                    GPIO_PIN_3
-#define USART2_RX_GPIO_PORT              GPIOA
-#define USART2_RX_AF                     GPIO_AF7_USART2
-
-#define STM32_USART3_ENABLED             1
-#define USART3_RX_GPIO_CLK_ENABLE()      __GPIOB_CLK_ENABLE()
-#define USART3_TX_GPIO_CLK_ENABLE()      __GPIOB_CLK_ENABLE()
-#define USART3_TX_PIN                    GPIO_PIN_10
-#define USART3_TX_GPIO_PORT              GPIOB
-#define USART3_TX_AF                     GPIO_AF7_USART3
-#define USART3_RX_PIN                    GPIO_PIN_11
-#define USART3_RX_GPIO_PORT              GPIOB
-#define USART3_RX_AF                     GPIO_AF7_USART3
-
-
 
 #define STM32_USART_FLAGS(uart)   uart->ISR
 #define STM32_USART_RXDATA(uart)  uart->RDR

--- a/src/drivers/serial/stm32_usart/stm32_usart_conf_f4.h
+++ b/src/drivers/serial/stm32_usart/stm32_usart_conf_f4.h
@@ -61,7 +61,6 @@ static_assert(USART2_IRQ == USART2_IRQn);
 #error Unsupported USARTx
 #endif
 
-
 #define STM32_USART2_ENABLED             1
 #define USART2_RX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOA_CLK_ENABLE()
 #define USART2_TX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOA_CLK_ENABLE()
@@ -81,16 +80,6 @@ static_assert(USART2_IRQ == USART2_IRQn);
 #define USART3_RX_PIN                    GPIO_PIN_9
 #define USART3_RX_GPIO_PORT              GPIOD
 #define USART3_RX_AF                     GPIO_AF7_USART3
-
-#define STM32_USART6_ENABLED             1
-#define USART6_RX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOC_CLK_ENABLE()
-#define USART6_TX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOC_CLK_ENABLE()
-#define USART6_TX_PIN                    GPIO_PIN_6
-#define USART6_TX_GPIO_PORT              GPIOC
-#define USART6_TX_AF                     GPIO_AF8_USART6
-#define USART6_RX_PIN                    GPIO_PIN_7
-#define USART6_RX_GPIO_PORT              GPIOC
-#define USART6_RX_AF                     GPIO_AF8_USART6
 
 
 #define STM32_USART_FLAGS(uart)   uart->SR

--- a/src/drivers/serial/stm32_usart/stm32_usart_conf_f4.h
+++ b/src/drivers/serial/stm32_usart/stm32_usart_conf_f4.h
@@ -61,26 +61,6 @@ static_assert(USART2_IRQ == USART2_IRQn);
 #error Unsupported USARTx
 #endif
 
-#define STM32_USART2_ENABLED             1
-#define USART2_RX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOA_CLK_ENABLE()
-#define USART2_TX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOA_CLK_ENABLE()
-#define USART2_TX_PIN                    GPIO_PIN_2
-#define USART2_TX_GPIO_PORT              GPIOA
-#define USART2_TX_AF                     GPIO_AF7_USART2
-#define USART2_RX_PIN                    GPIO_PIN_3
-#define USART2_RX_GPIO_PORT              GPIOA
-#define USART2_RX_AF                     GPIO_AF7_USART2
-
-#define STM32_USART3_ENABLED             1
-#define USART3_RX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOD_CLK_ENABLE()
-#define USART3_TX_GPIO_CLK_ENABLE()      __HAL_RCC_GPIOD_CLK_ENABLE()
-#define USART3_TX_PIN                    GPIO_PIN_8
-#define USART3_TX_GPIO_PORT              GPIOD
-#define USART3_TX_AF                     GPIO_AF7_USART3
-#define USART3_RX_PIN                    GPIO_PIN_9
-#define USART3_RX_GPIO_PORT              GPIOD
-#define USART3_RX_AF                     GPIO_AF7_USART3
-
 
 #define STM32_USART_FLAGS(uart)   uart->SR
 #define STM32_USART_RXDATA(uart)  uart->DR

--- a/src/drivers/serial/stm32_usart/stm32_usart_conf_l4.h
+++ b/src/drivers/serial/stm32_usart/stm32_usart_conf_l4.h
@@ -47,26 +47,6 @@ static_assert(USART2_IRQ == USART2_IRQn);
 #error "Unsupported USART number"
 #endif
 
-#define STM32_USART1_ENABLED             1
-#define USART1_RX_GPIO_CLK_ENABLE()      __GPIOB_CLK_ENABLE()
-#define USART1_TX_GPIO_CLK_ENABLE()      __GPIOB_CLK_ENABLE()
-#define USART1_TX_PIN                    GPIO_PIN_6
-#define USART1_TX_GPIO_PORT              GPIOB
-#define USART1_TX_AF                     GPIO_AF7_USART1
-#define USART1_RX_PIN                    GPIO_PIN_7
-#define USART1_RX_GPIO_PORT              GPIOB
-#define USART1_RX_AF                     GPIO_AF7_USART1
-
-#define STM32_USART2_ENABLED             1
-#define USART2_RX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
-#define USART2_TX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
-#define USART2_TX_PIN                    GPIO_PIN_2
-#define USART2_TX_GPIO_PORT              GPIOA
-#define USART2_TX_AF                     GPIO_AF7_USART2
-#define USART2_RX_PIN                    GPIO_PIN_3
-#define USART2_RX_GPIO_PORT              GPIOA
-#define USART2_RX_AF                     GPIO_AF7_USART2
-
 
 #define STM32_USART_FLAGS(uart)   uart->ISR
 #define STM32_USART_RXDATA(uart)  uart->RDR

--- a/src/drivers/serial/stm32_usart/stm_hal_msp.c
+++ b/src/drivers/serial/stm32_usart/stm_hal_msp.c
@@ -9,41 +9,43 @@
 
 #include <drivers/serial/stm_usart.h>
 
+#include <config/board_config.h>
+
 static void USART_CLK_ENABLE(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		__HAL_RCC_USART1_CLK_ENABLE();
+		CONF_USART1_CLK_ENABLE_UART();
 		break;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		__HAL_RCC_USART2_CLK_ENABLE();
+		CONF_USART2_CLK_ENABLE_UART();
 		break;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		__HAL_RCC_USART3_CLK_ENABLE();
+		CONF_USART3_CLK_ENABLE_UART();
 		break;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		__HAL_RCC_USART4_CLK_ENABLE();
+		CONF_USART4_CLK_ENABLE_UART();
 		break;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		__HAL_RCC_USART5_CLK_ENABLE();
+		CONF_USART5_CLK_ENABLE_UART();
 		break;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		__HAL_RCC_USART6_CLK_ENABLE();
+		CONF_USART6_CLK_ENABLE_UART();
 		break;
 	}
 #endif
@@ -54,39 +56,39 @@ static void USART_CLK_ENABLE(void *usart_base) {
 
 static void USART_TX_GPIO_CLK_ENABLE(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		USART1_TX_GPIO_CLK_ENABLE();
+		CONF_USART1_CLK_ENABLE_TX();
 		break;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		USART2_TX_GPIO_CLK_ENABLE();
+		CONF_USART2_CLK_ENABLE_TX();
 		break;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		USART3_TX_GPIO_CLK_ENABLE();
+		CONF_USART3_CLK_ENABLE_TX();
 		break;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		USART4_TX_GPIO_CLK_ENABLE();
+		CONF_USART4_CLK_ENABLE_TX();
 		break;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		USART5_TX_GPIO_CLK_ENABLE();
+		CONF_USART5_CLK_ENABLE_TX();
 		break;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		USART6_TX_GPIO_CLK_ENABLE();
+		CONF_USART6_CLK_ENABLE_TX();
 		break;
 	}
 #endif
@@ -97,39 +99,39 @@ static void USART_TX_GPIO_CLK_ENABLE(void *usart_base) {
 
 static void USART_RX_GPIO_CLK_ENABLE(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		USART1_RX_GPIO_CLK_ENABLE();
+		CONF_USART1_CLK_ENABLE_RX();
 		break;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		USART2_RX_GPIO_CLK_ENABLE();
+		CONF_USART2_CLK_ENABLE_RX();
 		break;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		USART3_RX_GPIO_CLK_ENABLE();
+		CONF_USART3_CLK_ENABLE_RX();
 		break;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		USART4_RX_GPIO_CLK_ENABLE();
+		CONF_USART4_CLK_ENABLE_RX();
 		break;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		USART5_RX_GPIO_CLK_ENABLE();
+		CONF_USART5_CLK_ENABLE_RX();
 		break;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		USART6_RX_GPIO_CLK_ENABLE();
+		CONF_USART6_CLK_ENABLE_RX();
 		break;
 	}
 #endif
@@ -140,34 +142,34 @@ static void USART_RX_GPIO_CLK_ENABLE(void *usart_base) {
 
 static uint16_t USART_RX_PIN(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		return USART1_RX_PIN;
+		return CONF_USART1_PIN_RX_NR;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		return USART2_RX_PIN;
+		return CONF_USART2_PIN_RX_NR;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		return USART3_RX_PIN;
+		return CONF_USART3_PIN_RX_NR;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		return USART4_RX_PIN;
+		return CONF_USART4_PIN_RX_NR;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		return USART5_RX_PIN;
+		return CONF_USART5_PIN_RX_NR;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		return USART6_RX_PIN;
+		return CONF_USART6_PIN_RX_NR;
 	}
 #endif
 	default:
@@ -178,34 +180,34 @@ static uint16_t USART_RX_PIN(void *usart_base) {
 
 static uint16_t USART_TX_PIN(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		return USART1_TX_PIN;
+		return CONF_USART1_PIN_TX_NR;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		return USART2_TX_PIN;
+		return CONF_USART2_PIN_TX_NR;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		return USART3_TX_PIN;
+		return CONF_USART3_PIN_TX_NR;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		return USART4_TX_PIN;
+		return CONF_USART4_PIN_TX_NR;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		return USART5_TX_PIN;
+		return CONF_USART5_PIN_TX_NR;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		return USART6_TX_PIN;
+		return CONF_USART6_PIN_TX_NR;
 	}
 #endif
 	default:
@@ -216,34 +218,34 @@ static uint16_t USART_TX_PIN(void *usart_base) {
 
 static GPIO_TypeDef *USART_RX_GPIO_PORT(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		return USART1_RX_GPIO_PORT;
+		return CONF_USART1_PIN_RX_PORT;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		return USART2_RX_GPIO_PORT;
+		return CONF_USART2_PIN_RX_PORT;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		return USART3_RX_GPIO_PORT;
+		return CONF_USART3_PIN_RX_PORT;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		return USART4_RX_GPIO_PORT;
+		return CONF_USART4_PIN_RX_PORT;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		return USART5_RX_GPIO_PORT;
+		return CONF_USART5_PIN_RX_PORT;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		return USART6_RX_GPIO_PORT;
+		return CONF_USART6_PIN_RX_PORT;
 	}
 #endif
 	default:
@@ -254,34 +256,34 @@ static GPIO_TypeDef *USART_RX_GPIO_PORT(void *usart_base) {
 
 static GPIO_TypeDef *USART_TX_GPIO_PORT(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		return USART1_TX_GPIO_PORT;
+		return CONF_USART1_PIN_TX_PORT;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		return USART2_TX_GPIO_PORT;
+		return CONF_USART2_PIN_TX_PORT;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		return USART3_TX_GPIO_PORT;
+		return CONF_USART3_PIN_TX_PORT;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		return USART4_TX_GPIO_PORT;
+		return CONF_USART4_PIN_TX_PORT;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		return USART5_TX_GPIO_PORT;
+		return CONF_USART5_PIN_TX_PORT;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		return USART6_TX_GPIO_PORT;
+		return CONF_USART6_PIN_TX_PORT;
 	}
 #endif
 	default:
@@ -292,34 +294,34 @@ static GPIO_TypeDef *USART_TX_GPIO_PORT(void *usart_base) {
 
 static uint8_t USART_TX_AF(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		return USART1_TX_AF;
+		return CONF_USART1_PIN_TX_AF;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		return USART2_TX_AF;
+		return CONF_USART2_PIN_TX_AF;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		return USART3_TX_AF;
+		return CONF_USART3_PIN_TX_AF;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		return USART4_TX_AF;
+		return CONF_USART4_PIN_TX_AF;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		return USART5_TX_AF;
+		return CONF_USART5_PIN_TX_AF;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		return USART6_TX_AF;
+		return CONF_USART6_PIN_TX_AF;
 	}
 #endif
 	default:
@@ -330,34 +332,34 @@ static uint8_t USART_TX_AF(void *usart_base) {
 
 static uint8_t USART_RX_AF(void *usart_base) {
 	switch((uintptr_t)usart_base) {
-#if defined(USART1) &&  defined(STM32_USART1_ENABLED)
+#if defined(USART1) &&  defined(CONF_USART1_ENABLED)
 	case (uintptr_t)USART1: {
-		return USART1_RX_AF;
+		return CONF_USART1_PIN_RX_AF;
 	}
 #endif
-#if defined(USART2) &&  defined(STM32_USART2_ENABLED)
+#if defined(USART2) &&  defined(CONF_USART2_ENABLED)
 	case (uintptr_t)USART2: {
-		return USART2_RX_AF;
+		return CONF_USART2_PIN_RX_AF;
 	}
 #endif
-#if defined(USART3) &&  defined(STM32_USART3_ENABLED)
+#if defined(USART3) &&  defined(CONF_USART3_ENABLED)
 	case (uintptr_t)USART3: {
-		return USART3_RX_AF;
+		return CONF_USART3_PIN_RX_AF;
 	}
 #endif
-#if defined(USART4) &&  defined(STM32_USART4_ENABLED)
+#if defined(USART4) &&  defined(CONF_USART4_ENABLED)
 	case (uintptr_t)USART4: {
-		return USART4_RX_AF;
+		return CONF_USART4_PIN_RX_AF;
 	}
 #endif
-#if defined(USART5) &&  defined(STM32_USART5_ENABLED)
+#if defined(USART5) &&  defined(CONF_USART5_ENABLED)
 	case (uintptr_t)USART5: {
-		return USART5_RX_AF;
+		return CONF_USART5_PIN_RX_AF;
 	}
 #endif
-#if defined(USART6) &&  defined(STM32_USART6_ENABLED)
+#if defined(USART6) &&  defined(CONF_USART6_ENABLED)
 	case (uintptr_t)USART6: {
-		return USART6_RX_AF;
+		return CONF_USART6_PIN_RX_AF;
 	}
 #endif
 	default:

--- a/templates/arm/nucleo_f429zi/board.conf.h
+++ b/templates/arm/nucleo_f429zi/board.conf.h
@@ -1,0 +1,7 @@
+#include <nucleo_f429zi.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[3].status = ENABLED;
+	uarts[6].status = ENABLED;
+}

--- a/templates/arm/nucleo_l476rg/board.conf.h
+++ b/templates/arm/nucleo_l476rg/board.conf.h
@@ -1,0 +1,6 @@
+#include <nucleo_l476rg.conf.h>
+
+CONFIG {
+	uarts[1].status = DISABLED;
+	uarts[2].status = ENABLED;
+}

--- a/templates/arm/nucleo_l476rg/build.conf
+++ b/templates/arm/nucleo_l476rg/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32l4
+PLATFORM = nucleo_f476rg
 
 ARCH = arm
 

--- a/templates/arm/stm32_dvfs/board.conf.h
+++ b/templates/arm/stm32_dvfs/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32f4discovery.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[6].status = ENABLED;
+}

--- a/templates/arm/stm32_modbus/board.conf.h
+++ b/templates/arm/stm32_modbus/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32f4discovery.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[6].status = ENABLED;
+}

--- a/templates/arm/stm32f3-discovery/board.conf.h
+++ b/templates/arm/stm32f3-discovery/board.conf.h
@@ -1,0 +1,5 @@
+#include <stm32f3discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+}

--- a/templates/arm/stm32f3-discovery/build.conf
+++ b/templates/arm/stm32f3-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM =
+PLATFORM = stm32f3_discovery
 
 ARCH = arm
 

--- a/templates/arm/stm32f4-discovery-clang/board.conf.h
+++ b/templates/arm/stm32f4-discovery-clang/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32f4discovery.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[6].status = ENABLED;
+}

--- a/templates/arm/stm32f4-discovery/board.conf.h
+++ b/templates/arm/stm32f4-discovery/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32f4discovery.conf.h>
+
+CONFIG {
+	uarts[2].status = DISABLED;
+	uarts[6].status = ENABLED;
+}

--- a/templates/arm/stm32f746g-discovery-lua/board.conf.h
+++ b/templates/arm/stm32f746g-discovery-lua/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/templates/arm/stm32f746g-discovery-lua/build.conf
+++ b/templates/arm/stm32f746g-discovery-lua/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f7
+PLATFORM = stm32f746g_discovery
 
 ARCH = arm
 

--- a/templates/arm/stm32f746g-discovery/board.conf.h
+++ b/templates/arm/stm32f746g-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/templates/arm/stm32f746g-discovery/build.conf
+++ b/templates/arm/stm32f746g-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f7
+PLATFORM = stm32f746g_discovery
 
 ARCH = arm
 

--- a/templates/arm/stm32f769i-discovery/board.conf.h
+++ b/templates/arm/stm32f769i-discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f769i_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/templates/arm/stm32f769i-discovery/build.conf
+++ b/templates/arm/stm32f769i-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM = stm32f7
+PLATFORM = stm32f769i_discovery
 
 ARCH = arm
 

--- a/templates/arm/stm32l4-discovery/board.conf.h
+++ b/templates/arm/stm32l4-discovery/board.conf.h
@@ -1,0 +1,6 @@
+#include <stm32l4discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+}

--- a/templates/arm/stm32l4-discovery/build.conf
+++ b/templates/arm/stm32l4-discovery/build.conf
@@ -1,6 +1,6 @@
 TARGET = embox
 
-PLATFORM =
+PLATFORM = stm32l4_discovery
 
 ARCH = arm
 


### PR DESCRIPTION
These changes provide a simple instrument for board description - like DTS but much simpler.

We only tried these changes with STM32 and only with UART yet.

Example:

Each stm32 template now contains `conf/board.conf.h`

```cpp
#include <stm32f4discovery.conf.h>

CONFIG {
    uarts[2].status = DISABLED;
    uarts[6].status = ENABLED;
}
```

File `stm32f4discovery.conf.h` located at board_config/ and contains description like:

```cpp
#include <gen_board_conf.h>
#include <stm32.h>

struct uart_conf uarts[] = {
    [2] = {
        .status = DISABLED,
        .name = "USART2",
        .dev = {
            .irqs = {
                VAL("", 38),
            },
            .pins = {
                PIN("TX", PA, PIN_2, AF7),
                PIN("RX", PA, PIN_3, AF7),
            },
            .clocks = {
                VAL("TX",   CLK_GPIOA),
                VAL("RX",   CLK_GPIOA),
                VAL("UART", CLK_USART2),
            }
        },
        .baudrate = 115200,
    },
***
```

After that, a bunch of macros will be generated and available through `#include <config/board_config.h>`