### PR TITLE
Add loadsect module to automatically load sections in external memory

### DIFF
--- a/mk/gen_ld_section_symbols.sh
+++ b/mk/gen_ld_section_symbols.sh
@@ -4,11 +4,9 @@
 CONFIG_LDS_H=$1
 # Output
 SECTION_SYMBOLS_LDS_H=$2
-# C arrays of text, data, rodata, bss symbols.
-SECTION_ARR_H=$3
 
-rm -f $SECTION_SYMBOLS_LDS_H $SECTION_ARR_H
-touch $SECTION_SYMBOLS_LDS_H $SECTION_ARR_H
+rm -f $SECTION_SYMBOLS_LDS_H
+touch $SECTION_SYMBOLS_LDS_H
 
 SECTIONS=$(grep -o 'LDS_SECTION_VMA_[0-9a-zA-Z_]*' $CONFIG_LDS_H | \
 			sed 's/LDS_SECTION_VMA_//g' | uniq)
@@ -17,39 +15,15 @@ SECTIONS=$(echo $SECTIONS | sed -E 's/\b(text|rodata|data|bss)\b//g')
 
 gensect() {
 	name=$1
-	decl_file=$(mktemp)
-	vma_file=$(mktemp)
-	lma_file=$(mktemp)
-	len_file=$(mktemp)
 
 	echo "/* $name */" >> $SECTION_SYMBOLS_LDS_H
-	echo "/* $name */" >> $SECTION_ARR_H
-
-	echo "void *sections_${name}_vma[] = {" >> $vma_file
-	echo "void *sections_${name}_lma[] = {" >> $lma_file
-	echo "unsigned int sections_${name}_len[] = {" >> $len_file
 
 	for section in $SECTIONS
 	do
 		# Match section name. For example, qt_bss, or opencv_text
 		if [[ $section =~ _$name$ ]]; then
 			echo "SECTION_SYMBOLS($section)" >> $SECTION_SYMBOLS_LDS_H
-			echo -e "extern char _${section}_vma, _${section}_lma, _${section}_len;" >> $decl_file
-			echo -e "\t&_${section}_vma," >> $vma_file
-			echo -e "\t&_${section}_lma," >> $lma_file
-			echo -e "\t(unsigned int)&_${section}_len," >> $len_file
 		fi
-	done
-
-	echo -e "" >> $decl_file
-	echo -e "};\n" >> $vma_file
-	echo -e "};\n" >> $lma_file
-	echo -e "};\n" >> $len_file
-
-	for f in $decl_file $vma_file $lma_file $len_file
-	do
-		cat $f >> $SECTION_ARR_H
-		rm $f
 	done
 }
 

--- a/mk/gen_ld_section_symbols.sh
+++ b/mk/gen_ld_section_symbols.sh
@@ -1,18 +1,67 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Input
 CONFIG_LDS_H=$1
 # Output
 SECTION_SYMBOLS_LDS_H=$2
+# C arrays of text, data, rodata, bss symbols.
+SECTION_ARR_H=$3
 
-rm -f $SECTION_SYMBOLS_LDS_H && touch $SECTION_SYMBOLS_LDS_H
+rm -f $SECTION_SYMBOLS_LDS_H $SECTION_ARR_H
+touch $SECTION_SYMBOLS_LDS_H $SECTION_ARR_H
 
-SECTIONS=`grep -o 'LDS_SECTION_VMA_[0-9a-zA-Z_]*' $CONFIG_LDS_H | \
-			sed 's/LDS_SECTION_VMA_//g' | uniq`
+SECTIONS=$(grep -o 'LDS_SECTION_VMA_[0-9a-zA-Z_]*' $CONFIG_LDS_H | \
+			sed 's/LDS_SECTION_VMA_//g' | uniq)
 
-SECTIONS=`echo $SECTIONS | sed -E 's/\b(text|rodata|data|bss)\b//g'`
+SECTIONS=$(echo $SECTIONS | sed -E 's/\b(text|rodata|data|bss)\b//g')
 
