### PR TITLE
Fix detection of default tunnel on QEMU startup

### DIFF
--- a/scripts/qemu/start_script
+++ b/scripts/qemu/start_script
@@ -11,7 +11,7 @@ $ip addr add   dev $TAP 10.0.2.10/24 #broadcast 10.0.2.255
 $ip addr add   dev $TAP fe80::10:0:2:10/64
 
 #Enable IP Forwarding for gateway interface
-GW=$($ip route | sed -n "s/default via .* dev \([0-9a-z_]\+\) .*$/\1/p")
+GW=$($ip route | sed -n "s/default via .* dev \([0-9a-z_]\+\) .*$/\1/p" | head -n 1)
 if [ "$GW" ]; then
 	echo "Enable IP Forwarding for $GW"
 	iptables -t nat -A POSTROUTING -o $GW -j MASQUERADE


### PR DESCRIPTION
The previous version could return two default gateways, so we need to pick the right (I decided it will be the first) one.

P.S. starting qemu fails later because of weird message `qemu-system-i386: Error loading uncompressed kernel without PVH ELF Note`, but it is very likely a separate issue
