### PR TITLE
add-exp-to-math

### DIFF
--- a/src/compat/libc/math/Mybuild
+++ b/src/compat/libc/math/Mybuild
@@ -20,6 +20,7 @@ static module math_simple extends embox.compat.libc.math {
 	source "ceil.c"
 	source "round.c", "roundl.c"
 	source "signbit.c"
+	source "exp.c"
 }
 
 static module math_openlibm extends embox.compat.libc.math {

--- a/src/compat/libc/math/exp.c
+++ b/src/compat/libc/math/exp.c
@@ -1,0 +1,6 @@
+#include "math_builtins.h"
+
+double exp(double x)
+{
+    return pow(M_E, x);
+}

--- a/src/compat/libc/math/math_builtins.h
+++ b/src/compat/libc/math/math_builtins.h
@@ -38,6 +38,7 @@ extern double fmod( double x, double y );
 extern double log(double x);
 extern double log10(double x);
 extern double pow(double x, double y);
+extern double exp(double x);
 extern double sqrt(double x);
 
 extern long double floorl(long double x);


### PR DESCRIPTION
1. Added file src\compat\libc\math\exp.c with implementation for exp function.
2. Added extern definition for exp function to src\compat\libc\math\math_builtins.h.
3. Updated embox.compat.libc.math_simple module in src\compat\libc\math\Mybuild with addition of: source "exp.c" statement.