### PR TITLE
makefile: -fdebug-prefix-map with correct argument

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -200,10 +200,21 @@ EMBOX_EXPORT_CPPFLAGS = $(call cppflags_fn,abspath)
 EMBOX_EXPORT_CPPFLAGS += $(filter-out -D%" -D%',$(cppflags))
 
 override COMMON_FLAGS := -pipe
-debug_prefix_map_supported:=$(shell $(CPP) /dev/zero --debug-prefix-map=./= 2>/dev/null && echo true)
+
+PREFIX_MAP:=TRUE
+ifdef PREFIX_MAP
+# check whether option is supported by sending all errors to /dev/null
+# if not supported 'echo true' will be ANDed with zero output
+# else it is supported
+# backslashed pwd at execution time in shell will produce root embox directory
+# this flag makes the pathnames to sources for debug symbols relative
+# to the the root embox directory, keep that in mind in order for the debugger
+# to properly find sources at runtime. If you don't want relative pathnames
+# for sources, comment the line PREFIX_MAP:=TRUE above
+debug_prefix_map_supported:=$(shell $(CPP) /dev/zero -fdebug-prefix-map=./=. 2>/dev/null && echo true)
 ifneq ($(debug_prefix_map_supported),)
-override COMMON_FLAGS += --debug-prefix-map=`pwd`=
-override COMMON_FLAGS += --debug-prefix-map=./=
+override COMMON_FLAGS += -fdebug-prefix-map=`pwd`=.
+endif
 endif
 
 # Assembler flags


### PR DESCRIPTION
--debug-prefix-map was being used which worked, but according to gcc documentation should have been -fdebug-prefix-map
It is used to substitute the absolute pathnames to source files connected with debug symbols with relative to the root directory of embox. 
Arguments are now passed in more correct manner ("-fdebug-prefix-map=\`pwd\`=." instead of "--debug-prefix-map=\`pwd\`="). In previous version debug information about pathnames was ending up in the relative path looking like absolute (for instance /src/some/command.c instead of ./src/some/command.c) which gdb successfully (and smartly) parsed, but some gdb plugins (nvim-gdb for instance) would find invalid, ending up in not finding the source.
Some code for easier switching off of this flag also added. If you need debug information about sources to contain absolute pathnames you can comment the PREFIX_MAP:=TRUE line in mk/flags.mk