### PR TITLE
Changed operation fcntl with F_SETFL flag

### DIFF
--- a/src/kernel/task/idesc/index_descriptor.c
+++ b/src/kernel/task/idesc/index_descriptor.c
@@ -71,6 +71,7 @@ int index_descriptor_flags_get(int fd) {
 	return idesc->idesc_flags & ~O_ACCESS_MASK;
 }
 
+#define SETFL_MASK (O_APPEND | O_NONBLOCK | O_NDELAY | O_DIRECT)
 int index_descriptor_flags_set(int fd, int flags) {
 	struct idesc *idesc;
 
@@ -79,8 +80,7 @@ int index_descriptor_flags_set(int fd, int flags) {
 		return -ENOENT;
 	}
 
-	flags &= ~O_ACCESS_MASK;
-	idesc->idesc_flags |= flags;
+    idesc->idesc_flags = (flags & SETFL_MASK) | (idesc->idesc_flags & ~SETFL_MASK);
 
 	return 0;
 }

--- a/src/kernel/task/idesc/index_descriptor.c
+++ b/src/kernel/task/idesc/index_descriptor.c
@@ -80,7 +80,7 @@ int index_descriptor_flags_set(int fd, int flags) {
 		return -ENOENT;
 	}
 
-    idesc->idesc_flags = (flags & SETFL_MASK) | (idesc->idesc_flags & ~SETFL_MASK);
+	idesc->idesc_flags = (flags & SETFL_MASK) | (idesc->idesc_flags & ~SETFL_MASK);
 
 	return 0;
 }


### PR DESCRIPTION
On Linux `fcntl` with F_SETFL can [change](https://linux.die.net/man/2/fcntl) only the O_APPEND, O_ASYNC, O_DIRECT, O_NOATIME, O_NONBLOCK flags.
In [Linux](https://github.com/torvalds/linux/blob/master/fs/fcntl.c) `SETFL_MASK = (O_APPEND | O_NONBLOCK | O_NDELAY | O_DIRECT | O_NOATIME)`. 
O_NOATIME is not defined in Embox