### PR TITLE
Network namespaces demo

### DIFF
--- a/src/cmds/addveth/Mybuild
+++ b/src/cmds/addveth/Mybuild
@@ -1,0 +1,7 @@
+package embox.cmd
+
+@AutoCmd
+@Cmd(name = "addveth")
+module addveth {
+	source "addveth.c"
+}

--- a/src/cmds/addveth/addveth.c
+++ b/src/cmds/addveth/addveth.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <net/net_namespace.h>
+#include <net/netdevice.h>
+#include <framework/cmd/api.h>
+
+int make_ns_set_dev(const char *ns, struct net_device *v) {
+	if (!(setns(ns) == 0 || unshare(ns) == 0)) {
+		printf("failed to set ns\n");
+		return -1;
+	}
+	dev_net_set(v, get_net_ns());
+	printf("eth dev name: %s\n", v->name);
+	return 0;
+}
+
+int main(int argc, char **argv) {
+	struct net_device *v1, *v2, *ret;
+
+	ret = veth_alloc(&v1, &v2);
+	if (ret == NULL)
+		return -1;
+
+	if (make_ns_set_dev(argv[1], v1) != 0)
+		return -1;
+	return make_ns_set_dev(argv[2], v2);
+}

--- a/src/cmds/lo_udp/Mybuild
+++ b/src/cmds/lo_udp/Mybuild
@@ -1,0 +1,12 @@
+package embox.cmd
+
+@AutoCmd
+@Cmd(name = "udp_s")
+module udp_s {
+	source "server.c"
+}
+@AutoCmd
+@Cmd(name = "udp_c")
+module udp_c {
+	source "client.c"
+}

--- a/src/cmds/lo_udp/client.c
+++ b/src/cmds/lo_udp/client.c
@@ -1,0 +1,73 @@
+/* Client side implementation of UDP client-server model */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <net/net_namespace.h>
+
+#define PORT	 8080
+#define MAXLINE 1024
+
+#define SERV_ADDR "10.0.0.1"
+#define CL_ADDR "10.0.0.2"
+
+int main(int argc, char *argv[]) {
+	int sockfd;
+	char *hello = "Hello from client";
+	struct sockaddr_in servaddr, cliaddr;
+	int len = sizeof(servaddr), n;
+	char buffer[MAXLINE];
+
+	if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) {
+		perror("socket creation failed");
+		exit(EXIT_FAILURE);
+	}
+
+	memset(&servaddr, 0, sizeof(servaddr));
+
+	memset(&cliaddr, 0, sizeof(cliaddr));
+
+	cliaddr.sin_family = AF_INET;
+	cliaddr.sin_port = htons(PORT);
+	if (inet_aton(CL_ADDR, &cliaddr.sin_addr) == 0) {
+		printf("Fail\n");
+		return 0;
+	}
+
+	if ( bind(sockfd, (const struct sockaddr *)&cliaddr,
+			sizeof(cliaddr)) < 0 ) {
+		perror("bind failed");
+		exit(EXIT_FAILURE);
+	}
+
+	servaddr.sin_family = AF_INET;
+	servaddr.sin_port = htons(PORT);
+	if (inet_aton(SERV_ADDR, &servaddr.sin_addr) == 0) {
+		printf("Fail\n");
+		return 0;
+	}
+
+	while (1) {
+		sendto(sockfd, (const char *)hello, strlen(hello),
+			0, (const struct sockaddr *) &servaddr,
+				sizeof(servaddr));
+		sleep(3);
+		n = recvfrom(sockfd, (char *)buffer, MAXLINE,
+					0, ( struct sockaddr *) &servaddr,
+					&len);
+		buffer[n] = '\0';
+		if (n > 0) {
+			printf("Server msg from port %d: %s; client net namespace %s\n",
+				ntohs(servaddr.sin_port), buffer,
+				(get_net_ns()).p->name);
+		}
+	}
+
+	close(sockfd);
+	return 0;
+}
+

--- a/src/cmds/lo_udp/server.c
+++ b/src/cmds/lo_udp/server.c
@@ -1,0 +1,65 @@
+/* Server side implementation of UDP client-server model */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <net/net_namespace.h>
+
+#define PORT	 8080
+#define MAXLINE 1024
+
+#define SERV_ADDR "10.0.0.1"
+
+int main(int argc, char *argv[]) {
+	int sockfd;
+	char buffer[MAXLINE];
+	struct sockaddr_in servaddr, cliaddr;
+	int len = sizeof(cliaddr), n;
+	char *hello = "Hello from server";
+
+	if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) {
+		perror("socket creation failed");
+		exit(EXIT_FAILURE);
+	}
+
+	memset(&servaddr, 0, sizeof(servaddr));
+	memset(&cliaddr, 0, sizeof(cliaddr));
+
+	servaddr.sin_family = AF_INET;
+	servaddr.sin_port = htons(PORT);
+	if (inet_aton(SERV_ADDR, &servaddr.sin_addr) == 0) {
+		printf("Fail\n");
+		return 0;
+	}
+
+	if ( bind(sockfd, (const struct sockaddr *)&servaddr,
+			sizeof(servaddr)) < 0 ) {
+		perror("bind failed");
+		exit(EXIT_FAILURE);
+	}
+
+	while (1) {
+		n = recvfrom(sockfd, (char *)buffer, MAXLINE,
+					0, ( struct sockaddr *) &cliaddr,
+					&len);
+		buffer[n] = '\0';
+		if (n > 0) {
+			printf("Client msg from port %d: %s; server net namespace %s\n",
+				ntohs(cliaddr.sin_port), buffer,
+				(get_net_ns()).p->name);
+
+			sendto(sockfd, (const char *)hello, strlen(hello),
+				0, (const struct sockaddr *) &cliaddr,
+					sizeof(cliaddr));
+		}
+	}
+
+	close(sockfd);
+	return 0;
+}
+

--- a/src/cmds/nsexec/Mybuild
+++ b/src/cmds/nsexec/Mybuild
@@ -1,0 +1,7 @@
+package embox.cmd
+
+@AutoCmd
+@Cmd(name = "nsexec")
+module nsexec {
+	source "nsexec.c"
+}

