### PR TITLE
drivers: Fix clock rate for integrator_pit

### DIFF
--- a/src/drivers/clock/integrator_pit/integrator_pit.c
+++ b/src/drivers/clock/integrator_pit/integrator_pit.c
@@ -70,7 +70,7 @@ static cycle_t integratorcp_counter_read(void) {
 }
 
 static struct time_counter_device integratorcp_counter_device = {
-	.cycle_hz = 1000,
+	.cycle_hz = CLOCK_RATE,
 	.read = integratorcp_counter_read,
 };
 


### PR DESCRIPTION
This incorrect rate sometimes led to long nanosleep() calibration.