### PR TITLE
add support for spi (poll and interrupt) for bcm2835

### DIFF
--- a/platform/raspberry_pi/rpi0-hw/mods.conf
+++ b/platform/raspberry_pi/rpi0-hw/mods.conf
@@ -22,6 +22,7 @@ configuration conf {
 	@Runlevel(2) include raspberry_pi.driver.jtag
 	@Runlevel(2) include embox.driver.clock.raspi_systick
 	include embox.kernel.time.jiffies(cs_name="raspi_systick")
+	@Runlevel(2) include embox.driver.spi.bcm283x_spi0
 
 	@Runlevel(2) include embox.driver.serial.pl011(
 				base_addr=0x20201000, irq_num=57,
@@ -112,6 +113,7 @@ configuration conf {
 
 	include embox.cmd.hardware.pin
 	include raspberry_pi.cmd.dma
+	include embox.cmd.hardware.spi
 
 	include embox.cmd.fs.mkramdisk
 	include embox.cmd.fs.dd

--- a/src/cmds/hardware/spi/Mybuild
+++ b/src/cmds/hardware/spi/Mybuild
@@ -2,21 +2,44 @@ package embox.cmd.hardware
 
 @AutoCmd
 @Cmd(name = "spi",
-	help = "Transfer data via SPI bus",
-	man = '''
-		NAME
-			spi -- Transfer data via SPI bus
-		SYNOPSIS
-			spi bus_number bus_line byte0 [byte1 [...]]
-		EXAMPLES
-			Reading JEDEC ID from NAND flash:
-				spi 0 1 0x9f 0x9f 0x9f 0x9f
-		AUTHORS
-			Denis Deryugin
-	''')
-module spi {
-	source "spi.c"
+    help = "Transfer data via SPI bus",
+    man = '''
+        NAME
+            spi -- Transfer data via SPI bus
+        SYNOPSIS
+            spi [-t<method>] [-d<clkdiv>] [lsmh] bus_number bus_line [byte0 byte1 [...]]
+        DESCRIPTION
+            'p' test sends 4-bytes in MODE0 for in/out, out only, then read only and
+            then repeats for 32 bytes in same three patterns.  What follows in MODE1/2/3
+            tests in in/out pattern for 4-bytes each. (Input bytes are not checked)
+            'i' Out and Incoming interrupts are set.
+            'w' Incoming interrupt is set, command waits for input (requires 12 bytes before
+                interrupt fires)
 
-	depends embox.driver.spi.core
-	depends embox.util.pretty_print
+            If no bytes are provided as arguments, a default pattern of 32 bytes is used (polling 
+            test excepted). 
+        OPTIONS
+            -l      list spi devices
+            -s      slave mode
+            -m      master mode
+            -t p    by polling method (all tests as master)
+               i    by interrupt 
+               w    interrupt input only, wait for input
+               d    by use of DMA 
+            -d XXX    clock divisor 0-65534 to define speed of device
+                    based upon CPU clock
+        EXAMPLES
+            Reading JEDEC ID from NAND flash:
+                spi 0 1 0x9f 0x9f 0x9f 0x9f
+        AUTHORS
+            Denis Deryugin
+    ''')
+module spi {
+    source "spi.c"
+
+    depends embox.driver.spi.core
+    depends embox.util.pretty_print
+    depends embox.compat.libc.stdio.printf
+    depends embox.compat.libc.str
+    depends embox.compat.posix.util.getopt
 }

--- a/src/cmds/hardware/spi/spi.c
+++ b/src/cmds/hardware/spi/spi.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <util/math.h>
 
 #include <drivers/spi.h>
 #include <util/pretty_print.h>
@@ -17,7 +18,81 @@
 static void print_help(char **argv) {
 	printf("Transfer bytes via SPI bus\n");
 	printf("Usage:\n");
-	printf("%s bus_number line_number byte0 [byte1 [byte2 [...]]]\n", argv[0]);
+	printf("%s spi [-t<method>] [-d<clkdiv>] [lsmh] bus_number bus_line [byte0 byte1 [...]]\n", argv[0]);
+}
+
+static int test_poll(struct spi_device *spi, int spi_line, uint8_t *dataOut, uint8_t *dataIn, int clkdiv) {
+		int res;
+
+		//////  SPI_MODE_0
+		spi->flags |= SPI_CS_ACTIVE | SPI_CS_MODE(SPI_MODE_0) | SPI_CS_DIVSOR(clkdiv);
+		res = spi_select(spi, spi_line);
+
+		// read/write
+		res = spi_transfer(spi, dataOut, dataIn, 4);
+		// write only
+		res = spi_transfer(spi, dataOut, NULL, 4);
+		// read only
+		res = spi_transfer(spi, NULL, dataIn, 4);
+		// read/write
+		res = spi_transfer(spi, dataOut, dataIn, 32);
+		// write only
+		res = spi_transfer(spi, dataOut, NULL, 32);
+		// read only
+		res = spi_transfer(spi, NULL, dataIn, 32);
+
+		//////  SPI_MODE_1
+		spi->flags = SPI_CS_ACTIVE | SPI_CS_MODE(SPI_MODE_1) | SPI_CS_DIVSOR(clkdiv);
+		res = spi_select(spi, spi_line);
+
+		// read/write
+		res = spi_transfer(spi, dataOut, dataIn, 4);
+
+		//////  SPI_MODE_2
+		spi->flags = SPI_CS_ACTIVE | SPI_CS_MODE(SPI_MODE_2) | SPI_CS_DIVSOR(clkdiv);
+		res = spi_select(spi, spi_line);
+
+		// read/write
+		res = spi_transfer(spi, dataOut, dataIn, 4);
+
+		//////  SPI_MODE_3
+		spi->flags = SPI_CS_ACTIVE | SPI_CS_MODE(SPI_MODE_3) | SPI_CS_DIVSOR(clkdiv);
+		res = spi_select(spi, spi_line);
+
+		// read/write
+		res = spi_transfer(spi, dataOut, dataIn, 4);
+		return res;
+}
+
+typedef enum {
+	UNKNOWN = 0, SEND_COMPLETE, DATA_RECEIVED
+} SPI_status;
+
+volatile static SPI_status spi_stat = UNKNOWN;
+volatile static int spi_bytes = 0;
+
+static void data_sent(struct spi_device *data) {
+	spi_bytes = data->count;
+	spi_stat = SEND_COMPLETE;
+};
+
+static void data_received(struct spi_device *data) {
+	spi_bytes = data->count;
+	spi_stat = DATA_RECEIVED;
+};
+
+static int test_interrupt(struct spi_device *dev, int spi_line, uint8_t *dataOut, uint8_t *dataIn, int clkdiv, int bytes) {
+	int ret;
+
+	dev->flags |= SPI_CS_ACTIVE | SPI_CS_MODE(SPI_MODE_0) | SPI_CS_DIVSOR(clkdiv)
+		| SPI_CS_IRQD | SPI_CS_IRQR;
+	dev->send_complete = data_sent;
+	dev->received_data = data_received;
+	ret = spi_select(dev, spi_line);
+	// trigger initiating send interrupt
+	ret = spi_transfer(dev, dataOut, dataIn, bytes);
+
+	return ret;
 }
 
 static void list_spi_devices(void) {
@@ -39,23 +114,48 @@ static void list_spi_devices(void) {
 	}
 }
 
+static void report(char *msg, uint8_t *data, int len) {
+
+	printf("%s(%d):",msg,len);
+	for (int i = 0; i < len; i++) {
+		printf("%02x", data[i]);
+	}	
+	printf("\n");
+}
+
 int main(int argc, char **argv) {
 	int spi_bus, spi_line;
-	int ret, opt, offt = 0;
+	int ret = 0, opt, optargs = 0;
 	bool set_mode = false, master_mode = false;
 	struct spi_device *dev;
+	char method = '_';
+	uint16_t clkdiv = 0;
+	uint8_t dataOut[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0xAD, 0xBE, 0xEF, 0xDE, 0x02, 0xBE, 0xEF, 0xDE, 0xAD, 0x03, 0xEF,
+						0xDE, 0xAD, 0xBE, 0x04, 0x05, 0xAD, 0xBE, 0xEF, 0xDE, 0x06, 0xBE, 0xEF, 0xDE, 0xAD, 0x07, 0xEF};
+	uint8_t dataIn[] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+	int bCount = 0;
+	#define DATA_INOUT_BYTES 32
+	#define MIN_ARGS 3
 
-	while (-1 != (opt = getopt(argc, argv, "lhsm"))) {
+	while (-1 != (opt = getopt(argc, argv, "lhsmt:d:"))) {
 		switch(opt) {
 		case 's':
 			set_mode = true;
 			master_mode = false;
-			offt++;
+			optargs++;
 			break;
 		case 'm':
 			set_mode = true;
 			master_mode = true;
-			offt++;
+			optargs++;
+			break;
+		case 't':
+			method = optarg[0];
+			optargs++;
+			break;
+		case 'd':
+			clkdiv = strtol(optarg, NULL, 0);
+			optargs++;
 			break;
 		case 'l':
 			list_spi_devices();
@@ -66,15 +166,16 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	if (argc < 4 + offt) {
+	if (argc < MIN_ARGS + optargs) {
 		print_help(argv);
 		return 0;
 	}
 
-	spi_bus = strtol(argv[1 + offt], NULL, 0);
-	spi_line = strtol(argv[2 + offt], NULL, 0);
+	spi_bus = strtol(argv[1 + optargs], NULL, 0);
+	spi_line = strtol(argv[2 + optargs], NULL, 0);
 
 	dev = spi_dev_by_id(spi_bus);
+	dev->flags = 0; 	
 	if (dev == NULL) {
 		printf("Failed to select bus #%d\n", spi_bus);
 		return -ENOENT;
@@ -94,26 +195,55 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	dev->flags |= SPI_CS_ACTIVE;
-	dev->flags |= SPI_CS_INACTIVE;
-	ret = spi_select(dev, spi_line);
-	if (ret < 0) {
-		printf("Failed to select line #%d!\n", spi_line);
+	// copy provided bytes into send buffer
+	for (int i = MIN_ARGS; i < min(argc - optargs,DATA_INOUT_BYTES+MIN_ARGS); i++) {
+		uint8_t buf_out;
+
+		buf_out = strtol(argv[i + optargs], NULL, 0);
+		dataOut[bCount++] = buf_out & 0xFF;
+	}
+	// If no data passed in command, set ptr to default count of data bytes
+	if( bCount == 0 ) bCount = DATA_INOUT_BYTES;
+
+
+	printf("\nexec: %c, clkdiv: %d, bus: %d, cs: %d\n",method, clkdiv, spi_bus, spi_line);
+	report("\nS", dataOut, bCount);
+
+	switch(method) {
+	case 'i':
+		ret = test_interrupt(dev, spi_line, dataOut, dataIn, clkdiv, -bCount);
+
+		// Busy wait until transfer done
+		while(spi_stat == UNKNOWN);
+		printf("Status %d, Bytes remain/received: %d\n", (int)spi_stat, spi_bytes);
+		break;
+	case 'w':
+		printf("Waiting for bytes received.\n");
+		ret = test_interrupt(dev, spi_line, NULL, dataIn, clkdiv, -bCount);
+
+		// Busy wait until transfer done
+		while(spi_stat == UNKNOWN);
+		printf("Status %d, Bytes remain/received: %d\n", (int)spi_stat, spi_bytes);
+		break;
+	case 'd':
+		printf("To be implemented.\n");
 		return ret;
+		break;
+	case 'p':
+		ret = test_poll(dev, spi_line, dataOut, dataIn, clkdiv);
+		break;
+	default:
+		dev->flags |= SPI_CS_ACTIVE;
+		dev->flags |= SPI_CS_INACTIVE;
+		ret = spi_select(dev, spi_line);
+		if (ret < 0) {
+			printf("Failed to select line #%d!\n", spi_line);
+			return ret;
+		}
+		spi_transfer(dev, dataOut, dataIn, bCount);
+		break;
 	}
+	report("\nR", dataIn, bCount);
 
-	printf("Received bytes:");
-	for (int i = 3; i < argc; i++) {
-		uint8_t buf_in, buf_out;
-
-		buf_out = strtol(argv[i + offt], NULL, 0);
-
-		spi_transfer(dev, &buf_out, &buf_in, 1);
-
-		printf(" %02x", buf_in);
-	}
-
-	printf("\n");
-
-	return 0;
+	return ret;
 }

--- a/src/drivers/mailbox/bcm2835_mailbox_property.c
+++ b/src/drivers/mailbox/bcm2835_mailbox_property.c
@@ -282,3 +282,21 @@ bcm2835_mailbox_property_t* bcm2835_property_get( bcm2835_mailbox_tag_t tag )
 
     return &property;
 }
+
+//
+// A null terminated list of properties to retrieve
+// 
+void bcm2835_property_value32(bcm2835_mailbox_tag_t *props, uint32_t *value32) {
+    bcm2835_mailbox_property_t *resp;
+
+    bcm2835_property_init();
+    for(int i = 0; props[i] != 0x0; i++) {
+        bcm2835_property_add_tag( props[i] );
+
+    }
+    bcm2835_property_process();
+    for(int i = 0; props[i] != 0x0; i++) {
+        resp = bcm2835_property_get( props[i] );
+        value32[i] = resp->data.value_32;
+    }
+}

--- a/src/drivers/mailbox/bcm2835_mailbox_property.h
+++ b/src/drivers/mailbox/bcm2835_mailbox_property.h
@@ -176,5 +176,7 @@ extern void bcm2835_property_init( void );
 extern void bcm2835_property_add_tag( bcm2835_mailbox_tag_t tag, ... );
 extern int bcm2835_property_process( void );
 extern bcm2835_mailbox_property_t* bcm2835_property_get( bcm2835_mailbox_tag_t tag );
+extern void bcm2835_property_value32(bcm2835_mailbox_tag_t *props, uint32_t *value32);
+
 
 #endif /* BCM2835_MAILBOX_INTERFACE_H */

--- a/src/drivers/spi/bcm283x/Mybuild
+++ b/src/drivers/spi/bcm283x/Mybuild
@@ -1,0 +1,19 @@
+package embox.driver.spi
+
+module bcm283x_spi0 {
+	option number base_addr = 0x20204000
+	option number spi_int = 54
+
+/*  Bus Display speed = core_freq/divisor. (on Pi3B, by default core_freq=400). 
+	A safe starting default value may be 40
+ */
+	option number spi_bus_clock_divisor = 40
+	option number log_level = 0
+
+	source "bcm283x_spi0.c"
+	source "bcm283x_spi0.h"
+
+	depends core
+	depends embox.driver.periph_memory
+	depends embox.driver.gpio.api
+}

--- a/src/drivers/spi/bcm283x/bcm283x_spi0.c
+++ b/src/drivers/spi/bcm283x/bcm283x_spi0.c
@@ -165,7 +165,6 @@ static int bcm283x_spi0_do_transfer(struct spi_device *dev, uint8_t *inbuf
     /* Do not add log_debug() or some another stuff here,
      * because we need to write all tx data before transfer competed. */
     REGS_SPI0->dlen = DLEN_NO_DMA_VALUE;
-    REGS_SPI0->cs |= SPI0_CS_CLEAR( SPI0_tx_fifo | SPI0_rx_fifo ) | SPI0_CS_TA; // clear FIFO and Assert
     while ( ( tx_cnt < tx_count && inbuf != NULL ) 
         ||  (rx_cnt < rx_count && outbuf != NULL ) ) {
         if(tx_cnt < tx_count ) {
@@ -234,7 +233,7 @@ static int bcm283x_spi0_transfer(struct spi_device *dev, uint8_t *inbuf
     if( ( (REGS_SPI0->cs & SPI0_CS_INTD) || (REGS_SPI0->cs & SPI0_CS_INTR) ) ) {
         if(count < 0) {
             // count < 0 is signal to trigger interrupt and return
-            dev->count = -1 * count;    /* set the target amount to output in series of interrupt transfers*/
+            dev->count = -1 * count;    /* set the target amount to output in series of interrupt transfers */
             dev->in = inbuf;
             dev->out = outbuf;
             REGS_SPI0->dlen = DLEN_NO_DMA_VALUE;
@@ -255,7 +254,7 @@ static int bcm283x_spi0_transfer(struct spi_device *dev, uint8_t *inbuf
         return -EINVAL;        
     } else { 
         // Poll mode - bytes send, bytes receive
-        
+        REGS_SPI0->cs |= SPI0_CS_CLEAR( SPI0_tx_fifo | SPI0_rx_fifo ) | SPI0_CS_TA; // clear FIFO and Assert
         bcm283x_spi0_do_transfer(dev, inbuf, outbuf, count, count);
         REGS_SPI0->cs &= ~SPI0_CS_TA; // De-assert
     }

--- a/src/drivers/spi/bcm283x/bcm283x_spi0.c
+++ b/src/drivers/spi/bcm283x/bcm283x_spi0.c
@@ -1,0 +1,274 @@
+/**
+ * @file bcm283x_spi0.c
+ * @brief 
+ * @author kpishere
+ * @version 0.1
+ * @date 2021.07.16
+ */
+#include <errno.h>
+
+#include <drivers/common/memory.h>
+#include <drivers/spi.h>
+#include <embox/unit.h>
+#include <framework/mod/options.h>
+#include <hal/reg.h>
+#include <util/log.h>
+#include <util/math.h>
+#include <kernel/irq.h>
+#include <kernel/printk.h>
+#include <asm/delay.h>
+
+#include <drivers/gpio/gpio.h>
+#include <drivers/gpio/bcm283x/bcm283x_gpio.h>
+#include <drivers/spi.h>
+
+#include "bcm283x_spi0.h"
+
+#define PBASE                     OPTION_GET(NUMBER,base_addr)
+#define SPI_BUS_CLOCK_DIVISOR     OPTION_GET(NUMBER, spi_bus_clock_divisor)
+#define SPI_INT0                  OPTION_GET(NUMBER,spi_int)
+
+// Toggle an extra GPIO pin at various points to debug/test timing
+#if 0
+    #define DRIVER_TESTING
+    #define PIN ( 1 << 25 )
+#endif
+
+/* Errata to BCM2835 behaviour: documentation states that the SPI0 DLEN register is only used for DMA. 
+ * However, even when DMA is not being utilized, setting it from a value != 0 or 1 gets rid of an 
+ * excess idle clock cycle that is present when transmitting each byte. (by default in Polled SPI 
+ * Mode each 8 bits transfer in 9 clocks) With DLEN=2 each byte is clocked to the bus in 8 cycles, 
+ * observed to improve max throughput from 56.8mbps to 63.3mbps (+11.4%, quite close to the 
+ * theoretical +12.5%)
+ * https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=181154
+ */
+#define DLEN_NO_DMA_VALUE 2;
+
+typedef struct {
+    uint32_t cs; /* SPI Master Control and Status */
+    
+/* RW: DMA Mode (DMAEN set)
+    If TA is clear, the first 32-bit write to this register will control 
+    SPIDLEN and SPICS. Subsequent reads and writes will be taken as 
+    four-byte data words to be read/written to the FIFOs Poll/Interrupt 
+    Mode (DMAEN clear, TA set) Writes to the register write bytes to TX FIFO. 
+    Reads from register read bytes from the RX FIFO
+ */
+    uint32_t fifo; /* SPI Master TX and RX FIFOs */
+
+/* RW: 15:0 Clock Divider SCLK = Core Clock / CDIV
+    If CDIV is set to 0, the divisor is 65536. The divisor must be a power of 2.
+    Odd numbers rounded down. The maximum SPI clock rate is of the APB clock.
+ */
+    uint32_t clk; /* SPI Master Clock Divider */
+
+/* RW: 15:0 Data Length - The number of bytes to transfer.
+    This field is only valid for DMA mode (DMAEN set) and controls how many bytes 
+    to transmit (and therefore receive).
+ */     
+    uint32_t dlen; /* SPI Master Data Length */
+
+/* RW: 3:0 This sets the Output Hold delay in APB clocks. A value of 0 causes a 1 clock delay. */
+    uint32_t ltoh; /* SPI LOSSI mode TOH */
+
+/* RW: This register controls the generation of the DREQ and Panic signals to an 
+    external DMA engine The DREQ signals are generated when the FIFOs reach their 
+    defined levels and need servicing. The Panic signals instruct the external DMA engine 
+    to raise the priority of its AXI requests.*/
+    uint32_t dc; /* SPI DMA DREQ Controls */
+} Bcm283x_spi0;
+
+#define REGS_SPI0 ((Bcm283x_spi0 *)(PBASE))
+#define BCM283X_SPI0_TX_FIFO_LEN (16*sizeof(uint32_t))
+#define BCM283X_SPI0_RX_FIFO_LEN (16*sizeof(uint32_t))
+#define BCM283X_SPI0_TX_FIFO_FL  (4*sizeof(uint32_t))
+#define BCM283X_SPI0_RX_FIFO_HW  (3*sizeof(uint32_t))
+
+static int bcm283x_spi0_init(void) {
+    uint32_t pins_spi_Alt0 =( 1 << 7 ) | ( 1 << 8 ) | ( 1 << 9 ) | ( 1 << 10 ) | ( 1 << 11 );    
+    gpio_setup_mode(GPIO_PORT_A, pins_spi_Alt0, GPIO_MODE_OUT_ALTERNATE | GPIO_ALTERNATE(GFAlt0) );
+
+#ifdef DRIVER_TESTING
+    gpio_setup_mode(GPIO_PORT_A, PIN, GPIO_MODE_OUTPUT);
+#endif
+
+    // Initialize the Control and Status register to defaults:
+    //CS=0 (Chip Select), CPHA=0 (Clock Phase), CPOL=0 (Clock Polarity), 
+    //CSPOL=0 (Chip Select Polarity), TA=0 (Transfer not active), and reset TX and RX queues.
+    REGS_SPI0->cs = SPI0_CS(0);
+    REGS_SPI0->clk = SPI_BUS_CLOCK_DIVISOR;
+    REGS_SPI0->dlen = DLEN_NO_DMA_VALUE;
+
+    return 0;
+}
+
+irq_return_t bcm283x_spi_intrd_irq_handler(unsigned int irq_nr, void *data);
+
+static int bcm283x_spi0_attach(struct spi_device *dev) {
+    int res = 0;
+
+    if( !(REGS_SPI0->cs & SPI0_CS_INTD) && !(REGS_SPI0->cs & SPI0_CS_INTR) ) {
+        res = irq_attach(SPI_INT0, bcm283x_spi_intrd_irq_handler, 0x00, dev, "SPI0 IRQ");
+    }
+    return res;
+}
+
+static int bcm283x_spi0_select(struct spi_device *dev, int cs) {
+    int res = 0;
+    if (cs < 0 || cs > 3) {
+        log_error("Only cs=0..3 are avalable!");
+        return -EINVAL;
+    }
+    if( dev->flags & SPI_CS_ACTIVE ) {
+    }
+    if( dev->flags & SPI_CS_INACTIVE ) {
+    }
+
+    // If flag set for either interrupt option, register interrupt function
+    if( dev->flags & SPI_CS_IRQD ) {   
+        res = bcm283x_spi0_attach(dev);     
+        REGS_SPI0->cs |= SPI0_CS_INTD;
+    }
+    if( dev->flags & SPI_CS_IRQR ) {        
+        res = bcm283x_spi0_attach(dev);     
+        REGS_SPI0->cs |= SPI0_CS_INTR;
+    }
+
+    // If no flags set for interrupt, detatch interrupt
+    if( !(dev->flags & SPI_CS_IRQR) && !(dev->flags & SPI_CS_IRQD)
+        && irq_nr_valid(SPI_INT0) == 0 ) {
+        res = irq_detach(SPI_INT0, dev);
+    }
+
+    // set default CPHA=0 (Clock Phase), CPOL=0 (Clock Polarity)
+    REGS_SPI0->cs &= ~(SPI0_CS_CPOL | SPI0_CS_CPHA); 
+    if(dev->flags & SPI_CS_MODE(SPI_MODE_1)) REGS_SPI0->cs |= SPI0_CS_CPHA;
+    if(dev->flags & SPI_CS_MODE(SPI_MODE_2)) REGS_SPI0->cs |= SPI0_CS_CPOL;
+
+    // A clock divisor value is set
+    if( (dev->flags >> 16) ) {
+        REGS_SPI0->clk = (dev->flags >> 16);
+    }
+
+    REGS_SPI0->cs &= ~SPI0_CS(0xFF);
+    REGS_SPI0->cs |= SPI0_CS(cs);
+
+    return res;
+}
+
+static int bcm283x_spi0_do_transfer(struct spi_device *dev, uint8_t *inbuf
+        , uint8_t *outbuf, int tx_count, int rx_count) {
+    int tx_cnt, rx_cnt;
+
+    irq_lock();
+    tx_cnt = rx_cnt = 0;
+    /* Do not add log_debug() or some another stuff here,
+     * because we need to write all tx data before transfer competed. */
+    REGS_SPI0->dlen = DLEN_NO_DMA_VALUE;
+    REGS_SPI0->cs |= SPI0_CS_CLEAR( SPI0_tx_fifo | SPI0_rx_fifo ) | SPI0_CS_TA; // clear FIFO and Assert
+    while ( ( tx_cnt < tx_count && inbuf != NULL ) 
+        ||  (rx_cnt < rx_count && outbuf != NULL ) ) {
+        if(tx_cnt < tx_count ) {
+            if( inbuf != NULL ) {
+                // Wait for FIFO to have 1-byte space    
+                while( !(REGS_SPI0->cs & SPI0_CS_TXD) ) {
+#ifdef DRIVER_TESTING
+                    gpio_set(GPIO_PORT_A, PIN, GPIO_PIN_HIGH );
+                    gpio_set(GPIO_PORT_A, PIN, GPIO_PIN_LOW );
+#endif
+                }; 
+                REGS_SPI0->fifo = inbuf[tx_cnt++];
+            } else { 
+                // write without waiting for buffer ready
+                REGS_SPI0->fifo = 0x00;
+            }
+        }
+        if( rx_cnt < rx_count && outbuf != NULL ) {
+            while ( !(REGS_SPI0->cs & SPI0_CS_RXD) ); // Wait for rx byte
+            outbuf[rx_cnt++] = REGS_SPI0->fifo;
+        }
+    }
+    // read out FIFO incoming buffer
+    while( REGS_SPI0->cs & SPI0_CS_RXD ) { 
+        uint32_t discard;
+        discard += REGS_SPI0->fifo;    
+    }
+    // Wait for tx to complete
+    while( !(REGS_SPI0->cs & SPI0_CS_DONE) ) {
+#ifdef DRIVER_TESTING
+        gpio_set(GPIO_PORT_A, PIN, GPIO_PIN_HIGH );
+        gpio_set(GPIO_PORT_A, PIN, GPIO_PIN_LOW );
+#endif
+    };   
+    irq_unlock();
+
+    return max(tx_cnt, rx_cnt);         
+}
+
+// Interrupt for data send required or complete
+irq_return_t bcm283x_spi_intrd_irq_handler(unsigned int irq_nr, void *data) {
+    irq_return_t ret = IRQ_HANDLED;
+    struct spi_device *dev = (struct spi_device *)data;
+
+    // Transmit and receive with CS asserted
+    if( (REGS_SPI0->cs & (SPI0_CS_DONE | SPI0_CS_TA)) && dev->count > 0 ) {
+        dev->count -= bcm283x_spi0_do_transfer(dev, dev->in, dev->out, min(BCM283X_SPI0_TX_FIFO_FL,dev->count)
+            , min(BCM283X_SPI0_TX_FIFO_FL,dev->count));
+        if(dev->count <= 0) REGS_SPI0->cs &= ~SPI0_CS_TA; // De-assert
+        if(dev->send_complete && dev->count <= 0 ) dev->send_complete(dev);
+    }
+    
+    // Receive with CS un-asserted
+    if( (REGS_SPI0->cs & SPI0_CS_RXR) ) {
+        dev->count = bcm283x_spi0_do_transfer(dev, dev->in, dev->out, min(BCM283X_SPI0_RX_FIFO_HW,dev->count)
+            , min(BCM283X_SPI0_RX_FIFO_HW,dev->count));
+        if(dev->received_data && dev->count > 0 ) dev->send_complete(dev);
+    }
+    return ret;
+}
+
+static int bcm283x_spi0_transfer(struct spi_device *dev, uint8_t *inbuf
+        , uint8_t *outbuf, int count) {
+
+    // Interrupt mode
+    if( ( (REGS_SPI0->cs & SPI0_CS_INTD) || (REGS_SPI0->cs & SPI0_CS_INTR) ) ) {
+        if(count < 0) {
+            // count < 0 is signal to trigger interrupt and return
+            dev->count = -1 * count;    /* set the target amount to output in series of interrupt transfers*/
+            dev->in = inbuf;
+            dev->out = outbuf;
+            REGS_SPI0->dlen = DLEN_NO_DMA_VALUE;
+            REGS_SPI0->cs |= SPI0_CS_CLEAR( SPI0_tx_fifo | SPI0_rx_fifo ) | SPI0_CS_TA; // clear FIFO and Assert
+            return 0;
+        } else {
+            // called in interrupt handler to send/receive data
+            dev->count -= bcm283x_spi0_do_transfer(dev, inbuf, outbuf, min(BCM283X_SPI0_TX_FIFO_FL,count), BCM283X_SPI0_RX_FIFO_HW);
+            REGS_SPI0->cs &= ~SPI0_CS_TA; // De-assert
+            return 0;
+        }
+    }
+
+    if(REGS_SPI0->cs & SPI0_CS_DMAEN) { 
+        // DMA enabled mode
+
+        log_error("DMA not supported (yet)!");
+        return -EINVAL;        
+    } else { 
+        // Poll mode - bytes send, bytes receive
+        
+        bcm283x_spi0_do_transfer(dev, inbuf, outbuf, count, count);
+        REGS_SPI0->cs &= ~SPI0_CS_TA; // De-assert
+    }
+    return 0;
+}
+
+struct spi_ops bcm283x_spi0_ops = {
+    .select   = bcm283x_spi0_select,
+    .transfer = bcm283x_spi0_transfer
+};
+
+PERIPH_MEMORY_DEFINE(bcm283x_spi0, PBASE, sizeof(Bcm283x_spi0));
+
+SPI_DEV_DEF("spi0", &bcm283x_spi0_ops, REGS_SPI0, 0);
+
+EMBOX_UNIT_INIT(bcm283x_spi0_init);

--- a/src/drivers/spi/bcm283x/bcm283x_spi0.h
+++ b/src/drivers/spi/bcm283x/bcm283x_spi0.h
@@ -1,0 +1,114 @@
+/**
+ * @file bcm283x_spi0.h
+ * @brief
+ * @author kpishere
+ * @version
+ * @date 2021.07.13
+ */
+
+#ifndef BCM283X_SPI0_H
+#define BCM283X_SPI0_H
+
+//
+// Control and Status register
+//
+#define SPI0_CS_RESERVED ( 0x3F << 26 ) /* Reserved - Write as 0, read as don't care */
+#define SPI0_CS_LENLONG ( 1 << 25 ) /* RW: Enable Long data word in Lossi mode if DMA_LEN is set \
+										0= writing to the FIFO will write a single byte \
+										1= writing to the FIFO will write a 32 bit word */
+#define SPI0_CS_DMA_LEN ( 1 << 24 ) /* RW: Enable DMA mode in Lossi mode */
+#define SPI0_CS_CSPOL2 ( 1 << 23 ) /* RW: Chip Select 2 Polarity \
+									0= Chip select is active low. 1= Chip select is active high */
+#define SPI0_CS_CSPOL1 ( 1 << 22 ) /* RW: Chip Select 1 Polarity \
+									0= Chip select is active low. 1= Chip select is active high */
+#define SPI0_CS_CSPOL0 ( 1 << 21 ) /* RW: Chip Select 0 Polarity \
+									0= Chip select is active low. 1= Chip select is active high. */
+#define SPI0_CS_RXF ( 1 << 20 )  /* RO: RXF - RX FIFO Full  0 = RXFIFO is not full. \
+								1 = RX FIFO is full. No further serial data will be sent/ \
+									received until data is read from FIFO. */
+#define SPI0_CS_RXR ( 1 << 19 ) /* RO: RXR RX FIFO needs Reading ( full) \
+								0 = RX FIFO is less than full (or not active TA = 0) \
+								1 = RX FIFO is or more full. Cleared by reading \
+									sufficient data from the RX FIFO or setting TA to 0. */
+#define SPI0_CS_TXD ( 1 << 18 ) /* RO: TXD TX FIFO can accept Data \
+								0 = TX FIFO is full and so cannot accept more data. \
+								1 = TX FIFO has space for at least 1 byte. */
+#define SPI0_CS_RXD ( 1 << 17 ) /* RO: RXD RX FIFO contains Data \
+								0 = RX FIFO is empty. \
+								1 = RX FIFO contains at least 1 byte. */
+#define SPI0_CS_DONE ( 1 << 16 ) /* RO: Done transfer Done \
+								0 = Transfer is in progress (or not active TA = 0) \
+								1 = Transfer is complete. Cleared by writing more data \
+								to the TX FIFO or setting TA to 0.  */
+#define SPI0_CS_TE_EN ( 1 << 15 ) /* RW: Unused */
+#define SPI0_CS_LMONO ( 1 << 14 ) /* RW: Unused */
+#define SPI0_CS_LEN ( 1 << 13 ) /* RW: LEN LoSSI enable \
+								The serial interface is configured as a LoSSI master. \
+								0 = The serial interface will behave as an SPI master. \
+								1 = The serial interface will behave as a LoSSI master. */
+#define SPI0_CS_REN ( 1 << 12 ) /* RW: REN Read Enable read enable if you are using \
+								bidirectional mode. If this bit is set, the SPI peripheral \
+								will be able to send data to this device. \
+								0 = We intend to write to the SPI peripheral. \
+								1 = We intend to read from the SPI peripheral. */
+#define SPI0_CS_ADCS ( 1 << 11 ) /* RW: ADCS Automatically Deassert Chip Select \
+								0 = Dont automatically deassert chip select at the end of a DMA \
+								transfer chip select is manually controlled by software. \
+								1 = Automatically deassert chip select at the end of a DMA \
+								transfer (as determined by SPIDLEN) */
+#define SPI0_CS_INTR ( 1 << 10 ) /* RW: INTR Interrupt on RXR \
+								0 = Dont generate interrupts on RX FIFO condition. \
+								1 = Generate interrupt while RXR = 1. */
+#define SPI0_CS_INTD ( 1 << 9 ) /* RW: INTD Interrupt on Done \
+								0 = Don t generate interrupt on transfer complete. \
+								1 = Generate interrupt when DONE = 1.  */
+#define SPI0_CS_DMAEN ( 1 << 8 ) /* RW: DMAEN DMA Enable 0 = No DMA requests will be issued. \
+								1 = Enable DMA operation. Peripheral generates data requests. \
+								These will be taken in four-byte words until the \
+								SPIDLEN has been reached.  */
+#define SPI0_CS_TA ( 1 << 7 ) /* RW: Transfer Active \
+								0 = Transfer not active./CS lines are all high \
+								(assuming CSPOL = 0). RXR and DONE are 0. Writes to \
+								SPIFIFO write data into bits -0 of SPICS allowing DMA \
+								data blocks to set mode before sending data. \
+								1 = Transfer active. /CS lines are set according to CS \
+								bits and CSPOL. Writes to SPIFIFO write data to TX FIFO. \
+								TA is cleared by a dma_frame_end pulse from the DMA controller */
+#define SPI0_CS_CSPOL ( 1 << 6 ) /* RW: Chip Select Polarity \
+								0 = Chip select lines are active low \
+								1 = Chip select lines are active high  */
+typedef enum {
+	SPI0_no_action = 0x00
+,	SPI0_tx_fifo = 0x10 /* Clear TX FIFO. One shot operation. */
+,	SPI0_rx_fifo = 0x20 /* Clear RX FIFO. One shot operation. */
+} SPI0_fifo_clear; /* If CLEAR and TA are both set in the same operation, \
+					the FIFOs are cleared before the new frame is started. 
+					Read back as 0.*/
+#define SPI0_CS_CLEAR(a) ( (a) & 0x30)
+#define SPI0_CS_CPOL ( 1 << 3 ) /* RW: Clock Polarity \
+					0 = Rest state of clock = low. 1 = Rest state of clock = high. */
+#define SPI0_CS_CPHA ( 1 << 2 ) /* RW: Clock Phase \
+					0 = First SCLK transition at middle of data bit. \
+					1 = First SCLK transition at beginning of data bit. */
+
+#define SPI0_CS(n) ( ((n) & 0x03) << 0 ) /* RW: Chip Select \
+					00 = Chip select 0 01 = Chip select 1 10 = Chip select 2 11 = Reserved */
+
+//
+// SPI DMA DREQ Controls Register
+//
+#define SPI0_DC_RPANIC(l) ( ((l) & 0xff) << 24 ) /* RW: DMA Read Panic Threshold. \
+					Generate the Panic signal to the RX DMA engine whenever the RX \
+					FIFO level is greater than this amount. */
+#define SPI0_DC_RDREQ(t) ( ((t) & 0xff) << 16 ) /* RW: DMA Read Request Threshold. \
+					Generate A DREQ to the RX DMA engine whenever the RX FIFO level \
+					is greater than this amount, (RX DREQ is also generated if the \
+					transfer has finished but the RXFIFO isn t empty). */
+#define  SPI0_DC_TPANIC(p) ( ((p) & 0xff) << 8 ) /* RW: DMA Write Panic Threshold. \
+					Generate the Panic signal to the TX DMA engine whenever the \
+					TX FIFO level is less than or equal to this amount. */
+#define  SPI0_DC_TDREQ(r) ( ((r) & 0xff) << 0 ) /* RW: DMA Write Request Threshold. \
+					Generate a DREQ signal to the TX DMA engine whenever the TX FIFO \
+					level is less than or equal to this amount. */
+
+#endif /* BCM283X_SPI_H */

--- a/src/drivers/spi/spi.h
+++ b/src/drivers/spi/spi.h
@@ -25,12 +25,28 @@ enum spi_mode_t {
 	SPI_MODE_T_SLAVE,
 };
 
+enum spi_pol_phase_t {
+	SPI_MODE_0 = 0x00,	/* CPOL = 0, CPHA = 0 */
+	SPI_MODE_1 = 0x01,  /* CPOL = 0, CPHA = 1 */
+	SPI_MODE_2 = 0x02,  /* CPOL = 1, CPHA = 0 */
+	SPI_MODE_3 = 0x03,  /* CPOL = 1, CPHA = 1 */
+};
+
+struct spi_device;
+
+typedef void (*irq_event_t)(struct spi_device *data);
+
 struct spi_device {
 	int    flags;
 	struct dev_module *dev;
 	struct spi_ops *spi_ops;
 	bool is_master;
 	void  *priv;
+	irq_event_t send_complete;
+	irq_event_t received_data;
+	uint8_t *in;
+	uint8_t *out;
+	int count;
 };
 
 struct spi_ops {
@@ -42,7 +58,24 @@ struct spi_ops {
 
 extern struct spi_device *spi_dev_by_id(int id);
 extern int spi_dev_id(struct spi_device *dev);
+
+/* In polling mode: 
+ * - either of *in or *out buffers can be set, cnt is zero to positive
+ *
+ * In interrupt mode:  
+ * - call with cnt < 0, set to -N bytes to write out. Interrupts will fire
+ *   until N bytes are written out to make cnt == 0
+ * - within interrupt handlers, function can be called as expected in polling mode
+ *   where cnt is positive.
+ * 
+ *   NB For BCM283X implementation: 
+ *   - count must not be larger than 16 bytes for sending within interrupt call 
+ *   - takes 12 bytes received to trigger interrupt
+ */
 extern int spi_transfer(struct spi_device *dev, uint8_t *in, uint8_t *out, int cnt);
+
+/* Set extra options in struct *dev before calling this function 
+ */
 extern int spi_select(struct spi_device *dev, int cs);
 extern int spi_set_master_mode(struct spi_device *dev);
 extern int spi_set_slave_mode(struct spi_device *dev);
@@ -73,5 +106,9 @@ struct spi_transfer_arg {
 /* CS modes */
 #define SPI_CS_ACTIVE   (1 << 0)
 #define SPI_CS_INACTIVE (1 << 1)
+#define SPI_CS_MODE(x)	( ( (x) & 0x03) << 2)		/* x is one of enum spi_pol_phase_t */
+#define SPI_CS_IRQD  	(1 << 4)					
+#define SPI_CS_IRQR  	(1 << 5)					
+#define SPI_CS_DIVSOR(x) ( ( (x) & 0xFFFF) << 16 ) 	/* Upper 16 bits used to set clock divisor */
 
 #endif /* DRIVERS_SPI_H_ */


### PR DESCRIPTION
SPI polling and interrupt are supported now in this PR.  Also incorporated all of your suggestions from last review.

SPI command incorporates interrupt tests, default data, and mode switch tests.  There is an interrupt wait for input test but it seems to have a rather short wait time before reporting zero value bytes received.  Don't have a use case for this right now, so will leave it at that.

Maybe somebody else will extend support in stm32 targets for selecting Mode 1/2/3 or interrupts?