### PR TITLE
Nuklear optimize for stm32

### DIFF
--- a/platform/nuklear/cmd/grfx_rawfb/Mybuild
+++ b/platform/nuklear/cmd/grfx_rawfb/Mybuild
@@ -13,6 +13,8 @@ package embox.cmd.grfxs
 	''')
 @BuildDepends(third_party.lib.nuklear)
 module grfx_rawfb {
+	option boolean use_dma = false
+
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/lib/nuklear/install")
 	source "grfx_rawfb.c"
 

--- a/platform/nuklear/cmd/grfx_rawfb/Mybuild
+++ b/platform/nuklear/cmd/grfx_rawfb/Mybuild
@@ -12,12 +12,27 @@ package embox.cmd.grfxs
 			Alexander Kalmuk
 	''')
 @BuildDepends(third_party.lib.nuklear)
+@BuildDepends(third_party.bsp.st_bsp_api)
 module grfx_rawfb {
-	option boolean use_dma = false
-
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/lib/nuklear/install")
 	source "grfx_rawfb.c"
 
 	depends third_party.lib.nuklear
 	depends embox.driver.input.core
+	depends third_party.bsp.st_bsp_api
+	depends rawfb_api
+}
+
+abstract module rawfb_api {
+}
+
+@BuildDepends(third_party.bsp.st_bsp_api)
+module rawfb_stm32_ltdc extends rawfb_api {
+	source "rawfb_stm32_ltdc.c"
+
+	depends third_party.bsp.st_bsp_api
+}
+
+module rawfb_memcpy extends rawfb_api {
+	source "rawfb_memcpy.c"
 }

--- a/platform/nuklear/cmd/grfx_rawfb/Mybuild
+++ b/platform/nuklear/cmd/grfx_rawfb/Mybuild
@@ -33,6 +33,13 @@ module rawfb_stm32_ltdc extends rawfb_api {
 	depends third_party.bsp.st_bsp_api
 }
 
+@BuildDepends(third_party.bsp.st_bsp_api)
+module rawfb_stm32_ltdc_alpha extends rawfb_api {
+	source "rawfb_stm32_ltdc_alpha.c"
+
+	depends third_party.bsp.st_bsp_api
+}
+
 module rawfb_memcpy extends rawfb_api {
 	source "rawfb_memcpy.c"
 }

--- a/platform/nuklear/cmd/grfx_rawfb/grfx_rawfb.c
+++ b/platform/nuklear/cmd/grfx_rawfb/grfx_rawfb.c
@@ -130,6 +130,8 @@ int main(int argc, char *argv[]) {
 	int bpp;
 	uint32_t width = 0, height = 0;
 	struct input_dev *mouse;
+	clock_t start_time, cur_time;
+	int frames;
 
 	fb_info = fb_lookup(0);
 
@@ -181,6 +183,8 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "Failed open mouse input device\n");
 		exit(1);
 	}
+
+	start_time = clock();
 
 	while (1) {
 		/* Input */
@@ -243,6 +247,16 @@ int main(int argc, char *argv[]) {
 							BGRA8888, fb_info->var.fmt);
 		} else {
 			memcpy(fb_info->screen_base, fb_buf, width * height * bpp);
+		}
+
+		frames++;
+
+		cur_time = clock();
+
+		if (cur_time - start_time > 1000) {
+			printf("FPS = %d\n", frames);
+			frames = 0;
+			start_time = clock();
 		}
 	}
 

--- a/platform/nuklear/cmd/grfx_rawfb/grfx_rawfb.c
+++ b/platform/nuklear/cmd/grfx_rawfb/grfx_rawfb.c
@@ -40,6 +40,12 @@
 #include <drivers/video/fb.h>
 #include <drivers/input/input_dev.h>
 
+#define USE_DMA   OPTION_GET(BOOLEAN, use_dma)
+
+#if USE_DMA
+#include <drivers/dma/dma.h>
+#endif
+
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
 #define NK_INCLUDE_STANDARD_VARARGS
@@ -57,6 +63,8 @@
 #define DTIME           20
 #define WINDOW_WIDTH    800
 #define WINDOW_HEIGHT   600
