### PR TITLE
Enable tish read from keyboard correctly

### DIFF
--- a/src/cmds/shell/Mybuild
+++ b/src/cmds/shell/Mybuild
@@ -26,6 +26,7 @@ abstract module shell_api {
 	''')
 module tish extends shell_api {
 	option number rich_prompt_support = 0
+	option number unset_nodelay_mode = 0
 
 	option string builtin_commands = "cd export exit logout"
 

--- a/src/cmds/shell/tish.c
+++ b/src/cmds/shell/tish.c
@@ -331,8 +331,10 @@ static int rich_prompt(const char *fmt, char *buf, size_t len) {
 
 static void sh_unset_nodelay_mode(void) {
 	int orig_ifd_flags = fcntl(STDIN_FILENO, F_GETFL, 0);
-	if (fcntl(STDIN_FILENO, F_SETFL, orig_ifd_flags & ~O_NONBLOCK) == -1) {
-		printf("cant unset_nodelay_mode\n");
+	if (orig_ifd_flags & O_NONBLOCK) {
+		if (fcntl(STDIN_FILENO, F_SETFL, orig_ifd_flags & ~O_NONBLOCK) == -1) {
+			printf("cant unset_nodelay_mode\n");
+		}
 	}
 }
 

--- a/src/cmds/shell/tish.c
+++ b/src/cmds/shell/tish.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <termios.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <pwd.h>
 
@@ -326,6 +327,13 @@ static int rich_prompt(const char *fmt, char *buf, size_t len) {
 	return 0;
 }
 
+static void sh_unset_nodelay_mode(void) {
+	int orig_ifd_flags = fcntl(STDIN_FILENO, F_GETFL, 0);
+	if (fcntl(STDIN_FILENO, F_SETFL, orig_ifd_flags & ~O_NONBLOCK) == -1) {
+		printf("cant unset_nodelay_mode\n");
+	}
+}
+
 static void tish_run(void) {
 	char *line;
 	char prompt_buf[PROMPT_BUF_LEN];
@@ -339,6 +347,8 @@ static void tish_run(void) {
 	readline_init();
 	rl_attempted_completion_function = cmd_completion;
 	rl_bind_key('\t', rl_complete);
+
+	sh_unset_nodelay_mode();
 
 #if 0
 	/**
@@ -385,6 +395,7 @@ static void tish_run(void) {
 		}
 
 		tish_collect_bg_childs();
+		sh_unset_nodelay_mode();
 
 		/* TODO now linenoise use sysalloc for memory allocation */
 		sysfree(line);

--- a/src/cmds/shell/tish.c
+++ b/src/cmds/shell/tish.c
@@ -329,6 +329,7 @@ static int rich_prompt(const char *fmt, char *buf, size_t len) {
 	return 0;
 }
 
+#if UNSET_NODELAY_MODE
 static void sh_unset_nodelay_mode(void) {
 	int orig_ifd_flags = fcntl(STDIN_FILENO, F_GETFL, 0);
 	if (orig_ifd_flags & O_NONBLOCK) {
@@ -337,6 +338,7 @@ static void sh_unset_nodelay_mode(void) {
 		}
 	}
 }
+#endif
 
 static void tish_run(void) {
 	char *line;
@@ -352,9 +354,9 @@ static void tish_run(void) {
 	rl_attempted_completion_function = cmd_completion;
 	rl_bind_key('\t', rl_complete);
 
-	if (UNSET_NODELAY_MODE) {
-		sh_unset_nodelay_mode();
-	}
+#if UNSET_NODELAY_MODE
+	sh_unset_nodelay_mode();
+#endif
 
 #if 0
 	/**
@@ -402,9 +404,9 @@ static void tish_run(void) {
 
 		tish_collect_bg_childs();
 		
-		if (UNSET_NODELAY_MODE) {
-			sh_unset_nodelay_mode();
-		}
+#if UNSET_NODELAY_MODE
+		sh_unset_nodelay_mode();
+#endif
 
 		/* TODO now linenoise use sysalloc for memory allocation */
 		sysfree(line);

--- a/src/cmds/shell/tish.c
+++ b/src/cmds/shell/tish.c
@@ -43,6 +43,8 @@
 
 #define RICH_PROMPT_SUPPORT OPTION_GET(NUMBER, rich_prompt_support)
 
+#define UNSET_NODELAY_MODE OPTION_GET(NUMBER, unset_nodelay_mode)
+
 #define BUILTIN_COMMANDS OPTION_STRING_GET(builtin_commands)
 
 #define PROMPT_BUF_LEN 32
@@ -348,7 +350,9 @@ static void tish_run(void) {
 	rl_attempted_completion_function = cmd_completion;
 	rl_bind_key('\t', rl_complete);
 
-	sh_unset_nodelay_mode();
+	if (UNSET_NODELAY_MODE) {
+		sh_unset_nodelay_mode();
+	}
 
 #if 0
 	/**
@@ -395,7 +399,10 @@ static void tish_run(void) {
 		}
 
 		tish_collect_bg_childs();
-		sh_unset_nodelay_mode();
+		
+		if (UNSET_NODELAY_MODE) {
+			sh_unset_nodelay_mode();
+		}
 
 		/* TODO now linenoise use sysalloc for memory allocation */
 		sysfree(line);

--- a/templates/x86/test/lang/mods.conf
+++ b/templates/x86/test/lang/mods.conf
@@ -69,7 +69,7 @@ configuration conf {
 	@Runlevel(1) include embox.test.third_party.trex_test
 
 
-	@Runlevel(2) include embox.cmd.sh.tish(prompt="%u@%h:%w%$", rich_prompt_support=1, builtin_commands="mruby exit logout cd export mount umount")
+	@Runlevel(2) include embox.cmd.sh.tish(prompt="%u@%h:%w%$", rich_prompt_support=1, unset_nodelay_mode=1, builtin_commands="mruby exit logout cd export mount umount")
 	@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=true)
 	include embox.cmd.net.arp
 	include embox.cmd.net.netstat


### PR DESCRIPTION
Fix #2263

In linux bash, `sh_unset_nodelay_mode()` is called when bash starts. There `fcntl` is called. Also in interactive mode if cmd sets `O_NONBLOCK` to stdin, bash unsets it before next cmd call.

Now `x86/test/lang` works correctly