### PR TITLE
lib/debug/ubsan: Initial implementation

### DIFF
--- a/src/lib/debug/Mybuild
+++ b/src/lib/debug/Mybuild
@@ -51,3 +51,7 @@ module no_gdbstub extends gdbstub_api {
 	@IncludeExport(path="debug", target_name="gdbstub.h")
 	source "no_gdbstub.h"
 }
+
+module ubsan  {
+	source "ubsan.c"
+}

--- a/src/lib/debug/Mybuild
+++ b/src/lib/debug/Mybuild
@@ -53,5 +53,6 @@ module no_gdbstub extends gdbstub_api {
 }
 
 module ubsan  {
+	option boolean stop_on_handle = false
 	source "ubsan.c"
 }

--- a/src/lib/debug/ubsan.c
+++ b/src/lib/debug/ubsan.c
@@ -7,13 +7,20 @@
  */
 
 #include <debug/whereami.h>
+#include <framework/mod/options.h>
+#include <kernel/panic.h>
 #include <kernel/printk.h>
 #include <util/location.h>
+
+#define STOP_ON_HANDLE       OPTION_GET(BOOLEAN,stop_on_handle)
 
 void print_ubsan_data(void *data) {
 	/* Assume every handler-specific data member starts with location */
 	struct location *l = data;
 	printk("%s:%d\n", l->file, l->line);
+	if (STOP_ON_HANDLE) {
+		panic("UbSan handle\n");
+	}
 }
 
 void __ubsan_handle_add_overflow(void *data, void *lhs, void *rhs) {

--- a/src/lib/debug/ubsan.c
+++ b/src/lib/debug/ubsan.c
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * @brief Handlers for -fsanitize=undefined flag
+ *
+ * @date   13 Apr 2023
+ * @author Denis Deryugin
+ */
+
+#include <debug/whereami.h>
+#include <kernel/printk.h>
+#include <util/location.h>
+
+void print_ubsan_data(void *data) {
+	/* Assume every handler-specific data member starts with location */
+	struct location *l = data;
+	printk("%s:%d\n", l->file, l->line);
+}
+
+void __ubsan_handle_add_overflow(void *data, void *lhs, void *rhs) {
+	printk("UbSan add overflow ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_sub_overflow(void *data, void *lhs, void *rhs) {
+	printk("UbSan sub overflow ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_mul_overflow(void *data, void *lhs, void *rhs) {
+	printk("UbSan mul overflow ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_negate_overflow(void *data, void *val) {
+	printk("UbSan negate overflow ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_divrem_overflow(void *data, void *lhs, void *rhs) {
+	printk("UbSan divrem overflow ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_pointer_overflow(void *data, void *base, void *result) {
+	printk("UbSan pointer overflow ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_type_mismatch(void *data, void *type) {
+	printk("UbSan type mismatch ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_type_mismatch_v1(void *data, void *type) {
+	printk("UbSan type mismatch ");
+	print_ubsan_data(data);
+}
+
+#if defined __GNUC__ && __GNUC__ < 10
+void __ubsan_handle_nonnull_arg(void *data, int num) {
+#else
+void __ubsan_handle_nonnull_arg(void *data) {
+#endif
+	printk("UbSan nonnull arg ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_shift_out_of_bounds(void *data, void *lhs, void *rhs) {
+	printk("UbSan shift out of bounds ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_out_of_bounds(void *data, void *base) {
+	printk("UbSan out of bounds ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_invalid_builtin(void *data) {
+	printk("UbSan invalid builtin ");
+	print_ubsan_data(data);
+}
+
+void __ubsan_handle_load_invalid_value(void *data, void *base) {
+	printk("UbSan load invalid value ");
+	print_ubsan_data(data);
+}

--- a/templates/x86/qemu/build.conf
+++ b/templates/x86/qemu/build.conf
@@ -4,7 +4,7 @@ ARCH = x86
 // For MAC OS X
 //CROSS_COMPILE = i386-elf-
 
-CFLAGS += -O0 -gdwarf-2
+CFLAGS += -O0 -gdwarf-2 -fsanitize=undefined
 CFLAGS += -m32
 CFLAGS += -mno-mmx -mno-sse -mno-sse2 -mno-sse3
 

--- a/templates/x86/qemu/mods.conf
+++ b/templates/x86/qemu/mods.conf
@@ -38,6 +38,7 @@ configuration conf {
 	@Runlevel(2) include embox.driver.usb.hc.ohci_pci
 
 	@Runlevel(2) include embox.lib.debug.whereami
+	@Runlevel(2) include embox.lib.debug.ubsan(stop_on_handle=false)
 	@Runlevel(2) include embox.profiler.tracing
 
 	@Runlevel(0) include embox.mem.phymem


### PR DESCRIPTION
Output in qemu for x86/debug template:

```
...
	unit: initializing embox.driver.tty.serial: done
	pci: Apple OHCI usb host driver inserted
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
	pci: Apple OHCI usb host handles 106b:003f bus 0 slot 4 func 0
	pci: virtio driver inserted
	pci: virtio handles 1af4:1000 bus 0 slot 3 func 0
	unit: initializing embox.driver.net.loopback: done
	unit: initializing embox.driver.serial.i8250: done
	unit: initializing embox.driver.clock.hpet: UbSan mismatch /home/dde/src/embox/build/base/gen/../../extbld/third_party/lib/acpi7
UbSan mismatch /home/dde/src/embox/build/base/gen/../../extbld/third_party/lib/acpica/acpica-unix-20210331/source/components/tables/tbx7
UbSan mismatch /home/dde/src/embox/build/base/gen/../../extbld/third_party/lib/acpica/acpica-unix-20210331/source/components/tables/tbx7
UbSan mismatch /home/dde/src/embox/build/base/gen/../../extbld/third_party/lib/acpica/acpica-unix-20210331/source/components/tables/tbx7
UbSan mismatch /home/dde/src/embox/build/base/gen/../../extbld/third_party/lib/acpica/acpica-unix-20210331/source/components/tables/tbx7
UbSan shift out of bounds /home/dde/src/embox/src/mem/vmem/mapper.c:26
done
	unit: initializing embox.driver.clock.tsc: done
	test: running embox.test.math.fpu_context_consistency_test . done
...
```

Didn't test it on any other platform tho ¯\_(ツ)_/¯