### PR TITLE
opendir function fix

### DIFF
--- a/src/compat/posix/fs/dirent/dirent_dvfs.c
+++ b/src/compat/posix/fs/dirent/dirent_dvfs.c
@@ -36,6 +36,12 @@ DIR *opendir(const char *path) {
 		return NULL;
 	}
 
+	if (!S_ISDIR(l.item->flags)) {
+		dentry_ref_dec(l.item);
+		SET_ERRNO(ENOTDIR);
+		return NULL;
+	}
+
 	if (!(d = pool_alloc(&dir_pool))) {
 		dentry_ref_dec(l.item);
 		SET_ERRNO(ENOMEM);


### PR DESCRIPTION
opendir function was fixed for case when opendir path argument points to file instead of directory.