### PR TITLE
add PiZero GPIO output, add comments for frame buffer, add JTAG command

### DIFF
--- a/platform/raspberry_pi/cmds/Mybuild
+++ b/platform/raspberry_pi/cmds/Mybuild
@@ -1,0 +1,22 @@
+package raspberry_pi.cmd
+
+@AutoCmd
+@Cmd(name = "jtag",
+	help = "Set GPIO pins for JTAG w. bcm283x (Pi Zero, ...)",
+	man = '''
+		NAME
+			jtag - configure GPIO for JTAG
+		SYNOPSIS
+			jtag
+		DESCRIPTION
+		OPTIONS
+		AUTHORS
+			kpishere
+	''')
+module jtag {
+	source "jtag.c"
+
+	depends embox.compat.libc.stdio.printf
+	depends embox.driver.gpio.core
+	depends raspberry_pi.driver.jtag
+}

--- a/platform/raspberry_pi/cmds/jtag.c
+++ b/platform/raspberry_pi/cmds/jtag.c
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * @brief Enable JTAG pins
+ *
+ * @date 27.06.2021
+ * @author kpishere
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <drivers/gpio/gpio.h>
+#include <drivers/jtag/jtag.h>
+
+static void print_usage(void) {
+	printf("USAGE:\njtag [<option>]\n"
+		" option: 0 (default)\n"
+		"    jtag 0 -- Pins 22-TRST, 4-TDI, 5-TDO, 6-RTCK, 12-TMS, 13-TCK\n"
+		"    jtag 1 -- Pins 22-TRST, 23-RTCK, 24-TDO, 25-TCK, 26-TDI, 27-TMS\n"
+		"    jtag 2 -- Pins 4-TDI, 5-TDO, 6-RTCK, 12-TMS, 13-TCK\n");
+}
+
+int main(int argc, char **argv) {
+	int opt;
+
+	while (-1 != (opt = getopt(argc, argv, "h"))) {
+		switch(opt) {
+		case 'h':
+			print_usage();
+			return 0;
+		default:
+			printf("Unknown option\n");
+			print_usage();
+			return 0;
+		}
+	}
+
+	if (argc < 2) {
+		opt = 0;
+	} else {
+		opt = argv[1][0] - '0';
+	}
+
+	if(gpio_jtag(opt) == 0) {
+		printf("Opt %d\n", opt);
+	} else {
+		print_usage();
+	}
+
+	return 0;
+}
+

--- a/platform/raspberry_pi/drivers/jtag/Mybuild
+++ b/platform/raspberry_pi/drivers/jtag/Mybuild
@@ -1,0 +1,26 @@
+package raspberry_pi.driver
+
+module jtag {
+	/* Optional JTAG configurations :
+	 * 
+	 * BCM283x (Raspberry Pi with 40 pin header) :
+	 *
+	 * Config: 0 - Pin 22-TRST set to GFAlt4 mode, pins 4-TDI
+	 *             , 5-TDO, 6-RTCK, 12-TMS, 13-TCK set to GFAlt5
+	 *
+	 * Config: 1 - Pins 22-TRST, 23-RTCK, 24-TDO, 25-TCK, 26-TDI
+	 *             ,and 27-TMS set to GFAlt4 mode
+	 *
+	 * Config: 2 - Pins 4-TDI, 5-TDO, 6-RTCK, 12-TMS, 13-TCK set to GFAlt5
+	 *
+	 */
+	option number gpio_jtag_config = 0 
+
+	source "jtag.c"
+
+	/* User API */
+	@IncludeExport(path="drivers/jtag")
+	source "jtag.h"
+
+	depends embox.driver.gpio.core
+}

--- a/platform/raspberry_pi/drivers/jtag/jtag.c
+++ b/platform/raspberry_pi/drivers/jtag/jtag.c
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    07.06.2021
+ * @author  kpishere
+ */
+
+#include <assert.h>
+#include <hal/reg.h>
+#include <drivers/common/memory.h>
+#include <embox/unit.h>
+#include <util/array.h>
+#include <kernel/printk.h>
+#include <kernel/panic.h>
+
+#include <framework/mod/options.h>
+#include <asm/delay.h>
+#include <drivers/gpio/gpio.h>
+#include <drivers/gpio/bcm283x/bcm283x_gpio.h>
+
+#define CONFIG_DEFAULT  OPTION_GET(NUMBER,gpio_jtag_config)
+
+#define OPTIONS 	3
+
+int gpio_jtag(uint8_t config) {
+    uint32_t pins_GFAlt5[OPTIONS] = {
+		( 1 << 4 ) | ( 1 << 5 ) | ( 1 << 6 ) | ( 1 << 12 ) | ( 1 << 13 )
+	,	0x00
+	,	( 1 << 4 ) | ( 1 << 5 ) | ( 1 << 6 ) | ( 1 << 12 ) | ( 1 << 13 )
+	};
+	uint32_t pins_GFAlt4[OPTIONS] = {
+		( 1 << 22 )
+	,	( 1 << 22 ) | ( 1 << 23) | ( 1 << 24 ) | ( 1 << 25 ) | ( 1 << 26 ) | ( 1 << 27 )
+	,	0x00
+	};
+
+	if(config < OPTIONS) {
+		gpio_setup_mode(GPIO_PORT_A, pins_GFAlt5[config], GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt5) );
+		gpio_setup_mode(GPIO_PORT_A, pins_GFAlt4[config], GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt4) );
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int gpio_jtag_init(void) {
+    int ret;
+
+	if(CONFIG_DEFAULT >= 0) {		
+		ret = gpio_jtag(CONFIG_DEFAULT);
+    	printk(" Opt %d ",CONFIG_DEFAULT);
+	}
+	
+	return ret;
+}
+
+EMBOX_UNIT_INIT(gpio_jtag_init);

