### PR TITLE
shell:hardlink /bin/sh for dropbear. execv add chk

### DIFF
--- a/src/cmds/shell/shell.c
+++ b/src/cmds/shell/shell.c
@@ -12,16 +12,27 @@ ARRAY_SPREAD_DEF(const struct shell, __shell_registry);
 
 const struct shell *shell_lookup(const char *shell_name) {
 	const struct shell *shell;
+    const char tish_cmd[] = "tish";
 
 	if (!strncmp(shell_name, "/bin/", strlen("/bin/"))) {
 		shell_name += strlen("/bin/");
 	}
 
-	array_spread_foreach_ptr(shell, __shell_registry) {
-		if (0 == strcmp(shell->name, shell_name)) {
-			return shell;
-		}
-	}
+    /* Make a hardlink /bin/sh to tish, until a more solid solution*/
+    if (strcmp(shell_name, "sh") == 0) {
+        array_spread_foreach_ptr(shell, __shell_registry) {
+            if (0 == strcmp(shell->name, tish_cmd)) {
+                return shell;
+            }
+        }
+    }
+    else {
+        array_spread_foreach_ptr(shell, __shell_registry) {
+            if (0 == strcmp(shell->name, shell_name)) {
+                return shell;
+            }
+        }
+    }
 
 	return NULL;
 }

--- a/src/compat/posix/proc/exec.c
+++ b/src/compat/posix/proc/exec.c
@@ -6,6 +6,7 @@
  * @date    02.06.2014
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <framework/cmd/api.h>
@@ -80,10 +81,13 @@ int execv(const char *path, char *const argv[]) {
     const struct cmd *cmd;
 
     /* check whether a valid executable command name is given */
-    cmd = cmd_lookup(path);
-    if(!cmd){
-        errno = ENOENT;
-        return -1;
+    const struct shell *sh = shell_lookup(path);
+    if (!sh) {
+        cmd = cmd_lookup(path);
+        if (!cmd) {
+            errno = ENOENT;
+            return -1;
+        }
     }
 
 	/* save starting arguments for the task */


### PR DESCRIPTION
One probable scenario: after execv gained ability to return back when executable couldn't be found, an issue in dropbear that otherwise wouldn't have come up, showed itself. On connection dropbear executes '/bin/sh/' which execv answered is unavailable, after which dropbear came to a series of unfortunate events, which need further investigation, and embox laid down flat.
Hardlinking /bin/sh to tish solved that problem(at least temporary).
Additional check in execv, fixing previous commit, added.