+
+static int fb_buf_idx;
 
 static inline int normalize_coord(int x, int a, int b) {
 	if (x < a) {
@@ -122,7 +130,8 @@ static void handle_touchscreen(struct input_dev *ts, struct fb_info *fb_info,
  * ===============================================================*/
 int main(int argc, char *argv[]) {
 	struct rawfb_context *rawfb;
-	void *fb_buf = NULL;
+	int i;
+	void *fb_buf[2] = { NULL };
 	unsigned char *tex_scratch;
 	long int screensize = 0;
 	uint8_t *fbp = 0;
@@ -131,7 +140,7 @@ int main(int argc, char *argv[]) {
 	uint32_t width = 0, height = 0;
 	struct input_dev *mouse;
 	clock_t start_time, cur_time;
-	int frames;
+	int frames = 0;
 
 	fb_info = fb_lookup(0);
 
@@ -156,35 +165,42 @@ int main(int argc, char *argv[]) {
 	width = fb_info->var.xres;
 	height = fb_info->var.yres;
 
-	fb_buf = malloc(height * width * 4);
-	if (!fb_buf) {
-		fprintf(stderr, "Cannot allocate buffer for screen\n");
-		exit(2);
+	for (i = 0; i < 2; i++) {
+		fb_buf[i] = malloc(height * width * 4);
+		if (!fb_buf[i]) {
+			fprintf(stderr, "Cannot allocate buffer for screen\n");
+			goto out_free_fb_buf;
+		}
 	}
+
 	tex_scratch = malloc(512 * 512);
 	if (!tex_scratch) {
 		fprintf(stderr, "Cannot allocate buffer for font\n");
-		exit(2);
+		goto out_free_fb_buf;
 	}
 
-	rawfb = nk_rawfb_init(fb_buf, tex_scratch, width, height, width * 4,
+	rawfb = nk_rawfb_init(fb_buf[0], tex_scratch, width, height, width * 4,
 		PIXEL_LAYOUT_XRGB_8888);
 	if (!rawfb) {
 		fprintf(stderr, "Cannot allocate rawfb\n");
-		exit(2);
+		goto out_free_fb_and_tex;
 	}
 
 	/* Input device - mouse. */
 	if (!(mouse = input_dev_lookup(argv[argc - 1]))) {
 		fprintf(stderr, "Cannot find mouse \"%s\"\n", argv[argc - 1]);
-		exit(1);
+		goto out_free;
 	}
 	if (0 > input_dev_open(mouse, NULL)) {
 		fprintf(stderr, "Failed open mouse input device\n");
-		exit(1);
+		goto out_free;
 	}
 
 	start_time = clock();
+
+#if USE_DMA
+	dma_config(0);
+#endif
 
 	while (1) {
 		/* Input */
@@ -243,11 +259,30 @@ int main(int argc, char *argv[]) {
 		nk_rawfb_render(rawfb, nk_rgb(30,30,30), 1);
 
 		if (fb_info->var.fmt != BGRA8888) {
-			pix_fmt_convert(fb_buf, fb_info->screen_base, width * height,
+			pix_fmt_convert(fb_buf[fb_buf_idx], fb_info->screen_base, width * height,
 							BGRA8888, fb_info->var.fmt);
 		} else {
-			memcpy(fb_info->screen_base, fb_buf, width * height * bpp);
+#if USE_DMA
+			int ret;
+
+			while (dma_in_progress(0)) {
+
+			}
+
+			ret = dma_transfer(0, (uint32_t) fb_info->screen_base,
+					(uint32_t) fb_buf[fb_buf_idx], (width * height * bpp) / 4);
+			if (ret < 0) {
+				printf("DMA transfer failed\n");
+			}
+#else
+			memcpy(fb_info->screen_base, fb_buf[fb_buf_idx], width * height * bpp);
+#endif
 		}
+
+		fb_buf_idx = (fb_buf_idx + 1) % 2;
+
+		nk_rawfb_resize_fb(rawfb, fb_buf[fb_buf_idx], width, height, width * 4,
+			PIXEL_LAYOUT_XRGB_8888);
 
 		frames++;
 
@@ -260,10 +295,18 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+out_free:
 	nk_rawfb_shutdown(rawfb);
 
-	free(fb_buf);
+out_free_fb_and_tex:
 	free(tex_scratch);
+
+out_free_fb_buf:
+	for (i = 0; i < 2; i++) {
+		if (fb_buf[i]) {
+			free(fb_buf[i]);
+		}
+	}
 
 	return 0;
 }

--- a/platform/nuklear/cmd/grfx_rawfb/rawfb.h
+++ b/platform/nuklear/cmd/grfx_rawfb/rawfb.h
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date   11.08.2020
+ * @author Alexander Kalmuk
+ */
+
+#ifndef GRFX_RAWFB_RAWFB_H_
+#define GRFX_RAWFB_RAWFB_H_
+
+struct fb_info;
+
+struct rawfb_fb_info {
+	struct fb_info *fb_info;
+	void *fb_buf[2];
+	int fb_buf_idx;
+	int width;
+	int height;
+	int bpp;
+	int clear_color;
+};
+
+extern void rawfb_init(struct rawfb_fb_info *fbs);
+extern void rawfb_swap_buffers(struct rawfb_fb_info *fbs);
+extern void rawfb_clear_screen(struct rawfb_fb_info *fbs);
+
+#endif /* GRFX_RAWFB_RAWFB_H_ */

--- a/platform/nuklear/cmd/grfx_rawfb/rawfb_memcpy.c
+++ b/platform/nuklear/cmd/grfx_rawfb/rawfb_memcpy.c
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date   11.08.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <drivers/video/fb.h>
+#include "rawfb.h"
+
+void rawfb_init(struct rawfb_fb_info *rfb) {
+}
+
+void rawfb_clear_screen(struct rawfb_fb_info *rfb) {
+	int i;
+	uint32_t *p = rfb->fb_buf[rfb->fb_buf_idx];
+
+	for (i = 0; i < rfb->width * rfb->height; i++) {
+		p[i] = rfb->clear_color;
+	}
+}
+
+void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
+	if (rfb->fb_info->var.fmt != BGRA8888) {
+		pix_fmt_convert(rfb->fb_buf[rfb->fb_buf_idx],
+						rfb->fb_info->screen_base, rfb->width * rfb->height,
+						BGRA8888, rfb->fb_info->var.fmt);
+	} else {
+		memcpy(rfb->fb_info->screen_base, rfb->fb_buf[rfb->fb_buf_idx],
+			rfb->width * rfb->height * rfb->bpp);
+	}
+}

--- a/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
+++ b/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
@@ -17,7 +17,15 @@
 #error Unsupported platform
 #endif
 
+#if defined STM32F746xx
 extern LTDC_HandleTypeDef hLtdcHandler;
+#define hltdc_handler hLtdcHandler
+#elif defined STM32F769xx
+extern LTDC_HandleTypeDef  hltdc_discovery;
+#define hltdc_handler hltdc_discovery
+#else
+#error Unsupported platform
+#endif
 
 static volatile int ltdc_li_triggered = 0;
 
@@ -29,7 +37,7 @@ void rawfb_init(struct rawfb_fb_info *rfb) {
 	BSP_LCD_LayerDefaultInit(0, (uint32_t) rfb->fb_buf[0]);
 	BSP_LCD_LayerDefaultInit(1, (uint32_t) rfb->fb_buf[1]);
 
-	HAL_LTDC_ProgramLineEvent(&hLtdcHandler, rfb->height - 1);
+	HAL_LTDC_ProgramLineEvent(&hltdc_handler, rfb->height - 1);
 }
 
 void rawfb_clear_screen(struct rawfb_fb_info *rfb) {
@@ -47,12 +55,12 @@ void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
 
 		ltdc_li_triggered = 0;
 		
-		HAL_LTDC_ProgramLineEvent(&hLtdcHandler, rfb->height - 1);
+		HAL_LTDC_ProgramLineEvent(&hltdc_handler, rfb->height - 1);
 
 		while (!ltdc_li_triggered) {
 		}
 
-		BSP_LCD_SetTransparency_NoReload(rfb->fb_buf_idx, 0xff);
+		BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0xff);
 	}
 
 	rfb->fb_buf_idx = (rfb->fb_buf_idx + 1) % 2;

--- a/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
+++ b/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
@@ -33,15 +33,53 @@ void HAL_LTDC_LineEvenCallback(LTDC_HandleTypeDef *hltdc) {
 	ltdc_li_triggered = 1;
 }
 
+static void dma2d_fill(uint32_t *dst, uint16_t xsize, uint16_t ysize, uint32_t color) {
+	DMA2D_HandleTypeDef hdma2d;
+
+	/*##-1- Configure the DMA2D Mode, Color Mode and output offset #############*/
+	hdma2d.Init.Mode          = DMA2D_R2M;
+	hdma2d.Init.ColorMode     = DMA2D_OUTPUT_ARGB8888;
+	hdma2d.Init.OutputOffset  = 0;
+#if defined STM32F769xx
+	hdma2d.Init.AlphaInverted = DMA2D_REGULAR_ALPHA;  /* No Output Alpha Inversion*/
+	hdma2d.Init.RedBlueSwap   = DMA2D_RB_REGULAR;     /* No Output Red & Blue swap */
+#endif
+
+	/*##-2- DMA2D Callbacks Configuration ######################################*/
+	hdma2d.XferCpltCallback  = NULL;
+
+	/*##-3- Foreground Configuration ###########################################*/
+	hdma2d.LayerCfg[1].AlphaMode = DMA2D_NO_MODIF_ALPHA;
+	hdma2d.LayerCfg[1].InputAlpha = 0xFF;
+	hdma2d.LayerCfg[1].InputColorMode = DMA2D_INPUT_ARGB8888;
+	hdma2d.LayerCfg[1].InputOffset = 0;
+#if defined STM32F769xx
+	hdma2d.LayerCfg[1].RedBlueSwap = DMA2D_RB_REGULAR; /* No ForeGround Red/Blue swap */
+	hdma2d.LayerCfg[1].AlphaInverted = DMA2D_REGULAR_ALPHA; /* No ForeGround Alpha inversion */
+#endif
+
+	hdma2d.Instance          = DMA2D;
+
+	/* DMA2D Initialization */
+	if (HAL_DMA2D_Init(&hdma2d) == HAL_OK)  {
+		if (HAL_DMA2D_ConfigLayer(&hdma2d, 1) == HAL_OK) {
+			if (HAL_DMA2D_Start(&hdma2d, color, (uint32_t)dst, xsize, ysize) == HAL_OK) {
+				/* Polling For DMA transfer */
+				HAL_DMA2D_PollForTransfer(&hdma2d, 100);
+			}
+		}
+	}
+}
+
 void rawfb_init(struct rawfb_fb_info *rfb) {
-	BSP_LCD_LayerDefaultInit(0, (uint32_t) rfb->fb_buf[0]);
-	BSP_LCD_LayerDefaultInit(1, (uint32_t) rfb->fb_buf[1]);
+	BSP_LCD_SelectLayer(0);
 
 	HAL_LTDC_ProgramLineEvent(&hltdc_handler, rfb->height - 1);
 }
 
 void rawfb_clear_screen(struct rawfb_fb_info *rfb) {
-	BSP_LCD_Clear(rfb->clear_color);
+	dma2d_fill(rfb->fb_buf[rfb->fb_buf_idx],
+	           rfb->width, rfb->height, rfb->clear_color);
 }
 
 void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
@@ -60,12 +98,10 @@ void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
 		while (!ltdc_li_triggered) {
 		}
 
-		BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0xff);
+		LTDC_LAYER(&hltdc_handler, 0)->CFBAR = ((uint32_t)rfb->fb_buf[rfb->fb_buf_idx]);
+		__HAL_LTDC_RELOAD_CONFIG(&hltdc_handler);
+
 	}
 
 	rfb->fb_buf_idx = (rfb->fb_buf_idx + 1) % 2;
-
-	BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0x00);
-
-	BSP_LCD_SelectLayer(rfb->fb_buf_idx);
 }

--- a/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
+++ b/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date   11.08.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <drivers/video/fb.h>
+#include "rawfb.h"
+
+#if defined STM32F746xx
+#include "stm32746g_discovery_lcd.h"
+#elif defined STM32F769xx
+#include "stm32f769i_discovery_lcd.h"
+#else
+#error Unsupported platform
+#endif
+
+extern LTDC_HandleTypeDef hLtdcHandler;
+
+static volatile int ltdc_li_triggered = 0;
+
+void HAL_LTDC_LineEvenCallback(LTDC_HandleTypeDef *hltdc) {
+	ltdc_li_triggered = 1;
+}
+
+void rawfb_init(struct rawfb_fb_info *rfb) {
+	BSP_LCD_LayerDefaultInit(0, (uint32_t) rfb->fb_buf[0]);
+	BSP_LCD_LayerDefaultInit(1, (uint32_t) rfb->fb_buf[1]);
+
+	HAL_LTDC_ProgramLineEvent(&hLtdcHandler, rfb->height - 1);
+}
+
+void rawfb_clear_screen(struct rawfb_fb_info *rfb) {
+	BSP_LCD_Clear(rfb->clear_color);
+}
+
+void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
+	if (rfb->fb_info->var.fmt != BGRA8888) {
+		pix_fmt_convert(rfb->fb_buf[rfb->fb_buf_idx],
+						rfb->fb_info->screen_base, rfb->width * rfb->height,
+						BGRA8888, rfb->fb_info->var.fmt);
+	} else {
+		/* Here we wait for the next display refresh, and after it happened
+		 * swap buffers. */
+
+		ltdc_li_triggered = 0;
+		
+		HAL_LTDC_ProgramLineEvent(&hLtdcHandler, rfb->height - 1);
+
+		while (!ltdc_li_triggered) {
+		}
+
+		BSP_LCD_SetTransparency_NoReload(rfb->fb_buf_idx, 0xff);
+	}
+
+	rfb->fb_buf_idx = (rfb->fb_buf_idx + 1) % 2;
+
+	BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0x00);
+
+	BSP_LCD_SelectLayer(rfb->fb_buf_idx);
+}

--- a/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc_alpha.c
+++ b/platform/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc_alpha.c
@@ -1,0 +1,112 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date   11.08.2020
+ * @author Alexander Kalmuk
+ */
+
+#include <drivers/video/fb.h>
+#include "rawfb.h"
+
+#if defined STM32F746xx
+#include "stm32746g_discovery_lcd.h"
+#elif defined STM32F769xx
+#include "stm32f769i_discovery_lcd.h"
+#else
+#error Unsupported platform
+#endif
+
+#if defined STM32F746xx
+extern LTDC_HandleTypeDef hLtdcHandler;
+#define hltdc_handler hLtdcHandler
+#elif defined STM32F769xx
+extern LTDC_HandleTypeDef  hltdc_discovery;
+#define hltdc_handler hltdc_discovery
+#else
+#error Unsupported platform
+#endif
+
+static volatile int ltdc_li_triggered = 0;
+
+void HAL_LTDC_LineEvenCallback(LTDC_HandleTypeDef *hltdc) {
+	ltdc_li_triggered = 1;
+}
+
+static void dma2d_fill(uint32_t *dst, uint16_t xsize, uint16_t ysize, uint32_t color) {
+	DMA2D_HandleTypeDef hdma2d;
+
+	/*##-1- Configure the DMA2D Mode, Color Mode and output offset #############*/
+	hdma2d.Init.Mode          = DMA2D_R2M;
+	hdma2d.Init.ColorMode     = DMA2D_OUTPUT_ARGB8888;
+	hdma2d.Init.OutputOffset  = 0;
+#ifdef STM32F769xx
+	hdma2d.Init.AlphaInverted = DMA2D_REGULAR_ALPHA;  /* No Output Alpha Inversion*/
+	hdma2d.Init.RedBlueSwap   = DMA2D_RB_REGULAR;     /* No Output Red & Blue swap */
+#endif
+
+	/*##-2- DMA2D Callbacks Configuration ######################################*/
+	hdma2d.XferCpltCallback  = NULL;
+
+	/*##-3- Foreground Configuration ###########################################*/
+	hdma2d.LayerCfg[1].AlphaMode = DMA2D_NO_MODIF_ALPHA;
+	hdma2d.LayerCfg[1].InputAlpha = 0xFF;
+	hdma2d.LayerCfg[1].InputColorMode = DMA2D_INPUT_ARGB8888;
+	hdma2d.LayerCfg[1].InputOffset = 0;
+#ifdef STM32F769xx
+	hdma2d.LayerCfg[1].RedBlueSwap = DMA2D_RB_REGULAR; /* No ForeGround Red/Blue swap */
+	hdma2d.LayerCfg[1].AlphaInverted = DMA2D_REGULAR_ALPHA; /* No ForeGround Alpha inversion */
+#endif
+
+	hdma2d.Instance          = DMA2D;
+
+	/* DMA2D Initialization */
+	if (HAL_DMA2D_Init(&hdma2d) == HAL_OK)  {
+		if (HAL_DMA2D_ConfigLayer(&hdma2d, 1) == HAL_OK) {
+			if (HAL_DMA2D_Start(&hdma2d, color, (uint32_t)dst, xsize, ysize) == HAL_OK) {
+				/* Polling For DMA transfer */
+				HAL_DMA2D_PollForTransfer(&hdma2d, 100);
+			}
+		}
+	}
+}
+
+void rawfb_init(struct rawfb_fb_info *rfb) {
+	BSP_LCD_LayerDefaultInit(0, (unsigned int) rfb->fb_buf[0]);
+	BSP_LCD_LayerDefaultInit(1, (unsigned int) rfb->fb_buf[1]);
+
+	BSP_LCD_SelectLayer(0);
+
+	HAL_LTDC_ProgramLineEvent(&hltdc_handler, rfb->height - 1);
+}
+
+void rawfb_clear_screen(struct rawfb_fb_info *rfb) {
+	dma2d_fill(rfb->fb_buf[rfb->fb_buf_idx],
+	           rfb->width, rfb->height, rfb->clear_color);
+}
+
+void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
+	if (rfb->fb_info->var.fmt != BGRA8888) {
+		pix_fmt_convert(rfb->fb_buf[rfb->fb_buf_idx],
+						rfb->fb_info->screen_base, rfb->width * rfb->height,
+						BGRA8888, rfb->fb_info->var.fmt);
+	} else {
+		/* Here we wait for the next display refresh, and after it happened
+		 * swap buffers. */
+
+		ltdc_li_triggered = 0;
+		
+		HAL_LTDC_ProgramLineEvent(&hltdc_handler, rfb->height - 1);
+
+		while (!ltdc_li_triggered) {
+		}
+
+		BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0xff);
+	}
+
+	rfb->fb_buf_idx = (rfb->fb_buf_idx + 1) % 2;
+
+	BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0x00);
+
+	BSP_LCD_SelectLayer(rfb->fb_buf_idx);
+}