--- a/platform/raspberry_pi/drivers/jtag/jtag.c
+++ b/platform/raspberry_pi/drivers/jtag/jtag.c
@@ -6,16 +6,10 @@
  * @author  kpishere
  */
 
-#include <assert.h>
-#include <hal/reg.h>
-#include <drivers/common/memory.h>
 #include <embox/unit.h>
-#include <util/array.h>
 #include <kernel/printk.h>
-#include <kernel/panic.h>
-
 #include <framework/mod/options.h>
-#include <asm/delay.h>
+
 #include <drivers/gpio/gpio.h>
 #include <drivers/gpio/bcm283x/bcm283x_gpio.h>
 
@@ -36,8 +30,12 @@ int gpio_jtag(uint8_t config) {
 	};
 
 	if(config < OPTIONS) {
-		gpio_setup_mode(GPIO_PORT_A, pins_GFAlt5[config], GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt5) );
-		gpio_setup_mode(GPIO_PORT_A, pins_GFAlt4[config], GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt4) );
+		if(pins_GFAlt5[config]) {
+			gpio_setup_mode(GPIO_PORT_A, pins_GFAlt5[config], GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt5) );
+		}
+		if(pins_GFAlt4[config]) {
+			gpio_setup_mode(GPIO_PORT_A, pins_GFAlt4[config], GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt4) );
+		}
 		return 0;
 	} else {
 		return -1;

--- a/platform/raspberry_pi/drivers/jtag/jtag.h
+++ b/platform/raspberry_pi/drivers/jtag/jtag.h
@@ -1,0 +1,8 @@
+
+#ifndef SRC_DRIVERS_JTAG_H_
+#define SRC_DRIVERS_JTAG_H_
+
+extern int gpio_jtag(uint8_t config);
+
+#endif // SRC_DRIVERS_JTAG_H_
+

--- a/platform/raspberry_pi/rpi0/mods.conf
+++ b/platform/raspberry_pi/rpi0/mods.conf
@@ -16,7 +16,9 @@ configuration conf {
 	@Runlevel(0) include embox.arch.system(core_freq=100000000)
 
 	@Runlevel(0) include embox.driver.interrupt.raspi
-	@Runlevel(1) include embox.driver.clock.raspi_systick
+	@Runlevel(1) include embox.driver.gpio.bcm283x_gpio
+	@Runlevel(2) include raspberry_pi.driver.jtag
+	@Runlevel(2) include embox.driver.clock.raspi_systick
 	include embox.kernel.time.jiffies(cs_name="raspi_systick")
 
 	@Runlevel(2) include embox.driver.serial.pl011(
@@ -24,7 +26,8 @@ configuration conf {
 				baud_rate=115200, uartclk=48000000)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__pl011")
 
-	@Runlevel(2) include embox.driver.video.raspi_video
+/*	@Runlevel(2) include embox.driver.video.raspi_video(fb_vc_bus=0x00000000) */
+	@Runlevel(2) include embox.driver.video.raspi_video(fb_vc_bus=0x40000000)
 	
 	include embox.kernel.spinlock(spin_debug=false)
 
@@ -101,6 +104,9 @@ configuration conf {
 	include embox.cmd.head
 
 	include embox.cmd.testing.block_dev_test
+	include raspberry_pi.cmd.jtag
+
+	include embox.cmd.hardware.pin
 
 	include embox.cmd.fs.mkramdisk
 	include embox.cmd.fs.dd

--- a/src/arch/arm/armlib/boot/reset_handler.S
+++ b/src/arch/arm/armlib/boot/reset_handler.S
@@ -24,9 +24,9 @@ reset_handler:
 
 	ldr r0, =_stack_top
 
-	msr CPSR_c, #0x16 | I_BIT | F_BIT
+	/* Set stack pointer same for all modes and disable interrupts in all modes */
+	msr CPSR_c, #ARM_MODE_MON | I_BIT | F_BIT
 	mov sp, r0
-
 	msr CPSR_c, #ARM_MODE_FIQ | I_BIT | F_BIT
 	mov sp, r0
 	msr CPSR_c, #ARM_MODE_SVC | I_BIT | F_BIT
@@ -38,6 +38,9 @@ reset_handler:
 	msr CPSR_c, #ARM_MODE_IRQ | I_BIT | F_BIT
 	mov sp, r0
 
+	/* put chip in System mode - move stack pointer down by IRQ_STACK_SIZE to make 
+	 * room for stack in above modes 
+	 */
 	msr CPSR_c, #ARM_MODE_SYS | I_BIT | F_BIT
 	sub r0, r0, #IRQ_STACK_SIZE
 	mov sp, r0

--- a/src/arch/arm/head.S
+++ b/src/arch/arm/head.S
@@ -86,37 +86,26 @@ sw_init_hook:
 #endif
 
 /* zero bss */
-	ldr r4, =_bss_vma
-	ldr r9, =_bss_vma
-	ldr r5, =_bss_len
-	add r9, r9, r5
-	mov r5, #0
-	mov r6, #0
-	mov r7, #0
-	mov r8, #0
-	b       2f 
-1:
-	// store multiple at r4.
-	stmia r4!, {r5-r8} 
-	// If we are still below _bss_vma+_bss_len, loop.
-2:
-	cmp r4, r9
-	blo 1b
+	ldr     r0, =_bss_vma
+	movs    r1, #0
+	ldr     r2, =_bss_len
+bss_loop:
+	str     r1, [r0]
+	adds    r0, r0, #4
+	subs    r2, r2, #4
+	bne     bss_loop
 
 /* copy data section */
 	ldr     r0, =_data_vma
 	ldr     r1, =_data_lma
-	sub 	r2, r1, r0
-	beq 	data_loop_done  ;@ Don't copy if same address	
-	ldr     r2, =_data_lma
-	ldr 	r3, =_data_len
-	add 	r2, r2, r3	
+	ldr     r2, =_data_len
 data_loop:
-	ldmia 	r1!, {r4-r7}
-	stmia 	r0!, {r4-r7}
-	cmp 	r1, r2
-	blo 	data_loop
-data_loop_done:
+	ldr     r3, [r1]
+	str     r3, [r0]
+	adds    r0, r0, #4
+	adds    r1, r1, #4
+	subs    r2, r2, #4
+	bne     data_loop
 
 #if MMU_BOOT
 	bl boot_mmu_finish

--- a/src/arch/arm/head.S
+++ b/src/arch/arm/head.S
@@ -86,26 +86,37 @@ sw_init_hook:
 #endif
 
 /* zero bss */
-	ldr     r0, =_bss_vma
-	movs    r1, #0
-	ldr     r2, =_bss_len
-bss_loop:
-	str     r1, [r0]
-	adds    r0, r0, #4
-	subs    r2, r2, #4
-	bne     bss_loop
+	ldr r4, =_bss_vma
+	ldr r9, =_bss_vma
+	ldr r5, =_bss_len
+	add r9, r9, r5
+	mov r5, #0
+	mov r6, #0
+	mov r7, #0
+	mov r8, #0
+	b       2f 
+1:
+	// store multiple at r4.
+	stmia r4!, {r5-r8} 
+	// If we are still below _bss_vma+_bss_len, loop.
+2:
+	cmp r4, r9
+	blo 1b
 
 /* copy data section */
 	ldr     r0, =_data_vma
 	ldr     r1, =_data_lma
-	ldr     r2, =_data_len
+	sub 	r2, r1, r0
+	beq 	data_loop_done  ;@ Don't copy if same address	
+	ldr     r2, =_data_lma
+	ldr 	r3, =_data_len
+	add 	r2, r2, r3	
 data_loop:
-	ldr     r3, [r1]
-	str     r3, [r0]
-	adds    r0, r0, #4
-	adds    r1, r1, #4
-	subs    r2, r2, #4
-	bne     data_loop
+	ldmia 	r1!, {r4-r7}
+	stmia 	r0!, {r4-r7}
+	cmp 	r1, r2
+	blo 	data_loop
+data_loop_done:
 
 #if MMU_BOOT
 	bl boot_mmu_finish

--- a/src/arch/arm/include/asm/delay.h
+++ b/src/arch/arm/include/asm/delay.h
@@ -1,0 +1,12 @@
+
+/**
+ * @file
+ * @brief
+ *
+ * @date    07.06.2021
+ * @author  kpishere
+ */
+
+#pragma once
+
+void delay(uint32_t ticks);

--- a/src/arch/arm/include/asm/modes.h
+++ b/src/arch/arm/include/asm/modes.h
@@ -14,6 +14,7 @@
 #define ARM_MODE_FIQ 0x11
 #define ARM_MODE_IRQ 0x12
 #define ARM_MODE_SVC 0x13
+#define ARM_MODE_MON 0x16
 #define ARM_MODE_ABT 0x17
 #define ARM_MODE_UND 0x1B
 #define ARM_MODE_USR 0x10

--- a/src/arch/arm/lib/delay/Mybuild
+++ b/src/arch/arm/lib/delay/Mybuild
@@ -1,0 +1,5 @@
+package embox.arch.arm.libarch
+
+static module delay {
+	source "delay.S"
+}

--- a/src/arch/arm/lib/delay/delay.S
+++ b/src/arch/arm/lib/delay/delay.S
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    07.06.2021
+ * @author  kpishere
+ */
+.globl delay
+delay:
+    subs r0, r0, #1
+    bne delay
+    bx lr

--- a/src/drivers/gpio/bcm283x/Mybuild
+++ b/src/drivers/gpio/bcm283x/Mybuild
@@ -1,0 +1,59 @@
+package embox.driver.gpio
+
+module bcm283x_gpio extends api {
+	/* 	RPI_VERSION == 0 then 0x20200000
+		RPI_VERSION == 3 then 0x3F200000
+		RPI_VERSION == 4 then 0xFE200000
+	*/
+	option number base_addr = 0x20200000
+
+	/* Pi Zero configuration (RPI_VERSION == 0) */
+	option number gpio_pins = 54
+	/* Port A has 0-31 pins, Port B has 32-53 pins numbered as 0-21 */
+	option number gpio_ports = 2
+
+	/* There is confusion about this.  There are three banks, only the first two
+	 * are linked to pins 0-53 (internally, of those, not all are on GPIO header)
+	 * An interrupt exists for each bank and the highest interrupt is for any 
+	 * GPIO pin.  We set just one, just the first bank for 
+	 * all pins connected to the 40-pin header.
+	 * 
+	 * Bank0( pins:  0-31 ) - 49 (interrupt)
+	 * Bank1( pins: 32-53 ) - 50 			 
+	 * Bank2( pins: 54-96 ) - 51 (not used)
+	 * all  ( pins: 00-96 ) - 52 
+	 */
+	option number gpu_irq_int = 49
+
+	/* Due to architecture constraints, setting of pull-up/down can only be 
+	 * applied accross all pins at the same time.  Hence, shadow registers 
+	 * exist in driver implementation to allow setting value to apply
+	 * per pin, then by applying _any_ setting to this pin (settings are
+	 * ignored in this case) with gpio_setup_mode() will cause the 
+	 * aggreggated pins settings to be applied for pull-up/down
+	 * functionality. All other functionality will be applied immediately.
+	 */
+
+	/* Bit mask for pullups, defaults set to as per BCM2835 ARM Peripherals
+	 * sec. 6.2 defaults for GPIO 0 thru 53
+	 */
+	option number gpu_pullup_porta_float = 0x30000000
+	option number gpu_pullup_porta_down  = 0xCFFFFE00
+	option number gpu_pullup_porta_up    = 0x000001FF
+
+	option number gpu_pullup_portb_float = 0x00003000
+	option number gpu_pullup_portb_down  = 0x00000FE3
+	option number gpu_pullup_portb_up    = 0x003FC01C
+
+	option number log_level=0
+
+	source "bcm283x_gpio.c"
+	source "bcm283x_gpio.h"
+
+	/* User API */
+	@IncludeExport(path="drivers/gpio/bcm283x")
+	source "bcm283x_gpio.h"
+
+	depends embox.driver.gpio.core
+	depends embox.arch.arm.libarch.delay
+}

--- a/src/drivers/gpio/bcm283x/bcm283x_gpio.c
+++ b/src/drivers/gpio/bcm283x/bcm283x_gpio.c
@@ -1,0 +1,317 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    07.06.2021
+ * @author  kpishere
+ */
+
+#include <assert.h>
+#include <hal/reg.h>
+#include <drivers/common/memory.h>
+#include <embox/unit.h>
+#include <util/array.h>
+#include <kernel/printk.h>
+#include <kernel/panic.h>
+
+#include <framework/mod/options.h>
+#include "bcm283x_gpio.h"
+#include <asm/delay.h>
+#include <drivers/gpio/gpio_driver.h>
+
+#define REG_BITS 32
+
+#define PBASE                       OPTION_GET(NUMBER,base_addr)   
+#define BCM283X_PINS_NUMBER         OPTION_GET(NUMBER,gpio_pins)
+#define BCM283X_GPIO_PORTS_COUNT    OPTION_GET(NUMBER,gpio_ports)
+#define GPU_IRQ                     OPTION_GET(NUMBER,gpu_irq_int)
+
+#define BCM283X_PULL_PORTA_DEFLT_FLOAT    OPTION_GET(NUMBER,gpu_pullup_porta_float)
+#define BCM283X_PULL_PORTA_DEFLT_DOWN     OPTION_GET(NUMBER,gpu_pullup_porta_down)
+#define BCM283X_PULL_PORTA_DEFLT_UP       OPTION_GET(NUMBER,gpu_pullup_porta_up)
+
+#define BCM283X_PULL_PORTB_DEFLT_FLOAT    OPTION_GET(NUMBER,gpu_pullup_portb_float)
+#define BCM283X_PULL_PORTB_DEFLT_DOWN     OPTION_GET(NUMBER,gpu_pullup_portb_down)
+#define BCM283X_PULL_PORTB_DEFLT_UP       OPTION_GET(NUMBER,gpu_pullup_portb_up)
+
+#define PORT_PIN_TO_PINNUMBER(pt, pn)   ( ( ((pt) & 0x3 ) * REG_BITS ) + ((pn) % REG_BITS )) 
+#define GPIO_ALTERNATE_INVERT(af) ( ((af) >> 17) & 0x07 )
+#define BCM283X_GPIO_CHIP_ID    0
+
+#define IRQ_NR_PORTA  49
+#define IRQ_NR_PORTB  50
+#define IRQ_NR_PORTC  51
+#define IRQ_NR_ALL    52
+
+typedef enum _GpioPullUpDn {
+    GPUDNone = 0,
+    GPUDDown = 1,
+    GPUDUp  = 2
+} GpioPullUpDn;
+
+#define GPIO_PULL_NONE_UP_DN_STATES 3
+
+struct GpioPinData {
+    /* 0 (reserved) - Pin output set 2 - GPIO pins 64-96 (reserved on Pi Zero)
+     * 1 (data[0]) - Pin output set 0 - GPIO pins 0-31
+     * 2 (data[1])- Pin output set 1 - GPIO pins 32-53 (54-63 not connected/reserved)
+     */
+    volatile uint32_t reserved;
+    volatile uint32_t data[BCM283X_GPIO_PORTS_COUNT];  
+};
+
+struct GpioRegs {
+    volatile uint32_t func_select[3 * BCM283X_GPIO_PORTS_COUNT];
+    struct GpioPinData output_set;              // Set as output
+    struct GpioPinData output_clear;            // Set as input, is default
+    struct GpioPinData level;                   // Read for value of pin
+    struct GpioPinData ev_detect_status;        // Edge event detected
+    struct GpioPinData re_detect_enable;        // Synchoronous rising edge event
+    struct GpioPinData fe_detect_enable;        // Synchoronous falling edge event
+    struct GpioPinData hi_detect_enable;        // Hi state detected
+    struct GpioPinData lo_detect_enable;        // Lo state detected
+    struct GpioPinData re_async_detect_enable;  // Enable async rising detection in ev_detect_status
+                                                //     (no sampling by clock cycle for edge detection)
+    struct GpioPinData fe_async_detect_enable;  // Enable async falling detection in ev_detect_status
+    volatile uint32_t reserved;
+    volatile uint32_t pupd_enable;              // See func bcm283x_gpio_pin_pullupdown() below
+    volatile uint32_t pupd_enable_clocks[BCM283X_GPIO_PORTS_COUNT];
+};
+
+#define REGS_GPIO ((struct GpioRegs *)(PBASE))
+
+//// Globals
+//
+static uint32_t _pinMaskPortA[GPIO_PULL_NONE_UP_DN_STATES];
+static uint32_t _pinMaskPortB[GPIO_PULL_NONE_UP_DN_STATES];
+//
+////
+
+// Assign desired pull state for one port+pin location, clear the other states for that port+pin
+static void bcm293x_gpio_assign_pullup(GpioPullUpDn pull, unsigned char port, gpio_mask_t pin) {
+    uint32_t *pullPorts[BCM283X_GPIO_PORTS_COUNT] = {_pinMaskPortA, _pinMaskPortB};
+    GpioPullUpDn stateSelection[GPIO_PULL_NONE_UP_DN_STATES];
+    switch(pull) {
+        case GPUDUp:
+            stateSelection[0] = GPUDUp;
+            stateSelection[1] = GPUDDown;
+            stateSelection[2] = GPUDNone;
+        break;
+        case GPUDDown:
+            stateSelection[0] = GPUDDown;
+            stateSelection[1] = GPUDNone;
+            stateSelection[2] = GPUDUp;
+        break;
+        case GPUDNone:
+            stateSelection[0] = GPUDNone;
+            stateSelection[1] = GPUDUp;
+            stateSelection[2] = GPUDDown;
+        break;
+    }
+    pullPorts[port][stateSelection[0]] |= (1 << pin);
+    pullPorts[port][stateSelection[1]] &= ~(1 << pin);
+    pullPorts[port][stateSelection[2]] &= ~(1 << pin);
+}
+
+///
+/// The function is set for every pin that has high value set on port
+///
+static void bcm283x_gpio_pin_set_func(unsigned char port, gpio_mask_t pins, GpioFunc func) {
+    uint32_t pinNumber, selector;
+    uint8_t bitStart, reg;
+
+    for(unsigned short r = 0; r < REG_BITS; r++ ) {
+        if( (pins >> r) & 0x01 ) {  // If bit is set, apply function
+            pinNumber = PORT_PIN_TO_PINNUMBER(port, r);
+            bitStart = (pinNumber * 3) % 30;
+            reg = pinNumber / 10;
+
+            selector = REGS_GPIO->func_select[reg];
+            selector &= ~(7 << bitStart);
+            selector |= (func << bitStart);
+
+            REGS_GPIO->func_select[reg] = selector;
+        }
+    }
+}
+
+/// This change must be applied accross all pins in one action.  The state can't be read back. 
+/// The change persists over a power on/off cycle.
+static void bcm283x_gpio_pin_pullupdown(GpioPullUpDn pullState, uint32_t pinMaskPortA, uint32_t pinMaskPortB) {
+    // Setup state to change to
+    REGS_GPIO->pupd_enable = pullState;
+    delay(150);
+    // Indicate pins to change
+    REGS_GPIO->pupd_enable_clocks[GPIO_PORT_A] = pinMaskPortA;
+    REGS_GPIO->pupd_enable_clocks[GPIO_PORT_B] = pinMaskPortB;
+    delay(150);
+    // Clear values to indicate change complete
+    REGS_GPIO->pupd_enable = 0;
+    REGS_GPIO->pupd_enable_clocks[GPIO_PORT_A] = 0;
+    REGS_GPIO->pupd_enable_clocks[GPIO_PORT_B] = 0;
+}
+
+///
+/// port = port A or B
+/// pins = a bit field for that port
+/// mode = a bit field indicating mode of operation
+///
+static int bcm283x_gpio_setup_mode(unsigned char port, gpio_mask_t pins, int mode) {
+    assert(((port == GPIO_PORT_A) || (port == GPIO_PORT_B)));
+
+    // Determine GPIO Function of Input/Output/Alternate X
+    if(mode & GPIO_MODE_OUT_ALTERNATE) {
+        bcm283x_gpio_pin_set_func(port,pins,GPIO_ALTERNATE_INVERT(mode));
+    } else if (mode & (GPIO_MODE_INPUT 
+        | GPIO_MODE_IN_PULL_UP | GPIO_MODE_IN_PULL_DOWN 
+        | GPIO_MODE_IN_SCHMITT 
+        | GPIO_MODE_INT_MODE_LEVEL0 | GPIO_MODE_INT_MODE_LEVEL1
+        | GPIO_MODE_INT_MODE_RISING | GPIO_MODE_INT_MODE_FALLING )) {
+        bcm283x_gpio_pin_set_func(port,pins,GFInput);        
+    } else {
+        bcm283x_gpio_pin_set_func(port,pins,GFOutput);        
+    }
+
+    // Synchornous rising edge
+    if( mode & GPIO_MODE_INT_MODE_RISING ) {
+        REGS_GPIO->re_detect_enable.data[port] |= pins;
+        REGS_GPIO->ev_detect_status.data[port] |= pins;   
+    } else {
+        REGS_GPIO->re_detect_enable.data[port] &= ~pins;
+    }
+
+    // Synchornous falling edge
+    if( mode & GPIO_MODE_INT_MODE_FALLING ) {
+        REGS_GPIO->fe_detect_enable.data[port] |= pins;
+        REGS_GPIO->ev_detect_status.data[port] |= pins;        
+    } else {
+        REGS_GPIO->fe_detect_enable.data[port] &= ~pins;
+    }
+
+    // Level Lo
+    if(  mode & GPIO_MODE_INT_MODE_LEVEL0 ) {
+        REGS_GPIO->lo_detect_enable.data[port] |= pins;
+        REGS_GPIO->ev_detect_status.data[port] |= pins;        
+    } else {
+        REGS_GPIO->lo_detect_enable.data[port] &= ~pins;
+    }
+
+    // Level Hi
+    if(  mode & GPIO_MODE_INT_MODE_LEVEL1 ) {
+        REGS_GPIO->hi_detect_enable.data[port] |= pins;
+        REGS_GPIO->ev_detect_status.data[port] |= pins;        
+    } else {
+        REGS_GPIO->hi_detect_enable.data[port] &= ~pins;
+    }
+
+    // Async mode = no sampleing, synch = sampleing 
+    // (kind of like a schmitt trigger in that debouncing happens)
+    if(mode & GPIO_MODE_IN_SCHMITT && mode & GPIO_MODE_INT_MODE_RISING) {
+        REGS_GPIO->re_async_detect_enable.data[port] &= ~pins;
+    } else {
+        REGS_GPIO->re_async_detect_enable.data[port] |= pins;
+    }
+
+    // Async mode = no sampleing, synch = sampleing 
+    // (kind of like a schmitt trigger in that debouncing happens)
+    if(mode & GPIO_MODE_IN_SCHMITT && mode & GPIO_MODE_INT_MODE_FALLING) {
+        REGS_GPIO->fe_async_detect_enable.data[port] &= ~pins;
+    } else {
+        REGS_GPIO->fe_async_detect_enable.data[port] |= pins;
+    }
+
+    // If no interrupt is requested, disable event interrupts
+    //
+    if(!(  mode & GPIO_MODE_INT_MODE_LEVEL1 
+        || mode & GPIO_MODE_INT_MODE_LEVEL0 
+        || mode & GPIO_MODE_INT_MODE_RISING
+        || mode & GPIO_MODE_INT_MODE_FALLING)) {
+        REGS_GPIO->ev_detect_status.data[port] &= ~pins;
+        REGS_GPIO->fe_async_detect_enable.data[port] &= ~pins;
+        REGS_GPIO->re_async_detect_enable.data[port] &= ~pins;
+    }
+
+    // Assign pull up / pull down -- floating isn't assigned as it is default state
+    if(mode & (GPIO_MODE_IN_PULL_UP | GPIO_MODE_OUT_PUSH_PULL) ) {
+        bcm293x_gpio_assign_pullup(GPUDUp, port, pins); 
+    }
+    if(mode & (GPIO_MODE_IN_PULL_DOWN | GPIO_MODE_VDD_LEVEL) ) {
+        bcm293x_gpio_assign_pullup(GPUDDown, port, pins); 
+    }
+    
+    // Assign pull up/down/float for all pins in one go (only way allowed)
+    for( GpioPullUpDn i = 0; i < GPIO_PULL_NONE_UP_DN_STATES; i++) {
+        bcm283x_gpio_pin_pullupdown(i, _pinMaskPortA[i], _pinMaskPortB[i]);
+    }
+
+    return 0;
+}
+
+static void bcm283x_gpio_set(unsigned char port, gpio_mask_t pins, char level) {
+    assert(((port == GPIO_PORT_A) || (port == GPIO_PORT_B)));
+    
+    if (level) {
+        REGS_GPIO->output_set.data[port] |= pins;
+    } else {
+        REGS_GPIO->output_clear.data[port] |= pins;
+    }
+}
+
+static gpio_mask_t bcm283x_gpio_get(unsigned char port, gpio_mask_t pins) {
+    assert(((port == GPIO_PORT_A) || (port == GPIO_PORT_B)));
+
+    return REGS_GPIO->level.data[port] & pins;
+}
+
+static struct gpio_chip bcm283x_gpio_chip = {
+    .setup_mode = bcm283x_gpio_setup_mode,
+    .get = bcm283x_gpio_get,
+    .set = bcm283x_gpio_set,
+    .nports = BCM283X_GPIO_PORTS_COUNT
+};
+
+irq_return_t bcm283x_gpio_irq_handler(unsigned int irq_nr, void *data) {
+    uint16_t ports[BCM283X_GPIO_PORTS_COUNT] = {0,0};
+
+    ports[0] = (IRQ_NR_PORTA == irq_nr || IRQ_NR_ALL == irq_nr );
+    ports[1] = (IRQ_NR_PORTB == irq_nr || IRQ_NR_ALL == irq_nr );
+
+    for(uint16_t port = 0; port < BCM283X_GPIO_PORTS_COUNT; port++) {
+        if(ports[port]) {
+            uint32_t pins = REGS_GPIO->ev_detect_status.data[port];
+
+            // Clear the interrupt event on GPIO port
+            REGS_GPIO->ev_detect_status.data[port] = 0xFFFFFFFF;
+
+            gpio_handle_irq(&bcm283x_gpio_chip, port, pins);            
+        }
+    }
+
+    return IRQ_HANDLED;
+}
+
+static int bcm283x_gpio_init(void) {
+    int res;
+
+    // We don't know the pull up/down state of GPIO pins
+    // so we'll set the change state to a default assignment.
+    // It is expected that pin PINNUMBER_APPLY_CONFIG will be set at 
+    // end of config in kernel! 
+    uint32_t a[GPIO_PULL_NONE_UP_DN_STATES] = {BCM283X_PULL_PORTA_DEFLT_FLOAT, BCM283X_PULL_PORTA_DEFLT_DOWN, BCM283X_PULL_PORTA_DEFLT_UP};
+    uint32_t b[GPIO_PULL_NONE_UP_DN_STATES] = {BCM283X_PULL_PORTB_DEFLT_FLOAT, BCM283X_PULL_PORTB_DEFLT_DOWN, BCM283X_PULL_PORTB_DEFLT_UP};
+
+    for( GpioPullUpDn i = GPUDNone; i < GPIO_PULL_NONE_UP_DN_STATES; i++ ) {
+        _pinMaskPortA[i] = a[i];
+        _pinMaskPortB[i] = b[i];
+    }
+
+    res = irq_attach(GPU_IRQ, bcm283x_gpio_irq_handler, 0, NULL, "BCM283x GPIO irq handler");
+    if (res >= 0) {
+        res = gpio_register_chip(&bcm283x_gpio_chip, BCM283X_GPIO_CHIP_ID);
+    }
+    return res;
+};
+
+EMBOX_UNIT_INIT(bcm283x_gpio_init);
+
+PERIPH_MEMORY_DEFINE(bcm283x_gpio, PBASE, sizeof(struct GpioRegs));

--- a/src/drivers/gpio/bcm283x/bcm283x_gpio.h
+++ b/src/drivers/gpio/bcm283x/bcm283x_gpio.h
@@ -1,0 +1,32 @@
+
+#ifndef SRC_DRIVERS_GPIO_BCM283X_BCM283X_GPIO_H_
+#define SRC_DRIVERS_GPIO_BCM283X_BCM283X_GPIO_H_
+
+// Misc. GPIO pins of note
+//
+#define GPIO_ONBOARD_LED_PIZERO     47
+
+/* Example use of GpioFunc :
+ *
+ * A Pi Zero specific definition:
+ * 
+ * 	gpio_setup_mode(GPIO_PORT_A, pins_GFAlt5, GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt5) );
+ * 
+ * A generic GPIO API definition:
+ * 
+ * 	gpio_setup_mode(GPIO_PORT_A, 0x00000002, GPIO_MODE_INPUT );
+ * 
+ */
+
+typedef enum _GpioFunc {
+    GFInput = 0,
+    GFOutput = 1,
+    GFAlt0 = 4,
+    GFAlt1 = 5,
+    GFAlt2 = 6,
+    GFAlt3 = 7,
+    GFAlt4 = 3,
+    GFAlt5 = 2
+} GpioFunc;
+
+#endif // SRC_DRIVERS_GPIO_BCM283X_BCM283X_GPIO_H_

--- a/src/drivers/interrupt/raspi_intc/raspi.c
+++ b/src/drivers/interrupt/raspi_intc/raspi.c
@@ -87,22 +87,18 @@ static int raspi_intc_init(void) {
 }
 
 void irqctrl_enable(unsigned int interrupt_nr) {
-	if (interrupt_nr < BANK_CAPACITY) {
-		regs->enable_irqs_1 = 1 << interrupt_nr;
-	} else if (interrupt_nr < BANK_CAPACITY*2) {
-		regs->enable_irqs_2 = 1 << (interrupt_nr - BANK_CAPACITY);
-	} else {
-		regs->enable_basic_irqs = 1 << (interrupt_nr - BANK_CAPACITY*2);
+	switch( interrupt_nr / BANK_CAPACITY ) {
+		case 0:	regs->enable_irqs_1 = 1 << interrupt_nr % BANK_CAPACITY;		break;
+		case 1:	regs->enable_irqs_2 = 1 << interrupt_nr % BANK_CAPACITY;		break;
+		case 2:	regs->enable_basic_irqs = 1 << interrupt_nr % BANK_CAPACITY;	break;
 	}
 }
 
 void irqctrl_disable(unsigned int interrupt_nr) {
-	if (interrupt_nr < BANK_CAPACITY) {
-		regs->disable_irqs_1 = 1 << interrupt_nr;
-	} else if (interrupt_nr < BANK_CAPACITY*2) {
-		regs->disable_irqs_2 = 1 << (interrupt_nr - BANK_CAPACITY);
-	} else {
-		regs->disable_basic_irqs = 1 << (interrupt_nr - BANK_CAPACITY*2);
+	switch( interrupt_nr / BANK_CAPACITY ) {
+		case 0:	regs->disable_irqs_1 = 1 << interrupt_nr % BANK_CAPACITY;		break;
+		case 1:	regs->disable_irqs_2 = 1 << interrupt_nr % BANK_CAPACITY;		break;
+		case 2:	regs->disable_basic_irqs = 1 << interrupt_nr % BANK_CAPACITY;	break;
 	}
 }
 

--- a/src/drivers/video/Mybuild
+++ b/src/drivers/video/Mybuild
@@ -61,7 +61,7 @@ module raspi_video {
 	 * By adding fb_vc_bus, we tell the GPU to use memory in the following way
 	 * 
 	 * L1 & L2 Cached 	 - 0x00000000 ; Only mode that works on qemu w. raspi0 emulation
-	 * L2 Cache coherent, non allocating - 0x40000000
+	 * L2 Cache coherent, non allocating - 0x40000000 ; This mode works with physical unit
 	 * L2 Cached (only)	 - 0x80000000 
 	 * Direct (no cache) - 0xC0000000
 	 */


### PR DESCRIPTION
Adding GPIO support for RaspberryPi Zero (unit tested on) but also likely works for Pi 1, Pi B, ... (BCM283x) models.

Added option to enable configuration for JTAG debugger.

Added a command to call JTAG config for GPIO pins and output pin configuration for the 40-pin header.

Also, reverted an earlier change for default memory address for the frame buffer.  This could be a QEMU bug but text has been added to explain how one value works with QEMU and the other value works with an actual physical device.

This PR relates to ticket #2459 