### PR TITLE
stmf7cube: updated to version 1.17.0

### DIFF
--- a/platform/stm32/f7/stm32746g_discovery/Mybuild
+++ b/platform/stm32/f7/stm32746g_discovery/Mybuild
@@ -4,7 +4,7 @@ package platform.stm32.f7.stm32746g_discovery
 @BuildArtifactPath(cppflags="-DSTM32F746xx")
 static module stm32f746g_conf extends third_party.bsp.stmf7cube.stm32f7_conf {
 	@IncludeExport(path="", target_name="stm32f7xx_hal_conf.h")
-	source "stm32f7xx_hal_conf_1.16.0.h"
+	source "stm32f7xx_hal_conf_1.17.0.h"
 }
 
 @BuildDepends(third_party.bsp.stmf7cube.cube)
@@ -12,17 +12,17 @@ module arch extends embox.arch.arch {
 	source "arch.c"
 
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Projects/STM32746G-Discovery/Templates/Src/system_stm32f7xx.c"
+	source "./STM32CubeF7-1.17.0/Projects/STM32746G-Discovery/Templates/Src/system_stm32f7xx.c"
 }
 
 @Build(stage=1)
 @BuildDepends(stm32f746g_conf)
 @BuildDepends(third_party.bsp.stmf7cube.cube)
