### PR TITLE
2281 gpio input

### DIFF
--- a/platform/stm32/templates/f7/stm32f746g-discovery/mods.conf
+++ b/platform/stm32/templates/f7/stm32f746g-discovery/mods.conf
@@ -36,6 +36,7 @@ configuration conf {
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
 	//@Runlevel(1) include embox.driver.serial.stm_ttyS1(baud_rate=115200, usartx=6)
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
+	@Runlevel(1) include embox.driver.gpio.stm32_gpio_f7
 	@Runlevel(1) include embox.driver.flash.stm32f7_qspi
 	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000)
 	@Runlevel(2) include embox.driver.sd.stm32f746g_discovery_sd
@@ -90,6 +91,8 @@ configuration conf {
 	//@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
 	include embox.init.system_start_service(log_level=3, tty_dev="ttyS0")
 
+	include embox.cmd.help
+	include embox.cmd.sys.version
 	include embox.cmd.mem
 	include embox.cmd.goto
 	include embox.cmd.net.tftp
@@ -107,16 +110,14 @@ configuration conf {
 	include embox.cmd.net.httpd_cgi
 	include embox.service.http_admin
 	include embox.demo.website
+	include embox.cmd.testing.fb_direct_access
+	include embox.cmd.testing.block_dev_test
+	include embox.cmd.hardware.pin
 
 	include embox.compat.posix.proc.vfork_exchanged
 	include embox.compat.posix.proc.exec_exchanged
 
-	include embox.cmd.testing.fb_direct_access
-	include embox.cmd.testing.block_dev_test
-
 	include embox.util.hashtable
-	include embox.cmd.help
-	include embox.cmd.sys.version
 	include embox.util.log
 	include embox.kernel.critical
 	include embox.kernel.irq_static

--- a/platform/stm32/templates/f7/stm32f769i-discovery/mods.conf
+++ b/platform/stm32/templates/f7/stm32f769i-discovery/mods.conf
@@ -28,6 +28,7 @@ configuration conf {
 	@Runlevel(1) include embox.driver.serial.stm_usart_f7(baud_rate=115200, usartx=1)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_usart_f7")
 	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=1)
+	@Runlevel(1) include embox.driver.gpio.stm32_gpio_f7
 	@Runlevel(1) include embox.driver.flash.stm32f7_qspi
 	@Runlevel(1) include embox.driver.video.stm32f7_lcd(fb_base=0x60000000)
 	@Runlevel(2) include embox.driver.sd.stm32f769i_discovery_sd
@@ -74,6 +75,8 @@ configuration conf {
 	@Runlevel(2) include embox.cmd.sh.tish(builtin_commands = "cd export exit logout httpd")
 	@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
 
+	include embox.cmd.help
+	include embox.cmd.sys.version
 	include embox.cmd.mem
 	include embox.cmd.goto
 	include embox.cmd.net.tftp
@@ -91,16 +94,14 @@ configuration conf {
 	include embox.cmd.net.httpd_cgi
 	include embox.service.http_admin
 	include embox.demo.website
+	include embox.cmd.testing.fb_direct_access
+	include embox.cmd.testing.block_dev_test
+	include embox.cmd.hardware.pin
 
 	include embox.compat.posix.proc.vfork_exchanged
 	include embox.compat.posix.proc.exec_exchanged
 
-	include embox.cmd.testing.fb_direct_access
-	include embox.cmd.testing.block_dev_test
-
 	include embox.util.hashtable
-	include embox.cmd.help
-	include embox.cmd.sys.version
 	include embox.util.log
 	include embox.kernel.critical
 	include embox.kernel.irq_static

--- a/src/drivers/gpio/Mybuild
+++ b/src/drivers/gpio/Mybuild
@@ -4,6 +4,7 @@ module core {
 	option number log_level = 1
 	option number gpio_chips_count = 1
 	option number gpio_irqs_count = 4 /* Number of GPIO pins irq handlers */
+	option number gpio_hnd_prio = 200
 
 	/* User API */
 	@IncludeExport(path="drivers/gpio")
@@ -14,6 +15,8 @@ module core {
 	source "gpio_driver.h"
 
 	source "gpio.c"
+
+	depends embox.kernel.lthread.lthread
 }
 
 /* Should be implemented by GPIO drivers */

--- a/src/drivers/gpio/gpio.c
+++ b/src/drivers/gpio/gpio.c
@@ -45,6 +45,7 @@ int gpio_register_chip(struct gpio_chip *chip, unsigned char chip_id) {
 		return -1;
 	}
 	gpio_chip_registry[chip_id] = chip;
+
 	return 0;
 }
 
@@ -67,6 +68,7 @@ void gpio_handle_irq(struct gpio_chip *chip, unsigned int irq_nr,
 
 int gpio_setup_mode(unsigned short port, gpio_mask_t pins, int mode) {
 	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
+
 	if (!chip) {
 		log_error("Chip not found, chip=%d", GPIO_CHIP(port));
 		return -EINVAL;
@@ -78,11 +80,13 @@ int gpio_setup_mode(unsigned short port, gpio_mask_t pins, int mode) {
 		return -EINVAL;
 	}
 	assert(chip->setup_mode);
+
 	return chip->setup_mode(port, pins, mode);
 }
 
 void gpio_set(unsigned short port, gpio_mask_t pins, char level) {
 	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
+
 	if (!chip) {
 		log_error("Chip not found, chip=%d", GPIO_CHIP(port));
 		return;
@@ -99,6 +103,7 @@ void gpio_set(unsigned short port, gpio_mask_t pins, char level) {
 
 gpio_mask_t gpio_get(unsigned short port, gpio_mask_t pins) {
 	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
+
 	if (!chip) {
 		log_error("Chip not found, chip=%d", GPIO_CHIP(port));
 		return -1;
@@ -110,12 +115,14 @@ gpio_mask_t gpio_get(unsigned short port, gpio_mask_t pins) {
 		return -EINVAL;
 	}
 	assert(chip->get);
+
 	return chip->get(port, pins);
 }
 
 void gpio_toggle(unsigned short port, gpio_mask_t pins) {
 	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
 	gpio_mask_t state;
+
 	if (!chip) {
 		log_error("Chip not found, chip=%d", GPIO_CHIP(port));
 		return;
@@ -136,6 +143,7 @@ int gpio_irq_attach(unsigned short port, gpio_mask_t pins,
 		irq_handler_t pin_handler, void *data) {
 	struct gpio_irq_handler *gpio_hnd;
 	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
+
 	if (!chip) {
 		log_error("Chip not found, chip=%d", GPIO_CHIP(port));
 		return -EINVAL;

--- a/src/drivers/gpio/gpio.c
+++ b/src/drivers/gpio/gpio.c
@@ -8,29 +8,44 @@
 #include <errno.h>
 #include <assert.h>
 
+#include <kernel/lthread/lthread.h>
 #include <mem/misc/pool.h>
+#include <util/bit.h>
 #include <util/dlist.h>
 #include <util/log.h>
 
 #include <drivers/gpio/gpio.h>
 #include <drivers/gpio/gpio_driver.h>
 
-#define GPIO_CHIPS_COUNT OPTION_GET(NUMBER,gpio_chips_count)
-#define GPIO_IRQS_COUNT OPTION_GET(NUMBER,gpio_irqs_count)
+#define GPIO_CHIPS_COUNT  OPTION_GET(NUMBER,gpio_chips_count)
+#define GPIO_IRQS_COUNT   OPTION_GET(NUMBER,gpio_irqs_count)
+#define GPIO_HND_PRIORITY OPTION_GET(NUMBER,gpio_hnd_prio)
+
+#define DO_IPL_LOCKED(job)       \
+	{                            \
+		ipl_t _ipl = ipl_save(); \
+		job;                     \
+		ipl_restore(_ipl);       \
+	}
 
 struct gpio_irq_handler {
 	struct gpio_chip *chip;
 	unsigned char port;
-	gpio_mask_t pins;
+	uint32_t pin;
 	void *data;
-	irq_handler_t handler;
+	void (*handler)(void *);
 	struct dlist_head link;
 };
+
+static int gpio_lthread_irq_hnd(struct lthread *self);
+static LTHREAD_DEF(gpio_lthread, gpio_lthread_irq_hnd, GPIO_HND_PRIORITY);
 
 static struct gpio_chip *gpio_chip_registry[GPIO_CHIPS_COUNT];
 
 POOL_DEF(gpio_irq_pool, struct gpio_irq_handler, GPIO_IRQS_COUNT);
+
 static DLIST_DEFINE(gpio_irq_list);
+static DLIST_DEFINE(gpio_pending_irq_list);
 
 int gpio_register_chip(struct gpio_chip *chip, unsigned char chip_id) {
 	assert(chip);
@@ -51,19 +66,6 @@ int gpio_register_chip(struct gpio_chip *chip, unsigned char chip_id) {
 
 static struct gpio_chip *gpio_get_chip(unsigned char chip_nr) {
 	return chip_nr < GPIO_CHIPS_COUNT ? gpio_chip_registry[chip_nr] : NULL;
-}
-
-void gpio_handle_irq(struct gpio_chip *chip, unsigned int irq_nr,
-		unsigned char port, gpio_mask_t changed_pins) {
-	struct gpio_irq_handler *gpio_hnd;
-
-	dlist_foreach_entry(gpio_hnd, &gpio_irq_list, link) {
-		if ((gpio_hnd->chip == chip)
-				&& (gpio_hnd->port == port)
-				&& (gpio_hnd->pins & changed_pins)) {
-			gpio_hnd->handler(irq_nr, gpio_hnd->data);
-		}
-	}
 }
 
 int gpio_setup_mode(unsigned short port, gpio_mask_t pins, int mode) {
@@ -139,8 +141,8 @@ void gpio_toggle(unsigned short port, gpio_mask_t pins) {
 	chip->set(port, ~state & pins, 1); /* Up all pins that were LOW */
 }
 
-int gpio_irq_attach(unsigned short port, gpio_mask_t pins,
-		irq_handler_t pin_handler, void *data) {
+int gpio_irq_attach(unsigned short port, uint32_t pin,
+		void (*pin_handler)(void *), void *data) {
 	struct gpio_irq_handler *gpio_hnd;
 	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
 
@@ -160,13 +162,84 @@ int gpio_irq_attach(unsigned short port, gpio_mask_t pins,
 			GPIO_CHIP(port), gpio_hnd);
 		return -ENOMEM;
 	}
-	dlist_add_next(dlist_head_init(&gpio_hnd->link), &gpio_irq_list);
 
 	gpio_hnd->chip = chip;
 	gpio_hnd->port = port;
-	gpio_hnd->pins = pins;
+	gpio_hnd->pin  = pin;
 	gpio_hnd->data = data;
 	gpio_hnd->handler = pin_handler;
 
+	DO_IPL_LOCKED(
+		dlist_add_next(dlist_head_init(&gpio_hnd->link), &gpio_irq_list);
+	);
+
 	return 0;
+}
+
+int gpio_irq_detach(unsigned short port, uint32_t pin) {
+	struct gpio_irq_handler *gpio_hnd;
+	struct gpio_chip *chip = gpio_get_chip(GPIO_CHIP(port));
+
+	if (!chip) {
+		log_error("Chip not found, chip=%d", GPIO_CHIP(port));
+		return -EINVAL;
+	}
+
+	port = GPIO_PORT(port);
+
+	dlist_foreach_entry_safe(gpio_hnd, &gpio_irq_list, link) {
+		if ((gpio_hnd->chip == chip)
+				&& (gpio_hnd->port == port)
+				&& (gpio_hnd->pin  == pin)) {
+			DO_IPL_LOCKED(dlist_del(&gpio_hnd->link));
+			pool_free(&gpio_irq_pool, gpio_hnd);
+
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+static int gpio_lthread_irq_hnd(struct lthread *self) {
+	struct gpio_irq_handler *gpio_hnd;
+
+	dlist_foreach_entry_safe(gpio_hnd, &gpio_pending_irq_list, link) {
+		gpio_hnd->handler(gpio_hnd->data);
+
+		/* Move handler back to gpio list. */
+		DO_IPL_LOCKED(
+			dlist_del(&gpio_hnd->link);
+			dlist_add_prev(&gpio_hnd->link, &gpio_irq_list);
+		);
+	}
+
+	return 0;
+}
+
+void gpio_handle_irq(struct gpio_chip *chip, uint8_t port, gpio_mask_t pins) {
+	struct gpio_irq_handler *gpio_hnd;
+	int pin;
+	int pending = 0;
+
+	bit_foreach(pin, pins) {
+		dlist_foreach_entry_safe(gpio_hnd, &gpio_irq_list, link) {
+			if ((gpio_hnd->chip == chip)
+					&& (gpio_hnd->port == port)
+					&& (gpio_hnd->pin  == (1 << pin))) {
+
+				/* Move handler to pending list to be processed in lthread. */
+				DO_IPL_LOCKED(
+					dlist_del(&gpio_hnd->link);
+					dlist_add_prev(&gpio_hnd->link, &gpio_pending_irq_list);
+				);
+
+				pending = 1;
+			}
+		}
+	}
+
+	if (pending) {
+		lthread_launch(&gpio_lthread);
+	}
 }

--- a/src/drivers/gpio/gpio.h
+++ b/src/drivers/gpio/gpio.h
@@ -78,6 +78,9 @@ typedef volatile unsigned long gpio_mask_t;
 #define GPIO_MODE_INT_MODE_FALLING  (1 << 29)
 #endif
 
+#define GPIO_MODE_INT_MODE_RISING_FALLING \
+	(GPIO_MODE_INT_MODE_RISING | GPIO_MODE_INT_MODE_FALLING)
+
 #ifndef GPIO_MODE_INT_MODE_LEVEL0
 #define GPIO_MODE_INT_MODE_LEVEL0   (1 << 28)
 #endif

--- a/src/drivers/gpio/gpio.h
+++ b/src/drivers/gpio/gpio.h
@@ -118,7 +118,8 @@ extern void gpio_toggle(unsigned short port, gpio_mask_t pins);
 
 extern gpio_mask_t gpio_get(unsigned short port, gpio_mask_t pins);
 
-extern int gpio_irq_attach(unsigned short port, gpio_mask_t pins,
-		irq_handler_t pin_handler, void *data);
+extern int gpio_irq_attach(unsigned short port, uint32_t pin,
+		void (*pin_handler)(void *), void *data);
+extern int gpio_irq_detach(unsigned short port, uint32_t pin);
 
 #endif /* DRIVERS_GPIO_H_ */

--- a/src/drivers/gpio/gpio_driver.h
+++ b/src/drivers/gpio/gpio_driver.h
@@ -21,8 +21,8 @@ struct gpio_chip {
 extern int gpio_register_chip(struct gpio_chip *gpio_chip, unsigned char chip_id);
 
 /* Drivers should call this function when interrupts happened
- * on the specified pins */
-extern void gpio_handle_irq(struct gpio_chip *gpio_chip, unsigned int irq_nr,
-		unsigned char port, gpio_mask_t changed_pins);
+ * on the specified pin. */
+extern void gpio_handle_irq(struct gpio_chip *chip, uint8_t port,
+                            gpio_mask_t pins);
 
 #endif /* DRIVERS_GPIO_DRIVER_H_ */

--- a/src/drivers/gpio/omap3/omap3_gpio.c
+++ b/src/drivers/gpio/omap3/omap3_gpio.c
@@ -128,7 +128,7 @@ irq_return_t irq_gpio_handler(unsigned int irq_nr, void *data) {
 	gpio_reg_write(gpio_base, GPIO_IRQSTATUS1, changed);
 	gpio_reg_write(gpio_base, GPIO_IRQSTATUS2, changed);
 
-	gpio_handle_irq(&omap3_gpio_chip, irq_nr, port, changed);
+	gpio_handle_irq(&omap3_gpio_chip, port, changed);
 
 	return IRQ_HANDLED;
 }

--- a/src/drivers/gpio/stm32/Mybuild
+++ b/src/drivers/gpio/stm32/Mybuild
@@ -8,6 +8,9 @@ module stm32_gpio_f1 extends api {
 	option number exti1_irq = 7
 	option number exti2_irq = 8
 	option number exti3_irq = 9
+	option number exti4_irq = 10
+	option number exti9_5_irq = 23
+	option number exti15_10_irq = 40
 
 	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
 	source "stm32_gpio_conf_f1.h"
@@ -27,6 +30,9 @@ module stm32_gpio_f4 extends api {
 	option number exti1_irq = 7
 	option number exti2_irq = 8
 	option number exti3_irq = 9
+	option number exti4_irq = 10
+	option number exti9_5_irq = 23
+	option number exti15_10_irq = 40
 
 	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
 	source "stm32_gpio_conf_f4.h"
@@ -46,6 +52,9 @@ module stm32_gpio_l4 extends api {
 	option number exti2_irq = 8
 	option number exti3_irq = 9
 	option number exti4_irq = 10
+	option number exti4_irq = 10
+	option number exti9_5_irq = 23
+	option number exti15_10_irq = 40
 
 	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
 	source "stm32_gpio_conf_l4.h"
@@ -64,6 +73,9 @@ module stm32_gpio_f3 extends api {
 	option number exti1_irq = 7
 	option number exti2_irq = 8
 	option number exti3_irq = 9
+	option number exti4_irq = 10
+	option number exti9_5_irq = 23
+	option number exti15_10_irq = 40
 
 	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
 	source "stm32_gpio_conf_f3.h"
@@ -83,6 +95,9 @@ module stm32_gpio_f7 extends api {
 	option number exti1_irq = 7
 	option number exti2_irq = 8
 	option number exti3_irq = 9
+	option number exti4_irq = 10
+	option number exti9_5_irq = 23
+	option number exti15_10_irq = 40
 
 	@IncludeExport(path="drivers/gpio", target_name="stm32.h")
 	source "stm32_gpio_conf_f7.h"

--- a/src/drivers/gpio/stm32/stm32_gpio_cube.c
+++ b/src/drivers/gpio/stm32/stm32_gpio_cube.c
@@ -100,10 +100,15 @@ static int stm32_gpio_setup_mode(unsigned char port, gpio_mask_t pins,
 		if (mode & GPIO_MODE_IN_PULL_DOWN) {
 			GPIO_InitStruct.Pull = GPIO_PULLDOWN;
 		}
-	} else if (mode & GPIO_MODE_INT_MODE_RISING) {
-		GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
-	} else if (mode & GPIO_MODE_INT_MODE_FALLING) {
-		GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+	} else if (mode & GPIO_MODE_INT_MODE_RISING_FALLING) {
+		if ((mode & GPIO_MODE_INT_MODE_RISING_FALLING)
+				== GPIO_MODE_INT_MODE_RISING_FALLING) {
+			GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
+		} else if (mode & GPIO_MODE_INT_MODE_RISING) {
+			GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
+		} else if (mode & GPIO_MODE_INT_MODE_FALLING) {
+			GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+		}
 	}
 
 	HAL_GPIO_Init(stm32_gpio_ports[port], &GPIO_InitStruct);

--- a/src/drivers/gpio/stm32/stm32_gpio_cube.c
+++ b/src/drivers/gpio/stm32/stm32_gpio_cube.c
@@ -36,8 +36,18 @@ static_assert(EXTI2_IRQ == EXTI2_IRQn);
 #define EXTI3_IRQ          OPTION_GET(NUMBER, exti3_irq)
 static_assert(EXTI3_IRQ == EXTI3_IRQn);
 
+#define EXTI4_IRQ          OPTION_GET(NUMBER, exti4_irq)
+static_assert(EXTI4_IRQ == EXTI4_IRQn);
+
+#define EXTI9_5_IRQ        OPTION_GET(NUMBER, exti9_5_irq)
+static_assert(EXTI9_5_IRQ == EXTI9_5_IRQn);
+
+#define EXTI15_10_IRQ     OPTION_GET(NUMBER, exti15_10_irq)
+static_assert(EXTI15_10_IRQ == EXTI15_10_IRQn);
+
 static const unsigned char exti_irqs[] = {
-	EXTI0_IRQ, EXTI1_IRQ, EXTI2_IRQ, EXTI3_IRQ
+	EXTI0_IRQ, EXTI1_IRQ, EXTI2_IRQ, EXTI3_IRQ, EXTI4_IRQ,
+	EXTI9_5_IRQ, EXTI15_10_IRQ,
 };
 
 static struct gpio_chip stm32_gpio_chip;
@@ -122,17 +132,17 @@ static gpio_mask_t stm32_gpio_get(unsigned char port, gpio_mask_t pins) {
 
 irq_return_t stm32_gpio_irq_handler(unsigned int irq_nr, void *data) {
 	int i;
-	unsigned int pin = 1 << (irq_nr - EXTI0_IRQ);
+	uint16_t pending;
 
-	if (__HAL_GPIO_EXTI_GET_IT(pin) == RESET) {
-		return IRQ_HANDLED;
-	}
-	 __HAL_GPIO_EXTI_CLEAR_IT(pin);
+	pending = __HAL_GPIO_EXTI_GET_FLAG(0xffff);
+
+	__HAL_GPIO_EXTI_CLEAR_IT(pending);
 
 	/* Notify all GPIO ports about interrupt */
 	for (i = 0; i < STM32_GPIO_PORTS_COUNT; i++) {
-		gpio_handle_irq(&stm32_gpio_chip, irq_nr, i, pin);
+		gpio_handle_irq(&stm32_gpio_chip, i, pending);
 	}
+
 	return IRQ_HANDLED;
 }
 
@@ -161,3 +171,6 @@ STATIC_IRQ_ATTACH(EXTI0_IRQ, stm32_gpio_irq_handler, NULL);
 STATIC_IRQ_ATTACH(EXTI1_IRQ, stm32_gpio_irq_handler, NULL);
 STATIC_IRQ_ATTACH(EXTI2_IRQ, stm32_gpio_irq_handler, NULL);
 STATIC_IRQ_ATTACH(EXTI3_IRQ, stm32_gpio_irq_handler, NULL);
+STATIC_IRQ_ATTACH(EXTI4_IRQ, stm32_gpio_irq_handler, NULL);
+STATIC_IRQ_ATTACH(EXTI9_5_IRQ, stm32_gpio_irq_handler, NULL);
+STATIC_IRQ_ATTACH(EXTI15_10_IRQ, stm32_gpio_irq_handler, NULL);


### PR DESCRIPTION
Fixes #2281 

You can verify gpio interrupts with `pin` command (more details here https://github.com/embox/embox/wiki/GPIO#pin-command)