### PR TITLE
i386: Fix gdb corrupt stack under QEMU

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -211,6 +211,14 @@ ifeq ($(GCC_VERSION_MAJOR),7)
 	override COMMON_CCFLAGS += -Wno-error=format-truncation=
 	override COMMON_CCFLAGS += -Wno-error=alloc-size-larger-than=
 endif
+ifeq ($(ARCH),x86)
+	ifeq ($(shell expr $(GCC_VERSION_MAJOR) \>= 8), 1)
+		# This fixes gdb corrupt stack when debugging with QEMU.
+		# This options is added here to suppress addbr32 instr generation,
+		# which is incorrectly interpreted by QEMU.
+		override COMMON_CCFLAGS += -fcf-protection=none
+	endif
+endif
 endif
 
 override COMMON_CCFLAGS += -Wformat

--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -198,6 +198,7 @@ override ASFLAGS += $(asflags)
 override COMMON_CCFLAGS := $(COMMON_FLAGS)
 override COMMON_CCFLAGS += -fno-strict-aliasing -fno-common
 override COMMON_CCFLAGS += -fno-stack-protector
+override COMMON_CCFLAGS += -fno-pic
 override COMMON_CCFLAGS += -Wall -Werror
 override COMMON_CCFLAGS += -Wundef -Wno-trigraphs -Wno-char-subscripts
 


### PR DESCRIPTION
* Fix GDB corrupt stack with GCC >= 8 under QEMU by adding `-fcf-protection=none` GCC flag (more detail here https://github.com/embox/embox/issues/2054).
* Use `-fno-pic` to suppress position-independent executable code with newer GCC versions, which avoids:
```
(gdb) n
0x001a280b in __x86.get_pc_thunk.bx ()
```