--- a/src/cmds/nsexec/nsexec.c
+++ b/src/cmds/nsexec/nsexec.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <net/net_namespace.h>
+#include <framework/cmd/api.h>
+
+int main(int argc, char **argv) {
+	char *ns = argv[1];
+	const struct cmd *cmd;
+
+	if (!(setns(ns) == 0 || unshare(ns) == 0))
+		return -1;
+
+	if (argc > 2) {
+		cmd = cmd_lookup(argv[2]);
+		argc -= 2;
+		argv += 2;
+		cmd_exec(cmd, argc, argv);
+	}
+	return 0;
+}

--- a/src/compat/posix/net/socket.c
+++ b/src/compat/posix/net/socket.c
@@ -30,6 +30,8 @@
 
 #include <util/macro.h>
 
+#include <net/net_namespace.h>
+
 static int get_index(struct sock *sk) {
 	struct idesc_table *it;
 
@@ -64,6 +66,7 @@ int socket(int domain, int type, int protocol) {
 		return SET_ERRNO(EMFILE);
 	}
 
+	assign_net_ns(sk->net_ns, get_net_ns());
 	return sockfd;
 }
 /* fcntl */
@@ -135,6 +138,7 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
 	if (ret < 0) {
 		return SET_ERRNO(-ret);
 	}
