### PR TITLE
ARMv7-M cpu cache enable

### DIFF
--- a/project/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
+++ b/project/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc.c
@@ -69,6 +69,8 @@ static void dma2d_fill(uint32_t *dst, uint16_t xsize, uint16_t ysize, uint32_t c
 			}
 		}
 	}
+
+	SCB_InvalidateDCache();
 }
 
 void rawfb_init(struct rawfb_fb_info *rfb) {
@@ -97,6 +99,8 @@ void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
 
 		while (!ltdc_li_triggered) {
 		}
+
+		SCB_CleanDCache();
 
 		LTDC_LAYER(&hltdc_handler, 0)->CFBAR = ((uint32_t)rfb->fb_buf[rfb->fb_buf_idx]);
 		__HAL_LTDC_RELOAD_CONFIG(&hltdc_handler);

--- a/project/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc_alpha.c
+++ b/project/nuklear/cmd/grfx_rawfb/rawfb_stm32_ltdc_alpha.c
@@ -69,6 +69,8 @@ static void dma2d_fill(uint32_t *dst, uint16_t xsize, uint16_t ysize, uint32_t c
 			}
 		}
 	}
+
+	SCB_InvalidateDCache();
 }
 
 void rawfb_init(struct rawfb_fb_info *rfb) {
@@ -100,6 +102,8 @@ void rawfb_swap_buffers(struct rawfb_fb_info *rfb) {
 
 		while (!ltdc_li_triggered) {
 		}
+
+		SCB_CleanDCache();
 
 		BSP_LCD_SetTransparency(rfb->fb_buf_idx, 0xff);
 	}

--- a/project/nuklear/templates/stm32f746g-discovery/mods.conf
+++ b/project/nuklear/templates/stm32f746g-discovery/mods.conf
@@ -3,7 +3,8 @@ package genconfig
 configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
-	@Runlevel(0) include third_party.bsp.stmf7cube.arch(enable_cpu_cache=true)
+	@Runlevel(0) include third_party.bsp.stmf7cube.arch
+	@Runlevel(0) include embox.arch.arm.armmlib.armv7m_cpu_cache
 	include third_party.bsp.stmf7cube.sdram(fmc_swap=true)
 	include embox.arch.arm.vfork
 

--- a/project/nuklear/templates/stm32f769i-discovery/mods.conf
+++ b/project/nuklear/templates/stm32f769i-discovery/mods.conf
@@ -3,7 +3,8 @@ package genconfig
 configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
-	@Runlevel(0) include third_party.bsp.stmf7cube.arch(enable_cpu_cache=true)
+	@Runlevel(0) include third_party.bsp.stmf7cube.arch
+	@Runlevel(0) include embox.arch.arm.armmlib.armv7m_cpu_cache
 	include third_party.bsp.stmf7cube.sdram(fmc_swap=true)
 	include embox.arch.arm.vfork
 

--- a/src/arch/arm/armmlib/cpu_cache/Mybuild
+++ b/src/arch/arm/armmlib/cpu_cache/Mybuild
@@ -12,7 +12,13 @@ module cpu_cache_none extends cpu_cache_api {
 
 module armv7m_cpu_cache extends cpu_cache_api {
 	option number log_level = 1
+
 	option number sram_nocache_section_size = 0x0
+
+	option number nocache_region0_addr = 0x0
+	option number nocache_region0_size = 0x0
+	option number nocache_region1_addr = 0x0
+	option number nocache_region1_size = 0x0
 
 	source "armv7m_cpu_cache.c"
 	source "mpu_nocache_regions.lds.S"

--- a/src/arch/arm/armmlib/cpu_cache/Mybuild
+++ b/src/arch/arm/armmlib/cpu_cache/Mybuild
@@ -1,0 +1,22 @@
+package embox.arch.arm.armmlib
+
+@DefaultImpl(cpu_cache_none)
+abstract module cpu_cache_api {
+
+}
+
+module cpu_cache_none extends cpu_cache_api {
+	@IncludeExport(path="arm", target_name="cpu_cache.h")
+	source "cpu_cache_none.h"
+}
+
+module armv7m_cpu_cache extends cpu_cache_api {
+	option number log_level = 1
+	option number sram_nocache_section_size = 0x0
+
+	source "armv7m_cpu_cache.c"
+	source "mpu_nocache_regions.lds.S"
+
+	@IncludeExport(path="arm", target_name="cpu_cache.h")
+	source "cpu_cache.h"
+}

--- a/src/arch/arm/armmlib/cpu_cache/armv7m_cpu_cache.c
+++ b/src/arch/arm/armmlib/cpu_cache/armv7m_cpu_cache.c
@@ -1,0 +1,118 @@
+/**
+ * @file
+ * @brief Enables I-Cache and D-Cache for ARMv7-M.
+ *
+ * @date    26.08.2020
+ * @author  Alexander Kalmuk
+ */
+
+#include <stdint.h>
+#include <assert.h>
+#include <util/log.h>
+#include <hal/reg.h>
+#include <embox/unit.h>
+#include <asm/arm_m_regs.h>
+
+EMBOX_UNIT_INIT(arm_cpu_cache_init);
+
+#define SCB_CCSIDR_SETS(ccsidr) \
+	(((ccsidr) >> SCB_CCSIDR_SETS_POS) & SCB_CCSIDR_SETS_MASK)
+
+#define SCB_CCSIDR_WAYS(ccsidr) \
+	(((ccsidr) >> SCB_CCSIDR_WAYS_POS) & SCB_CCSIDR_WAYS_MASK)
+
+extern char _sram_nocache_start;
+extern char _sram_nocache_size;
+extern char _sram_nocache_log_size;
+
+static inline void arm_mpu_disable(void) {
+	dsb();
+
+	REG64_CLEAR(SCB_SHCSR, SCB_SHCSR_MEMFAULTENA);
+
+	REG32_STORE(MPU_CTRL, 0);
+}
+
+static inline void arm_mpu_enable(void) {
+	REG32_STORE(MPU_CTRL, MPU_CTRL_PRIVDEFENA | MPU_CTRL_ENABLE);
+
+	REG64_ORIN(SCB_SHCSR, SCB_SHCSR_MEMFAULTENA);
+
+	dsb();
+	isb();
+}
+
+static void arm_mpu_configure(int region, uint32_t base_addr,
+		uint32_t log_size, uint32_t attrs) {
+	REG32_STORE(MPU_RNR, region);
+	REG32_STORE(MPU_RBAR, base_addr);
+	REG32_STORE(MPU_RASR, attrs | ((log_size - 1) << MPU_RASR_SIZE_POS));
+}
+
+static void arm_mpu_init_nocache_regions(void) {
+	uint32_t sram_nocache_start = (uint32_t) &_sram_nocache_start;
+	uint32_t sram_nocache_size = (uint32_t) &_sram_nocache_size;
+	uint32_t sram_nocache_log_size = (uint32_t) &_sram_nocache_log_size;
+	unsigned region = 0;
+
+	arm_mpu_disable();
+
+	if (sram_nocache_size > 0) {
+		log_debug("\nSRAM non-cacheble: start=0x%08x, region size=0x%x (bytes)",
+			sram_nocache_start, sram_nocache_size);
+
+		/* Non-cacheable region with full read/write access */
+		arm_mpu_configure(region++, sram_nocache_start, sram_nocache_log_size,
+			(1 << MPU_RASR_ENABLE_POS) | (0x3 << MPU_RASR_AP_POS));
+	}
+
+	arm_mpu_enable();
+}
+
+static void arm_cpu_icache_enable(void) {
+	dsb();
+	isb();
+
+	/* Invalidate I-Cache */
+	REG32_STORE(SCB_ICIALLU, 0);
+	/* Enable I-Cache */
+	REG32_ORIN(SCB_CCR, SCB_CCR_IC);
+
+	dsb();
+	isb();
+}
+
+static void arm_cpu_dcache_enable(void) {
+	uint32_t ccsidr, sets, ways;
+
+	/* Level 1 data cache */
+	REG32_STORE(SCB_CSSELR, (0U << 1U) | 0U);
+	dsb();
+
+	ccsidr = REG32_LOAD(SCB_CCSIDR);
+
+	/* Invalidate D-Cache */
+	sets = SCB_CCSIDR_SETS(ccsidr);
+	do {
+		ways = SCB_CCSIDR_WAYS(ccsidr);
+		do {
+			REG32_STORE(SCB_DCISW, (sets << SCB_DCISW_SET_POS) |
+	                               (ways << SCB_DCISW_WAY_POS));
+		} while (ways--);
+	} while (sets--);
+	dsb();
+
+	REG32_ORIN(SCB_CCR, SCB_CCR_DC);
+
+	dsb();
+	isb();
+}
+
+static int arm_cpu_cache_init(void) {
+	arm_mpu_init_nocache_regions();
+
+	arm_cpu_icache_enable();
+	arm_cpu_dcache_enable();
+
+	return 0;
+}

--- a/src/arch/arm/armmlib/cpu_cache/cpu_cache.h
+++ b/src/arch/arm/armmlib/cpu_cache/cpu_cache.h
@@ -1,0 +1,15 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    26.08.2020
+ * @author  Alexander Kalmuk
+ */
+
+#ifndef ARCH_ARM_ARMMLIB_CPU_CACHE_H_
+#define ARCH_ARM_ARMMLIB_CPU_CACHE_H_
+
+#define SRAM_NOCACHE_SECTION \
+	__attribute__ ((section(".bss.sram_nocache")))
+
+#endif /* ARCH_ARM_ARMMLIB_CPU_CACHE_H_ */

--- a/src/arch/arm/armmlib/cpu_cache/cpu_cache_none.h
+++ b/src/arch/arm/armmlib/cpu_cache/cpu_cache_none.h
@@ -1,0 +1,14 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    26.08.2020
+ * @author  Alexander Kalmuk
+ */
+
+#ifndef ARCH_ARM_ARMMLIB_CPU_CACHE_NONE_H_
+#define ARCH_ARM_ARMMLIB_CPU_CACHE_NONE_H_
+
+#define SRAM_NOCACHE_SECTION
+
+#endif /* ARCH_ARM_ARMMLIB_CPU_NOCACHE_NONE_H_ */

--- a/src/arch/arm/armmlib/cpu_cache/mpu_nocache_regions.lds.S
+++ b/src/arch/arm/armmlib/cpu_cache/mpu_nocache_regions.lds.S
@@ -1,0 +1,29 @@
+#include <arm/cpu_cache.h>
+#include <framework/mod/options.h>
+
+#define SRAM_NOCACHE_SIZE OPTION_GET(NUMBER, sram_nocache_section_size)
+
+SECTIONS {
+	/* MPU region must be aligned to its own size */
+	.bss.sram_nocache : ALIGN(SRAM_NOCACHE_SIZE) {
+		_sram_nocache_start = .;
+		*(.bss.sram_nocache)
+		*(.bss.sram_nocache*)
+		. = ALIGN(SRAM_NOCACHE_SIZE);
+		_sram_nocache_end = .;
+
+		/* Each MPU region size must be always aligned to power of 2 */
+		ASSERT((0 == SRAM_NOCACHE_SIZE) || \
+	           (SRAM_NOCACHE_SIZE == (1 << LOG2CEIL(SRAM_NOCACHE_SIZE))),
+		       "Error: sram_nocache_section_size is not a power of 2.
+		        Please change it in mods.conf");
+
+		/* This oveflow check is used due to non-usual section alignment to its
+		 * own size. */
+		ASSERT((0 == _sram_nocache_size) || (SRAM_NOCACHE_SIZE == _sram_nocache_size),
+		       "Error: sram_nocache_section_size overflow.
+		        Please increase it in mods.conf");
+	}
+	_sram_nocache_size = _sram_nocache_end - _sram_nocache_start;
+	_sram_nocache_log_size = LOG2CEIL(_sram_nocache_size);
+}

--- a/src/arch/arm/cortexm3/Mybuild
+++ b/src/arch/arm/cortexm3/Mybuild
@@ -5,5 +5,6 @@ module bundle {
 	depends embox.arch.arm.armmlib.locore
 	depends embox.arch.arm.armmlib.interrupt
 	depends embox.arch.arm.armmlib.context
+	depends embox.arch.arm.armmlib.cpu_cache_api
 }
 

--- a/src/arch/arm/include/asm/arm_m_regs.h
+++ b/src/arch/arm/include/asm/arm_m_regs.h
@@ -8,8 +8,11 @@
 #ifndef ARCH_ARM_ASM_ARM_M_REGS_H_
 #define ARCH_ARM_ASM_ARM_M_REGS_H_
 
-/* System Control Block */
-#define ARM_M_SCB_BASE              0xe000ed00
+#define ARM_M_SCS_BASE              0xe000e000
+
+/************ System Control Block registers (SCB) ************/
+
+#define ARM_M_SCB_BASE              (ARM_M_SCS_BASE + 0xd00)
 
 #define SCB_ICSR                    (ARM_M_SCB_BASE + 0x04)
 # define SCB_ICSR_RETTOBASE         (1 << 11)
@@ -17,6 +20,15 @@
 
 #define SCB_VTOR                    (ARM_M_SCB_BASE + 0x08)
 # define SCB_VTOR_IN_RAM            (1 << 29)
+
+/* Configuration Control Register */
+#define SCB_CCR                     (ARM_M_SCB_BASE + 0x14)
+# define SCB_CCR_IC                 (1 << 17) /* I-cache enable */
+# define SCB_CCR_DC                 (1 << 16) /* D-cache enable */
+
+/* System Handler Control and State Register */
+#define SCB_SHCSR                   (ARM_M_SCB_BASE + 0x24)
+# define SCB_SHCSR_MEMFAULTENA      (1 << 16)
 
 #define SCB_MEM_FAULT_STATUS        (ARM_M_SCB_BASE + 0x28)
 # define SCB_MEM_FAULT_MMARVALID    (1 << 7)
@@ -28,5 +40,51 @@
 #define SCB_HARD_FAULT_STATUS       (ARM_M_SCB_BASE + 0x2C)
 #define SCB_MEM_FAULT_ADDRESS       (ARM_M_SCB_BASE + 0x34)
 #define SCB_BUS_FAULT_ADDRESS       (ARM_M_SCB_BASE + 0x38)
+
+/* Cache Size ID Register */
+#define SCB_CCSIDR                  (ARM_M_SCB_BASE + 0x80)
+# define SCB_CCSIDR_SETS_POS        13
+# define SCB_CCSIDR_SETS_MASK       0x7fff
+# define SCB_CCSIDR_WAYS_POS        3
+# define SCB_CCSIDR_WAYS_MASK       0x3ff
+/* Cache Size Selection Register */
+#define SCB_CSSELR                  (ARM_M_SCB_BASE + 0x84)
+/* I-Cache Invalidate All to PoU */
+#define SCB_ICIALLU                 (ARM_M_SCB_BASE + 0x250)
+/* D-Cache Invalidate by Set-way */
+#define SCB_DCISW                   (ARM_M_SCB_BASE + 0x260)
+# define SCB_DCISW_WAY_POS          30
+# define SCB_DCISW_SET_POS          5
+
+/************ MPU registers ************/
+#define ARM_M_MPU_BASE              (ARM_M_SCS_BASE + 0xd90)
+
+#define MPU_TYPE                    (ARM_M_MPU_BASE + 0x00)
+
+#define MPU_CTRL                    (ARM_M_MPU_BASE + 0x04)
+# define MPU_CTRL_PRIVDEFENA        (1 << 2)
+# define MPU_CTRL_HFNMIENA          (1 << 1)
+# define MPU_CTRL_ENABLE            (1 << 0)
+
+#define MPU_RNR                     (ARM_M_MPU_BASE + 0x08)
+
+#define MPU_RBAR                    (ARM_M_MPU_BASE + 0x0C)
+
+#define MPU_RASR                    (ARM_M_MPU_BASE + 0x10)
+# define MPU_RASR_XN_POS            28
+# define MPU_RASR_AP_POS            24
+# define MPU_RASR_TEX_POS           19
+# define MPU_RASR_S_POS             18
+# define MPU_RASR_C_POS             17
+# define MPU_RASR_B_POS             16
+# define MPU_RASR_SRD_POS           8
+# define MPU_RASR_SIZE_POS          1
+# define MPU_RASR_ENABLE_POS        0
+
+#define isb() \
+	__asm__ volatile ("isb")
+
+#define dsb() \
+	__asm__ volatile ("dsb")
 
 #endif /* ARCH_ARM_ASM_ARM_M_REGS_H_ */

--- a/templates/arm/stm32f746g-discovery/mods.conf
+++ b/templates/arm/stm32f746g-discovery/mods.conf
@@ -5,6 +5,15 @@ configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
 	@Runlevel(0) include third_party.bsp.stmf7cube.arch
+	/* Can be enabled after SD card will be fixed. Currently it uses DMA
+	 * and may become broken. */
+	/*
+	@Runlevel(0) include embox.arch.arm.armmlib.armv7m_cpu_cache(
+		log_level=4,
+		sram_nocache_section_size=0x4000,
+		nocache_region0_addr=0x60000000, nocache_region0_size=0x00100000
+	)
+	*/
 	include embox.arch.arm.vfork
 
 	@Runlevel(0) include embox.kernel.stack(stack_size=8192,alignment=4)

--- a/templates/arm/stm32f769i-discovery/mods.conf
+++ b/templates/arm/stm32f769i-discovery/mods.conf
@@ -4,6 +4,15 @@ configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=216000000)
 	@Runlevel(0) include embox.arch.arm.cortexm3.bundle
 	@Runlevel(0) include third_party.bsp.stmf7cube.arch
+	/* Can be enabled after SD card will be fixed. Currently it uses DMA
+	 * and may become broken. */
+	/*
+	@Runlevel(0) include embox.arch.arm.armmlib.armv7m_cpu_cache(
+		log_level=4,
+		sram_nocache_section_size=0x4000,
+		nocache_region0_addr=0x60000000, nocache_region0_size=0x00200000
+	)
+	*/
 	include embox.arch.arm.vfork
 
 	@Runlevel(0) include embox.kernel.stack(stack_size=8192,alignment=4)

--- a/third-party/bsp/stmf7cube/Mybuild
+++ b/third-party/bsp/stmf7cube/Mybuild
@@ -15,8 +15,6 @@ abstract module stm32f7_discovery_bsp {
 
 @BuildDepends(third_party.bsp.stmf7cube.cube)
 module arch extends embox.arch.arch {
-	option boolean enable_cpu_cache = false
-
 	source "arch.c"
 
 	depends third_party.bsp.stmf7cube.cube

--- a/third-party/bsp/stmf7cube/arch.c
+++ b/third-party/bsp/stmf7cube/arch.c
@@ -29,11 +29,6 @@
 #include <framework/mod/options.h>
 #include <module/embox/arch/system.h>
 
-#define ENABLE_CPU_CACHE   OPTION_GET(BOOLEAN, enable_cpu_cache)
-
-#define SRAM1_START        0x20010000
-#define SDRAM_START        0x60000000
-
 static void SystemClock_Config(void)
 {
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -74,63 +69,10 @@ static void SystemClock_Config(void)
   }
 }
 
-#if ENABLE_CPU_CACHE
-static void cpu_cache_enable(void) {
-	SCB_EnableICache();
-	SCB_EnableDCache();
-}
-
-/*
- * TODO We should avoid using WT mode if it's possible:
- *
- * Certain Cortex-M7 revisions have errata related to the use of write-through cache -
- * https://static.docs.arm.com/epm064408/80/Cortex-M7_Software_Developers_Errata_Notice_v8.pdf#page=11
- **/
-static void mpu_config(void) {
-	MPU_Region_InitTypeDef MPU_InitStruct;
-
-	/* Disable the MPU */
-	HAL_MPU_Disable();
-
-	/* Write Through mode */
-	MPU_InitStruct.Enable = MPU_REGION_ENABLE;
-	MPU_InitStruct.AccessPermission = MPU_REGION_FULL_ACCESS;
-	MPU_InitStruct.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;
-	MPU_InitStruct.IsCacheable = MPU_ACCESS_CACHEABLE;
-	MPU_InitStruct.IsShareable = MPU_ACCESS_NOT_SHAREABLE;
-	MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
-	MPU_InitStruct.SubRegionDisable = 0x00;
-	MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_ENABLE;
-
-	/* Configure the MPU attributes as WT for SRAM
-	 * The Base Address is 0x20010000 since this memory interface is the AXI.
-	 * The Region Size is 256KB, it is related to SRAM1 and SRAM2  memory size.
-	 */
-	MPU_InitStruct.Number = MPU_REGION_NUMBER1;
-	MPU_InitStruct.BaseAddress = SRAM1_START;
-	MPU_InitStruct.Size = MPU_REGION_SIZE_256KB;
-	HAL_MPU_ConfigRegion(&MPU_InitStruct);
-
-	/* SDRAM */
-	MPU_InitStruct.Number = MPU_REGION_NUMBER2;
-	MPU_InitStruct.BaseAddress = SDRAM_START;
-	MPU_InitStruct.Size = MPU_REGION_SIZE_8MB;
-	HAL_MPU_ConfigRegion(&MPU_InitStruct);
-
-	/* Enable the MPU */
-	HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
-}
-#endif
-
 void arch_init(void) {
 	ipl_t ipl = ipl_save();
 
 	static_assert(OPTION_MODULE_GET(embox__arch__system, NUMBER, core_freq) == 216000000);
-
-#if ENABLE_CPU_CACHE
-	mpu_config();
-	cpu_cache_enable();
-#endif
 
 	SystemInit();
 	HAL_Init();


### PR DESCRIPTION
This PR aims to make the previous version of CPU caches for ARMv7-M cleaner. (it's a part of the issue https://github.com/embox/embox/issues/2016).

* Add I-Cache and D-Cache fo ARMv7-M in default write-back mode (basically for SRAM and SDRAM) with the ability to declare non-cacheable memory regions, instead of hardcoded write-through mode before.
* Use non-cacheable memory in stm32 ethernet driver
* Nuklear uses cache clean/ cache inval because it requires two frame buffers which cannot be marked as non-cachable. They were marked as write-through before, but it still requires cache invalidate.

btw, I do not enable d-cache for the stm32f7 basic templates (just add cpu cache commented) because new problems with SD card controller can arise - it uses DMA to work with Embox's block devices and I cannot make this memory non-cacheable right now in a simple elegant way.