### PR TITLE
third-party: fix curl deps

### DIFF
--- a/third-party/lib/curl/Mybuild
+++ b/third-party/lib/curl/Mybuild
@@ -6,4 +6,5 @@ module curl {
 	source "libcurl.a"
 
 	depends embox.compat.posix.LibPosix
+	depends embox.compat.posix.time.time
 }


### PR DESCRIPTION
`gmtime` provided by `embox.compat.posix.time.time` is required for `Curl_gmtime`.