### PR TITLE
arch: Add 'wait' instruction into arch_adle for MIPS

### DIFF
--- a/src/arch/mips/kernel/arch.c
+++ b/src/arch/mips/kernel/arch.c
@@ -16,7 +16,7 @@ void arch_init(void) {
 }
 
 void arch_idle(void) {
-
+	__asm__ __volatile__ ("wait");
 }
 
 void _NORETURN arch_shutdown(arch_shutdown_mode_t mode) {


### PR DESCRIPTION
Close #2547