+gensect() {
+	name=$1
+	decl_file=$(mktemp)
+	vma_file=$(mktemp)
+	lma_file=$(mktemp)
+	len_file=$(mktemp)
+
+	echo "/* $name */" >> $SECTION_SYMBOLS_LDS_H
+	echo "/* $name */" >> $SECTION_ARR_H
+
+	echo "void *sections_${name}_vma[] = {" >> $vma_file
+	echo "void *sections_${name}_lma[] = {" >> $lma_file
+	echo "unsigned int sections_${name}_len[] = {" >> $len_file
+
+	for section in $SECTIONS
+	do
+		# Match section name. For example, qt_bss, or opencv_text
+		if [[ $section =~ _$name$ ]]; then
+			echo "SECTION_SYMBOLS($section)" >> $SECTION_SYMBOLS_LDS_H
+			echo -e "extern char _${section}_vma, _${section}_lma, _${section}_len;" >> $decl_file
+			echo -e "\t&_${section}_vma," >> $vma_file
+			echo -e "\t&_${section}_lma," >> $lma_file
+			echo -e "\t(unsigned int)&_${section}_len," >> $len_file
+		fi
+	done
+
+	echo -e "" >> $decl_file
+	echo -e "};\n" >> $vma_file
+	echo -e "};\n" >> $lma_file
+	echo -e "};\n" >> $len_file
+
+	for f in $decl_file $vma_file $lma_file $len_file
+	do
+		cat $f >> $SECTION_ARR_H
+		rm $f
+	done
+}
+
+gensect text
+gensect rodata
+gensect data
+gensect bss
+
+echo "/* Other sections (not text, rodata, data or bss) */" >> $SECTION_SYMBOLS_LDS_H
 for section in $SECTIONS
 do
-	echo "SECTION_SYMBOLS($section)" >> $SECTION_SYMBOLS_LDS_H
+	if ! [[ $section =~ (_text|_data|_rodata|_bss)$ ]]; then
+		echo "SECTION_SYMBOLS($section)" >> $SECTION_SYMBOLS_LDS_H
+	fi
 done

--- a/mk/gen_sections_c.sh
+++ b/mk/gen_sections_c.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Input
+CONFIG_LDS_H=build/base/gen/config.lds.h
+
+SECTIONS=$(grep -o 'LDS_SECTION_VMA_[0-9a-zA-Z_]*' $CONFIG_LDS_H | \
+			sed 's/LDS_SECTION_VMA_//g' | uniq)
+
+SECTIONS=$(echo $SECTIONS | sed -E 's/\b(text|rodata|data|bss)\b//g')
+
+gensect() {
+	name=$1
+	decl_file=$(mktemp)
+	vma_file=$(mktemp)
+	lma_file=$(mktemp)
+	len_file=$(mktemp)
+
+	echo "/* $name */"
+
+	echo "void *sections_${name}_vma[] = {" >> $vma_file
+	echo "void *sections_${name}_lma[] = {" >> $lma_file
+	echo "unsigned int sections_${name}_len[] = {" >> $len_file
+
+	for section in $SECTIONS
+	do
+		# Match section name. For example, qt_bss, or opencv_text
+		if [[ $section =~ _$name$ ]]; then
+			echo -e "extern char _${section}_vma, _${section}_lma, _${section}_len;" >> $decl_file
+			echo -e "\t&_${section}_vma," >> $vma_file
+			echo -e "\t&_${section}_lma," >> $lma_file
+			echo -e "\t(unsigned int)&_${section}_len," >> $len_file
+		fi
+	done
+
+	echo -e "" >> $decl_file
+
+	echo -e "\t(void *)0," >> $vma_file
+	echo -e "\t(void *)0," >> $lma_file
+	echo -e "\t(unsigned int)-1," >> $len_file
+
+	for f in $vma_file $lma_file $len_file
+	do
+		echo -e "};\n" >> $f
+	done
+
+	for f in $decl_file $vma_file $lma_file $len_file
+	do
+		cat $f
+		rm $f
+	done
+}
+
+gensect text
+gensect rodata
+gensect data
+gensect bss

--- a/mk/script/build/oldconf-gen.mk
+++ b/mk/script/build/oldconf-gen.mk
@@ -43,6 +43,7 @@ regions_lds_h  := $(SRCGEN_DIR)/regions.lds.h
 sections_lds_h := $(SRCGEN_DIR)/sections.lds.h
 phdrs_lds_h    := $(SRCGEN_DIR)/phdrs.lds.h
 section_symbols_lds_h := $(SRCGEN_DIR)/section_symbols.lds.h
