### PR TITLE
Fix duplicating cppflags in extbld

### DIFF
--- a/mk/extbld/arch-embox-gcc
+++ b/mk/extbld/arch-embox-gcc
@@ -11,8 +11,8 @@ cppflags="$EMBOX_DEPS_CPPFLAGS_BEFORE $EMBOX_IMPORTED_CPPFLAGS $EMBOX_DEPS_CPPFL
 
 cmd=$(basename $0)
 case $cmd in
-	*-gcc|*-clang) C_CXX_FLAGS="$EMBOX_IMPORTED_CFLAGS   $cppflags";;
-	*-g++)         C_CXX_FLAGS="$EMBOX_IMPORTED_CXXFLAGS $cppflags";;
+	*-gcc|*-clang) C_CXX_FLAGS="$cppflags $EMBOX_IMPORTED_CFLAGS";;
+	*-g++)         C_CXX_FLAGS="$cppflags $EMBOX_IMPORTED_CXXFLAGS";;
 	*)             echo "Unknown flags for $cmd"; exit 1;;
 esac
 
@@ -33,7 +33,6 @@ case " $@ " in
 	*" -l"*) echo -e "\n\nWARNING!!! You're linking something with it\n\n";;
 esac
 
-ARG_LINE="$ARG_LINE $EMBOX_IMPORTED_CPPFLAGS"
 PWD_ARG_LINE="$(for i in $ARG_LINE; do echo ${i/$PWD/.}; done)"
 # echo "$EMBOX_CROSS_COMPILE${cmd#arch-embox-} $@ $PWD_ARG_LINE" >&2
 


### PR DESCRIPTION
Fix duplicating CPPFLAGS passed to third-party apps. Also, fix the order of CPPFLAGS and CFLAGS.