### PR TITLE
add-_SC_OPEN_MAX-to-unistd-h

### DIFF
--- a/src/compat/libc/stdlib/sysconf.c
+++ b/src/compat/libc/stdlib/sysconf.c
@@ -30,6 +30,8 @@ long int sysconf(int name) {
 	case _SC_PHYS_PAGES:
 		//FIXME
 		return 0x1000;
+	case _SC_OPEN_MAX:
+		return _SC_OPEN_MAX;
 	default:
 		return -EINVAL;
 	}

--- a/src/compat/posix/include/unistd.h
+++ b/src/compat/posix/include/unistd.h
@@ -34,6 +34,8 @@
 #define _SC_NPROCESSORS_CONF  _SC_NPROCESSORS_ONLN
 #define _SC_PHYS_PAGES        104
 
+#define _SC_OPEN_MAX          20
+
 /*
 _SC_2_C_BIND
 _SC_2_C_DEV


### PR DESCRIPTION
1. Added #define _SC_OPEN_MAX (The maximum number of open files per process) with minimum value 20 to src\compat\posix\include\unistd.h file.
2. Updated switch statement in src\compat\libc\stdlib\sysconf.c file with added case statement for _SC_OPEN_MAX.