+	assign_net_ns(new_sk->net_ns, sk->net_ns);
 
 	new_sockfd = get_index(new_sk);
 	if (new_sockfd < 0) {

--- a/src/drivers/net/veth/Mybuild
+++ b/src/drivers/net/veth/Mybuild
@@ -1,0 +1,9 @@
+package embox.driver.net
+
+module veth {
+	source "veth.c"
+
+	depends embox.net.entry_api
+	depends embox.net.l2.ethernet
+	depends embox.net.dev
+}

--- a/src/drivers/net/veth/veth.c
+++ b/src/drivers/net/veth/veth.c
@@ -1,0 +1,74 @@
+
+#include <assert.h>
+#include <embox/unit.h>
+#include <errno.h>
+#include <net/l2/ethernet.h>
+#include <net/l3/arp.h>
+#include <net/netdevice.h>
+#include <net/inetdevice.h>
+#include <net/skbuff.h>
+#include <net/l0/net_entry.h>
+#include <net/net_namespace.h>
+#include <net/netdevice.h>
+
+static int veth_xmit(struct net_device *dev,
+		struct sk_buff *skb) {
+	struct net_device_stats *lb_stats;
+	size_t skb_len;
+
+	if ((skb == NULL) || (dev == NULL)) {
+		return -EINVAL;
+	}
+
+	skb_len = skb->len;
+
+	lb_stats = &dev->stats;
+
+	skb->dev = (struct net_device *) dev->priv;
+	if (netif_rx(skb) == NET_RX_SUCCESS) {
+		lb_stats->rx_packets++;
+		lb_stats->rx_bytes += skb_len;
+	} else {
+		lb_stats->rx_err++;
+	}
+
+	return 0;
+}
+
+static const struct net_driver veth_ops = {
+	.xmit = veth_xmit
+};
+
+struct net_device *veth_alloc(struct net_device **v1, struct net_device **v2) {
+	struct net_device *veth1, *veth2;
+	int ret;
+
+	veth1 = etherdev_alloc(sizeof(struct net_device *));
+	if (!veth1) {
+		return NULL;
+	}
+	ret = inetdev_register_dev(veth1);
+	if (ret != 0) {
+		return NULL;
+	}
+
+	veth2 = etherdev_alloc(sizeof(struct net_device *));
+	if (!veth2) {
+		return NULL;
+	}
+	ret = inetdev_register_dev(veth2);
+	if (ret != 0) {
+		return NULL;
+	}
+
+	assign_net_ns(veth1->net_ns, init_net_ns);
+	assign_net_ns(veth2->net_ns, init_net_ns);
+	veth1->priv = (void *)veth2;
+	veth2->priv = (void *)veth1;
+	veth1->drv_ops = &veth_ops;
+	veth2->drv_ops = &veth_ops;
+
+	*v1 = veth1;
+	*v2 = veth2;
+	return (struct net_device *)1;
+}

--- a/src/include/net/inetdevice.h
+++ b/src/include/net/inetdevice.h
@@ -41,6 +41,8 @@ extern int inetdev_unregister_dev(struct net_device *dev);
  * @param if_name - interface name
  */
 extern struct in_device * inetdev_get_by_name(const char *name);
+extern struct in_device * inetdev_get_by_name_netns(const char *name,
+					net_namespace_p net_ns);
 
 /**
  * get pointer on in_device struct linked with pointed net_device
@@ -60,6 +62,8 @@ extern struct in_device * inetdev_get_by_addr(in_addr_t addr);
  * @return pointer to the loopback device
  */
 extern struct in_device * inetdev_get_loopback_dev(void);
+
+struct in_device * inetdev_get_loopback_dev_netns(net_namespace_p net_ns);
 
 /**
  * Set IP address (sw)
@@ -89,6 +93,9 @@ extern in_addr_t inetdev_get_addr(struct in_device *in_dev);
 extern struct in_device * inetdev_get_first(void);
 extern struct in_device * inetdev_get_next(struct in_device *in_dev);
 
+extern struct in_device * inetdev_get_first_all(void);
+extern struct in_device * inetdev_get_next_all(struct in_device *in_dev);
+
 /**
  * generate new id for requiered interface
  */
@@ -108,5 +115,7 @@ static inline unsigned int inetdev_get_ip_id(struct in_device *in_dev) {
  * @param check_multicast - should we check multicast addresses
  */
 extern int ip_is_local(in_addr_t addr, int opts);
+extern int ip_is_local_net_ns(in_addr_t addr, int opts,
+		net_namespace_p net_ns);
 
 #endif /* NET_INETDEVICE_H_ */

--- a/src/include/net/l3/route.h
+++ b/src/include/net/l3/route.h
@@ -15,6 +15,7 @@
 #include <net/l3/ipv4/ip.h>
 #include <stddef.h>
 #include <net/netdevice.h>
+#include <net/net_namespace.h>
 
 struct net_device;
 
@@ -27,6 +28,7 @@ typedef struct rt_entry {
 	uint32_t     rt_flags;
 	in_addr_t    rt_mask;
 	in_addr_t    rt_gateway;
+	net_namespace_p net_ns;
 } rt_entry_t;
 
 /**< Flags */
@@ -54,6 +56,9 @@ typedef struct rt_entry {
 extern int rt_add_route(struct net_device *dev, in_addr_t dst,
 				in_addr_t mask, in_addr_t gw, int flags);
 
+extern int rt_add_route_netns(struct net_device *dev, in_addr_t dst,
+			in_addr_t mask, in_addr_t gw, int flags,
+			net_namespace_p net_ns);
 /**
  * Remove route from table.
  * @param dev Iface
@@ -85,6 +90,8 @@ extern int ip_route(sk_buff_t *skb, struct net_device *wanna_dev,
  * @return error code
  */
 extern int rt_fib_route_ip(in_addr_t source_addr, in_addr_t *new_addr);
+extern int rt_fib_route_ip_net_ns(in_addr_t source_addr, in_addr_t *new_addr,
+				net_namespace_p net_ns);
 
 /**
  * Get IP address of local interface from which packet would be sent
@@ -95,9 +102,13 @@ extern int rt_fib_route_ip(in_addr_t source_addr, in_addr_t *new_addr);
  */
 extern int rt_fib_source_ip(in_addr_t dst, struct net_device *dev,
 		in_addr_t *out_src);
+extern int rt_fib_source_ip_net_ns(in_addr_t dst, struct net_device *dev,
+		in_addr_t *out_src, net_namespace_p net_ns);
 
 extern int rt_fib_out_dev(in_addr_t dst, const struct sock *sk,
 		struct net_device **out_dev);
+extern int rt_fib_out_dev_net_ns(in_addr_t dst, const struct sock *sk,
+		struct net_device **out_dev, net_namespace_p net_ns);
 
 /**
  * @param dst - ip address of destination
@@ -106,6 +117,10 @@ extern int rt_fib_out_dev(in_addr_t dst, const struct sock *sk,
  * @retval NULL if entity not found
  */
 extern struct rt_entry* rt_fib_get_best(in_addr_t dst, struct net_device *out_dev);
+
+extern struct rt_entry * rt_fib_get_best_net_ns(in_addr_t dst,
+						struct net_device *out_dev,
+						net_namespace_p net_ns);
 
 /**
  * Get first element from route from table.

--- a/src/include/net/netdevice.h
+++ b/src/include/net/netdevice.h
@@ -15,6 +15,7 @@
 #include <net/if.h>
 #include <net/skbuff.h>
 #include <util/dlist.h>
+#include <net/net_namespace.h>
 
 /**
  * Prototypes
@@ -127,6 +128,7 @@ typedef struct net_device {
 	struct sk_buff_head dev_queue;    /* rx skb queue */
 	struct sk_buff_head dev_queue_tx; /* tx skb queue */
 	struct net_node *pnet_node;
+	net_namespace_p net_ns;
 	void *priv; /**< private data */
 } net_device_t;
 
@@ -154,6 +156,10 @@ extern struct net_device * netdev_get_by_name(const char *name);
  */
 extern struct net_device * netdev_alloc(const char *name,
 		int (*setup)(struct net_device *), size_t priv_size);
+
+extern void dev_net_set(struct net_device *dev, net_namespace_p net_ns);
+extern struct net_device *veth_alloc(struct net_device **v1,
+				struct net_device **v2);
 
 /**
  * Free network device

--- a/src/include/net/sock.h
+++ b/src/include/net/sock.h
@@ -24,6 +24,8 @@
 #include <net/skbuff.h>
 #include <netinet/in.h>
 
+#include <net/net_namespace.h>
+
 
 struct proto_sock; //TODO What does it mean
 struct sock_family_ops;
@@ -90,6 +92,7 @@ struct sock {
 	struct timeval last_packet_tstamp;
 	size_t addr_len;
 	int err;
+	net_namespace_p net_ns;
 };
 
 static inline int sock_err(struct sock *sk) {

--- a/src/kernel/nsproxy/Mybuild
+++ b/src/kernel/nsproxy/Mybuild
@@ -1,0 +1,19 @@
+package embox.kernel
+
+@DefaultImpl(nsproxy_stub)
+abstract module nsproxy {
+}
+
+module nsproxy_nonstub extends nsproxy {
+	@IncludeExport(target_name="nsproxy.h")
+	source "nsproxy.h"
+
+	source "nsproxy.c"
+
+	depends embox.kernel.task.multi
+}
+
+module nsproxy_stub extends nsproxy {
+	@IncludeExport(target_name="nsproxy.h")
+	source "nsproxy_stub.h"
+}

--- a/src/kernel/nsproxy/nsproxy.c
+++ b/src/kernel/nsproxy/nsproxy.c
@@ -1,0 +1,5 @@
+#include <nsproxy.h>
+
+struct nsproxy init_nsproxy = {
+	.net_ns = { .p = &init_net_ns_s }
+};

--- a/src/kernel/nsproxy/nsproxy.h
+++ b/src/kernel/nsproxy/nsproxy.h
@@ -1,0 +1,19 @@
+#ifndef NSPROXY_H_
+#define NSPROXY_H_
+
+#include <net/net_namespace.h>
+
+typedef struct nsproxy {
+	net_namespace_p net_ns;
+} nsproxy_t;
+
+extern struct nsproxy init_nsproxy;
+
+#define set_task_proxy(tsk, parent) \
+	if (parent) { \
+		tsk->nsproxy = parent->nsproxy; \
+	} else { \
+		tsk->nsproxy = init_nsproxy; \
+	}
+
+#endif /* NSPROXY_H_ */

--- a/src/kernel/nsproxy/nsproxy_stub.h
+++ b/src/kernel/nsproxy/nsproxy_stub.h
@@ -1,0 +1,11 @@
+#ifndef NSPROXY_H_
+#define NSPROXY_H_
+
+#include <net/net_namespace.h>
+
+typedef struct nsproxy {
+} nsproxy_t;
+
+#define set_task_proxy(tsk, parent)
+
+#endif /* NSPROXY_H_ */

--- a/src/kernel/task/multi/Mybuild
+++ b/src/kernel/task/multi/Mybuild
@@ -22,6 +22,7 @@ module multi extends api {
 	 * thread_self to determine current thread
 	 */
 
+	depends embox.kernel.nsproxy
 	@NoRuntime depends embox.compat.libc.assert
 	@NoRuntime depends embox.compat.libc.str
 }

--- a/src/kernel/task/multi/multi.c
+++ b/src/kernel/task/multi/multi.c
@@ -21,6 +21,7 @@
 #include <kernel/task/resource/errno.h>
 #include <kernel/task/task_table.h>
 #include <kernel/thread.h>
+#include <nsproxy.h>
 
 #include <util/binalign.h>
 #include <util/err.h>
@@ -287,6 +288,8 @@ void task_init(struct task *tsk, int id, struct task *parent, const char *name,
 	if (parent) {
 		dlist_add_prev(&tsk->child_lnk, &parent->child_list);
 	}
+
+	set_task_proxy(tsk, parent)
 
 	task_setrlim_stack_size(tsk, task_get_stack_size(parent));
 

--- a/src/kernel/task/multi/multi.h
+++ b/src/kernel/task/multi/multi.h
@@ -18,6 +18,8 @@
 #include <kernel/thread.h>
 #include <kernel/task/task_priority.h>
 
+#include <nsproxy.h>
+
 #define MAX_TASK_NAME_LEN 20
 
 struct thread;
@@ -38,6 +40,7 @@ struct task {
 	struct thread *tsk_main;
 	task_priority_t tsk_priority;
 	clock_t tsk_clock;
+	struct nsproxy nsproxy;
 	char resources[];
 };
 

--- a/src/net/Mybuild
+++ b/src/net/Mybuild
@@ -12,14 +12,31 @@ module dev {
 	depends embox.net.netlink
 }
 
-module core {
+@DefaultImpl(core_no_net_ns)
+abstract module core {
+}
+
+module core_no_net_ns extends core {
 	option number amount_interface=4
+	option number log_level = 1
 
 	source "inetdev.c"
-	
+
 	depends dev /* for dev.c */
 	depends embox.util.dlist
 	depends embox.mem.pool
+	depends embox.net.net_namespace
+}
+
+module core_net_ns extends core {
+	option number amount_interface=4
+	option number log_level = 1
+
+	source "inetdev_net_ns.c"
+	depends dev /* for dev.c */
+	depends embox.util.dlist
+	depends embox.mem.pool
+	depends embox.net.net_namespace
 }
 
 module sock {

--- a/src/net/inetdev_net_ns.c
+++ b/src/net/inetdev_net_ns.c
@@ -9,18 +9,14 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <stddef.h>
-#include <string.h>
-
-#include <util/dlist.h>
-
+#include <framework/mod/options.h>
 #include <mem/misc/pool.h>
-
-#include <net/netlink.h>
 #include <net/inetdevice.h>
 #include <net/netdevice.h>
-
-#include <framework/mod/options.h>
+#include <stddef.h>
+#include <string.h>
+#include <util/dlist.h>
+#include <net/net_namespace.h>
 
 #define MODOPS_AMOUNT_INTERFACE OPTION_GET(NUMBER, amount_interface)
 
@@ -52,8 +48,6 @@ int inetdev_register_dev(struct net_device *dev) {
 
 	dlist_add_prev_entry(in_dev, &inetdev_list, lnk);
 
-	netlink_notify_newlink(dev);
-
 	return 0;
 }
 
@@ -70,8 +64,6 @@ int inetdev_unregister_dev(struct net_device *dev) {
 		return -ESRCH;
 	}
 
-	netlink_notify_dellink(dev);
-
 	ret = netdev_unregister(dev);
 	if (ret != 0) {
 		pool_free(&inetdev_pool, in_dev);
@@ -84,16 +76,24 @@ int inetdev_unregister_dev(struct net_device *dev) {
 	return 0;
 }
 
+#include <util/log.h>
 struct in_device * inetdev_get_by_name(const char *name) {
+	return inetdev_get_by_name_netns(name, get_net_ns());
+}
+
+struct in_device * inetdev_get_by_name_netns(const char *name,
+					net_namespace_p net_ns) {
 	struct in_device *in_dev;
 
 	if (name == NULL) {
-		return NULL; /* error: invalid name */
+		return NULL; /* error: invalid name or net namespace */
 	}
 
 	dlist_foreach_entry(in_dev, &inetdev_list, lnk) {
 		assert(in_dev->dev != NULL);
-		if (strcmp(name, &in_dev->dev->name[0]) == 0) {
+		//if ((net_ns == in_dev->dev->net_ns) &&
+		if (cmp_net_ns(net_ns, in_dev->dev->net_ns) &&
+			(strcmp(name, &in_dev->dev->name[0]) == 0)) {
 			return in_dev;
 		}
 	}
@@ -106,7 +106,7 @@ struct in_device * inetdev_get_by_dev(struct net_device *dev) {
 		return NULL; /* error: invalid argument */
 	}
 
-	return inetdev_get_by_name(&dev->name[0]);
+	return inetdev_get_by_name_netns(&dev->name[0], dev->net_ns);
 }
 
 struct in_device * inetdev_get_by_addr(in_addr_t addr) {
@@ -121,8 +121,12 @@ struct in_device * inetdev_get_by_addr(in_addr_t addr) {
 	return NULL; /* error: no such device */
 }
 
+struct in_device *inetdev_get_loopback_dev_netns(net_namespace_p net_ns) {
+	return inetdev_get_by_name_netns("lo", net_ns);
+}
+
 struct in_device * inetdev_get_loopback_dev(void) {
-	return inetdev_get_by_name("lo");
+	return inetdev_get_by_name_netns("lo", get_net_ns());
 }
 
 int inetdev_set_addr(struct in_device *in_dev, in_addr_t addr) {
@@ -164,11 +168,52 @@ in_addr_t inetdev_get_addr(struct in_device *in_dev) {
 	return in_dev->ifa_address;
 }
 
+struct in_device * inetdev_get_next_net_ns(struct in_device *in_dev,
+					   net_namespace_p netns) {
+	if (in_dev == NULL) {
+		return NULL; /* error: invalid argument */
+	}
+
+	while (1) {
+		if (in_dev == dlist_last_entry(&inetdev_list,
+					struct in_device, lnk)) {
+			return NULL; /* error: there are no more devices */
+		}
+		in_dev = dlist_entry(in_dev->lnk.next, struct in_device, lnk);
+		if (!cmp_net_ns(in_dev->dev->net_ns, netns)) {
+			continue;
+		} else {
+			return in_dev;
+		}
+	}
+
+	return NULL;
+}
+
+struct in_device * inetdev_get_first_net_ns(net_namespace_p netns) {
+	struct in_device * in_dev;
+	in_dev = dlist_next_entry_or_null(&inetdev_list, struct in_device, lnk);
+
+	if (!cmp_net_ns(in_dev->dev->net_ns, netns)) {
+		return inetdev_get_next_net_ns(in_dev, netns);
+	}
+
+	return in_dev;
+}
+
 struct in_device * inetdev_get_first(void) {
-	return dlist_next_entry_or_null(&inetdev_list, struct in_device, lnk);
+	return inetdev_get_first_net_ns(get_net_ns());
 }
 
 struct in_device * inetdev_get_next(struct in_device *in_dev) {
+	return inetdev_get_next_net_ns(in_dev, get_net_ns());
+}
+
+struct in_device * inetdev_get_first_all(void) {
+	return dlist_next_entry_or_null(&inetdev_list, struct in_device, lnk);
+}
+
+struct in_device * inetdev_get_next_all(struct in_device *in_dev) {
 	if (in_dev == NULL) {
 		return NULL; /* error: invalid argument */
 	}
@@ -209,25 +254,32 @@ int ip_is_local(in_addr_t addr, int opts) {
 	return false;
 }
 
-struct in_device * inetdev_get_by_name_netns(const char *name,
-					net_namespace_p net_ns) {
-	return inetdev_get_by_name(name);
-}
-
-struct in_device *inetdev_get_loopback_dev_netns(net_namespace_p net_ns) {
-	return inetdev_get_loopback_dev();
-}
-
-struct in_device * inetdev_get_next_net_ns(struct in_device *in_dev,
-					   net_namespace_p netns) {
-	return inetdev_get_next(in_dev);
-}
-
-struct in_device * inetdev_get_first_net_ns(net_namespace_p netns) {
-	return inetdev_get_first();
-}
-
 int ip_is_local_net_ns(in_addr_t addr, int opts,
 		net_namespace_p net_ns) {
-	return ip_is_local(addr, opts);
+	struct in_device *in_dev;
+
+	if (ipv4_is_loopback(addr)) {
+		return true;
+	}
+
+	if ((opts & IP_LOCAL_BROADCAST) && ipv4_is_broadcast(addr)) {
+		return true;
+	}
+
+	if ((opts & IP_LOCAL_MULTICAST) && ipv4_is_multicast(addr)) {
+		return true;
+	}
+
+	dlist_foreach_entry(in_dev, &inetdev_list, lnk) {
+		if (!cmp_net_ns(in_dev->dev->net_ns, net_ns))
+			continue;
+		if (in_dev->ifa_address == addr) {
+			return true;
+		}
+		if ((opts & IP_LOCAL_BROADCAST) && (in_dev->ifa_broadcast == addr)) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/net/l3/Mybuild
+++ b/src/net/l3/Mybuild
@@ -63,9 +63,22 @@ module rarp {
 	@NoRuntime depends embox.net.skbuff
 }
 
-module route {
+@DefaultImpl(route_no_net_ns)
+abstract module route {
+}
+
+module route_no_net_ns extends route {
 	option number route_table_size=8
 	source "route.c"
+
+	depends core /* for inetdev.c */
+	depends embox.mem.pool
+	depends embox.util.dlist
+}
+
+module route_net_ns extends route {
+	option number route_table_size=8
+	source "route_net_ns.c"
 
 	depends core /* for inetdev.c */
 	depends embox.mem.pool

--- a/src/net/l3/icmpv4.c
+++ b/src/net/l3/icmpv4.c
@@ -338,9 +338,10 @@ int icmp_discard(struct sk_buff *skb, uint8_t type, uint8_t code,
 	uint8_t *body_msg;
 	size_t body_msg_sz;
 
-	if (!(ip_is_local(
-			ip_hdr(skb)->saddr, 0)
-			|| ip_is_local(ip_hdr(skb)->daddr, 0))
+	if (!(ip_is_local_net_ns(
+			ip_hdr(skb)->saddr, 0, skb->dev->net_ns)
+			|| ip_is_local_net_ns(ip_hdr(skb)->daddr, 0,
+						skb->dev->net_ns))
 			|| (ip_hdr(skb)->frag_off & htons(IP_OFFSET))
 			|| (ip_data_length(ip_hdr(skb)) < ICMP_DISCARD_MIN_SIZE)
 			|| (ip_hdr(skb)->proto != IPPROTO_ICMP)

--- a/src/net/l3/ipv4/ip_input.c
+++ b/src/net/l3/ipv4/ip_input.c
@@ -114,7 +114,8 @@ static int ip_rcv(struct sk_buff *skb, struct net_device *dev) {
 		 * Check the destination address, and if it doesn't match
 		 * any of own addresses, retransmit packet according to the routing table.
 		 */
-		if (!ip_is_local(iph->daddr, IP_LOCAL_BROADCAST)) {
+		if (!ip_is_local_net_ns(iph->daddr, IP_LOCAL_BROADCAST,
+					skb->dev->net_ns)) {
 			if (0 != nf_test_skb(NF_CHAIN_FORWARD, NF_TARGET_ACCEPT, skb)) {
 				log_debug("ip_rcv: dropped by forward netfilter");
 				stats->rx_dropped++;

--- a/src/net/l4/udp.c
+++ b/src/net/l4/udp.c
@@ -37,6 +37,8 @@ EMBOX_NET_PROTO(ETH_P_IPV6, IPPROTO_UDP, udp_rcv,
 static int udp4_rcv_tester(const struct sock *sk,
 		const struct sk_buff *skb) {
 	assert(sk != NULL);
+	if (!cmp_net_ns(sk->net_ns, skb->dev->net_ns))
+		return 0;
 	return (sk->opt.so_domain == AF_INET)
 			&& ip_tester_dst_or_any(sk, skb)
 			&& (sock_inet_get_src_port(sk) == udp_hdr(skb)->dest);

--- a/src/net/net_namespace/Mybuild
+++ b/src/net/net_namespace/Mybuild
@@ -1,0 +1,21 @@
+package embox.net
+
+@DefaultImpl(net_namespace_stub)
+abstract module net_namespace {
+}
+
+module net_namespace_nonstub extends net_namespace {
+	option number amount_net_ns=20
+
+	@IncludeExport(path="net",target_name="net_namespace.h")
+	source "net_namespace.h"
+
+	source "net_namespace.c"
+	depends embox.driver.net.loopback
+}
+
+module net_namespace_stub extends net_namespace {
+	@IncludeExport(path="net",target_name="net_namespace.h")
+	source "net_namespace_stub.h"
+	source "net_namespace_stub.c"
+}

--- a/src/net/net_namespace/net_namespace.c
+++ b/src/net/net_namespace/net_namespace.c
@@ -1,0 +1,107 @@
+#include <net/net_namespace.h>
+#include <net/netdevice.h>
+#include <kernel/task.h>
+#include <mem/misc/pool.h>
+#include <embox/unit.h>
+#include <net/inetdevice.h>
+
+EMBOX_UNIT_INIT(set_init_net_ns);
+
+#define MODOPS_AMOUNT_NET_NS_OBJS OPTION_GET(NUMBER, amount_net_ns)
+POOL_DEF(net_ns_pool, struct net_namespace, MODOPS_AMOUNT_NET_NS_OBJS);
+
+static DLIST_DEFINE(net_ns_list_d);
+struct dlist_head *net_ns_list = &net_ns_list_d;
+
+struct net_namespace init_net_ns_s;
+net_namespace_p init_net_ns = { .p = &init_net_ns_s };
+
+#define assign_net_ns_p_and_ret(net_ns_p, net_ns) \
+	net_ns_p.p = net_ns; \
+	return net_ns_p;
+
+static net_namespace_p net_ns_lookup(const char *name) {
+	struct net_namespace *net_ns;
+	net_namespace_p net_ns_p;
+
+	dlist_foreach_entry_safe(net_ns, net_ns_list, lnk) {
+		if (strcmp(name, net_ns->name) == 0) {
+			assign_net_ns_p_and_ret(net_ns_p, net_ns);
+		}
+	}
+
+	assign_net_ns_p_and_ret(net_ns_p, NULL);
+}
+
+static net_namespace_p alloc_net_ns(const char *name) {
+	ipl_t ipl;
+	struct net_namespace *net_ns;
+	net_namespace_p net_ns_p;
+	size_t namelen;
+
+	if ((namelen = strlen(name)) > NAME_MAX) {
+		assign_net_ns_p_and_ret(net_ns_p, NULL);
+	}
+
+	if ((net_ns_lookup(name)).p != NULL) {
+		assign_net_ns_p_and_ret(net_ns_p, NULL);
+	}
+
+	net_ns = pool_alloc((struct pool*)&net_ns_pool);
+	if (net_ns == NULL) {
+		assign_net_ns_p_and_ret(net_ns_p, NULL);
+	}
+	memcpy(net_ns->name, name, strlen(name) + 1);
+
+	ipl = ipl_save();
+	dlist_add_prev_entry(net_ns, net_ns_list, lnk);
+	ipl_restore(ipl);
+
+	assign_net_ns_p_and_ret(net_ns_p, net_ns);
+}
+
+//User space:
+int setns(const char *name) {
+	return (assign_net_ns((task_self())->nsproxy.net_ns,
+			      net_ns_lookup(name))) == NULL ? -1 : 0;
+}
+
+int unshare(const char *name) {
+	net_namespace_p net_ns;
+
+	net_ns = alloc_net_ns(name);
+	if (net_ns.p == NULL) {
+		return -1;
+	}
+
+	return setns(name);
+}
+//
+
+static int init_net_ns_devs(void) {
+	static int init = 0;
+
+	if (init)
+		return 0;
+	struct in_device *iface;
+	for (iface = inetdev_get_first_all(); iface != NULL;
+			iface = inetdev_get_next_all(iface)) {
+		dev_net_set(iface->dev, init_net_ns);
+	}
+	init = 1;
+	return 0;
+}
+
+net_namespace_p get_net_ns() {
+	init_net_ns_devs();
+	return (task_self())->nsproxy.net_ns;
+}
+
+static int set_init_net_ns(void) {
+	ipl_t ipl;
+	ipl = ipl_save();
+	dlist_add_prev_entry(&init_net_ns_s, net_ns_list, lnk);
+	ipl_restore(ipl);
+	memcpy(init_net_ns_s.name, "init_net_ns", strlen("init_net_ns") + 1);
+	return 0;
+}

--- a/src/net/net_namespace/net_namespace.h
+++ b/src/net/net_namespace/net_namespace.h
@@ -1,0 +1,32 @@
+#ifndef NET_NAMESPACE_H_
+#define NET_NAMESPACE_H_
+
+#include <limits.h>
+#include <util/dlist.h>
+
+typedef struct net_namespace {
+	struct dlist_head lnk;
+	char name[NAME_MAX + 1];
+} net_namespace_t;
+
+typedef struct net_namespace_pointer {
+	struct net_namespace *p;
+} net_namespace_p;
+
+extern struct net_namespace init_net_ns_s;
+extern net_namespace_p init_net_ns;
+
+extern net_namespace_p get_net_ns();
+extern int setns(const char *name);
+extern int unshare(const char *name);
+
+#define assign_net_ns(net_ns1, net_ns2) ((net_ns1).p = (net_ns2).p)
+#define cmp_net_ns(net_ns1, net_ns2) ((net_ns1).p == (net_ns2).p)
+
+#define fill_net_ns_from_sk(net_ns, sk, out_skb)					\
+	(net_ns).p = sk != NULL ? (sk->net_ns).p : ((*out_skb)->dev->net_ns).p;		\
+	if ((sk != NULL) && (*out_skb != NULL)) {					\
+		(net_ns).p = ((sk->net_ns).p != NULL) ? (sk->net_ns).p : ((*out_skb)->dev->net_ns).p; \
+	}
+
+#endif /* NET_NAMESPACE_H_ */

--- a/src/net/net_namespace/net_namespace_stub.c
+++ b/src/net/net_namespace/net_namespace_stub.c
@@ -1,0 +1,15 @@
+#include <errno.h>
+#include <net/net_namespace.h>
+
+int setns(const char *name) {
+	return -ENOTSUP;
+}
+
+int unshare(const char *name) {
+	return -ENOTSUP;
+}
+
+net_namespace_p empty_net_ns_p_obj;
+net_namespace_p get_net_ns() {
+	return empty_net_ns_p_obj;
+}

--- a/src/net/net_namespace/net_namespace_stub.h
+++ b/src/net/net_namespace/net_namespace_stub.h
@@ -1,0 +1,23 @@
+#ifndef NET_NAMESPACE_H_
+#define NET_NAMESPACE_H_
+
+#include <util/dlist.h>
+#include <limits.h>
+
+typedef struct net_namespace {
+} net_namespace_t;
+
+typedef struct net_namespace_ptr {
+} net_namespace_p;
+
+extern net_namespace_p init_net_ns;
+
+extern net_namespace_p get_net_ns();
+extern int setns(const char *name);
+extern int unshare(const char *name);
+
+#define assign_net_ns(net_ns1, net_ns2)
+#define cmp_net_ns(net_ns1, net_ns2) 1
+
+#define fill_net_ns_from_sk(net_ns, sk, out_skb)
+#endif /* NET_NAMESPACE_H_ */

--- a/src/net/netdev.c
+++ b/src/net/netdev.c
@@ -79,6 +79,10 @@ static int netdev_init(struct net_device *dev, const char *name,
 	return (*setup)(dev);
 }
 
+void dev_net_set(struct net_device *dev, net_namespace_p net_ns) {
+	assign_net_ns(dev->net_ns, net_ns);
+}
+
 struct net_device * netdev_alloc(const char *name,
 		int (*setup)(struct net_device *), size_t priv_size) {
 	int ret;

--- a/templates/x86/netns/build.conf
+++ b/templates/x86/netns/build.conf
@@ -1,0 +1,10 @@
+TARGET = embox
+ARCH = x86
+
+// For MAC OS X
+//CROSS_COMPILE = i386-elf-
+
+CFLAGS += -O0 -gdwarf-2
+CFLAGS += -nostdinc -m32 -march=i386 -fno-stack-protector -Wno-array-bounds
+
+LDFLAGS += -m elf_i386

--- a/templates/x86/netns/lds.conf
+++ b/templates/x86/netns/lds.conf
@@ -1,0 +1,8 @@
+/* region (origin, length) */
+RAM (0x00100000, 256M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/templates/x86/netns/mods.conf
+++ b/templates/x86/netns/mods.conf
@@ -1,0 +1,238 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.x86.kernel.arch
+	include embox.arch.x86.kernel.locore
+	include embox.arch.x86.kernel.context
+	include embox.arch.x86.kernel.interrupt
+
+	include embox.arch.x86.vfork
+	include embox.arch.x86.stackframe
+	include embox.arch.x86.libarch
+	include embox.arch.x86.mmu
+	include embox.arch.x86.mmuinfo
+
+	@Runlevel(0) include embox.driver.interrupt.i8259
+	@Runlevel(0) include embox.driver.clock.pit
+	include embox.kernel.time.jiffies(cs_name="pit")
+	@Runlevel(2) include embox.driver.clock.tsc
+	@Runlevel(2) include embox.driver.clock.hpet
+
+	@Runlevel(2) include embox.driver.serial.i8250(baud_rate=38400)
+	@Runlevel(2) include embox.driver.diag(impl="embox__driver__serial__i8250")
+
+	@Runlevel(2) include embox.driver.virtual.null
+	@Runlevel(2) include embox.driver.virtual.zero
+
+	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(2) include embox.driver.net.virtio
+	@Runlevel(1) include embox.driver.net.usbnet
+	@Runlevel(2) include embox.driver.net.veth
+
+	@Runlevel(1) include embox.driver.ide
+
+	@Runlevel(1) include embox.driver.usb.class.mass_storage
+	@Runlevel(1) include embox.driver.usb.class.ccid(log_level=4)
+	@Runlevel(1) include embox.driver.usb.class.hid
+	@Runlevel(2) include embox.driver.usb.hc.ohci_pci
+
+	@Runlevel(2) include embox.lib.debug.whereami
+	@Runlevel(2) include embox.profiler.tracing
+
+	@Runlevel(0) include embox.mem.phymem
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
+	@Runlevel(2) include embox.kernel.time.kernel_time
+	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)
+	include embox.kernel.stack(stack_size=0x20000)
+	include embox.kernel.sched.strategy.priority_based
+	include embox.kernel.thread.signal.sigstate
+	include embox.kernel.thread.signal.siginfoq
+	include embox.kernel.task.resource.env(env_str_len=64)
+	include embox.kernel.nsproxy_nonstub
+
+	include embox.mem.pool_adapter
+	@Runlevel(2) include embox.mem.static_heap(heap_size=0x8000000)
+	include embox.mem.heap_bm(heap_size=0x4000000)
+	include embox.mem.bitmask
+
+/* for old fs comment dvfs part */
+	@Runlevel(2) include embox.fs.node(fnode_quantity=1024)
+	@Runlevel(2) include embox.fs.rootfs
+	@Runlevel(2) include embox.fs.driver.initfs
+	@Runlevel(2) include embox.fs.driver.ramfs
+	@Runlevel(2) include embox.fs.driver.ext2
+	@Runlevel(2) include embox.fs.driver.fat
+	@Runlevel(2) include embox.fs.driver.nfs
+	include embox.fs.driver.devfs_old
+
+/* for dvfs comment old fs part */
+/*
+	@Runlevel(2) include embox.fs.dvfs.core
+	@Runlevel(2) include embox.fs.driver.fat_dvfs
+	@Runlevel(2) include embox.fs.driver.initfs_dvfs
+	@Runlevel(2) include embox.fs.rootfs_dvfs
+	include embox.compat.posix.fs.all_dvfs
+	include embox.compat.posix.fs.ftruncate_dvfs
+	include embox.compat.posix.fs.file_dvfs
+	include embox.compat.posix.fs.lseek_dvfs
+	include embox.compat.libc.stdio.rename_dvfs
+	include embox.fs.driver.devfs_dvfs
+*/
+
+	@Runlevel(2) include embox.test.critical
+	@Runlevel(2) include embox.test.recursion
+
+	@Runlevel(2) include embox.test.stdio.printf_test
+	@Runlevel(2) include embox.test.posix.poll_test
+	@Runlevel(2) include embox.test.posix.select_test
+	@Runlevel(2) include embox.test.posix.pipe_test
+	@Runlevel(2) include embox.test.posix.ppty_test
+	@Runlevel(2) include embox.test.stdlib.bsearch_test
+	@Runlevel(2) include embox.test.stdlib.qsort_test
+	@Runlevel(2) include embox.test.posix.environ_test
+	@Runlevel(2) include embox.test.posix.getopt_test
+
+	@Runlevel(1) include embox.test.math.math_test
+	@Runlevel(2) include embox.test.math.fpu_context_consistency_test
+
+	@Runlevel(2) include embox.cmd.sh.tish(
+				prompt="%u@%h:%w%$", rich_prompt_support=1,
+				builtin_commands="exit logout cd export mount umount")
+	include embox.init.system_start_service(log_level=3, tty_dev="ttyS0", cmd_max_len=100, cmd_max_argv=20)
+	include embox.cmd.service
+
+	include embox.cmd.net.arp
+	include embox.cmd.net.netstat
+	include embox.cmd.net.arping
+	include embox.cmd.net.rarping
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.ping
+	include embox.cmd.net.iptables
+	include embox.cmd.net.route
+	include embox.cmd.net.ftp
+	include embox.cmd.net.tftp
+	include embox.cmd.net.snmpd
+	include embox.cmd.net.ntpdate
+	include embox.cmd.net.ntpd
+	include embox.cmd.net.telnetd
+	include embox.cmd.net.nslookup
+	include embox.cmd.net.getmail
+	include embox.cmd.net.sendmail
+	include embox.cmd.net.httpd(use_real_cmd=true, use_parallel_cgi=false)
+	include embox.cmd.net.httpd_cgi
+	include embox.service.http_admin
+	include embox.demo.website
+	include embox.cmd.net.netmanager
+	include embox.cmd.net.net_service
+
+	include embox.cmd.wc
+	include embox.cmd.head
+
+	include embox.cmd.fs.dd
+	include embox.cmd.fs.md5sum
+	include embox.cmd.fs.uniq
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.cd
+	include embox.cmd.fs.pwd
+	include embox.cmd.fs.ls
+	include embox.cmd.fs.du
+	include embox.cmd.fs.rm
+	include embox.cmd.fs.mkfs
+	include embox.cmd.fs.mount
+	include embox.cmd.fs.more
+	include embox.cmd.fs.umount
+	include embox.cmd.fs.stat
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.mkdir
+	include embox.cmd.fs.cp
+	include embox.cmd.fs.mv
+
+	include embox.cmd.help
+	include embox.cmd.man
+
+	include embox.cmd.sys.uname
+	include embox.cmd.sys.env
+	include embox.cmd.sys.export
+	include embox.cmd.sys.version
+	include embox.cmd.sys.date
+	include embox.cmd.sys.time
+	include embox.cmd.sys.shutdown
+
+	include embox.cmd.lsmod
+	include embox.cmd.test
+
+	include embox.cmd.proc.nice
+	include embox.cmd.proc.renice
+
+	include embox.cmd.proc.thread
+	include embox.cmd.proc.top
+
+	include embox.cmd.mmuinfo
+	include embox.cmd.hw.mmutrans
+	include embox.cmd.mem
+
+	include embox.cmd.ide
+	include embox.cmd.lspci
+	include embox.cmd.blockdev
+	include embox.cmd.hw.lsusb
+	include embox.cmd.hw.lsblk
+	include embox.cmd.hw.lshw
+	include embox.cmd.hw.partition
+	include embox.cmd.hw.ccid_cmd
+
+	include embox.cmd.cpuinfo
+
+	include embox.cmd.testing.block_dev_test
+	include embox.cmd.testing.ticker
+
+	@Runlevel(2) include embox.net.core_net_ns(amount_interface=10)
+	/* @Runlevel(2) include embox.net.core */
+	@Runlevel(2) include embox.net.skbuff(amount_skb=4000)
+	@Runlevel(2) include embox.net.skbuff_data(
+				amount_skb_data=4000, data_size=1514,
+				data_align=1, data_padto=1,ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(
+				amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev(netdev_quantity=10)
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.tcp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.tcp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.net_entry
+	@Runlevel(2) include embox.net.net_namespace_nonstub
+	@Runlevel(2) include embox.net.route_net_ns
+	/* AF_INET, SOCK_STREAM, default */
+	include embox.net.lib.dns_file
+
+	include embox.compat.libc.all
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.libc.math_builtins
+	include embox.compat.posix.pthread_key
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.fs.rewinddir_stub
+
+	include embox.compat.atomic.pseudo_atomic
+
+	include embox.util.LibUtil
+	include embox.framework.LibFramework
+
+	include embox.cmd.udp_c
+	include embox.cmd.udp_s
+	include embox.cmd.nsexec
+	include embox.cmd.addveth
+}

--- a/templates/x86/netns/rootfs/network
+++ b/templates/x86/netns/rootfs/network
@@ -1,0 +1,9 @@
+iface eth0 inet static
+	address 10.0.2.16
+	netmask 255.255.255.0
+	gateway 10.0.2.10
+	hwaddress aa:bb:cc:dd:ee:02
+
+iface lo inet static
+	address 127.0.0.1
+	netmask 255.0.0.0

--- a/templates/x86/netns/system_start.inc
+++ b/templates/x86/netns/system_start.inc
@@ -1,0 +1,18 @@
+"export PWD=/",
+"export HOME=/",
+"partition",
+// "mkdir -v /bin",
+// "mount -t binfs / /bin",
+"netmanager",
+"service telnetd",
+"service httpd",
+
+"addveth ns1 ns2",
+"nsexec ns1 ifconfig eth1 10.0.0.1 netmask 255.255.255.0 hw ether aa:bb:cc:dd:ee:03 up",
+"nsexec ns1 route add 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.2 eth1",
+"nsexec ns1 service udp_s",
+"nsexec ns2 ifconfig eth2 10.0.0.2 netmask 255.255.255.0 hw ether aa:bb:cc:dd:ee:04 up",
+"nsexec ns2 route add 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1 eth2",
+"nsexec ns2 service udp_c",
+
+"nsexec init_net_ns tish",


### PR DESCRIPTION
In this pull request namespace feature is partially implemented in net stack with
simple demo: UDP peers are communicating with each other using the same port number
with virtual pair of Ethernet devices (similar to Linux veth(4)) residing in
separate net namespaces.
This demo might be run with the following commands sequence:

```
$ make confload-x86/netns
$ make
$ sudo ./scripts/qemu/auto_qemu
```

The following output of running UDP client and server is observed with frequency of several seconds:
```
Server msg from port 8080: Hello from server; client net namespace ns2
Client msg from port 8080: Hello from client; server net namespace ns1
```