+section_symbols_arr_h := $(SRCGEN_DIR)/section_symbols.h
 
 all : $(build_mk) $(config_lds_h) $(regions_lds_h) \
 	$(sections_lds_h) $(phdrs_lds_h) $(section_symbols_lds_h)
@@ -69,7 +70,7 @@ gen_phdrs = \
 	$(abspath $(ROOT_DIR))/mk/gen_ld_phdrs.sh $1 $2
 
 gen_section_symbols = \
-	$(abspath $(ROOT_DIR))/mk/gen_ld_section_symbols.sh $1 $2
+	$(abspath $(ROOT_DIR))/mk/gen_ld_section_symbols.sh $1 $2 $(section_symbols_arr_h)
 
 $(config_lds_h) :
 	@$(call cmd_notouch_stdout,$@, \

--- a/mk/script/build/oldconf-gen.mk
+++ b/mk/script/build/oldconf-gen.mk
@@ -70,7 +70,7 @@ gen_phdrs = \
 	$(abspath $(ROOT_DIR))/mk/gen_ld_phdrs.sh $1 $2
 
 gen_section_symbols = \
-	$(abspath $(ROOT_DIR))/mk/gen_ld_section_symbols.sh $1 $2 $(section_symbols_arr_h)
+	$(abspath $(ROOT_DIR))/mk/gen_ld_section_symbols.sh $1 $2
 
 $(config_lds_h) :
 	@$(call cmd_notouch_stdout,$@, \

--- a/project/opencv/cmds/Mybuild
+++ b/project/opencv/cmds/Mybuild
@@ -13,6 +13,7 @@ module imagecapture {
 	depends third_party.lib.opencv.all
 }
 
+@LinkerSection(text="edges_text",rodata="edges_rodata",data="edges_data",bss="edges_bss",arm_exidx="edges_arm_exidx",arm_extab="edges_arm_extab")
 @AutoCmd
 @Cmd(name = "edges",
 	help = "Basic OpenCV test")

--- a/src/mem/Mybuild
+++ b/src/mem/Mybuild
@@ -5,4 +5,5 @@ module phymem {
 
 	source "phymem.c"
 	depends embox.mem.vmem_device_memory
+	depends embox.mem.sections
 }

--- a/src/mem/loadsect/Mybuild
+++ b/src/mem/loadsect/Mybuild
@@ -1,0 +1,11 @@
+package embox.mem
+
+module loadsect {
+	option number log_level=1
+
+	/* Cflags accepts only options without spaces, so make it as two ops. */
+	@Cflags("-include")
+	@Cflags("$(BUILD_DIR)/gen/section_symbols.h")
+
+	source "loadsect.c"
+}

--- a/src/mem/loadsect/Mybuild
+++ b/src/mem/loadsect/Mybuild
@@ -3,9 +3,12 @@ package embox.mem
 module loadsect {
 	option number log_level=1
 
-	/* Cflags accepts only options without spaces, so make it as two ops. */
-	@Cflags("-include")
-	@Cflags("$(BUILD_DIR)/gen/section_symbols.h")
-
 	source "loadsect.c"
+
+	depends sections
+}
+
+module sections {
+	@Generated(script="./mk/gen_sections_c.sh")
+	source "sections.c"
 }

--- a/src/mem/loadsect/loadsect.c
+++ b/src/mem/loadsect/loadsect.c
@@ -13,48 +13,62 @@
 
 EMBOX_UNIT_INIT(load_all_sections);
 
-/* Loads multiple sections. For example, all text sections. */
-static void load_sections(void *vmas[], void *lmas[], unsigned int lens[], int n) {
-	int i;
+extern void *sections_text_vma[];
+extern void *sections_text_lma[];
+extern unsigned int sections_text_len[];
 
-	for (i = 0; i < n; i++) {
-		if (0 == lens[i]) {
-			continue;
-		}
-		if (vmas[i] != lmas[i]) {
+extern void *sections_data_vma[];
+extern void *sections_data_lma[];
+extern unsigned int sections_data_len[];
+
+extern void *sections_rodata_vma[];
+extern void *sections_rodata_lma[];
+extern unsigned int sections_rodata_len[];
+
+extern void *sections_bss_vma[];
+extern void *sections_bss_lma[];
+extern unsigned int sections_bss_len[];
+
+/* Loads multiple sections. For example, all text sections. */
+static void load_sections(void *vmas[], void *lmas[], unsigned int lens[]) {
+	int i = 0;
+
+	while (vmas[i]) {
+		if (lens[i] && vmas[i] != lmas[i]) {
 			log_debug("vma=%p, lma=%p, len=0x%x", vmas[i], lmas[i], lens[i]);
 			memcpy(vmas[i], lmas[i], lens[i]);
 		}
+		i++;
 	}
 }
 
 /* Zeroes multiple sections. For example, all bss sections. */
-static void zero_sections(void *vmas[], unsigned int lens[], int n) {
-	int i;
+static void zero_sections(void *vmas[], unsigned int lens[]) {
+	int i = 0;
 
-	for (i = 0; i < n; i++) {
-		if (0 == lens[i]) {
-			continue;
+	while (vmas[i]) {
+		if (0 != lens[i]) {
+			log_debug("vma=%p, len=0x%x", vmas[i], lens[i]);
+			memset(vmas[i], 0, lens[i]);
 		}
-		log_debug("vma=%p, len=0x%x", vmas[i], lens[i]);
-		memset(vmas[i], 0, lens[i]);
+		i++;
 	}
 }
 
 static int load_all_sections(void) {
 	log_debug("");
+
 	log_debug("Loading text sections:");
-	load_sections(sections_text_vma, sections_text_lma, sections_text_len,
-	                 ARRAY_SIZE(sections_text_vma));
+	load_sections(sections_text_vma, sections_text_lma, sections_text_len);
+
 	log_debug("Loading rodata sections:");
-	load_sections(sections_rodata_vma, sections_rodata_lma, sections_rodata_len,
-	                 ARRAY_SIZE(sections_rodata_vma));
+	load_sections(sections_rodata_vma, sections_rodata_lma, sections_rodata_len);
+
 	log_debug("Loading data sections:");
-	load_sections(sections_data_vma, sections_data_lma, sections_data_len,
-	                 ARRAY_SIZE(sections_data_vma));
+	load_sections(sections_data_vma, sections_data_lma, sections_data_len);
+
 	log_debug("Zeroing bss sections:");
-	zero_sections(sections_bss_vma, sections_bss_len,
-	                 ARRAY_SIZE(sections_bss_vma));
+	zero_sections(sections_bss_vma, sections_bss_len);
 
 	return 0;
 }

--- a/src/mem/loadsect/loadsect.c
+++ b/src/mem/loadsect/loadsect.c
@@ -1,0 +1,60 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date   26.04.2021
+ * @author Alexander Kalmuk
+ */
+
+#include <string.h>
+#include <util/array.h>
+#include <util/log.h>
+#include <embox/unit.h>
+
+EMBOX_UNIT_INIT(load_all_sections);
+
+/* Loads multiple sections. For example, all text sections. */
+static void load_sections(void *vmas[], void *lmas[], unsigned int lens[], int n) {
+	int i;
+
+	for (i = 0; i < n; i++) {
+		if (0 == lens[i]) {
+			continue;
+		}
+		if (vmas[i] != lmas[i]) {
+			log_debug("vma=%p, lma=%p, len=0x%x", vmas[i], lmas[i], lens[i]);
+			memcpy(vmas[i], lmas[i], lens[i]);
+		}
+	}
+}
+
+/* Zeroes multiple sections. For example, all bss sections. */
+static void zero_sections(void *vmas[], unsigned int lens[], int n) {
+	int i;
+
+	for (i = 0; i < n; i++) {
+		if (0 == lens[i]) {
+			continue;
+		}
+		log_debug("vma=%p, len=0x%x", vmas[i], lens[i]);
+		memset(vmas[i], 0, lens[i]);
+	}
+}
+
+static int load_all_sections(void) {
+	log_debug("");
+	log_debug("Loading text sections:");
+	load_sections(sections_text_vma, sections_text_lma, sections_text_len,
+	                 ARRAY_SIZE(sections_text_vma));
+	log_debug("Loading rodata sections:");
+	load_sections(sections_rodata_vma, sections_rodata_lma, sections_rodata_len,
+	                 ARRAY_SIZE(sections_rodata_vma));
+	log_debug("Loading data sections:");
+	load_sections(sections_data_vma, sections_data_lma, sections_data_len,
+	                 ARRAY_SIZE(sections_data_vma));
+	log_debug("Zeroing bss sections:");
+	zero_sections(sections_bss_vma, sections_bss_len,
+	                 ARRAY_SIZE(sections_bss_vma));
+
+	return 0;
+}

--- a/src/mem/phymem.c
+++ b/src/mem/phymem.c
@@ -18,11 +18,21 @@ EMBOX_UNIT_INIT(phymem_init);
 
 struct page_allocator *__phymem_allocator;
 
+extern char _ram_base;
+extern char _ram_size;
+
 static int phymem_init(void) {
 	char *const phymem_alloc_start = phymem_allocated_start();
 	char *const phymem_alloc_end = phymem_allocated_end();
 	const size_t mem_len = phymem_alloc_end - phymem_alloc_start;
 	void *va;
+
+	if (phymem_alloc_start > phymem_alloc_end) {
+		log_error("phymem_start (%p) > phymem_end (%p)",
+		           phymem_alloc_start, phymem_alloc_end);
+
+		return -1;
+	}
 
 	log_boot_start();
 	log_boot("start=%p end=%p size=%zu\n", phymem_alloc_start, phymem_alloc_end, mem_len);
@@ -40,16 +50,64 @@ static int phymem_init(void) {
 	return phymem_alloc_start == va ? 0 : -EIO;
 }
 
+/* Find section within RAM. */
+static uintptr_t find_sections_end(void *vmas[], unsigned int lens[]) {
+	int i = 0;
+	uintptr_t l = 0, end, ram_end;
+
+	ram_end = (uintptr_t) &_ram_base + (size_t) &_ram_size;
+
+	while (vmas[i]) {
+		if (lens[i]) {
+			end = (uintptr_t) vmas[i] + lens[i];
+
+			if (end <= ram_end && end > l) {
+				l = (uintptr_t) vmas[i] + lens[i];
+			}
+		}
+		i++;
+	}
+
+	return l;
+}
+
 char * const phymem_allocated_start(void) {
 	extern char _reserve_end;
 
-	return (char *) binalign_bound((uintptr_t) &_reserve_end, PAGE_SIZE());
+	extern void *sections_text_vma[];
+	extern unsigned int sections_text_len[];
+	extern void *sections_data_vma[];
+	extern unsigned int sections_data_len[];
+	extern void *sections_rodata_vma[];
+	extern unsigned int sections_rodata_len[];
+	extern void *sections_bss_vma[];
+	extern unsigned int sections_bss_len[];
+	struct {
+		void **vmas;
+		unsigned int *lens;
+	} sect[4] = {
+		{ sections_text_vma, sections_text_len },
+		{ sections_rodata_vma, sections_rodata_len },
+		{ sections_data_vma, sections_data_len },
+		{ sections_bss_vma, sections_bss_len },
+	};
+
+	uintptr_t sections_end, tmp;
+	int i;
+
+	sections_end = (uintptr_t) &_reserve_end;
+
+	for (i = 0; i < 4; i++) {
+		tmp = find_sections_end(sect[i].vmas, sect[i].lens);
+		if (sections_end < tmp) {
+			sections_end = tmp;
+		}
+	}
+
+	return (char *) binalign_bound(sections_end, PAGE_SIZE());
 }
 
 char *const phymem_allocated_end(void) {
-	extern char _ram_base;
-	extern char _ram_size;
-
 	return (char *)
 			binalign_bound((uintptr_t) &_ram_base + (size_t) &_ram_size, PAGE_SIZE());
 }


### PR DESCRIPTION
When you define linker sections in lds.conf like:

```
/* OpenCV */ 
section (cv_text, QSPI, QSPI)
phdr    (cv_text, PT_LOAD, FLAGS(5))

section (cv_rodata, QSPI, QSPI)
phdr    (cv_rodata, PT_LOAD, FLAGS(5))

section (cv_data, RAM, QSPI)
phdr    (cv_data, PT_LOAD, FLAGS(6))

section (cv_bss, RAM, QSPI)
phdr    (cv_bss, PT_LOAD, FLAGS(6))
```

these sections can be automatically loaded to the specified memories (e.g. to QSPI, SDRAM, RAM) if you specify

```
@Runlevel(1) include embox.mem.loadsect
```

in mods.conf