### PR TITLE
opencv: Add imshowfb

### DIFF
--- a/project/opencv/lib/Mybuild
+++ b/project/opencv/lib/Mybuild
@@ -1,0 +1,13 @@
+package platform.opencv.lib
+
+@BuildDepends(third_party.lib.opencv.all)
+@Build(stage=2)
+static module cv_embox_imshowfb {
+	@IncludeExport
+	source "cv_embox_imshowfb.hpp"
+
+	source "cv_embox_imshowfb.cpp"
+
+	depends embox.driver.video.fb
+	depends third_party.lib.opencv.all
+}

--- a/project/opencv/lib/cv_embox_imshowfb.cpp
+++ b/project/opencv/lib/cv_embox_imshowfb.cpp
@@ -1,0 +1,39 @@
+/**
+ * @file
+ *
+ * @date   12.04.2021
+ * @author Alexander Kalmuk
+ */
+
+#include <stdio.h>
+#include <drivers/video/fb.h>
+#include <algorithm>
+#include <cv_embox_imshowfb.hpp>
+
+void imshowfb(cv::Mat& img, int fbx) {
+    struct fb_info *fbi;
+    int w, h;
+
+    fbi = fb_lookup(fbx);
+    if (!fbi) {
+		fprintf(stderr, "%s: fb%d not found\n", __func__, fbx);
+
+        return;
+    }
+
+    h = std::min((int) fbi->var.yres, img.rows);
+    w = std::min((int) (fbi->var.bits_per_pixel * fbi->var.xres) / 8, 3 * img.cols);
+
+    for (int y = 0; y < h; y++) {
+        const uchar *row = &img.at<uchar>(y, 0);
+        for (int x = 0; x < w; x += 3) {
+            unsigned rgb888    =
+                0xFF000000 |
+                unsigned(row[x + 2]) |
+                (unsigned(row[x + 1]) << 8) |
+                (unsigned(row[x]) << 16);
+
+            ((uint32_t *) fbi->screen_base)[fbi->var.xres * y + x / 3] = rgb888;
+        }
+    }
+}

--- a/project/opencv/lib/cv_embox_imshowfb.hpp
+++ b/project/opencv/lib/cv_embox_imshowfb.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ *
+ * @date   12.04.2021
+ * @author Alexander Kalmuk
+ */
+
+#ifndef PROJECT_OPENCV_LIB_CV_EMBOX_IMSHOWFB_HPP
+#define PROJECT_OPENCV_LIB_CV_EMBOX_IMSHOWFB_HPP
+
+#ifndef __cplusplus
+#  error cv_embox_imshowfb.hpp header must be compiled as C++
+#endif
+
+#include <opencv2/core/mat.hpp>
+
+/* It's an analogue of OpenCV imshow(), which draws image directly
+ * to the framebuffer instead of a graphical window. It makes easy
+ * to see the resulting image without underlaying window system.
+ *
+ * It means that all usages of imshow() in the application have to
+ * be replaced with imshowfb(). */
+extern void imshowfb(cv::Mat& img, int fbx);
+
+#endif /* PROJECT_OPENCV_LIB_CV_EMBOX_IMSHOWFB_HPP */


### PR DESCRIPTION
It's an analogue of `imshow`, which draws image directly to the framebuffer instead of a graphical window.