### PR TITLE
Ubsan compilation

### DIFF
--- a/src/compat/libc/string/Mybuild
+++ b/src/compat/libc/string/Mybuild
@@ -19,7 +19,6 @@ static module str {
 	source "strcmp.c"
 	source "strcoll.c"
 	source "strxfrm.c"
-	source "stpcpy.c"
 	source "strcpy.c"
 	source "strcspn.c"
 	@NoRuntime depends strerror
@@ -42,6 +41,10 @@ static module str {
 	source "ffs.c"
 	source "bcopy.c"
 	source "bzero.c"
+}
+
+static module stpcpy {
+	source "stpcpy.c"
 }
 
 static module str_dup {

--- a/templates/arm/qemu/build.conf
+++ b/templates/arm/qemu/build.conf
@@ -6,7 +6,7 @@ PLATFORM = integratorcp
 CROSS_COMPILE = arm-none-eabi-
 
 CFLAGS += -O0 -g3
-#CFLAGS += -fsanitize=undefined
+CFLAGS += -fsanitize=undefined
 CFLAGS += -march=armv5te -mtune=arm926ej-s
 CFLAGS += -mapcs-frame
 


### PR DESCRIPTION
It looks like gcc has a bug, and 'stpcpy' function name is a problem 🤷
This function is not used in the OS itself, so just extract it to a separate module, and it works fine

Minimal example to reproduce this bug:

```
> cat stpcpy.c
char *stpcpy(char *, const char *) {
  return 0;
}
> arm-none-eabi-gcc -fsanitize=undefined -c -o stpcpy.o stpcpy.c -save-temps
stpcpy.s: Assembler messages:
stpcpy.s:52: Error: expected comma after name `' in .size directive
```
