### PR TITLE
cmds: Fix integer overflow involving m_blocks

### DIFF
--- a/src/cmds/testing/block_dev/block_dev_test.c
+++ b/src/cmds/testing/block_dev/block_dev_test.c
@@ -178,8 +178,8 @@ static int block_dev_test(struct block_dev *bdev, uint64_t s_block, uint64_t n_b
 		blocks = total_blocks;
 	}
 
-	read_buf = malloc(blk_sz * m_blocks);
-	write_buf = malloc(blk_sz * m_blocks);
+	read_buf = calloc(m_blocks, blk_sz);
+	write_buf = calloc(m_blocks, blk_sz);
 
 	if (read_buf == NULL || write_buf == NULL) {
 		printf("Failed to allocate memory for buffer!\n");


### PR DESCRIPTION
m_blocks is derived from user input (a command-line argument). If m_blocks is large enough, the multiplication to calculate malloc() size could overflow.