### PR TITLE
Added support for wcsnlen() in wchar module

### DIFF
--- a/src/compat/libc/include/wchar.h
+++ b/src/compat/libc/include/wchar.h
@@ -41,6 +41,7 @@ extern int wcscmp(const wchar_t *s1, const wchar_t *s2);
 extern wchar_t *wcsncpy(wchar_t *dst, const wchar_t *src, size_t n);
 extern int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n);
 extern size_t wcslen(const wchar_t *s);
+extern size_t wcsnlen(const wchar_t *s, size_t maxlen);
 extern wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n);
 extern wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n);
 extern wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n);

--- a/src/compat/libc/wchar/Mybuild
+++ b/src/compat/libc/wchar/Mybuild
@@ -7,6 +7,7 @@ static module wchar {
 	source "wcstrtoumax.c"
 	source "wctype.c"
 	source "wcslen.c"
+	source "wcsnlen.c"
 	source "wmemset.c"
 	source "wmemmove.c"
 	source "wmemcpy.c"

--- a/src/compat/libc/wchar/wcsnlen.c
+++ b/src/compat/libc/wchar/wcsnlen.c
@@ -1,0 +1,22 @@
+/**
+ * @file
+ *
+ * @date Feb 20, 2021
+ * @author Vedant Paranjape
+ */
+
+#include <wchar.h>
+#include <inttypes.h>
+#include <string.h>
+
+size_t wcsnlen(const wchar_t *s, size_t maxlen) {
+	size_t len = 0;
+
+	for (len = 0; len < maxlen; len++, s++) {
+		if (!*s) {
+			break;
+		}
+	}
+
+	return (len);
+}

--- a/src/tests/stdlib/Mybuild
+++ b/src/tests/stdlib/Mybuild
@@ -186,3 +186,10 @@ module strpbrk_test {
 	depends embox.compat.libc.str
 	depends embox.framework.LibFramework
 }
+
+module wcslen_test {
+	source "wcslen.c"
+
+	depends embox.compat.libc.wchar
+	depends embox.framework.LibFramework
+}

--- a/src/tests/stdlib/wcslen.c
+++ b/src/tests/stdlib/wcslen.c
@@ -1,0 +1,29 @@
+/**
+ * @file
+ *
+ * @date Feb 20, 2021
+ * @author: Vedant Paranjape
+ */
+
+#include <wchar.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("test suit for wcslen()");
+
+TEST_CASE("get length with wcslen()") {
+	wchar_t str[] = L"covid19sucks";
+	size_t len;
+
+	len = sizeof(str) / 4 - 1;
+
+	test_assert_equal(len, wcslen(str));
+}
+
+TEST_CASE("use wcsnlen() with maxlen less than string length") {
+	wchar_t str[] = L"covid19sucks";
+	size_t len;
+
+	len = sizeof(str) / 4 - 1;
+
+	test_assert_equal(len, wcsnlen(str, len));
+}


### PR DESCRIPTION
For simplicity of review, I have divided the PR into 2 commits.

### Added compatibility layer for wcsnlen() in wchar module (c2bda28)
Implements `wcsnlen()` function, which was missing in the compat layer. Referred to [this source implementation](https://android.googlesource.com/platform/bionic/+/ics-mr0/libc/wchar/wcsnlen.c)

### Fixes (#2348) Added test cases for wcslen() and wcsnlen() (6805282)
Adds test case to test if `wcslen()` and `wcsnlen()` works correctly. Used the template from test in `stdlib/strlen.c` 