### PR TITLE
Updated strlen test cases to also test strlen() and not only strnlen()

### DIFF
--- a/src/tests/stdlib/strlen.c
+++ b/src/tests/stdlib/strlen.c
@@ -14,9 +14,9 @@ TEST_CASE("get length with strnlen()") {
 	char str[] = "string";
 	size_t len;
 
-	len = sizeof(str);
+	len = sizeof(str) - 1;
 
-	test_assert_equal(len - 1, strnlen(str, len));
+	test_assert_equal(len, strlen(str));
 }
 
 TEST_CASE("use strnlen() with maxlen less than string length") {


### PR DESCRIPTION
Earlier the strlen test cases, didn't use `strlen()`, rather only `strnlen()`. Changed it as dicussed with @alexkalmuk 

I had to update the commit message to include issue number, so had to force push :0

Edit: It failed on `x86/smp` platform, don't see the reason behind this.