-@BuildArtifactPath(cppflags="$(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/,Drivers/BSP/STM32746G-Discovery)")
+@BuildArtifactPath(cppflags="$(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/,Drivers/BSP/STM32746G-Discovery)")
 static module bsp extends third_party.bsp.st_bsp_api {
 	/* Cubse LCD call SDRAM_Init, we don't wont that, so tell Cube's LCD do not init SDRAM */
 	@DefineMacro("DATA_IN_ExtSDRAM")
-	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/STM32746G-Discovery")
+	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/STM32746G-Discovery")
 	source "stm32746g_discovery.c",
 			"stm32746g_discovery_sdram.c",
 			"stm32746g_discovery_lcd.c",

--- a/platform/stm32/f7/stm32f769i_discovery/Mybuild
+++ b/platform/stm32/f7/stm32f769i_discovery/Mybuild
@@ -4,7 +4,7 @@ package platform.stm32.f7.stm32f769i_discovery
 @BuildArtifactPath(cppflags="-DSTM32F769xx")
 static module stm32f769i_conf extends third_party.bsp.stmf7cube.stm32f7_conf {
 	@IncludeExport(path="", target_name="stm32f7xx_hal_conf.h")
-	source "stm32f7xx_hal_conf_1.16.0.h"
+	source "stm32f7xx_hal_conf_1.17.0.h"
 }
 
 @BuildDepends(third_party.bsp.stmf7cube.cube)
@@ -12,17 +12,17 @@ module arch extends embox.arch.arch {
 	source "arch.c"
 
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Projects/STM32F769I-Discovery/Templates/Src/system_stm32f7xx.c"
+	source "./STM32CubeF7-1.17.0/Projects/STM32F769I-Discovery/Templates/Src/system_stm32f7xx.c"
 }
 
 @Build(stage=1)
 @BuildDepends(stm32f769i_conf)
 @BuildDepends(third_party.bsp.stmf7cube.cube)
-@BuildArtifactPath(cppflags="$(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/,Drivers/BSP/STM32F769I-Discovery)")
+@BuildArtifactPath(cppflags="$(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/,Drivers/BSP/STM32F769I-Discovery)")
 static module bsp extends third_party.bsp.st_bsp_api {
 	/* Cubse LCD call SDRAM_Init, we don't wont that, so tell Cube's LCD do not init SDRAM */
 	@DefineMacro("DATA_IN_ExtSDRAM")
-	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/STM32F769I-Discovery")
+	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/STM32F769I-Discovery")
 	source "stm32f769i_discovery.c",
 			"stm32f769i_discovery_sdram.c",
 			"stm32f769i_discovery_lcd.c",

--- a/third-party/bsp/stmf7cube/components/Mybuild
+++ b/third-party/bsp/stmf7cube/components/Mybuild
@@ -3,25 +3,25 @@ package third_party.bsp.stmf7cube
 @Build(stage=1)
 @BuildDepends(third_party.bsp.stmf7cube.cube)
 static module stm32f7_discovery_components {
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/Components/ft5336")
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/Components/ft5336")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Drivers/BSP/Components/ft5336/ft5336.c"
+	source "./STM32CubeF7-1.17.0/Drivers/BSP/Components/ft5336/ft5336.c"
 
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/Components/ft6x06")
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/Components/ft6x06")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Drivers/BSP/Components/ft6x06/ft6x06.c"
+	source "./STM32CubeF7-1.17.0/Drivers/BSP/Components/ft6x06/ft6x06.c"
 
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/Components/wm8994")
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/Components/wm8994")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Drivers/BSP/Components/wm8994/wm8994.c"
+	source "./STM32CubeF7-1.17.0/Drivers/BSP/Components/wm8994/wm8994.c"
 
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/Components/ov9655")
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/Components/ov9655")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Drivers/BSP/Components/ov9655/ov9655.c"
+	source "./STM32CubeF7-1.17.0/Drivers/BSP/Components/ov9655/ov9655.c"
 
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Drivers/BSP/Components/otm8009a")
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Drivers/BSP/Components/otm8009a")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Drivers/BSP/Components/otm8009a/otm8009a.c"
+	source "./STM32CubeF7-1.17.0/Drivers/BSP/Components/otm8009a/otm8009a.c"
 
 	depends third_party.bsp.stmf7cube.cube
 }

--- a/third-party/bsp/stmf7cube/cube/Makefile
+++ b/third-party/bsp/stmf7cube/cube/Makefile
@@ -1,12 +1,12 @@
 
 PKG_NAME := stm32cubef7
 
-PKG_VER  := v1.16.0
-PKG_MD5     := 9586ec0996e154c21dbb31f92834c3aa
-PKG_PATCHES := sd_read_1_16_0.patch
+#PKG_VER  := v1.16.0
+#PKG_MD5     := 9586ec0996e154c21dbb31f92834c3aa
+#PKG_PATCHES := sd_read_1_16_0.patch
 
-#PKG_VER  := v1.17.0
-#PKG_MD5     := b5b0f62b5cbcda9f21abdf8e82e247ba
+PKG_VER  := v1.17.0
+PKG_MD5     := b5b0f62b5cbcda9f21abdf8e82e247ba
 
 PKG_SOURCES := https://github.com/STMicroelectronics/STM32CubeF7/archive/refs/tags/$(PKG_VER).zip
 

--- a/third-party/bsp/stmf7cube/cube/Mybuild
+++ b/third-party/bsp/stmf7cube/cube/Mybuild
@@ -1,7 +1,7 @@
 package third_party.bsp.stmf7cube
 
-@BuildArtifactPath(cppflags="-DUSE_HAL_DRIVER -DSTM32F7_CUBE -DSTM32F7_CUBE_1_16_0")
-@BuildArtifactPath(cppflags="$(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/,Drivers/STM32F7xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32F7xx/Include Drivers/CMSIS/Include)")
+@BuildArtifactPath(cppflags="-DUSE_HAL_DRIVER -DSTM32F7_CUBE -DSTM32F7_CUBE_1_17_0")
+@BuildArtifactPath(cppflags="$(addprefix -I$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/,Drivers/STM32F7xx_HAL_Driver/Inc Drivers/CMSIS/Device/ST/STM32F7xx/Include Drivers/CMSIS/Include)")
 module cube_cppflags {
 
 }
@@ -15,7 +15,7 @@ static module cube {
 
 	@Cflags("-Wno-unused")
 	@Cflags("-Wno-attributes")
-	@AddPrefix("^BUILD/extbld/^MOD_PATH/STM32CubeF7-1.16.0/Drivers/STM32F7xx_HAL_Driver/Src")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/STM32CubeF7-1.17.0/Drivers/STM32F7xx_HAL_Driver/Src")
 	source
 		"stm32f7xx_hal.c",
 		"stm32f7xx_hal_adc.c",

--- a/third-party/bsp/stmf7cube/middlewares/Mybuild
+++ b/third-party/bsp/stmf7cube/middlewares/Mybuild
@@ -3,20 +3,20 @@ package third_party.bsp.stmf7cube
 @Build(stage=1)
 @BuildDepends(third_party.bsp.stmf7cube.cube)
 static module middlewares_usb_device {
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Core/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Core/Inc")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c"
+	source "./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c"
 
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Inc")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_bot.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_data.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_storage_template.c"
+	source "./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_bot.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_data.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_storage_template.c"
 
 	depends third_party.bsp.stmf7cube.cube
 }
@@ -24,19 +24,19 @@ static module middlewares_usb_device {
 @Build(stage=1)
 @BuildDepends(third_party.bsp.stmf7cube.cube)
 static module middlewares_usb_host {
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Core/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Core/Inc")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_conf_template.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_core.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_ctlreq.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_ioreq.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_pipes.c"
+	source "./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_conf_template.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_core.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_ctlreq.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_ioreq.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_pipes.c"
 
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Inc")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Inc")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc_bot.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c",
-			"./STM32CubeF7-1.16.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc_scsi.c"
+	source "./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc_bot.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c",
+			"./STM32CubeF7-1.17.0/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc_scsi.c"
 
 	depends third_party.bsp.stmf7cube.cube
 }
@@ -46,9 +46,9 @@ static module middlewares_usb_host {
 static module middlewares_fat_fs {
 	@DefineMacro("_STR_VOLUME_ID=0")
 	/* FIXME: Do not use FatFs config from USB_Host/MSC_Standalone */
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Middlewares/Third_Party/FatFs/src")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Middlewares/Third_Party/FatFs/src")
 	@AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Middlewares/Third_Party/FatFs/src/ff.c"
+	source "./STM32CubeF7-1.17.0/Middlewares/Third_Party/FatFs/src/ff.c"
 	
 	depends third_party.bsp.stmf7cube.cube
 }

--- a/third-party/bsp/stmf7cube/utilities/Mybuild
+++ b/third-party/bsp/stmf7cube/utilities/Mybuild
@@ -3,7 +3,7 @@ package third_party.bsp.stmf7cube
 @Build(stage=1)
 @BuildDepends(third_party.bsp.stmf7cube.cube)
 static module stm32f7_discovery_utilities {
-    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.16.0/Utilities/Log")
+    @IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/bsp/stmf7cube/cube/STM32CubeF7-1.17.0/Utilities/Log")
     @AddPrefix("^BUILD/extbld/third_party/bsp/stmf7cube/cube")
-	source "./STM32CubeF7-1.16.0/Utilities/Log/lcd_log.c"
+	source "./STM32CubeF7-1.17.0/Utilities/Log/lcd_log.c"
 }


### PR DESCRIPTION
third-party\bsp\stmf7cube\cube\Mybuild:
changed version 1.16.0 to 1.17.0
third-party\bsp\stmf7cube\cube\Makefile:
commented out code related to 1.16.0, uncommented code for 1.17.0
third-party\bsp\stmf7cube\components\Mybuild
changed version 1.16.0 to 1.17.0
platform\stm32\f7\stm32746g_discovery\Mybuild
changed version 1.16.0 to 1.17.0.
platform\stm32\f7\stm32f769i_discovery\Mybuild
changed version 1.16.0 to 1.17.0.
third-party\bsp\stmf7cube\utilities\Mybuild
changed version 1.16.0 to 1.17.0.
third-party\bsp\stmf7cube\middlewares\Mybuild
changed version 1.16.0 to 1.17.0.