### PR TITLE
Fix comparisons that are always false

### DIFF
--- a/src/cmds/net/tftp/tftp.c
+++ b/src/cmds/net/tftp/tftp.c
@@ -129,7 +129,7 @@ static int tftp_recv_file(char *filename, char *hostname, char binary_on, void *
 		}
 
 		if (addr == NULL) {
-			if (0 > fwrite(buf, 1, bytes, fp)) {
+			if (bytes > fwrite(buf, 1, bytes, fp)) {
 				tftp_delete_stream(s);
 				return -2;
 			}

--- a/src/drivers/serial/uart_dev.c
+++ b/src/drivers/serial/uart_dev.c
@@ -89,11 +89,13 @@ static void uart_internal_init(struct uart *uart) {
 int uart_register(struct uart *uart,
 		const struct uart_params *uart_defparams) {
 	int res;
+	size_t allocated_idx;
 
-	uart->idx = index_alloc(&serial_indexator, INDEX_MIN);
-	if(uart->idx < 0) {
+	allocated_idx = index_alloc(&serial_indexator, INDEX_MIN);
+	if (allocated_idx == INDEX_NONE) {
 		return -EBUSY;
 	}
+	uart->idx = (unsigned char)allocated_idx;
 
 	snprintf(uart->dev_name, UART_NAME_MAXLEN, "ttyS%d", uart->idx);
 


### PR DESCRIPTION
fwrite() returns a size_t, which means that 0 > fwrite(...) will never hold.
Similarly, the type of uart->idx is unsigned char. Thus, the comparison uart->index < 0 is always false.