### PR TITLE
docs: fix simple typo, wront -> wrong

### DIFF
--- a/src/drivers/virtio/virtio.h
+++ b/src/drivers/virtio/virtio.h
@@ -36,7 +36,7 @@
 											device */
 #define VIRTIO_CONFIG_S_DRIVER_OK   0x04 /* Driver is set up and ready to drive
 											the device */
-#define VIRTIO_CONFIG_S_FAILED      0x80 /* Something went wront */
+#define VIRTIO_CONFIG_S_FAILED      0x80 /* Something went wrong */
 
 /**
  * VirtIO Ring Alignment


### PR DESCRIPTION
There is a small typo in src/drivers/virtio/virtio.h.

Should read `wrong` rather than `wront`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md