### PR TITLE
pjsip fix on qemu

### DIFF
--- a/project/pjsip/templates/arm-qemu/mods.conf
+++ b/project/pjsip/templates/arm-qemu/mods.conf
@@ -1,33 +1,34 @@
 package genconfig
 
 configuration conf {
-	@Runlevel(0) include embox.arch.system(core_freq=200000000)
+	@Runlevel(0) include embox.arch.system(core_freq=0x10000000)
 	@Runlevel(0) include embox.arch.generic.arch
 	@Runlevel(0) include embox.arch.arm.armlib.static_excpt_table
 	@Runlevel(0) include embox.arch.arm.cortexa8.bundle
 	@Runlevel(0) include embox.kernel.cpu.bkl
 	@Runlevel(0) include embox.kernel.cpu.cpudata
 	@Runlevel(0) include embox.kernel.irq
-	include embox.arch.arm.vfork
+	@Runlevel(0) include embox.arch.arm.vfork
+	@Runlevel(0) include embox.driver.cache.pl310(base_addr=0x1e00a000)
+
+	@Runlevel(0) include embox.arch.arm.mmu_small_page
+//	@Runlevel(0) include embox.arch.arm.fpu.vfp
+
 	include embox.arch.arm.libarch
-
-	@Runlevel(0) include embox.arch.arm.mmu_small_page(
-				domain_access=1,v5_format=1)
-	//@Runlevel(0) include embox.mem.vmem
-
 	include embox.mem.bitmask(page_size=0x1000)
 	@Runlevel(2) include embox.mem.static_heap(heap_size=0x1000000)
 
+	@Runlevel(0) include embox.mem.mmap
 	@Runlevel(0) include embox.kernel.critical
 
 	@Runlevel(0) include embox.driver.interrupt.cortex_a9_gic(cpu_base_addr=0x1e000100,distributor_base_addr=0x1e001000)
 	@Runlevel(0) include embox.kernel.stack(stack_size=4096)
-	@Runlevel(2) include embox.driver.serial.pl011(base_addr=0x10009000, irq_num=37, baud_rate=115200) /* irq_num 5+32 */
+	@Runlevel(2) include embox.driver.serial.pl011(base_addr=0x10009000, irq_num=37 /* 32+5 */,baud_rate=115200)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__pl011")
 	@Runlevel(0) include embox.driver.clock.cortexa9(periph_base_addr=0x1e000000,irq_num=29)
 	@Runlevel(1) include embox.driver.net.lan9118
 	@Runlevel(1) include embox.driver.net.lan9118_non_gpio_irq(base_address=0x4E000000,irq_nr=47,memory_region_size = 0x1000000)
-	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(1) include embox.driver.net.loopback
 
 	include embox.compat.libc.stdio.print(support_floating=0)
 

--- a/src/drivers/audio/portaudio/Mybuild
+++ b/src/drivers/audio/portaudio/Mybuild
@@ -15,7 +15,7 @@ module audio_utils {
 module portaudio_lib extends portaudio_api {
 	option number max_dev_count=4
 	option number pa_stream_count=2
-	option number log_level=0
+	option number log_level=1
 
 	source "portaudio_lib.c"
 	source "portaudio_info.c"

--- a/src/drivers/audio/portaudio/portaudio_lib.c
+++ b/src/drivers/audio/portaudio/portaudio_lib.c
@@ -158,20 +158,23 @@ static void *pa_thread_hnd(void *arg) {
 			return NULL;
 		}
 
-		out_buf = audio_dev_get_out_cur_ptr(audio_dev);
-		in_buf  = audio_dev_get_in_cur_ptr(audio_dev);
-
-		log_debug("out_buf = 0x%X, buf_len %d", out_buf, buf_len);
-
-		if (out_buf) {
+		switch (audio_dev->dir) {
+		case AUDIO_DEV_OUTPUT:
+			out_buf = audio_dev_get_out_cur_ptr(audio_dev);
+			log_debug("out_buf = 0x%X, buf_len %d", out_buf, buf_len);
 			memset(out_buf, 0, buf_len);
-		}
+			break;
+		case AUDIO_DEV_INPUT:
+			in_buf  = audio_dev_get_in_cur_ptr(audio_dev);
+			log_debug("in_buf = 0x%X, buf_len %d", in_buf, buf_len);
 
-		if (audio_dev->dir == AUDIO_DEV_INPUT) {
 			pa_do_rate_conversion(pa_stream, audio_dev, in_buf,
 				inp_frames);
 			pa_do_channel_conversion(pa_stream, audio_dev, in_buf,
 				inp_frames);
+			break;
+		default:
+			break;
 		}
 
 		err = pa_stream->callback(in_buf,

--- a/third-party/pjproject/Makefile
+++ b/third-party/pjproject/Makefile
@@ -28,6 +28,9 @@ DISABLE_FEATURES := \
 	g7221-codec \
 	#g711-codec
 
+# Build fix for GCC9 because of old STLport
+PJSIP_BUILD_FIXUP_CFLAGS := -Wno-narrowing
+
 PJPROJECT_ROOT := $(ROOT_DIR)/third-party/pjproject
 PJSIP_CPPFLAGS := -I$(PJPROJECT_ROOT)/include $(EMBOX_DEPS_CPPFLAGS) -I$(SRC_DIR)/compat/cxx/include 
 PJSIP_CPPFLAGS += -I$(SRC_DIR)/compat/libc/include -I$(SRC_DIR)/compat/posix/include
@@ -45,7 +48,7 @@ $(CONFIGURE) :
 			--prefix=/ \
 			$(DISABLE_FEATURES:%=--disable-%) \
 			--with-external-pa; \
-		echo export CFLAGS+="$(PJSIP_CPPFLAGS)" > user.mak; \
+		echo export CFLAGS+="$(PJSIP_CPPFLAGS) $(PJSIP_BUILD_FIXUP_CFLAGS)" > user.mak; \
 		echo export CXXFLAGS+="$(EMBOX_CXXFLAGS) $(PJSIP_CPPFLAGS)" >> user.mak; \
 	)
 	cp ./config_site.h $(BUILD_ROOT)/pjlib/include/pj/config_site.h


### PR DESCRIPTION
* x86-qemu:
   * Build fix
   * Fix es1370
* arm-qemu build fix
* Improve audio play to handle chunks. Helps to play WAV's created with `ffmpeg -i file.mp3 file.wav` (before it was incorrect data length there)