### PR TITLE
modify memory clear for faster execution, skip unnecessary memory copies

### DIFF
--- a/platform/raspberry_pi/rpi0/mods.conf
+++ b/platform/raspberry_pi/rpi0/mods.conf
@@ -2,6 +2,7 @@
 package genconfig
 
 configuration conf {
+	@RunLevel(0) include embox.arch.arm.head(use_fast_boot=true)
 	@Runlevel(0) include embox.arch.arm.armv6.arm11
 	@Runlevel(0) include embox.arch.arm.armlib.interrupt
 	@Runlevel(0) include embox.arch.arm.armlib.context

--- a/src/arch/arm/Mybuild
+++ b/src/arch/arm/Mybuild
@@ -7,5 +7,6 @@ abstract module cmsis { }
 
 module head {
 	option boolean mmu_boot=false
+	option boolean use_fast_boot=false
 	source "head.S"
 }

--- a/src/arch/arm/head.S
+++ b/src/arch/arm/head.S
@@ -7,7 +7,8 @@
 
 #include <framework/mod/options.h>
 
-#define MMU_BOOT OPTION_GET(BOOLEAN,mmu_boot)
+#define MMU_BOOT 		OPTION_GET(BOOLEAN,mmu_boot)
+#define MMU_FAST_BOOT 	OPTION_GET(BOOLEAN,use_fast_boot)
 
 .weak hardware_init_hook
 .weak software_init_hook
@@ -86,6 +87,24 @@ sw_init_hook:
 #endif
 
 /* zero bss */
+#if MMU_FAST_BOOT
+	ldr r4, =_bss_vma
+ 	ldr r9, =_bss_vma
+ 	ldr r5, =_bss_len
+ 	add r9, r9, r5
+ 	mov r5, #0
+ 	mov r6, #0
+ 	mov r7, #0
+ 	mov r8, #0
+ 	b       2f 
+ 1:
+ 	// store multiple at r4.
+ 	stmia r4!, {r5-r8} 
+ 	// If we are still below _bss_vma+_bss_len, loop.
+ 2:
+ 	cmp r4, r9
+ 	blo 1b
+#else
 	ldr     r0, =_bss_vma
 	movs    r1, #0
 	ldr     r2, =_bss_len
@@ -94,10 +113,24 @@ bss_loop:
 	adds    r0, r0, #4
 	subs    r2, r2, #4
 	bne     bss_loop
+#endif
 
 /* copy data section */
 	ldr     r0, =_data_vma
 	ldr     r1, =_data_lma
+#if MMU_FAST_BOOT
+	sub 	r2, r1, r0
+ 	beq 	data_loop_done  ;@ Don't copy if same address	
+ 	ldr     r2, =_data_lma
+ 	ldr 	r3, =_data_len
+ 	add 	r2, r2, r3	
+data_loop:
+	ldmia 	r1!, {r4-r7}
+ 	stmia 	r0!, {r4-r7}
+ 	cmp 	r1, r2
+ 	blo 	data_loop
+data_loop_done:
+#else
 	ldr     r2, =_data_len
 data_loop:
 	ldr     r3, [r1]
@@ -106,6 +139,7 @@ data_loop:
 	adds    r1, r1, #4
 	subs    r2, r2, #4
 	bne     data_loop
+#endif
 
 #if MMU_BOOT
 	bl boot_mmu_finish


### PR DESCRIPTION
This is a non-critical change as it only executes on start-up.  With memory virtualization on (I think it is off now?) the memory copy could be faster in page swapping.

But, as you say, if this STMIA isn't supported on some sub-architectures, that becomes a pain to support unless it really has value. (Anybody want to test this?)

Regardless, it is here for your amusement.