### PR TITLE
mem: Remove 'const' modifier on a function return type

### DIFF
--- a/src/include/mem/phymem.h
+++ b/src/include/mem/phymem.h
@@ -18,8 +18,8 @@ extern struct page_allocator *__phymem_allocator;
 extern void *phymem_alloc(size_t page_number);
 extern void phymem_free(void *page, size_t page_number);
 
-extern char *const phymem_allocated_start(void);
-extern char *const phymem_allocated_end(void);
+extern char *phymem_allocated_start(void);
+extern char *phymem_allocated_end(void);
 extern struct page_allocator *phy_allocator(void);
 
 #endif /* MEM_PHYMEM_H_ */

--- a/src/mem/phymem.c
+++ b/src/mem/phymem.c
@@ -71,7 +71,7 @@ static uintptr_t find_sections_end(void *vmas[], unsigned int lens[]) {
 	return l;
 }
 
-char * const phymem_allocated_start(void) {
+char *phymem_allocated_start(void) {
 	extern char _reserve_end;
 
 	extern void *sections_text_vma[];
@@ -107,7 +107,7 @@ char * const phymem_allocated_start(void) {
 	return (char *) binalign_bound(sections_end, PAGE_SIZE());
 }
 
-char *const phymem_allocated_end(void) {
+char *phymem_allocated_end(void) {
 	return (char *)
 			binalign_bound((uintptr_t) &_ram_base + (size_t) &_ram_size, PAGE_SIZE());
 }


### PR DESCRIPTION
A 'const' modifier on a function return type is useless and should be removed for clarity.