--- a/platform/nuklear/templates/stm32f746g-discovery/mods.conf
+++ b/platform/nuklear/templates/stm32f746g-discovery/mods.conf
@@ -3,7 +3,7 @@ package genconfig
 configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
-	@Runlevel(0) include third_party.bsp.stmf7cube.arch
+	@Runlevel(0) include third_party.bsp.stmf7cube.arch(enable_cpu_cache=true)
 	include third_party.bsp.stmf7cube.sdram(fmc_swap=true)
 	include embox.arch.arm.vfork
 
@@ -13,11 +13,10 @@ configuration conf {
 	@Runlevel(0) include embox.arch.arm.fpu.cortex_m7_fp
 	@Runlevel(0) include embox.arch.arm.fpu.fpv5(log_level=1)
 
-	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic
 	@Runlevel(1) include embox.driver.clock.cortexm_systick
 	@Runlevel(1) include embox.driver.serial.stm_usart_f7(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
-	@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
 
 	include embox.kernel.task.multi
@@ -25,6 +24,8 @@ configuration conf {
 
 	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, bpp=32)
 	@Runlevel(2) include embox.driver.input.touchscreen.stm32f7cube_ts
+
+	@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
 
 	include embox.cmd.hw.input
 	include embox.cmd.testing.input.touchscreen_test
@@ -61,7 +62,7 @@ configuration conf {
 	include embox.cmd.sys.version
 	include embox.util.log
 	include embox.kernel.critical
-	include embox.kernel.irq
+	include embox.kernel.irq_static
 	include embox.mem.pool_adapter
 
 	include embox.util.LibUtil
@@ -93,7 +94,7 @@ configuration conf {
 
 	include embox.cmd.grfxs.grfx_canvas
 	include embox.cmd.grfxs.grfx_skinning
-	include embox.cmd.grfxs.grfx_rawfb
+	include embox.cmd.grfxs.grfx_rawfb(use_dma=false)
 
 	include embox.compat.libc.math_openlibm
 }

--- a/platform/nuklear/templates/stm32f746g-discovery/mods.conf
+++ b/platform/nuklear/templates/stm32f746g-discovery/mods.conf
@@ -22,7 +22,7 @@ configuration conf {
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=10)
 
-	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, bpp=32)
+	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, ltdc_irq=88, bpp=32)
 	@Runlevel(2) include embox.driver.input.touchscreen.stm32f7cube_ts
 
 	@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
@@ -94,7 +94,9 @@ configuration conf {
 
 	include embox.cmd.grfxs.grfx_canvas
 	include embox.cmd.grfxs.grfx_skinning
-	include embox.cmd.grfxs.grfx_rawfb(use_dma=false)
+
+	include embox.cmd.grfxs.grfx_rawfb
+	include embox.cmd.grfxs.rawfb_stm32_ltdc
 
 	include embox.compat.libc.math_openlibm
 }

--- a/platform/nuklear/templates/stm32f746g-discovery/mods.conf
+++ b/platform/nuklear/templates/stm32f746g-discovery/mods.conf
@@ -25,7 +25,7 @@ configuration conf {
 	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, ltdc_irq=88, bpp=32)
 	@Runlevel(2) include embox.driver.input.touchscreen.stm32f7cube_ts
 
-	@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
+	//@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
 
 	include embox.cmd.hw.input
 	include embox.cmd.testing.input.touchscreen_test
@@ -96,7 +96,7 @@ configuration conf {
 	include embox.cmd.grfxs.grfx_skinning
 
 	include embox.cmd.grfxs.grfx_rawfb
-	include embox.cmd.grfxs.rawfb_stm32_ltdc
+	include embox.cmd.grfxs.rawfb_stm32_ltdc_alpha
 
 	include embox.compat.libc.math_openlibm
 }

--- a/platform/nuklear/templates/stm32f746g-discovery/start_script.inc
+++ b/platform/nuklear/templates/stm32f746g-discovery/start_script.inc
@@ -1,0 +1,1 @@
+"grfx_rawfb stm32-ts",

--- a/platform/nuklear/templates/stm32f769i-discovery/mods.conf
+++ b/platform/nuklear/templates/stm32f769i-discovery/mods.conf
@@ -18,7 +18,7 @@ configuration conf {
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=10)
 
-	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, bpp=32)
+	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, ltdc_irq=88, bpp=32)
 	@Runlevel(2) include embox.driver.input.touchscreen.stm32f7cube_ts
 
 	@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
