### PR TITLE
fix build for confload-project/paho_mqtt_cpp/arm_qemu

### DIFF
--- a/project/paho_mqtt_cpp/templates/arm_qemu/mods.conf
+++ b/project/paho_mqtt_cpp/templates/arm_qemu/mods.conf
@@ -34,6 +34,31 @@ configuration conf {
 
 	include embox.kernel.spinlock(spin_debug=false)
 
+	include embox.compat.posix.idx.select
+	include embox.compat.posix.net.getaddrinfo(addrinfo_pool_size=8)
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=4000)
+	@Runlevel(2) include embox.net.skbuff_data(
+				amount_skb_data=4000, data_size=1514,
+				data_align=1, data_padto=1,ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(
+				amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.af_packet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.tcp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.tcp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.net_entry
+	include embox.net.lib.dns_file
+
 	@Runlevel(2) include embox.lib.debug.whereami
 	@Runlevel(2) include embox.profiler.tracing
 	

--- a/project/paho_mqtt_cpp/templates/arm_qemu/paho_mqtt_cpp_publish.inc
+++ b/project/paho_mqtt_cpp/templates/arm_qemu/paho_mqtt_cpp_publish.inc
@@ -1,0 +1,3 @@
+#define MQTT_SERVER_ADDRESS     "tcp://10.0.2.10:1883"
+#define MQTT_SERVER_TOPIC       "hello"
+

--- a/project/paho_mqtt_cpp/templates/arm_qemu/paho_mqtt_cpp_subscribe.inc
+++ b/project/paho_mqtt_cpp/templates/arm_qemu/paho_mqtt_cpp_subscribe.inc
@@ -1,0 +1,2 @@
+#define MQTT_SERVER_ADDRESS     "tcp://10.0.2.10:1883"
+#define MQTT_SERVER_TOPIC       "hello"

--- a/project/paho_mqtt_cpp/templates/arm_qemu/system_start.inc
+++ b/project/paho_mqtt_cpp/templates/arm_qemu/system_start.inc
@@ -1,3 +1,7 @@
 "export PWD=/",
 "export HOME=/",
+"netmanager",
+"service telnetd",
+"service httpd",
+"stl_demo_sort1",
 "tish",


### PR DESCRIPTION
1. Updated project/paho_mqtt_cpp/templates/arm_qemu/mods.conf: 1.1. added networking modules (udp modules can be removed for mosquitto client) 1.2. added embox.compat.posix.idx.select module
2. Updated project/paho_mqtt_cpp/templates/arm_qemu/system_start.inc. Added: 2.1. "netmanager"
2.2. "service telnetd"  - (why is it needed?)
2.3. "service httpd" - (why is it needed?)
2.4. "stl_demo_sort1" - (why is it needed?)
3. Added two configuration files: 3.1. project/paho_mqtt_cpp/templates/arm_qemu/paho_mqtt_cpp_publish.inc with
3.1.1. MQTT_SERVER_ADDRESS     "tcp://10.0.2.10:1883"
3.1.2. MQTT_SERVER_TOPIC       "hello"
3.2. project/paho_mqtt_cpp/templates/arm_qemu/paho_mqtt_cpp_subscribe.inc with
3.2.1. MQTT_SERVER_ADDRESS     "tcp://10.0.2.10:1883"
3.2.2. MQTT_SERVER_TOPIC       "hello"