### PR TITLE
fix max interrupt channels for nucleo-l476rg platform

### DIFF
--- a/platform/stm32/templates/l4/nucleo_l476rg/mods.conf
+++ b/platform/stm32/templates/l4/nucleo_l476rg/mods.conf
@@ -8,7 +8,7 @@ configuration conf {
 
 	@Runlevel(0) include embox.kernel.stack(stack_size=4096,alignment=4)
 
-	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=32)
+	@Runlevel(1) include embox.driver.interrupt.cortexm_nvic(irq_table_size=82)
 	@Runlevel(1) include embox.driver.clock.cortexm_systick
 	include embox.kernel.time.jiffies(cs_name="cortexm_systick")
 
@@ -69,6 +69,5 @@ configuration conf {
 	include embox.mem.static_heap(heap_size=0x400)
 	include embox.mem.bitmask(page_size=64)
 
-	include embox.driver.char_dev_stub
 	include embox.fs.driver.devfs_stub
 }


### PR DESCRIPTION
Fixed system start on nucleo-l476rg (there was problem with irq_table_size, l47x have 82 interrupt channels, RM0351, p. 396). 

Also was removed char_dev_stub to avoid build error ```(Unknown):: error: Module embox.driver.char_dev extends module supertype already extended by incompatible embox.driver.char_dev_stub(conf/mods.conf:72:10)```