### PR TITLE
fb_direct_access fails for platform/raspberry_pi/rpi0 #2453

### DIFF
--- a/src/drivers/video/Mybuild
+++ b/src/drivers/video/Mybuild
@@ -51,6 +51,21 @@ module bochs {
 
 module raspi_video {
 	option number base_addr = 0x2000B880
+	option number fb_xres = 1024
+	option number fb_yres = 768
+	option number fb_bpp = 16
+
+	/**
+	 * Send the address of the frame buffer + fb_vc_bus to the mailbox
+	 *
+	 * By adding fb_vc_bus, we tell the GPU to use memory in the following way
+	 * 
+	 * L1 & L2 Cached 	 - 0x00000000 ; Only mode that works on qemu w. raspi0 emulation
+	 * L2 Cache coherent, non allocating - 0x40000000
+	 * L2 Cached (only)	 - 0x80000000 
+	 * Direct (no cache) - 0xC0000000
+	 */
+	option number fb_vc_bus = 0x00000000
 
 	source "raspi_video.c"
 


### PR DESCRIPTION
fix memory mapping mode for pi zero on qemu

move parameters to MyBuild and add brief description

fix for bug #2453 