### PR TITLE
buildsystem: Move apps sections generation to the final stage

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -18,6 +18,7 @@ build_gen_ts := $(BUILD_DIR)/build-gen.timestamp
 build : $(build_gen_ts)
 	@$(MAKE) -f mk/script/build/oldconf-gen.mk MAKEFILES=''
 	@$(MAKE) -f mk/board_conf/board-conf-gen.mk MAKEFILES=''
+	@$(MAKE) -f mk/script/lds-apps.mk > $(SRCGEN_DIR)/apps.lds.h
 	@$(MAKE) -f mk/script/incinst.mk
 	@$(MAKE) -f mk/extbld/toolchain.mk MAKEFILES=''
 	@$(MAKE) -f mk/extbld.mk MAKEFILES='' __extbld-1

--- a/mk/image.lds.S
+++ b/mk/image.lds.S
@@ -1,5 +1,6 @@
 
 #include <asm-generic/embox.lds.h>
+#include <apps.lds.h>
 
 #ifdef ARCH_TEXT_ALIGNMENT
 # define TEXT_ALIGNMENT    ARCH_TEXT_ALIGNMENT
@@ -30,6 +31,7 @@ SECTION_SYMBOLS(bss)
 SECTIONS {
 	.text : ALIGN(TEXT_ALIGNMENT) {
 
+		LDS_MODULES_TEXT
 		*(.text)
 		*(.text.*)
 
@@ -37,6 +39,7 @@ SECTIONS {
 
 	.rodata : ALIGN(DATA_ALIGNMENT) {
 
+		LDS_MODULES_RODATA
 		*(.rodata)
 		*(.rodata.*)
 		*(.const)
@@ -69,6 +72,9 @@ SECTIONS {
 
 	.data : ALIGN(DATA_ALIGNMENT) {
 
+		LDS_MODULES_DATA
+		_app_data_vma = .;
+		LDS_APPS_DATA
 		*(.data)
 		*(.sdata)
 		*(.data.*)
@@ -79,6 +85,8 @@ SECTIONS {
 
 	.bss : ALIGN(DATA_ALIGNMENT) {
 
+		LDS_MODULES_BSS
+		LDS_APPS_BSS
 		*(.bss)
 		*(.sbss)
 		*(.bss.[a-zA-Z0-9_-]*) /* this hell is to exclude '.bss..reserve'. */
@@ -91,6 +99,8 @@ SECTIONS {
 
 		*(.bss..reserve)
 		*(.bss..reserve.*)
+
+		LDS_APP_DATA_RESERVE_BSS
 
 		ALIGNMENT();
 		_reserve_end = .;

--- a/mk/script/build/build-gen.mk
+++ b/mk/script/build/build-gen.mk
@@ -803,6 +803,9 @@ $(@source_dist) :
 @dist_cpfiles += $(addprefix dist-cpfile-/$(DIST_BASE_DIR)/, \
 	$(SRC_DIR)/arch/$(ARCH)/embox.lds.S)
 
+@dist_cpfiles += $(addprefix dist-cpfile-/$(DIST_BASE_DIR)/, \
+	$(SRC_DIR)/arch/$(ARCH)/embox.lds.S)
+
 __source_dirs := $(sort $(dir $(call source_file,$(build_sources))))
 @dist_cpfiles += $(addprefix dist-cpfile-/$(DIST_BASE_DIR)/, \
 	$(wildcard $(foreach e,*.h include/*.h include/*/*.h *.inc Makefile *.txt *.patch *.diff, \

--- a/src/arch/usermode86/Mybuild
+++ b/src/arch/usermode86/Mybuild
@@ -1,0 +1,5 @@
+package embox.arch.usermode86
+
+module apps_lds {
+	source "apps.lds.S"
+}

--- a/src/arch/usermode86/apps.lds.S
+++ b/src/arch/usermode86/apps.lds.S
@@ -1,0 +1,29 @@
+/* It's required to provide some undefined apps symbols.
+ * usermode86 doesn't use mk/image.lds.S like other arch's.
+ * This code should be checked if we want to use apps for usermode86.
+ */
+
+#include <asm-generic/embox.lds.h>
+#include <apps.lds.h>
+
+SECTIONS {
+	.text : {
+		LDS_MODULES_TEXT
+	}
+
+	.rodata : {
+		LDS_MODULES_RODATA
+	}
+
+	.data : {
+		LDS_MODULES_DATA
+		_app_data_vma = .;
+		LDS_APPS_DATA
+	}
+
+	.bss : {
+		LDS_MODULES_BSS
+		LDS_APPS_BSS
+		LDS_APP_DATA_RESERVE_BSS
+	}
+}

--- a/src/framework/mod/Mybuild
+++ b/src/framework/mod/Mybuild
@@ -10,9 +10,6 @@ module mod {
 	@Generated(script="$(MAKE) -f mk/script/c-runtime-inject.mk")
 	source "depsinject.c"
 
-	@Generated(script="$(MAKE) -f mk/script/lds-apps.mk")
-	source "apps.lds.S"
-
 	depends embox.util.Array
 	depends embox.util.log
 

--- a/templates/usermode86/debug/mods.conf
+++ b/templates/usermode86/debug/mods.conf
@@ -5,6 +5,7 @@ configuration conf {
 	include embox.arch.usermode86.locore
 	include embox.arch.usermode86.ipl
 	include embox.arch.usermode86.context
+	include embox.arch.usermode86.apps_lds
 	include embox.compat.posix.proc.exec_stub
 	include embox.compat.posix.proc.vfork_stub
 

--- a/templates/x86/test/ping-target/mods.conf
+++ b/templates/x86/test/ping-target/mods.conf
@@ -5,6 +5,7 @@ configuration conf {
 	include embox.arch.usermode86.locore
 	include embox.arch.usermode86.ipl
 	include embox.arch.usermode86.context
+	include embox.arch.usermode86.apps_lds
 	include embox.compat.posix.proc.exec_stub
 	include embox.compat.posix.proc.vfork_stub
 


### PR DESCRIPTION
Combining module's/app's sections into a single one (that's what lds-apps.mk does) is only correct at the final linking when we get a non-relocatable object file. At the earlier stages attempts to perform such a linkage on a relocatable object file may lead to undefined behaviour.