@@ -87,6 +87,9 @@ configuration conf {
 	include embox.cmd.grfxs.grfx_canvas
 	include embox.cmd.grfxs.grfx_skinning
 	include embox.cmd.grfxs.grfx_rawfb(use_dma=false)
+
+	include embox.cmd.grfxs.grfx_rawfb
+	include embox.cmd.grfxs.rawfb_stm32_ltdc
 
 	include third_party.bsp.stm32f769i_cube.stm32f7_discovery_bsp
 	include third_party.bsp.stmf7cube.cmsis

--- a/platform/nuklear/templates/stm32f769i-discovery/mods.conf
+++ b/platform/nuklear/templates/stm32f769i-discovery/mods.conf
@@ -3,17 +3,16 @@ package genconfig
 configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
-	@Runlevel(0) include third_party.bsp.stmf7cube.arch
+	@Runlevel(0) include third_party.bsp.stmf7cube.arch(enable_cpu_cache=true)
 	include third_party.bsp.stmf7cube.sdram(fmc_swap=true)
 	include embox.arch.arm.vfork
 
 	@Runlevel(0) include embox.kernel.stack(stack_size=16384,alignment=4)
 
-	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=128)
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic
 	@Runlevel(1) include embox.driver.clock.cortexm_systick
 	@Runlevel(1) include embox.driver.serial.stm_usart_f7(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
-	@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
 
 	include embox.kernel.task.multi
@@ -21,6 +20,8 @@ configuration conf {
 
 	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, bpp=32)
 	@Runlevel(2) include embox.driver.input.touchscreen.stm32f7cube_ts
+
+	@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
 
 	include embox.cmd.hw.input
 	include embox.cmd.testing.input.touchscreen_test
@@ -57,7 +58,7 @@ configuration conf {
 	include embox.cmd.sys.version
 	include embox.util.log
 	include embox.kernel.critical
-	include embox.kernel.irq
+	include embox.kernel.irq_static
 	include embox.mem.pool_adapter
 
 	include embox.util.LibUtil
@@ -85,7 +86,7 @@ configuration conf {
 
 	include embox.cmd.grfxs.grfx_canvas
 	include embox.cmd.grfxs.grfx_skinning
-	include embox.cmd.grfxs.grfx_rawfb
+	include embox.cmd.grfxs.grfx_rawfb(use_dma=false)
 
 	include third_party.bsp.stm32f769i_cube.stm32f7_discovery_bsp
 	include third_party.bsp.stmf7cube.cmsis

--- a/platform/nuklear/templates/stm32f769i-discovery/mods.conf
+++ b/platform/nuklear/templates/stm32f769i-discovery/mods.conf
@@ -18,10 +18,12 @@ configuration conf {
 	include embox.kernel.task.multi
 	include embox.kernel.task.resource.idesc_table(idesc_table_size=10)
 
-	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000, ltdc_irq=88, bpp=32)
+	@Runlevel(1) include embox.driver.video.stm32f7_lcd(
+		fb_base=0x60000000, width=800, height=480, ltdc_irq=88, bpp=32
+	)
 	@Runlevel(2) include embox.driver.input.touchscreen.stm32f7cube_ts
 
-	@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
+	//@Runlevel(2) include embox.driver.dma.stm32f7_dma(dma2_stream0_irq=56, log_level=1)
 
 	include embox.cmd.hw.input
 	include embox.cmd.testing.input.touchscreen_test
@@ -86,7 +88,6 @@ configuration conf {
 
 	include embox.cmd.grfxs.grfx_canvas
 	include embox.cmd.grfxs.grfx_skinning
-	include embox.cmd.grfxs.grfx_rawfb(use_dma=false)
 
 	include embox.cmd.grfxs.grfx_rawfb
 	include embox.cmd.grfxs.rawfb_stm32_ltdc

--- a/platform/nuklear/templates/stm32f769i-discovery/start_script.inc
+++ b/platform/nuklear/templates/stm32f769i-discovery/start_script.inc
@@ -1,0 +1,1 @@
+"grfx_rawfb stm32-ts",

--- a/platform/nuklear/templates/x86_qemu/mods.conf
+++ b/platform/nuklear/templates/x86_qemu/mods.conf
@@ -136,5 +136,7 @@ configuration conf {
 
 	include embox.cmd.grfxs.grfx_canvas
 	include embox.cmd.grfxs.grfx_skinning
+
 	include embox.cmd.grfxs.grfx_rawfb
+	include embox.cmd.grfxs.rawfb_memcpy
 }

--- a/src/drivers/dma/Mybuild
+++ b/src/drivers/dma/Mybuild
@@ -1,0 +1,6 @@
+package embox.driver.dma
+
+abstract module dma_api {
+	@IncludeExport(path="drivers/dma")
+	source "dma.h"
+}

--- a/src/drivers/dma/dma.h
+++ b/src/drivers/dma/dma.h
@@ -1,0 +1,18 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    26.07.2020
+ * @author  Alexander Kalmuk
+ */
+
+#ifndef DRIVERS_DMA_DMA_H_
+#define DRIVERS_DMA_DMA_H_
+
+#include <stdint.h>
+
+extern int dma_config(int dma_chan);
+extern int dma_transfer(int dma_chan, uint32_t dst, uint32_t src, int words);
+extern int dma_in_progress(int dma_chan);
+
+#endif /* DRIVERS_DMA_DMA_H_ */

--- a/src/drivers/dma/stm32_cube/Mybuild
+++ b/src/drivers/dma/stm32_cube/Mybuild
@@ -1,0 +1,12 @@
+package embox.driver.dma
+
+@BuildDepends(third_party.bsp.st_bsp_api)
+module stm32f7_dma extends dma_api {
+	option number dma2_stream0_irq
+
+	option number log_level = 1
+
+	source "stm32f7_dma.c"
+
+	@NoRuntime depends third_party.bsp.st_bsp_api
+}

--- a/src/drivers/dma/stm32_cube/stm32f7_dma.c
+++ b/src/drivers/dma/stm32_cube/stm32f7_dma.c
@@ -1,0 +1,132 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    26.07.2020
+ * @author  Alexander Kalmuk
+ */
+
+#include <string.h>
+#include <assert.h>
+#include <util/log.h>
+#include <kernel/irq.h>
+#include <embox/unit.h>
+#include <framework/mod/options.h>
+#include <drivers/dma/dma.h>
+
+#include <stm32f7xx_hal.h>
+#include <stm32f7xx_hal_dma.h>
+
+EMBOX_UNIT_INIT(dma_init);
+
+#define DMA_MAX_SIZE (64 * 1024 - 1)
+
+#define DMA2_STREAM0_IRQ   OPTION_GET(NUMBER, dma2_stream0_irq)
+static_assert(DMA2_STREAM0_IRQ == DMA2_Stream0_IRQn);
+
+static DMA_HandleTypeDef dma_handle;
+
+static uint32_t dma_dst, dma_src;
+static unsigned dma_words;
+
+static irq_return_t dma2_stream0_irq_handler(unsigned int irq_num, void *dev_id) {
+	HAL_DMA_IRQHandler(&dma_handle);
+
+	return IRQ_HANDLED;
+}
+STATIC_IRQ_ATTACH(DMA2_STREAM0_IRQ, dma2_stream0_irq_handler, NULL);
+
+static void dma_xfer_complete(DMA_HandleTypeDef *hdma) {
+	int words;
+
+	(void) hdma;
+
+	if (dma_words <= DMA_MAX_SIZE) {
+		dma_words = 0;
+		return;
+	}
+
+	dma_words -= DMA_MAX_SIZE;
+	dma_dst += DMA_MAX_SIZE * 4;
+	dma_src += DMA_MAX_SIZE * 4;
+
+	words = dma_words > DMA_MAX_SIZE ? DMA_MAX_SIZE : dma_words;
+
+	if (HAL_DMA_Start_IT(&dma_handle, dma_src, dma_dst, words) != HAL_OK) {
+		log_error("HAL_DMA_Start_IT error!");
+	}
+}
+
+int dma_in_progress(int dma_chan) {
+	assert(dma_chan == 0);
+
+	return (HAL_DMA_GetState(&dma_handle) != HAL_DMA_STATE_READY);
+}
+
+static void dma_init_chan(DMA_HandleTypeDef *dma_handle, int chan) {
+	dma_handle->Init.Direction = DMA_MEMORY_TO_MEMORY;
+	dma_handle->Init.PeriphInc = DMA_PINC_ENABLE;
+	dma_handle->Init.MemInc = DMA_MINC_ENABLE;
+	dma_handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
+	dma_handle->Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
+	dma_handle->Init.Mode = DMA_NORMAL;
+	dma_handle->Init.Priority = DMA_PRIORITY_HIGH;
+	dma_handle->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
+	dma_handle->Init.FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
+	dma_handle->Init.MemBurst = DMA_MBURST_SINGLE;
+	dma_handle->Init.PeriphBurst = DMA_PBURST_SINGLE;
+
+	dma_handle->Init.Channel = chan;
+}
+
+int dma_config(int dma_chan) {
+	assert(dma_chan == 0);
+
+	__HAL_RCC_DMA2_CLK_ENABLE();
+
+	dma_init_chan(&dma_handle, dma_chan);
+
+	dma_handle.Instance = DMA2_Stream0;
+	if (HAL_DMA_Init(&dma_handle) != HAL_OK) {
+		log_error("DMA init failed");
+		return -1;
+	}
+	HAL_DMA_RegisterCallback(&dma_handle, HAL_DMA_XFER_CPLT_CB_ID,
+			dma_xfer_complete);
+
+	return 0;
+}
+
+int dma_transfer(int dma_chan, uint32_t dst, uint32_t src, int words) {
+	assert(dma_chan == 0);
+
+	log_debug("chan=%d, dst=0x%08x, src=0x%08x, words=%d",
+		dma_chan, dst, src, words);
+
+	dma_dst = dst;
+	dma_src = src;
+	dma_words = words;
+
+	if (words > DMA_MAX_SIZE) {
+		words = DMA_MAX_SIZE;
+	}
+
+	if (HAL_DMA_Start_IT(&dma_handle, src, dst, words) != HAL_OK) {
+		log_error("HAL_DMA_Start_IT error!");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int dma_init(void) {
+	int ret = 0;
+
+	ret = irq_attach(DMA2_STREAM0_IRQ, dma2_stream0_irq_handler,
+			0, NULL, "dma2_stream0");
+	if (ret < 0) {
+		log_error("irq_attach failed\n");
+	}
+
+	return ret;
+}

--- a/src/drivers/video/stm32f7_lcd/Mybuild
+++ b/src/drivers/video/stm32f7_lcd/Mybuild
@@ -2,7 +2,10 @@ package embox.driver.video
 
 @BuildDepends(third_party.bsp.st_bsp_api)
 module stm32f7_lcd {
+	option number log_level=1
+
 	option number fb_base = 0xc0000000
+	option number ltdc_irq = 88
 	option number height = 272
 	option number width = 480
 	option number bpp = 32

--- a/src/drivers/video/stm32f7_lcd/stm32f7_lcd.c
+++ b/src/drivers/video/stm32f7_lcd/stm32f7_lcd.c
@@ -115,9 +115,17 @@ static void stm32f7_lcd_imageblit(struct fb_info *info,
 }
 
 static irq_return_t ltdc_irq_handler(unsigned int irq_num, void *dev_id) {
-	extern LTDC_HandleTypeDef hLtdcHandler;
+#if defined STM32F746xx
+extern LTDC_HandleTypeDef hLtdcHandler;
+#define hltdc_handler hLtdcHandler
+#elif defined STM32F769xx
+extern LTDC_HandleTypeDef  hltdc_discovery;
+#define hltdc_handler hltdc_discovery
+#else
+#error Unsupported platform
+#endif
 
-	HAL_LTDC_IRQHandler(&hLtdcHandler);
+	HAL_LTDC_IRQHandler(&hltdc_handler);
 
 	return IRQ_HANDLED;
 }

--- a/src/drivers/video/stm32f7_lcd/stm32f7_lcd.c
+++ b/src/drivers/video/stm32f7_lcd/stm32f7_lcd.c
@@ -24,11 +24,14 @@
 #include "stm32f769i_discovery_lcd.h"
 /* This macro is not defined for STM32F769I, but it still
  * works just fine with the same numeric constatnt */
-#define LTDC_ACTIVE_LAYER 1
 void     BSP_LCD_LayerRgb565Init(uint16_t LayerIndex, uint32_t FB_Address);
 #else
 #error Unsupported platform
 #endif
+
+/* Initialize layer 0 as active for all F7 boards. */
+#undef LTDC_ACTIVE_LAYER
+#define LTDC_ACTIVE_LAYER 0
 
 #include <embox/unit.h>
 EMBOX_UNIT_INIT(stm32f7_lcd_init);

--- a/templates/arm/qt-stm32f7discovery/board.conf.h
+++ b/templates/arm/qt-stm32f7discovery/board.conf.h
@@ -1,0 +1,7 @@
+#include <stm32f746g_discovery.conf.h>
+
+CONFIG {
+	uarts[1].status = ENABLED;
+	uarts[2].status = DISABLED;
+	uarts[6].status = DISABLED;
+}

--- a/third-party/bsp/stmf7cube/Mybuild
+++ b/third-party/bsp/stmf7cube/Mybuild
@@ -15,6 +15,8 @@ abstract module stm32f7_discovery_bsp {
 
 @BuildDepends(third_party.bsp.stmf7cube.cube)
 module arch extends embox.arch.arch {
+	option boolean enable_cpu_cache = false
+
 	source "arch.c"
 
 	depends third_party.bsp.stmf7cube.cube

--- a/third-party/bsp/stmf7cube/arch.c
+++ b/third-party/bsp/stmf7cube/arch.c
@@ -29,6 +29,11 @@
 #include <framework/mod/options.h>
 #include <module/embox/arch/system.h>
 
+#define ENABLE_CPU_CACHE   OPTION_GET(BOOLEAN, enable_cpu_cache)
+
+#define SRAM1_START        0x20010000
+#define SDRAM_START        0x60000000
+
 static void SystemClock_Config(void)
 {
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -69,10 +74,63 @@ static void SystemClock_Config(void)
   }
 }
 
+#if ENABLE_CPU_CACHE
+static void cpu_cache_enable(void) {
+	SCB_EnableICache();
+	SCB_EnableDCache();
+}
+
+/*
+ * TODO We should avoid using WT mode if it's possible:
+ *
+ * Certain Cortex-M7 revisions have errata related to the use of write-through cache -
+ * https://static.docs.arm.com/epm064408/80/Cortex-M7_Software_Developers_Errata_Notice_v8.pdf#page=11
+ **/
+static void mpu_config(void) {
+	MPU_Region_InitTypeDef MPU_InitStruct;
+
+	/* Disable the MPU */
+	HAL_MPU_Disable();
+
+	/* Write Through mode */
+	MPU_InitStruct.Enable = MPU_REGION_ENABLE;
+	MPU_InitStruct.AccessPermission = MPU_REGION_FULL_ACCESS;
+	MPU_InitStruct.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;
+	MPU_InitStruct.IsCacheable = MPU_ACCESS_CACHEABLE;
+	MPU_InitStruct.IsShareable = MPU_ACCESS_NOT_SHAREABLE;
+	MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
+	MPU_InitStruct.SubRegionDisable = 0x00;
+	MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_ENABLE;
+
+	/* Configure the MPU attributes as WT for SRAM
+	 * The Base Address is 0x20010000 since this memory interface is the AXI.
+	 * The Region Size is 256KB, it is related to SRAM1 and SRAM2  memory size.
+	 */
+	MPU_InitStruct.Number = MPU_REGION_NUMBER1;
+	MPU_InitStruct.BaseAddress = SRAM1_START;
+	MPU_InitStruct.Size = MPU_REGION_SIZE_256KB;
+	HAL_MPU_ConfigRegion(&MPU_InitStruct);
+
+	/* SDRAM */
+	MPU_InitStruct.Number = MPU_REGION_NUMBER2;
+	MPU_InitStruct.BaseAddress = SDRAM_START;
+	MPU_InitStruct.Size = MPU_REGION_SIZE_8MB;
+	HAL_MPU_ConfigRegion(&MPU_InitStruct);
+
+	/* Enable the MPU */
+	HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
+}
+#endif
+
 void arch_init(void) {
 	ipl_t ipl = ipl_save();
 
 	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 216000000);
+
+#if ENABLE_CPU_CACHE
+	mpu_config();
+	cpu_cache_enable();
+#endif
 
 	SystemInit();
 	HAL_Init();

--- a/third-party/ntfs-3g/Makefile
+++ b/third-party/ntfs-3g/Makefile
@@ -2,7 +2,9 @@
 PKG_NAME := ntfs-3g_ntfsprogs
 PKG_VER  := 2013.1.13
 
-PKG_SOURCES := http://tuxera.com/opensource/$(PKG_NAME)-$(PKG_VER).tgz
+PKG_SOURCES := http://tuxera.com/opensource/$(PKG_NAME)-$(PKG_VER).tgz \
+               http://ftp.osuosl.org/pub/blfs/conglomeration/ntfs-3g/$(PKG_NAME)-$(PKG_VER).tgz
+
 PKG_MD5     := 2d6fb47ddf62b51733227126fe9227fe
 
 PKG_PATCHES := patch.txt


### PR DESCRIPTION
Apply double buffering and LTDC features to optimize Nuklear rawfb example on stm32f7 up to 60 FPS.