### PR TITLE
Issue 2665 fix stm32 qt

### DIFF
--- a/scripts/gdb_load_stm32.sh
+++ b/scripts/gdb_load_stm32.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+grep 'QSPI)' ./conf/lds.conf > /dev/null && echo "This script doesn't work with QSPI sections!" && exit -1
+
+GDB=arm-none-eabi-gdb
+GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32f7_qspi.XXXX)
+EMBOX_ELF=build/base/bin/embox
+EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
+
+create_gdb_script() {
+	rm -f $GDB_CMD_FILE
+
+	echo "target ext :3333" >> $GDB_CMD_FILE
+	echo "monitor reset halt" >> $GDB_CMD_FILE
+	echo "load" >> $GDB_CMD_FILE
+	echo "continue" >> $GDB_CMD_FILE
+
+	# Show generated GDB sctipt
+	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+}
+
+create_gdb_script
+
+$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+
+rm $GDB_CMD_FILE

--- a/src/drivers/input/input_dev_devfs.c
+++ b/src/drivers/input/input_dev_devfs.c
@@ -110,7 +110,7 @@ int input_dev_private_register(struct input_dev *inpdev) {
 
 	memset(dev, 0, sizeof(*dev));
 
-	strncat(dev->name, inpdev->name, sizeof dev->name);
+	strncat(dev->name, inpdev->name, sizeof(dev->name) - 1);
 
 	dev->dev_iops = &input_dev_fs_iops;
 	dev->dev_open = input_dev_fs_open;


### PR DESCRIPTION
This is simple script to check if current config has QSPI. If it has no SPI, then it can be loaded to the board with simple GDB command