### PR TITLE
Add tests for the strcat and strncat functions

### DIFF
--- a/src/tests/string/Mybuild
+++ b/src/tests/string/Mybuild
@@ -1,0 +1,11 @@
+package embox.test.str
+
+module strcat_test {
+	source "strcat_test.c"
+	depends embox.compat.libc.str
+}
+
+module strncat_test {
+	source "strncat_test.c"
+	depends embox.compat.libc.str
+}

--- a/src/tests/string/strcat_test.c
+++ b/src/tests/string/strcat_test.c
@@ -1,0 +1,27 @@
+/**
+ * @file strcat_test.c
+ * @brief Test for the 'strcat' function.
+ *
+ * @date February, 2021
+ * @author André Perez
+ */
+
+#include <string.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("string/strcat test");
+
+TEST_CASE("strcat") {
+  /* Destination string */
+  char dest[34] = "Embox: ";
+
+  /* Source string */
+  const char src[] = "Real Time Operating System";
+
+  /* The pointer returned by 'strcat' must be 'dest'. */
+  test_assert_equal(strcat(dest, src), dest);
+
+  /* After concatenation, 'dest' (as string) must be equal to
+     'Embox: Real Time Operating System'. */
+  test_assert_str_equal(dest, "Embox: Real Time Operating System");
+}

--- a/src/tests/string/strncat_test.c
+++ b/src/tests/string/strncat_test.c
@@ -1,0 +1,27 @@
+/**
+ * @file strncat_test.c
+ * @brief Test for the 'strncat' function.
+ *
+ * @date February, 2021
+ * @author André Perez
+ */
+
+#include <string.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("string/strncat test");
+
+TEST_CASE("strncat") {
+  /* Destination string */
+  char dest[17] = "Embox: ";
+
+  /* Source string */
+  const char src[] = "Real Time Operating System";
+
+  /* The pointer returned by 'strncat' must be 'dest'. */
+  test_assert_equal(strncat(dest, src, 9), dest);
+
+  /* After concatenation, 'dest' (as string) must be equal to
+     'Embox: Real Time'. */
+  test_assert_str_equal(dest, "Embox: Real Time");
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -93,6 +93,8 @@ configuration conf {
 	@Runlevel(1) include embox.test.stdlib.strncpy_test
 	@Runlevel(1) include embox.test.stdlib.strrchr_test
 	@Runlevel(1) include embox.test.stdlib.strchrnul_test
+	@Runlevel(1) include embox.test.str.strcat_test
+	@Runlevel(1) include embox.test.str.strncat_test
 	@Runlevel(1) include embox.test.posix.environ_test
 	@Runlevel(1) include embox.test.posix.timerfd_test
 	@Runlevel(1) include embox.test.posix.fork.test_fork_static


### PR DESCRIPTION
This PR implements tests for the `strcat` and `strncat` functions.

Fixes #1852.