### PR TITLE
Correctly close file descriptor on failure

### DIFF
--- a/src/lib/bmp/bmp.c
+++ b/src/lib/bmp/bmp.c
@@ -139,6 +139,7 @@ int bmp_load(char *file_name, struct bmp *bmp_data) {
 		/* 16bpp very unusual format and is not supported in most parsers */
 		case 16:
 			printf("Error : 16bit bmp not supported\n");
+			close(fd);
 			return -1;
 
 		case 8:


### PR DESCRIPTION
I realize it probably doesn't matter at all since nobody uses 16bpp BMPs, 
but for the love of God...