### PR TITLE
x86: Add region for multiboot section in arch/x86/embox.lds.S

### DIFF
--- a/src/arch/x86/embox.lds.S
+++ b/src/arch/x86/embox.lds.S
@@ -26,7 +26,7 @@ SECTIONS {
 		_traps_text_end = .;
 		KEEP(*(.text));
 		KEEP(*(.text.*));
-	}
+	} SECTION_REGION(text) :text
 #if 0
 	.eh_frame : {
 		KEEP(*(.eh_frame))


### PR DESCRIPTION
Fix #2468 