### PR TITLE
third-party: efm: changed the path to the sources archive

### DIFF
--- a/third-party/efm/Makefile
+++ b/third-party/efm/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME := efm
-PKG_VER  := v1.0.0-alpha
+PKG_VER  := ed4a16901b347762c2a2a21eba2f84d06317ed07
 
-PKG_SOURCES := https://github.com/t0bro/efm/archive/refs/tags/$(PKG_VER).tar.gz
-PKG_MD5     := 8805ada164ce0ad6bb80f44ca82b92cd
+PKG_SOURCES := https://github.com/embox/efm/archive/$(PKG_VER).zip
+PKG_MD5     := edd02177de489eb969fa49791d118361
 
 include $(EXTBLD_LIB)
 

--- a/third-party/efm/Makefile
+++ b/third-party/efm/Makefile
@@ -1,0 +1,17 @@
+PKG_NAME := efm
+PKG_VER  := v1.0.0-alpha
+
+PKG_SOURCES := https://github.com/t0bro/efm/archive/refs/tags/$(PKG_VER).tar.gz
+PKG_MD5     := 8805ada164ce0ad6bb80f44ca82b92cd
+
+include $(EXTBLD_LIB)
+
+$(BUILD) :
+	cd $(PKG_SOURCE_DIR) && ( \
+		$(MAKE) CC=$(EMBOX_GCC) MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)'; \
+	)
+	touch $@
+
+$(INSTALL) :
+	cp $(PKG_SOURCE_DIR)/$(PKG_NAME) $(PKG_INSTALL_DIR)/$(PKG_NAME).o
+	touch $@

--- a/third-party/efm/Mybuild
+++ b/third-party/efm/Mybuild
@@ -1,0 +1,19 @@
+package third_party.cmd
+
+@App
+@AutoCmd
+@Build(stage=2,script="$(EXTERNAL_MAKE)")
+@Cmd(name = "efm",
+	help = "Embedded file manager",
+	man = '''
+		NAME
+			efm - Embedded file manager
+		SYNOPSIS
+			efm [OPTIONS] ...
+		AUTHORS
+			Yury Bobrov (ubobrov@yandex.ru), github.com/t0bro
+	''')
+module efm {
+	source "^BUILD/extbld/^MOD_PATH/install/efm.o"
+}
+


### PR DESCRIPTION
There is a corrected path to the efm sources in the thirdparty/efm/Makefile now.