### PR TITLE
Fix shell scripts according to ShellCheck guidelines

### DIFF
--- a/scripts/app_diff.sh
+++ b/scripts/app_diff.sh
@@ -25,40 +25,40 @@ print_usage() {
 	echo -e "  export PATCHES_APPLY_BEFORE=third_party/fuse/patch1.txt:third_party/fuse/patch2.txt"
 }
 
-if [ -z $APP_ARCHIVE_PATH ] || [ -z $APP_PATH ]; then
+if [ -z "$APP_ARCHIVE_PATH" ] || [ -z "$APP_PATH" ]; then
 	print_usage
 	exit 1
 fi
 
 shift 2
-DIFF_OPTIONS=$@
+DIFF_OPTIONS=( "$@" )
 
 EXTRACT_FOLDER=.orig_archive
 
 mkdir -p $EXTRACT_FOLDER
 
-ARCHIVE_BASENAME=$(basename $APP_ARCHIVE_PATH)
+ARCHIVE_BASENAME=$(basename "$APP_ARCHIVE_PATH")
 case $ARCHIVE_BASENAME in
 	*tar|*tar.gz|*tar.xz|*tar.bz2|*tgz|*tbz)
-		tar -xf $APP_ARCHIVE_PATH -C $EXTRACT_FOLDER ;;
+		tar -xf "$APP_ARCHIVE_PATH" -C "$EXTRACT_FOLDER" ;;
 	*zip)
-		unzip -qq $APP_ARCHIVE_PATH -d $EXTRACT_FOLDER ;;
+		unzip -qq "$APP_ARCHIVE_PATH" -d "$EXTRACT_FOLDER" ;;
 	*)
 		echo "Unsupported archive extension"; exit 1 ;;
 esac
 
-pushd $EXTRACT_FOLDER > /dev/null
+pushd $EXTRACT_FOLDER > /dev/null || { echo "Changing dir to $EXTRACT_FOLDER failed"; exit 1; }
 
 # Apply patches if any
-if [ ! -z "$PATCHES_APPLY_BEFORE" ]; then
+if [ -n "$PATCHES_APPLY_BEFORE" ]; then
 	IFS=:
 	for i in ${PATCHES_APPLY_BEFORE}
 	do
-		patch -s -p0 < $ROOT_DIR/$i
+		patch -s -p0 < "$ROOT_DIR"/"$i"
 	done
 fi
-LC_ALL=C diff -aur $DIFF_OPTIONS * ../$APP_PATH | grep -v '^Only in'
+LC_ALL=C diff -aur "${DIFF_OPTIONS[@]}" ./* ../"$APP_PATH" | grep -v '^Only in'
 
-popd > /dev/null
+popd > /dev/null || { echo "Returning to a previous dir failed. Tempdir $EXTRACT_FOLDER will not be removed."; exit 1; }
 
 rm -rf $EXTRACT_FOLDER

--- a/scripts/autotest/run.sh
+++ b/scripts/autotest/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-BASEDIR=$(realpath ${BASH_SOURCE%/*})
+BASEDIR=$(realpath "${BASH_SOURCE%/*}")
 TESTSUITE_DIR=$BASEDIR/testsuite
-TESTSUITE_LIST=$(ls $TESTSUITE_DIR)
+TESTSUITE_LIST=$(ls "$TESTSUITE_DIR")
 
 TESTCASE_DIR=
 TESTCASE_LIST=
@@ -25,24 +25,24 @@ fi
 
 TESTSUITE=$1
 
-if [ -z $TESTSUITE ]; then
+if [ -z "$TESTSUITE" ]; then
 	show_available_testsuites
 	exit 1
 fi
 
 TESTCASE_DIR=$BASEDIR/testsuite/$TESTSUITE
-TESTCASE_LIST=$(for i in $(ls -d $TESTCASE_DIR/*/); do basename $i; done)
+TESTCASE_LIST=$(for i in $(ls -d "$TESTCASE_DIR"/*/); do basename "$i"; done)
 
 shift
-TESTCASES=$@
+TESTCASES=( "$@" )
 
-if [ -z "$TESTCASES" ]; then
+if [ ${#TESTCASES[@]} -eq 0 ]; then
 	show_available_testcases
 	exit 1
 fi
 
-for testcase in $TESTCASES; do
-	if [ -z "$(echo $TESTCASE_LIST | fgrep -w $testcase)" ]; then
+for testcase in "${TESTCASES[@]}"; do
+	if ! echo $TESTCASE_LIST | grep -q -F -w "$testcase"; then
 		echo "Test '$testcase' is not part of testsuite '$TESTSUITE'"
 		exit 1
 	fi
@@ -64,7 +64,7 @@ if [ -z "$TEST_CURRENT_CONFIG" ]; then
 	exit 1
 fi
 
-printf "\nCurrent configuration: \"$TEST_CURRENT_CONFIG\"\n"
+printf "\nCurrent configuration: \"%s\"\n" "$TEST_CURRENT_CONFIG"
 
 if [ -z "$TEST_PRINT_ALL" ]; then
 	TEST_PRINT_ALL=1
@@ -72,19 +72,19 @@ fi
 
 echo "Starting testsuite $TESTSUITE ..."
 
-rm -f $TESTSUITE.log
+rm -f "$TESTSUITE.log"
 
 testsuite_res=0
 summary=
-for testcase in $TESTCASES; do
+for testcase in "${TESTCASES[@]}"; do
 	echo "  Starting test $TESTSUITE/$testcase ..."
 
-	if [ ${TEST_PRINT_ALL} -eq 0 ]; then
-		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
-			$EMBOX_IP $HOST_IP $EMBOX_PROMPT > ${TESTSUITE}_$testcase.log
+	if [ "${TEST_PRINT_ALL}" -eq 0 ]; then
+		expect "$BASEDIR/framework/core.exp" "$BASEDIR/testsuite/$TESTSUITE" "$testcase" \
+			"$EMBOX_IP" "$HOST_IP" "$EMBOX_PROMPT" > "${TESTSUITE}_$testcase.log"
 	else
-		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
-			$EMBOX_IP $HOST_IP $EMBOX_PROMPT
+		expect "$BASEDIR/framework/core.exp" "$BASEDIR/testsuite/$TESTSUITE" "$testcase" \
+			"$EMBOX_IP" "$HOST_IP" "$EMBOX_PROMPT"
 	fi
 	rc=$?
 

--- a/scripts/autotest/run_scripts/run_qemu_default.sh
+++ b/scripts/autotest/run_scripts/run_qemu_default.sh
@@ -2,6 +2,8 @@
 
 QEMU=./scripts/qemu/auto_qemu
 
-cd $TEST_EMBOX_ROOT
-$QEMU
-cd -
+# Using subshell to avoid having to cd back
+(
+    cd "$TEST_EMBOX_ROOT" || { echo "Failed to cd to $TEST_EMBOX_ROOT"; exit 1; }
+    $QEMU
+) || exit 1

--- a/scripts/autotest/run_scripts/run_qemu_ide.sh
+++ b/scripts/autotest/run_scripts/run_qemu_ide.sh
@@ -3,10 +3,12 @@
 QEMU=./scripts/qemu/auto_qemu
 IMG=$(mktemp -d)/hda_vfat.img
 
-dd if=/dev/zero of=$IMG bs=1M count=64
-/sbin/mkfs.vfat -n "LINUX" $IMG -I
+dd if=/dev/zero of="$IMG" bs=1M count=64
+/sbin/mkfs.vfat -n "LINUX" "$IMG" -I
 
-cd $TEST_EMBOX_ROOT
-$QEMU -hda $IMG
-rm -r $(dirname $IMG)
-cd -
+# Using subshell to avoid manual cd back
+(
+    cd "$TEST_EMBOX_ROOT" || { echo "Failed to cd to $TEST_EMBOX_ROOT"; exit 1; }
+    $QEMU -hda "$IMG"
+    rm -r "$(dirname "$IMG")"
+) || exit 1

--- a/scripts/autotest/run_scripts/run_qemu_mmc.sh
+++ b/scripts/autotest/run_scripts/run_qemu_mmc.sh
@@ -3,9 +3,11 @@
 QEMU=./scripts/qemu/auto_qemu
 IMG=$(mktemp -d)/mmc.img
 
-./scripts/disk/partitions.sh $IMG
+./scripts/disk/partitions.sh "$IMG"
 
-cd $TEST_EMBOX_ROOT
-$QEMU -sd $IMG $@
-rm -r $(dirname $IMG)
-cd -
+# Using subshell to avoid having to cd back
+(
+    cd "$TEST_EMBOX_ROOT" || { echo "Failed to cd to $TEST_EMBOX_ROOT"; exit 1; }
+    $QEMU -sd "$IMG" "$@"
+    rm -r "$(dirname "$IMG")"
+) || exit 1

--- a/scripts/autotest/run_scripts/run_qemu_usb.sh
+++ b/scripts/autotest/run_scripts/run_qemu_usb.sh
@@ -7,6 +7,8 @@ qemu-img create -f qcow2 $image_file_name 512M
 
 /sbin/mkfs.vfat $image_file_name
 
-cd $TEST_EMBOX_ROOT
-$QEMU -drive id=my_usb_disk,file=$image_file_name,if=none,format=raw -device usb-storage,drive=my_usb_disk $@
-cd -
+# Using subshell to avoid having to cd back
+(
+    cd "$TEST_EMBOX_ROOT" || { echo "Failed to cd to $TEST_EMBOX_ROOT"; exit 1; }
+    $QEMU -drive id=my_usb_disk,file=$image_file_name,if=none,format=raw -device usb-storage,drive=my_usb_disk "$@"
+) || exit 1

--- a/scripts/codestyle/format_files.sh
+++ b/scripts/codestyle/format_files.sh
@@ -7,17 +7,14 @@ if [ -z "$1" ]; then
 	exit
 fi
 
-files=$(cat $1)
-
 mkdir -p out
 
-for item in $files ; do
-
-	dn=$(dirname $item)
-	mkdir -p out/$dn
-	uncrustify -f $item -c uncrustify_cfg.ini > out/$item
-
-done
+while read -r item;
+do
+	dn=$(dirname "$item")
+	mkdir -p "out/$dn"
+	uncrustify -f "$item" -c uncrustify_cfg.ini > "out/$item"
+done < "$1"
 
 find out -type f -empty -delete
 rsync -ah out/ ./

--- a/scripts/codestyle/install_uncrustify.sh
+++ b/scripts/codestyle/install_uncrustify.sh
@@ -4,15 +4,15 @@ set -xe
 
 RELEASE=0.65
 
-mkdir -p $SRC
-cd $SRC
+mkdir -p "$SRC"
+cd "$SRC"
 
-wget -c https://github.com/uncrustify/uncrustify/archive/uncrustify-${RELEASE}.tar.gz
-tar axf uncrustify-${RELEASE}.tar.gz
+wget -c "https://github.com/uncrustify/uncrustify/archive/uncrustify-${RELEASE}.tar.gz"
+tar axf "uncrustify-${RELEASE}.tar.gz"
 
 mkdir build
 cd build
 
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL ../uncrustify-uncrustify-${RELEASE}
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$INSTALL" ../uncrustify-uncrustify-"${RELEASE}"
 
 make install

--- a/scripts/codestyle/run_uncrustify.sh
+++ b/scripts/codestyle/run_uncrustify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TEMPDIR="out"
-UNCRUSTIFY_BASE=$(dirname $0)
+UNCRUSTIFY_BASE=$(dirname "$0")
 
 verbose="true"
 
@@ -35,12 +35,12 @@ done
 
 # the rest will go to git diff directly
 shift $(($OPTIND - 1))
-diffargs="$@"
+diffargs=( "$@" )
 
 tmpundiff=$TEMPDIR/diff
 mkdir -p $tmpundiff
 
-git diff --no-prefix $diffargs -- 'src/*.[ch]' | awk -v outpref=$tmpundiff -f $UNCRUSTIFY_BASE/undiff.awk
+git diff --no-prefix "${diffargs[@]}" -- 'src/*.[ch]' | awk -v outpref="$tmpundiff" -f "$UNCRUSTIFY_BASE"/undiff.awk
 
 result=0
 
@@ -50,19 +50,19 @@ else
 	fixdiffarg="--quiet"
 fi
 
-for f in $(cd $tmpundiff; find -type f); do
-	from=$tmpundiff/$f 
+for f in $(cd $tmpundiff; find . -type f); do
+	from=$tmpundiff/$f
 	to=$TEMPDIR/fixed/$f
-	mkdir -p $(dirname $to)
+	mkdir -p "$(dirname "$to")"
 
-	uncrustify --frag -c $UNCRUSTIFY_BASE/uncrustify_cfg.ini -f $from > $to 2>/dev/null
-	if [ ! -s $to ]; then 
+	uncrustify --frag -c "$UNCRUSTIFY_BASE"/uncrustify_cfg.ini -f "$from" > "$to" 2>/dev/null
+	if [ ! -s "$to" ]; then
 		continue
 	fi
 
 
-	git diff $fixdiffarg --no-index -- $from $to | tail -n +3
-	if [ ${PIPESTATUS[0]} != 0 ]; then
+	git diff $fixdiffarg --no-index -- "$from" "$to" | tail -n +3
+	if [ "${PIPESTATUS[0]}" != 0 ]; then
 		[ $verbose ] || echo "Codestyle issue: $f"
 		result=1
 	fi

--- a/scripts/codestyle/travis_uncrustify.sh
+++ b/scripts/codestyle/travis_uncrustify.sh
@@ -5,12 +5,12 @@ git fetch --depth=1000 # unlikely the branch will have more than 1000 commits
 
 revs="$(git rev-parse --short master)...$(git rev-parse --short HEAD)"
 
-echo Checking $revs for code style conformance
+echo Checking "$revs" for code style conformance
 
-$(dirname $0)/run_uncrustify.sh $revs
+"$(dirname "$0")"/run_uncrustify.sh $revs
 result=$?
 
-if [ $result != 0 ] && [ x"$TRAVIS_PULL_REQUEST" = xfalse ]; then
+if [ $result != 0 ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
 	echo "Ignoring code style violations (non-PR job)"
 	result=0
 fi

--- a/scripts/continuous/build.sh
+++ b/scripts/continuous/build.sh
@@ -15,7 +15,7 @@ function bell() {
 bell &
 bell_pid=$!
 
-make -j $(nproc) &> build.log
+make -j "$(nproc)" &> build.log
 RETVAL=$?
 tail -c 3M build.log
 

--- a/scripts/continuous/prepare.sh
+++ b/scripts/continuous/prepare.sh
@@ -4,12 +4,12 @@ target=${1//\//__}
 
 x86__test__net() {
 	make confload-x86/test/ping-target
-	make -j $(nproc)
+	make -j "$(nproc)"
 	cp build/base/bin/embox ./ping-target
 }
 
-if ! [ $target ] || ! type -t $target > /dev/null; then
-	echo nothing to prepare for \"$1\"
+if ! [ "$target" ] || ! type -t "$target" > /dev/null; then
+	echo nothing to prepare for \""$1"\"
 	exit 0
 fi
-$target "$@"
+"$target" "$@"

--- a/scripts/continuous/run.sh
+++ b/scripts/continuous/run.sh
@@ -41,10 +41,10 @@ atml2run=(
 	['x86/smp']=default_run
 	['x86/user_apps']=default_run
 	['x86/test/lang']=default_run
-	['x86/test/fs']="$(dirname $0)/fs/run.sh $ATML"
-	['x86/test/net']="$(dirname $0)/net/run.sh $ATML"
+	['x86/test/fs']="$(dirname "$0")/fs/run.sh $ATML"
+	['x86/test/net']="$(dirname "$0")/net/run.sh $ATML"
 	['x86/test/packetdrill']=packetdrill_run
-	['x86/test/qt-vnc']="$(dirname $0)/qt/run.sh $ATML"
+	['x86/test/qt-vnc']="$(dirname "$0")/qt/run.sh $ATML"
 	['sparc/qemu']=default_run
 	['mips/qemu']=default_run
 	['ppc/qemu']=default_run
@@ -61,7 +61,7 @@ atml2run=(
 
 sudo_var_pass() {
 	if [ ${!1+defined} ]; then
-		echo $1=${!1}
+		echo "$1=${!1}"
 	else
 		#output is passed to sudo that not likes empty arguments
 		echo __T=
@@ -85,8 +85,8 @@ run_bg() {
 	#"sparc/qemu" not supported due qemu bug
 	atml2sim=(
 		['x86/smp']="$RUN_QEMU -smp 2"
-		['sparc/debug']="$(dirname $0)/tsim_run.sh $OUTPUT_FILE $SIM_ARG $EMKERNEL"
-		['usermode86/debug']="$(dirname $0)/../usermode_start.sh"
+		['sparc/debug']="$(dirname "$0")/tsim_run.sh $OUTPUT_FILE $SIM_ARG $EMKERNEL"
+		['usermode86/debug']="$(dirname "$0")/../usermode_start.sh"
 	)
 
 	run_cmd=${atml2sim[$ATML]}
@@ -107,7 +107,7 @@ run_bg() {
 
 	export OUTPUT_FILE
 	export -f run_check
-	timeout $TIMEOUT bash -c '
+	timeout "$TIMEOUT" bash -c '
 			while run_check; [ $? == 2 ]; do
 				sleep 1
 			done' && \
@@ -121,7 +121,7 @@ kill_bg() {
 	then
 		echo "warning: No background process running"
 	else
-		pstree -A -p $sim_bg | sed 's/[0-9a-z{}_\.+`-]*(\([0-9]\+\))/\1 /g' | xargs sudo kill
+		pstree -A -p "$sim_bg" | sed 's/[0-9a-z{}_\.+`-]*(\([0-9]\+\))/\1 /g' | xargs sudo kill
 	fi
 
 	cat $OUTPUT_FILE
@@ -189,7 +189,7 @@ restore_conf() {
 	fi
 }
 
-if ! echo ${!atml2run[@]} | grep $ATML &>/dev/null; then
+if ! echo "${!atml2run[@]}" | grep "$ATML" &>/dev/null; then
 	echo Warning: template testing not supported >&2
 	exit 0
 fi

--- a/scripts/continuous/touch-mk-cache.sh
+++ b/scripts/continuous/touch-mk-cache.sh
@@ -3,7 +3,7 @@
 C=./mk/.cache
 
 touch $C/mk/*
-find  $C/mybuild/files | xargs touch
+find  $C/mybuild/files -exec touch ';'
 touch $C/mybuild/myfiles-model.mk
 touch $C/mybuild/myfiles-list.mk
 exit 0

--- a/scripts/continuous/tsim_run.sh
+++ b/scripts/continuous/tsim_run.sh
@@ -3,4 +3,4 @@
 OUTPUT_FILE=$1
 shift
 
-echo "c" | tsim-leon3 $@ > $OUTPUT_FILE
+echo "c" | tsim-leon3 "$@" > $OUTPUT_FILE

--- a/scripts/dialog/da14680/flash_qspi.sh
+++ b/scripts/dialog/da14680/flash_qspi.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-if [ -z $DIALOG_DA14680_SDK_ROOT ]; then
+if [ -z "$DIALOG_DA14680_SDK_ROOT" ]; then
 	printf "DIALOG_DA14680_SDK_ROOT is not set. Please specify DA14680 SDK path.\n"
 	printf "  Example: export DIALOG_DA14680_SDK_ROOT=~/DA1468x_DA15xxx_SDK_1.0.14.1081\n"
 	exit 1
 fi
 
-if [ -z $JLINK_ROOT ]; then
+if [ -z "$JLINK_ROOT" ]; then
 	printf "JLINK_ROOT is not set. Please specify the path.\n"
 	printf "  Example: export JLINK_ROOT=~/SEGGER/JLink_6.40\n"
 	exit 1
@@ -15,4 +15,4 @@ fi
 IMAGE=build/base/bin/embox.bin
 SCRIPT=$DIALOG_DA14680_SDK_ROOT/utilities/scripts/qspi/program_qspi_jtag.sh
 
-$SCRIPT --jlink_path $JLINK_ROOT $IMAGE
+"$SCRIPT" --jlink_path "$JLINK_ROOT" $IMAGE

--- a/scripts/dialog/da14680/gdb_start.sh
+++ b/scripts/dialog/da14680/gdb_start.sh
@@ -2,4 +2,4 @@
 
 IMAGE=build/base/bin/embox
 
-arm-none-eabi-gdb -x $(dirname $0)/da14680_gdb_start_script $IMAGE
+arm-none-eabi-gdb -x "$(dirname "$0")"/da14680_gdb_start_script $IMAGE

--- a/scripts/dialog/da14680/jlink_gdb_server_start.sh
+++ b/scripts/dialog/da14680/jlink_gdb_server_start.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ -z $JLINK_ROOT ]; then
+if [ -z "$JLINK_ROOT" ]; then
 	printf "JLINK_ROOT is not set. Please specify the path.\n"
 	printf "  Example: export JLINK_ROOT=~/SEGGER/JLink_6.40\n"
 	exit 1
 fi
 
-$JLINK_ROOT/JLinkGDBServerCLExe \
+"$JLINK_ROOT"/JLinkGDBServerCLExe \
 	-device DA14680 -if SWD -speed 8000 \
-	-port 2331 -swoport 2332 -telnetport 2333 -singlerun $@
+	-port 2331 -swoport 2332 -telnetport 2333 -singlerun "$@"

--- a/scripts/dialog/da14695/flash_qspi.sh
+++ b/scripts/dialog/da14695/flash_qspi.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-if [ -z $DIALOG_DA14695_SDK_ROOT ]; then
+if [ -z "$DIALOG_DA14695_SDK_ROOT" ]; then
 	printf "DIALOG_DA14695_SDK_ROOT is not set. Please specify DA14695 SDK path.\n"
 	printf "  Example: export DIALOG_DA14695_SDK_ROOT=~/SDK_10.0.8.105\n"
 	exit 1
 fi
 
-if [ -z $JLINK_ROOT ]; then
+if [ -z "$JLINK_ROOT" ]; then
 	printf "JLINK_ROOT is not set. Please specify the path.\n"
 	printf "  Example: export JLINK_ROOT=~/SEGGER/JLink_6.40\n"
 	exit 1
@@ -15,4 +15,4 @@ fi
 IMAGE=build/base/bin/embox.bin
 SCRIPT=$DIALOG_DA14695_SDK_ROOT/utilities/python_scripts/qspi/program_qspi.py
 
-$SCRIPT --jlink --jlink_path $JLINK_ROOT --prod_header $IMAGE
+"$SCRIPT" --jlink --jlink_path "$JLINK_ROOT" --prod_header $IMAGE

--- a/scripts/dialog/da14695/gdb_start.sh
+++ b/scripts/dialog/da14695/gdb_start.sh
@@ -2,4 +2,4 @@
 
 IMAGE=build/base/bin/embox
 
-arm-none-eabi-gdb -x $(dirname $0)/da14695_gdb_start_script $IMAGE
+arm-none-eabi-gdb -x "$(dirname "$0")"/da14695_gdb_start_script $IMAGE

--- a/scripts/dialog/da14695/jlink_gdb_server_start.sh
+++ b/scripts/dialog/da14695/jlink_gdb_server_start.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ -z $JLINK_ROOT ]; then
+if [ -z "$JLINK_ROOT" ]; then
 	printf "JLINK_ROOT is not set. Please specify the path.\n"
 	printf "  Example: export JLINK_ROOT=~/SEGGER/JLink_6.40\n"
 	exit 1
 fi
 
-$JLINK_ROOT/JLinkGDBServerCLExe \
+"$JLINK_ROOT"/JLinkGDBServerCLExe \
 	-device CORTEX-M33 -if SWD -speed 4000 \
-	-port 2331 -swoport 2332 -telnetport 2333 -singlerun $@
+	-port 2331 -swoport 2332 -telnetport 2333 -singlerun "$@"

--- a/scripts/disk/img2vdi.sh
+++ b/scripts/disk/img2vdi.sh
@@ -2,8 +2,8 @@
 #
 
 if [ $# -ne 1 ]; then
-	echo "Usage: `basename $0` path/to/file.img"
-	exit $E_BADARGS
+	echo "Usage: $(basename "$0") path/to/file.img"
+	exit "$E_BADARGS"
 fi
 
 IMG_DIR=$(dirname "$1")
@@ -13,7 +13,7 @@ VDI_DIR=$IMG_DIR
 VDI_NAME=${IMG_NAME%.*}.vdi
 VDI_UUID="d713cd0d-0dfc-415c-931e-61ab199d4817"
 
-rm -rf $VDI_DIR/$VDI_NAME
-VBoxManage convertfromraw --format VDI $IMG_DIR/$IMG_NAME $VDI_DIR/$VDI_NAME
-VBoxManage internalcommands sethduuid $VDI_DIR/$VDI_NAME $VDI_UUID
-chmod 777 $VDI_DIR/$VDI_NAME
+rm -rf "${VDI_DIR:?}"/"${VDI_NAME:?}"
+VBoxManage convertfromraw --format VDI "$IMG_DIR"/"$IMG_NAME" "$VDI_DIR"/"$VDI_NAME"
+VBoxManage internalcommands sethduuid "$VDI_DIR"/"$VDI_NAME" $VDI_UUID
+chmod 777 "$VDI_DIR"/"$VDI_NAME"

--- a/scripts/disk/make_img.sh
+++ b/scripts/disk/make_img.sh
@@ -2,7 +2,7 @@
 # Gotta have a grub 0.97-like installed on your system
 #
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || { echo "Failed to cd to $(dirname "$0")"; exit 1; }
 
 KERNEL_NAME="embox"
 BIN_DIR="../../build/base/bin"

--- a/scripts/disk/partitions.sh
+++ b/scripts/disk/partitions.sh
@@ -26,27 +26,27 @@ if [[ ! $PARTS = 1 && ! $PARTS = 2 && ! $PARTS = 3 && ! $PARTS = 4 ]]; then
 	exit 1
 fi
 
-MKFS_PATH=`sudo which mkfs.$FS 2> /dev/null`
+MKFS_PATH=$(sudo which mkfs."$FS" 2> /dev/null)
 [ "$MKFS_PATH" == "" ] && echo "Command mkfs.$FS not found" && exit
 
-dd if=/dev/zero of=$IMG count=$SIZE bs=1M
-sudo parted $IMG -s mktable msdos || exit
+dd if=/dev/zero "of=$IMG" "count=$SIZE" bs=1M
+sudo parted "$IMG" -s mktable msdos || exit
 
-for i in $(seq 1 $PARTS)
+for i in $(seq 1 "$PARTS")
 do
-	sudo parted $IMG -s mkpart primary fat32 \
+	sudo parted "$IMG" -s mkpart primary fat32 \
 		$(( $i * $SIZE / ($PARTS + 1) )) $(( (1 + $i) * $SIZE / ($PARTS + 1) ))
 done
 
-sudo kpartx -d $IMG || exit
+sudo kpartx -d "$IMG" || exit
 
-LOOPDEV=$(sudo kpartx -av $IMG | head -n 1 | awk "{ print \$3"})
+LOOPDEV=$(sudo kpartx -av "$IMG" | head -n 1 | awk "{ print \$3 }")
 LOOPDEV=${LOOPDEV::-1}
 
-for i in $(seq 1 $PARTS)
+for i in $(seq 1 "$PARTS")
 do
-	sudo mkfs.$FS -n "PART$i" -I /dev/mapper/$LOOPDEV$i
-	sudo mount /dev/mapper/$LOOPDEV$i /mnt
+	sudo "mkfs.$FS" -n "PART$i" -I "/dev/mapper/$LOOPDEV$i"
+	sudo mount "/dev/mapper/$LOOPDEV$i" /mnt
 	sudo bash -c "echo Partition $i file >> /mnt/part$i\_file"
 	sudo umount /mnt
 	sync

--- a/scripts/docker/container/bin/gdbwrapper2
+++ b/scripts/docker/container/bin/gdbwrapper2
@@ -1,18 +1,17 @@
 #!/bin/sh
 
-. $(dirname $0)/../gdbwrapper_lib.sh
+. "$(dirname "$0")"/../gdbwrapper_lib.sh
 
 # make alias from host path to container path. After this no
 # path substitution will be reqired (like gdb substitute-path)
-if [ $PROJECT_LOC ]; then
-	sudo mkdir -p $PROJECT_LOC
-	mount | grep -q $PROJECT_LOC
-	if [ $? != 0 ]; then
-		sudo mount --bind $EMBOX_DIR $PROJECT_LOC
+if [ "$PROJECT_LOC" ]; then
+	sudo mkdir -p "$PROJECT_LOC"
+	if ! mount | grep -q "$PROJECT_LOC"; then
+		sudo mount --bind "$EMBOX_DIR" "$PROJECT_LOC"
 	fi
 fi
 
-echo $$ > $GDBPID
+echo $$ > "$GDBPID"
 
 # TODO add gdb cross-compile prefix detection
 exec gdb "$@"

--- a/scripts/docker/container/bin/killgdbwrapper
+++ b/scripts/docker/container/bin/killgdbwrapper
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-. $(dirname $0)/../gdbwrapper_lib.sh
+. "$(dirname "$0")"/../gdbwrapper_lib.sh
 
 SIG=$1
 
-[ -f $GDBPID ] && PID=$(cat $GDBPID)
+[ -f "$GDBPID" ] && PID=$(cat "$GDBPID")
 
-[ $PID ] && kill -s $SIG $PID
+[ "$PID" ] && kill -s "$SIG" "$PID"

--- a/scripts/docker/docker_start.sh
+++ b/scripts/docker/docker_start.sh
@@ -20,11 +20,11 @@ expose_ports_args() {
 
 docker run -d --privileged \
 	--name emdocker \
-	-v $PWD:/embox \
+	-v "$PWD":/embox \
 	$(expose_ports_args $(localport $EMBOX_PORTS)) \
 	${dockerimage:-embox/emdocker}
 
-. $(dirname $0)/docker_rc.sh
+. "$(dirname "$0")"/docker_rc.sh
 
 # wait till docker started, otherwise getting "No 'user' user found"
 waittries=${DOCKER_START_WAIT_TIME_SEC:-10}
@@ -38,7 +38,7 @@ while [ 0 -lt $waittries ]; do
 	waittries=$(($waittries - 1))
 done
 
-if [ x0 = x$started ]; then
+if [ 0 = $started ]; then
 	echo "Container is not stated for some time, trying one more time in verbose mode" >&2
 	echo "If it fail, try to change timeout specifying DOCKER_START_WAIT_TIME_SEC env, like" >&2
 	echo "" >&2
@@ -46,7 +46,7 @@ if [ x0 = x$started ]; then
 	dr true && started=1
 fi
 
-if [ x0 = x$started ]; then
+if [ 0 = $started ]; then
 	echo "Can't start container" >&2
 	exit 1
 fi

--- a/scripts/docker/gdbhostwrapper
+++ b/scripts/docker/gdbhostwrapper
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 function myreadlink() {
-	(cd "$1" && echo "$(pwd -P)")
+	(cd "$1" && pwd -P)
 }
 
-dr=$(dirname $0)/docker_run.sh
-EMBOX_LOC=$(myreadlink $(dirname $0)/../../)
+dr=$(dirname "$0")/docker_run.sh
+EMBOX_LOC=$(myreadlink "$(dirname "$0")"/../../)
 
 on_sig() {
 	intr=1
@@ -16,7 +16,7 @@ for i in 1 2 3 9 14 15; do
 	trap "on_sig $i;" $i
 done
 
-$dr PROJECT_LOC=$EMBOX_LOC gdbwrapper2 <&0 "$@" &
+$dr PROJECT_LOC="$EMBOX_LOC" gdbwrapper2 <&0 "$@" &
 
 PID=$!
 

--- a/scripts/gdb_erase_stm32h7.sh
+++ b/scripts/gdb_erase_stm32h7.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32.XXXX)
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "monitor flash banks" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset halt"
+	    echo "monitor flash banks"
 
-	# Erase sector flash0 and flash1
-	echo "monitor stm32h7x mass_erase 0" >> $GDB_CMD_FILE
-	echo "monitor stm32h7x mass_erase 1" >> $GDB_CMD_FILE
+	    # Erase sector flash0 and flash1
+	    echo "monitor stm32h7x mass_erase 0"
+	    echo "monitor stm32h7x mass_erase 1"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 create_gdb_script
 
-$GDB -batch -x $GDB_CMD_FILE
-rm -f $GDB_CMD_FILE
+$GDB -batch -x "$GDB_CMD_FILE"
+rm -f "$GDB_CMD_FILE"

--- a/scripts/gdb_load_stm32.sh
+++ b/scripts/gdb_load_stm32.sh
@@ -1,26 +1,28 @@
 #!/usr/bin/env bash
 
-grep 'QSPI)' ./conf/lds.conf > /dev/null && echo "This script doesn't work with QSPI sections!" && exit -1
+grep 'QSPI)' ./conf/lds.conf > /dev/null && echo "This script doesn't work with QSPI sections!" && exit 1
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32f7_qspi.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32f7_qspi.XXXX)
 EMBOX_ELF=build/base/bin/embox
-EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "load" >> $GDB_CMD_FILE
-	echo "continue" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset halt"
+	    echo "load"
+	    echo "continue"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 create_gdb_script
 
-$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+$GDB -x "$GDB_CMD_FILE" "$EMBOX_ELF"
 
-rm $GDB_CMD_FILE
+rm "$GDB_CMD_FILE"

--- a/scripts/gdb_run_stm32f7_qspi.sh
+++ b/scripts/gdb_run_stm32f7_qspi.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32f7_qspi.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32f7_qspi.XXXX)
 EMBOX_ELF=build/base/bin/embox
-EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
-QSPI_BIN=$(mktemp --tmpdir=$PWD qspi_XXXX.bin)
+EMBOX_BIN=$(mktemp --tmpdir="$PWD" embox_XXXX.bin)
+QSPI_BIN=$(mktemp --tmpdir="$PWD" qspi_XXXX.bin)
 
 prepare_bin() {
 	EMBOX_SECTIONS="--only-section=.text \
@@ -22,41 +22,48 @@ prepare_bin() {
 			       --remove-section=.data \
 			       --remove-section=.bss"
 
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $QSPI_BIN $QSPI_SECTIONS
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $EMBOX_BIN $EMBOX_SECTIONS
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$QSPI_BIN" $QSPI_SECTIONS
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$EMBOX_BIN" $EMBOX_SECTIONS
 }
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "monitor reset init" >> $GDB_CMD_FILE
-	echo "monitor flash banks" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset halt"
+	    echo "monitor reset init"
+	    echo "monitor flash banks"
 
-	# Write embox.bin
-	echo "monitor stm32f2x mass_erase 0" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 0 $EMBOX_BIN" >> $GDB_CMD_FILE
+	    # Write embox.bin
+	    echo "monitor stm32f2x mass_erase 0"
+	    echo "monitor flash write_bank 0 $EMBOX_BIN"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Write qspi.bin
-	sect_size=$(stat -c%s $QSPI_BIN)
+	sect_size=$(stat -c%s "$QSPI_BIN")
 	sectors=$((($sect_size + 65535) / 65536)) # Sector size is 64K for stm32f7 QSPI
-	echo "monitor flash erase_sector 3 0 $sectors" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 3 $QSPI_BIN" >> $GDB_CMD_FILE
-	## Check qspi.bin is written correctly
-	echo "monitor flash verify_bank 3 $QSPI_BIN" >> $GDB_CMD_FILE
 
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "continue" >> $GDB_CMD_FILE
+	{
+	    echo "monitor flash erase_sector 3 0 $sectors"
+	    echo "monitor flash write_bank 3 $QSPI_BIN"
+	    ## Check qspi.bin is written correctly
+	    echo "monitor flash verify_bank 3 $QSPI_BIN"
+
+	    echo "monitor reset halt"
+	    echo "continue"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 prepare_bin
 create_gdb_script
 
-$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+$GDB -x "$GDB_CMD_FILE" "$EMBOX_ELF"
 
-rm $GDB_CMD_FILE
-rm $EMBOX_BIN $QSPI_BIN
+rm "$GDB_CMD_FILE"
+rm "$EMBOX_BIN" "$QSPI_BIN"

--- a/scripts/gdb_run_stm32h7_qspi.sh
+++ b/scripts/gdb_run_stm32h7_qspi.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32h7_qspi.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32h7_qspi.XXXX)
 EMBOX_ELF=build/base/bin/embox
-EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
-EMBOX_BIN0=$(mktemp --tmpdir=$PWD embox_bank0_XXXX.bin)
-EMBOX_BIN1=$(mktemp --tmpdir=$PWD embox_bank1_XXXX.bin)
-QSPI_BIN=$(mktemp --tmpdir=$PWD qspi_XXXX.bin)
+EMBOX_BIN=$(mktemp --tmpdir="$PWD" embox_XXXX.bin)
+EMBOX_BIN0=$(mktemp --tmpdir="$PWD" embox_bank0_XXXX.bin)
+EMBOX_BIN1=$(mktemp --tmpdir="$PWD" embox_bank1_XXXX.bin)
+QSPI_BIN=$(mktemp --tmpdir="$PWD" qspi_XXXX.bin)
 
 prepare_bin() {
 	EMBOX_SECTIONS="--only-section=.text \
@@ -24,45 +24,52 @@ prepare_bin() {
 			       --remove-section=.data \
 			       --remove-section=.bss"
 
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $QSPI_BIN $QSPI_SECTIONS
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $EMBOX_BIN $EMBOX_SECTIONS
-	dd if=$EMBOX_BIN of=$EMBOX_BIN0 bs=1 count=$((1024 * 1024))
-	dd if=$EMBOX_BIN of=$EMBOX_BIN1 bs=1 skip=$((1024 * 1024))	
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$QSPI_BIN" $QSPI_SECTIONS
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$EMBOX_BIN" $EMBOX_SECTIONS
+	dd if="$EMBOX_BIN" of="$EMBOX_BIN0" bs=1 count=$((1024 * 1024))
+	dd if="$EMBOX_BIN" of="$EMBOX_BIN1" bs=1 skip=$((1024 * 1024))
 }
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset init" >> $GDB_CMD_FILE
-	echo "monitor flash banks" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset init"
+	    echo "monitor flash banks"
 
-	# Write embox.bin
-	echo "monitor stm32h7x mass_erase 0" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 0 $EMBOX_BIN0" >> $GDB_CMD_FILE
+	    # Write embox.bin
+	    echo "monitor stm32h7x mass_erase 0"
+	    echo "monitor flash write_bank 0 $EMBOX_BIN0"
 
-	echo "monitor stm32h7x mass_erase 1" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 1 $EMBOX_BIN1" >> $GDB_CMD_FILE
+	    echo "monitor stm32h7x mass_erase 1"
+	    echo "monitor flash write_bank 1 $EMBOX_BIN1"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Write qspi.bin
-	sect_size=$(stat -c%s $QSPI_BIN)
+	sect_size=$(stat -c%s "$QSPI_BIN")
 	sectors=$((($sect_size + 65535) / 65536)) # Sector size is 64K for stm32h7 QSPI
-	echo "monitor flash erase_sector 2 0 $sectors" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 2 $QSPI_BIN" >> $GDB_CMD_FILE
-	## Check qspi.bin is written correctly
-	echo "monitor flash verify_bank 2 $QSPI_BIN" >> $GDB_CMD_FILE
 
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "continue" >> $GDB_CMD_FILE
+	{
+	    echo "monitor flash erase_sector 2 0 $sectors"
+	    echo "monitor flash write_bank 2 $QSPI_BIN"
+	    ## Check qspi.bin is written correctly
+	    echo "monitor flash verify_bank 2 $QSPI_BIN"
+
+	    echo "monitor reset halt"
+	    echo "continue"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 prepare_bin
 create_gdb_script
 
-$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+$GDB -x "$GDB_CMD_FILE" "$EMBOX_ELF"
 
-rm $GDB_CMD_FILE
-rm $EMBOX_BIN $QSPI_BIN $EMBOX_BIN0 $EMBOX_BIN1
+rm "$GDB_CMD_FILE"
+rm "$EMBOX_BIN" "$QSPI_BIN" "$EMBOX_BIN0" "$EMBOX_BIN1"

--- a/scripts/ld_map_info.sh
+++ b/scripts/ld_map_info.sh
@@ -11,7 +11,7 @@ print_help() {
 MAP=$1
 PATTERN=$2
 
-if [ -z $MAP ] || [ -z $PATTERN ]; then
+if [ -z "$MAP" ] || [ -z "$PATTERN" ]; then
 	print_help
 	exit 1
 fi
@@ -24,7 +24,7 @@ fi
 
 export PATTERN_VAR="$PATTERN"
 
-cat $MAP | \
+cat "$MAP" | \
 	$AWK '($0 ~ ENVIRON["PATTERN_VAR"] || prev ~ ENVIRON["PATTERN_VAR"]) && /\.o/ \
 	     { printf "%-20x%-20d%s\n", $(NF-1), $(NF-1), $NF }; { prev=$0 }' | sort -n -k2 | \
 	$AWK 'BEGIN { printf "%-20s%-20s%s\n", "Size (hex)", "Size (dec)", "File" }

--- a/scripts/live-flash
+++ b/scripts/live-flash
@@ -3,13 +3,12 @@
 SYSLINUX_ROOT=/usr/lib/syslinux
 SYSLINUX_MBR=$(find $SYSLINUX_ROOT -name mbr.bin)
 SYSLINUX_BIOS_DIR=$(find $SYSLINUX_ROOT -type d -name bios)
-SYSLINUX_SHARE=${SYSLINUX_ROOT}/usr/share/syslinux
 
 EMBOX_MULTIBOOT=./build/base/bin/embox
 
 MOUNT_POINT=/media/embox-live
 
-DATA_DIR=$(dirname $0)/bootloader_cfgs
+DATA_DIR=$(dirname "$0")/bootloader_cfgs
 
 usage() {
 	echo "Make live usb."
@@ -33,35 +32,35 @@ usage() {
 
 grub1_do () {
 	DRIVE=$1
-	sudo grub-install --root-directory=$MOUNT_POINT $DRIVE
+	sudo grub-install --root-directory=$MOUNT_POINT "$DRIVE"
 
-	sudo cp $DATA_DIR/grub1-config $MOUNT_POINT/boot/grub/menu.lst
+	sudo cp "$DATA_DIR"/grub1-config $MOUNT_POINT/boot/grub/menu.lst
 }
 
 grub2_do () {
 	DRIVE=$1
 
 	[ -d $MOUNT_POINT/boot ] || sudo mkdir -p $MOUNT_POINT/boot
-	sudo grub-install --target=i386-pc --boot-directory=$MOUNT_POINT/boot $DRIVE
+	sudo grub-install --target=i386-pc --boot-directory=$MOUNT_POINT/boot "$DRIVE"
 
-	sudo cp $DATA_DIR/grub2-config $MOUNT_POINT/boot/grub/grub.cfg
+	sudo cp "$DATA_DIR"/grub2-config $MOUNT_POINT/boot/grub/grub.cfg
 }
 
 syslinux_do() {
 	DRIVE=$1
 	MP=$2
-	SYSLINUX_DIR=$MP/boot/syslinux
+	SYSLINUX_DIR="$MP"/boot/syslinux
 
-	[ -d $SYSLINUX_DIR ] || sudo mkdir -p $SYSLINUX_DIR
+	[ -d "$SYSLINUX_DIR" ] || sudo mkdir -p "$SYSLINUX_DIR"
 
 	# Based on https://wiki.archlinux.org/index.php/Syslinux#Manual_install
 
-	sudo extlinux --install $SYSLINUX_DIR
+	sudo extlinux --install "$SYSLINUX_DIR"
 
-	sudo dd if=$SYSLINUX_MBR of=$DRIVE bs=440 count=1 conv=notrunc
-	sudo cp ${SYSLINUX_BIOS_DIR}/*.c32 $SYSLINUX_DIR/
+	sudo dd if="$SYSLINUX_MBR" of="$DRIVE" bs=440 count=1 conv=notrunc
+	sudo cp "${SYSLINUX_BIOS_DIR}"/*.c32 "$SYSLINUX_DIR"/
 
-	sudo cp $DATA_DIR/syslinux-config $MP/boot/syslinux/syslinux.cfg
+	sudo cp "$DATA_DIR"/syslinux-config "$MP"/boot/syslinux/syslinux.cfg
 }
 
 if [ ! $# = 2 ]; then
@@ -69,7 +68,7 @@ if [ ! $# = 2 ]; then
 	exit 1
 fi
 
-if [ -z $LIVEFLASH_CPONLY ]; then
+if [ -z "$LIVEFLASH_CPONLY" ]; then
 	case $1 in
 		grub|grub2|syslinux) ;; # ok
 		*) # error
@@ -85,32 +84,32 @@ DRIVE=$2
 LOOPDEV=
 PARTITION=${DRIVE}1
 [ -d $MOUNT_POINT ] || sudo mkdir $MOUNT_POINT
-sudo umount $PARTITION
+sudo umount "$PARTITION"
 
-if [ -z $LIVEFLASH_CPONLY ]; then
-	if [ ! -b $DRIVE ]; then
-		dd if=/dev/zero of=$DRIVE bs=1M count=512
-		LOOPDEV=`losetup -f`
+if [ -z "$LIVEFLASH_CPONLY" ]; then
+	if [ ! -b "$DRIVE" ]; then
+		dd if=/dev/zero of="$DRIVE" bs=1M count=512
+		LOOPDEV=$(losetup -f)
 		PARTITION=${LOOPDEV}p1
-		echo ",,L,*" | sfdisk $DRIVE
-		sudo losetup -P $LOOPDEV $DRIVE
+		echo ",,L,*" | sfdisk "$DRIVE"
+		sudo losetup -P "$LOOPDEV" "$DRIVE"
 	else
 		# I am not sure if this required or not, just derived
 		# from older commits.
-		dd if=/dev/zero of=$DRIVE bs=512 count=1
-		echo "60,,L,*" | sfdisk $DRIVE
+		dd if=/dev/zero of="$DRIVE" bs=512 count=1
+		echo "60,,L,*" | sfdisk "$DRIVE"
 
 	fi
-	MKE2FS_DEVICE_SECTSIZE=512 sudo mke2fs $PARTITION -b 1024 -v
+	MKE2FS_DEVICE_SECTSIZE=512 sudo mke2fs "$PARTITION" -b 1024 -v
 fi
 
-sudo mount $PARTITION $MOUNT_POINT
+sudo mount "$PARTITION" $MOUNT_POINT
 
-if [ -z $LIVEFLASH_CPONLY ]; then
+if [ -z "$LIVEFLASH_CPONLY" ]; then
 	case $1 in
-		grub)      grub1_do $DRIVE $MOUNT_POINT ;;
-		grub2)     grub2_do $DRIVE $MOUNT_POINT ;;
-		syslinux)  syslinux_do $DRIVE $MOUNT_POINT ;;
+		grub)      grub1_do "$DRIVE" $MOUNT_POINT ;;
+		grub2)     grub2_do "$DRIVE" $MOUNT_POINT ;;
+		syslinux)  syslinux_do "$DRIVE" $MOUNT_POINT ;;
 	esac
 fi
 
@@ -119,6 +118,6 @@ sudo cp $EMBOX_MULTIBOOT $MOUNT_POINT/boot/embox
 sudo umount $MOUNT_POINT
 sudo rm -rf $MOUNT_POINT
 
-if [ ! -b $DRIVE ]; then
-	sudo losetup -d $LOOPDEV
+if [ ! -b "$DRIVE" ]; then
+	sudo losetup -d "$LOOPDEV"
 fi

--- a/scripts/mandatory_img.sh
+++ b/scripts/mandatory_img.sh
@@ -7,19 +7,19 @@ IMG=${2:-mandatory.img}
 
 LABEL=SMAC32LABEL
 
-dd if=/dev/zero bs=1 count=$SZ of=$IMG
-MKE2FS_DEVICE_SECTSIZE=512 mke2fs -q -b 1024 $IMG
+dd if=/dev/zero bs=1 count="$SZ" of="$IMG"
+MKE2FS_DEVICE_SECTSIZE=512 mke2fs -q -b 1024 "$IMG"
 
 tmp_mount=$(mktemp -d)
 
-mount -o loop $IMG $tmp_mount
+mount -o loop "$IMG" "$tmp_mount"
 
 for i in confidentially secret service unclassified; do
-	echo hello > $tmp_mount/$i
-	chmod 777 $tmp_mount/$i
-	attr -s $LABEL -V $i $tmp_mount/$i
+	echo hello > "$tmp_mount"/$i
+	chmod 777 "$tmp_mount"/$i
+	attr -s $LABEL -V $i "$tmp_mount"/$i
 
 done
 
-umount $tmp_mount
-rmdir $tmp_mount
+umount "$tmp_mount"
+rmdir "$tmp_mount"

--- a/scripts/mqtt/auto_qemu
+++ b/scripts/mqtt/auto_qemu
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check associative arrays support
-[ ${BASH_VERSION:0:1} -ge 4 ] || { echo "Bash 4.0 or later is required"; exit 1; }
+[ "${BASH_VERSION:0:1}" -ge 4 ] || { echo "Bash 4.0 or later is required"; exit 1; }
 
 DATADIR="$(dirname "$0")"
 CONFDIR=./conf
@@ -10,25 +10,22 @@ MODS_CONF=$CONFDIR/mods.config
 LDS_CONF=$CONFDIR/lds.conf
 BUILD_CONF=$CONFDIR/build.conf
 
-ARCHs=()
-NICs=()
-
 info() {
-	echo -e $@ >&2
+	echo -e "$@" >&2
 }
 
 error() {
-	echo -e $@ >&2
+	echo -e "$@" >&2
 	exit 1
 }
 
 guessed_info() {
-	info $1: ${!1} "$2"
+	info "$1": "${!1}" "$2"
 }
 
 error_empty() {
 	if [ -z "${!1}" ]; then
-		error $1 is empty
+		error "$1" is empty
 	fi
 }
 
@@ -53,8 +50,8 @@ get_user_empty_guess AUTOQEMU_ARCH guess_arch
 
 guess_mem() {
 	ram=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/^RAM *([0-9x]*, *\([0-9]*\)M)/\1/p')
-	if [ $ram ]; then
-		echo $ram
+	if [ "$ram" ]; then
+		echo "$ram"
 	else
 		echo 128
 	fi
@@ -94,43 +91,40 @@ guessed_info AUTOQEMU_DIAG_CONFIG "(got)"
 guess_kvm() {
 	ret=""
 	# Build kvm argument
-	if [ "$AUTOQEMU_ARCH" = "x86" -a "$OSTYPE" = "linux-gnu" ]; then
-		egrep '(vmx|svm)' /proc/cpuinfo > /dev/null
-		if [ $? -eq 0 ]; then
+	if [ "$AUTOQEMU_ARCH" = "x86" ] && [ "$OSTYPE" = "linux-gnu" ]; then
+		if grep -q -E '(vmx|svm)' /proc/cpuinfo; then
 			ret="-enable-kvm"
 		else
 			info VT is not supported by CPU
 		fi
 
-		dmesg | tail | grep "kvm: disabled by bios" > /dev/null
-		if [ $? -eq 0 ]; then
+		if dmesg | tail | grep -q "kvm: disabled by bios"; then
 			info "kvm disabled by bios. You can enable VT in bios"
 			ret=
 		fi
 
-		lsmod | egrep '(kvm_intel|kvm_amd)' > /dev/null
-		if [ $? -ne 0 ]; then
+		if ! lsmod | grep -q -E '(kvm_intel|kvm_amd)'; then
 			info no kvm kernel module loaded
 			ret=
 		fi
 	fi
-	echo $ret;
+	echo "$ret";
 }
 get_user_undef_guess AUTOQEMU_KVM_ARG guess_kvm
 
 guess_load_arg() {
 	NAND_SIZE=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/.*\<AUTOQEMU_UIMAGE_SIZE_MB=\([0-9]\+\).*$/\1/p')
-	if [ ! $NAND_SIZE ]; then
+	if [ ! "$NAND_SIZE" ]; then
 		echo "-kernel ${KERNEL:-./build/base/bin/embox}"
 	else
-		if [ ! $AUTOQEMU_NAND_BUILD_SKIP ];  then
+		if [ ! "$AUTOQEMU_NAND_BUILD_SKIP" ];  then
 			echo "Making uImage..." >&2
 			OMAP_UBOOT_IMAGE_BOARD=overo ./scripts/uboot-uimage >/dev/null
 			if [ 0 -ne $? ]; then
 				exit 1
 			fi
 			echo "Making nand image..." >&2
-			./scripts/qemu/beagle/run.sh beagle_nand.img ./uImage $NAND_SIZE >/dev/null 2>/dev/null
+			./scripts/qemu/beagle/run.sh beagle_nand.img ./uImage "$NAND_SIZE" >/dev/null 2>/dev/null
 			rm ./uImage
 		fi
 		echo "-mtdblock beagle_nand.img"
@@ -181,9 +175,9 @@ ARCH2QEMU=(
 
 QEMU=${AUTOQEMU_PREFIX}qemu-system-${ARCH2QEMU[$AUTOQEMU_ARCH]:-$AUTOQEMU_ARCH}
 AWK=$(which gawk >/dev/null && echo gawk || echo awk)
-QEMU_VER=$($QEMU --version | $AWK -f $DATADIR/qemuver.awk)
+QEMU_VER=$($QEMU --version | $AWK -f "$DATADIR"/qemuver.awk)
 
-if [ $QEMU_VER -gt 010200 ]; then
+if [ "$QEMU_VER" -gt 010200 ]; then
 	MB_XEMACLINE="xlnx.xps-ethernetlite"
 else
 	MB_XEMACLINE="xilinx-ethlite"
@@ -202,25 +196,25 @@ NIC2QEMU=(
 	[fec]="imx.enet"
 )
 
-IFS=" " read -a qemu_nics <<< "$AUTOQEMU_NICS"
-IFS=" " read -a qemu_nics_config <<< "$AUTOQEMU_NICS_CONFIG"
+IFS=" " read -r -a qemu_nics <<< "$AUTOQEMU_NICS"
+IFS=" " read -r -a qemu_nics_config <<< "$AUTOQEMU_NICS_CONFIG"
 sudo=""
 nic_lines=""
 nic_n=${#qemu_nics[*]}
-if [ $nic_n -gt 0 ]; then
+if [ "$nic_n" -gt 0 ]; then
 	sudo='sudo -E'
 	for ni in "${!qemu_nics[@]}"; do
 
 		nic_model=${NIC2QEMU[${qemu_nics[$ni]}]}
 		echo
-		if [ ! $nic_model ]; then
+		if [ ! "$nic_model" ]; then
 			error "nic model ${qemu_nics[$ni]} is not supported"
 		fi
 
-		if [ ${qemu_nics_config[$ni]} ] && [ ${qemu_nics_config[$ni]} != "-" ]; then
+		if [ "${qemu_nics_config[$ni]}" ] && [ "${qemu_nics_config[$ni]}" != "-" ]; then
 			host_nic_config=${qemu_nics_config[$ni]}
 		else
-			if [ $nic_model = "virtio" ]; then
+			if [ "$nic_model" = "virtio" ]; then
 				vnet_hdr="vnet_hdr=no"
 			else
 				vnet_hdr=""
@@ -246,20 +240,17 @@ AUDIO2QEMU=(
 	[aaci_pl041]="default"
 )
 
-AUDIO_DEV=" " read -a qemu_sound <<< "$AUTOQEMU_AUDIO"
-AUDIO_DEV=" " read -a qemu_sound_config <<< "$AUTOQEMU_AUDIO_CONFIG"
+AUDIO_DEV=" " read -r -a qemu_sound <<< "$AUTOQEMU_AUDIO"
 
 sound_lines=""
 sound_n=${#qemu_sound[*]}
-if [ $sound_n -gt 0 ]; then
+if [ "$sound_n" -gt 0 ]; then
 
 	for so in "${!qemu_sound[@]}"; do
 		sound_model=${AUDIO2QEMU[${qemu_sound[$so]}]}
 		echo
-		if [ $sound_model = "default" ]; then
-			sound_lines="$sound_lines"
-		else
-			if [ ! $sound_model ]; then
+		if [ "$sound_model" != "default" ]; then
+			if [ ! "$sound_model" ]; then
 				error "sound model ${qemu_sound[$ni]} is not supported"
 			fi
 			sound_lines="$sound_lines -soundhw $sound_model"
@@ -271,7 +262,7 @@ if [ $sound_n -gt 0 ]; then
 		info 'Using host ALSA subsystem. You can change it by setting QEMU_AUDIO_DRV'
 		info 'For example, "export QEMU_AUDIO_DRV=oss"\n'
 	fi
-	info 'QEMU_AUDIO_DRV is now' ${QEMU_AUDIO_DRV} '\n'
+	info 'QEMU_AUDIO_DRV is now' "${QEMU_AUDIO_DRV}" '\n'
 fi
 
 
@@ -286,14 +277,14 @@ GRAPHIC2QEMU=(
 qemu_graphic=$(guess_graphic)
 graphic_lines="-nographic"
 graphic_n=${#qemu_graphic[*]}
-if [ $graphic_n -gt 0 ]; then
+if [ "$graphic_n" -gt 0 ]; then
 	if [ -z "${AUTOQEMU_NOGRAPHIC_ARG+defined}" ]; then
 		for so in $qemu_graphic; do
 			graphic_model=${GRAPHIC2QEMU[$so]}
-			if [ ! $graphic_model ]; then
+			if [ ! "$graphic_model" ]; then
 				graphic_lines="-nographic"
 			else
-				if [ $graphic_model = "pl110" ]; then
+				if [ "$graphic_model" = "pl110" ]; then
 					graphic_lines="-serial stdio"
 				else
 					graphic_lines="-vga $graphic_model -serial stdio"
@@ -301,13 +292,13 @@ if [ $graphic_n -gt 0 ]; then
 				break
 			fi
 		done
-		if [ $graphic_lines = "-nographic" ]; then
-			if [ $(guess_diag) = "embox__driver__console__vc__vga" ]; then
+		if [ "$graphic_lines" = "-nographic" ]; then
+			if [ "$(guess_diag)" = "embox__driver__console__vc__vga" ]; then
 				graphic_lines="-vga std"
 			fi
 		fi
-		if [ $graphic_lines = "-nographic" ]; then
-			if [ $(guess_diag) = "embox__driver__console__vc__vga" ]; then
+		if [ "$graphic_lines" = "-nographic" ]; then
+			if [ "$(guess_diag)" = "embox__driver__console__vc__vga" ]; then
 				graphic_lines="-vga std"
 			fi
 		fi
@@ -318,7 +309,7 @@ if [ $graphic_n -gt 0 ]; then
 
 fi
 
-ARG_LINE="$sudo $QEMU $AUTOQEMU_MACHINE $AUTOQEMU_LOAD_ARG $AUTOQEMU_KVM_ARG -m $AUTOQEMU_MEM $nic_lines $sound_lines $graphic_lines $@"
+ARG_LINE="$sudo $QEMU $AUTOQEMU_MACHINE $AUTOQEMU_LOAD_ARG $AUTOQEMU_KVM_ARG -m $AUTOQEMU_MEM $nic_lines $sound_lines $graphic_lines $*"
 
 info "$ARG_LINE"
 $ARG_LINE

--- a/scripts/mqtt/qemu_with_disk.sh
+++ b/scripts/mqtt/qemu_with_disk.sh
@@ -8,25 +8,22 @@ MODS_CONF=$CONFDIR/mods.config
 LDS_CONF=$CONFDIR/lds.conf
 BUILD_CONF=$CONFDIR/build.conf
 
-ARCHs=()
-NICs=()
-
 info() {
-	echo $@ >&2
+	echo "$@" >&2
 }
 
 error() {
-	echo $@ >&2
+	echo "$@" >&2
 	exit 1
 }
 
 guessed_info() {
-	info Guessed $1 is: ${!1}
+	info Guessed "$1" is: "${!1}"
 }
 
 error_empty() {
 	if [ -z "${!1}" ]; then
-		error $1 is not defined
+		error "$1" is not defined
 	fi
 }
 
@@ -41,7 +38,7 @@ get_user_empty_guess() {
 get_user_undef_guess() {
 	if [ -z "${!1+defined}" ]; then
 		eval "$1=\"$($2)\""
-		guessed_info $1
+		guessed_info "$1"
 	fi
 }
 
@@ -50,8 +47,8 @@ get_user_empty_guess AUTOQEMU_ARCH guess_arch
 
 guess_mem() {
 	ram=$(sed -n 's/^RAM *([0-9x]*, *\([0-9]*\)M)/\1/p' $LDS_CONF)
-	if [ $ram ]; then
-		echo $ram
+	if [ "$ram" ]; then
+		echo "$ram"
 	else
 		echo 128
 	fi
@@ -64,36 +61,32 @@ get_user_undef_guess AUTOQEMU_NICS guess_nics
 guess_kvm() {
 	ret=""
 	# Build kvm argument
-	if [ $AUTOQEMU_ARCH = "x86" ]; then
-		egrep '(vmx|svm)' /proc/cpuinfo > /dev/null
-		if [ $? -eq 0 ]; then
+	if [ "$AUTOQEMU_ARCH" = "x86" ]; then
+		if grep -q -E '(vmx|svm)' /proc/cpuinfo; then
 			ret="-enable-kvm"
 		else
 			info VT is not supported by CPU
 		fi
 
-		dmesg | tail | grep "kvm: disabled by bios" > /dev/null
-		if [ $? -eq 0 ]; then
+		if dmesg | tail | grep -q "kvm: disabled by bios"; then
 			info "kvm disabled by bios. You can enable VT in bios"
 			ret=
 		fi
 
-		lsmod | egrep '(kvm_intel|kvm_amd)' > /dev/null
-		if [ $? -ne 0 ]; then
+		if ! lsmod | grep -q -E '(kvm_intel|kvm_amd)'; then
 			info no kvm kernel module loaded
 			ret=
 		fi
 	fi
-	echo $ret;
+	echo "$ret";
 }
 get_user_undef_guess AUTOQEMU_KVM_ARG guess_kvm
 
 guess_load_arg() {
-	if [ $AUTOQEMU_ARCH != "arm" ]; then
+	if [ "$AUTOQEMU_ARCH" != "arm" ]; then
 		echo "-kernel $KERNEL"
 	else
-		./scripts/uboot-uimage >/dev/null
-		if [ 0 -ne $? ]; then
+		if ! ./scripts/uboot-uimage >/dev/null; then
 			exit 1
 		fi
 		./scripts/qemu/beagle/run.sh beagle_nand.img ./uImage >/dev/null 2>/dev/null
@@ -125,7 +118,7 @@ NIC2QEMU=(
 	[lan9118]="lan9118"
 )
 
-qemu_nics=$(echo $AUTOQEMU_NICS ${!NIC2QEMU[@]} | sed 's/\ \+/\n/g' | sort | uniq -d)
+qemu_nics=$(echo $AUTOQEMU_NICS "${!NIC2QEMU[@]}" | sed 's/\ \+/\n/g' | sort | uniq -d)
 
 qemu_start_script=${AUTOQEMU_START_SCRIPT:-$DATADIR/start_script}
 qemu_stop_script=${AUTOQEMU_STOP_SCRIPT:-$DATADIR/stop_script}
@@ -147,7 +140,7 @@ HDD_IMAGE="qemu_ext2_image.img"
 mkdir qemu_tmp_dir
 ./scripts/continuous/fs/img-manage.sh $FS_TYPE $HDD_IMAGE build "qemu_tmp_dir"
 rmdir qemu_tmp_dir
-ARG_LINE="$sudo $AUTOQEMU_PREFIX${ARCH2QEMU[$AUTOQEMU_ARCH]} $AUTOQEMU_LOAD_ARG $AUTOQEMU_KVM_ARG -m $AUTOQEMU_MEM $nic_lines ${AUTOQEMU_NOGRAPHIC_ARG--nographic} -hda $HDD_IMAGE $@"
+ARG_LINE="$sudo $AUTOQEMU_PREFIX${ARCH2QEMU[$AUTOQEMU_ARCH]} $AUTOQEMU_LOAD_ARG $AUTOQEMU_KVM_ARG -m $AUTOQEMU_MEM $nic_lines ${AUTOQEMU_NOGRAPHIC_ARG--nographic} -hda $HDD_IMAGE $*"
 
 info "$ARG_LINE"
 $ARG_LINE

--- a/scripts/mqtt/start_script
+++ b/scripts/mqtt/start_script
@@ -4,18 +4,18 @@ TAP=$1
 ip=$(which ip)
 USER=$(whoami)
 
-$ip tuntap add $TAP mode tap user "$USER"
-$ip link set   dev $TAP up
-$ip addr flush dev $TAP
-$ip link set   dev $TAP address aa:bb:cc:dd:ee:ff
-$ip addr add   dev $TAP 10.0.2.10/24 #broadcast 10.0.2.255
-$ip addr add   dev $TAP fe80::10:0:2:10/64
-$ip link set $TAP master br0
+$ip tuntap add "$TAP" mode tap user "$USER"
+$ip link set   dev "$TAP" up
+$ip addr flush dev "$TAP"
+$ip link set   dev "$TAP" address aa:bb:cc:dd:ee:ff
+$ip addr add   dev "$TAP" 10.0.2.10/24 #broadcast 10.0.2.255
+$ip addr add   dev "$TAP" fe80::10:0:2:10/64
+$ip link set "$TAP" master br0
 
 # Enable IP Forwarding for gateway interface
 gw=$($ip route | sed -n "s/default via .* dev \([0-9a-z_]\+\) .*$/\1/p")
 if [ "$gw" ]; then
 	echo "Enable IP Forwarding for $gw"
 	sysctl net.ipv4.ip_forward=1
-	iptables -t nat -A POSTROUTING -o $gw -j MASQUERADE
+	iptables -t nat -A POSTROUTING -o "$gw" -j MASQUERADE
 fi

--- a/scripts/mqtt/stop_script
+++ b/scripts/mqtt/stop_script
@@ -3,6 +3,6 @@
 TAP=$1
 ip=$(which ip)
 
-$ip link set   dev $TAP down
-$ip addr flush dev $TAP
-$ip tuntap del mode tap $TAP
+$ip link set   dev "$TAP" down
+$ip addr flush dev "$TAP"
+$ip tuntap del mode tap "$TAP"

--- a/scripts/mqtt/up_bridge.sh
+++ b/scripts/mqtt/up_bridge.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 ip=$(which ip)
 
 $ip link add name br0 type bridge

--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check associative arrays support
-[ ${BASH_VERSION:0:1} -ge 4 ] || { echo "Bash 4.0 or later is required"; exit 1; }
+[ "${BASH_VERSION:0:1}" -ge 4 ] || { echo "Bash 4.0 or later is required"; exit 1; }
 
 DATADIR="$(dirname "$0")"
 CONFDIR=./conf
@@ -10,25 +10,22 @@ MODS_CONF=$CONFDIR/mods.conf
 LDS_CONF=$CONFDIR/lds.conf
 BUILD_CONF=$CONFDIR/build.conf
 
-ARCHs=()
-NICs=()
-
 info() {
-	echo -e $@ >&2
+	echo -e "$@" >&2
 }
 
 error() {
-	echo -e $@ >&2
+	echo -e "$@" >&2
 	exit 1
 }
 
 guessed_info() {
-	info $1: ${!1} "$2"
+	info "$1": "${!1}" "$2"
 }
 
 error_empty() {
 	if [ -z "${!1}" ]; then
-		error $1 is empty
+		error "$1" is empty
 	fi
 }
 
@@ -53,8 +50,8 @@ get_user_empty_guess AUTOQEMU_ARCH guess_arch
 
 guess_mem() {
 	ram=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/^RAM *([0-9x]*, *\([0-9]*\)M)/\1/p')
-	if [ $ram ]; then
-		echo $ram
+	if [ "$ram" ]; then
+		echo "$ram"
 	else
 		echo 128
 	fi
@@ -101,47 +98,44 @@ guessed_info AUTOQEMU_DIAG_CONFIG "(got)"
 guess_kvm() {
 	ret=""
 	# Build kvm argument
-	if [ "$AUTOQEMU_ARCH" = "x86" -a "$OSTYPE" = "linux-gnu" ]; then
-		egrep '(vmx|svm)' /proc/cpuinfo > /dev/null
-		if [ $? -eq 0 ]; then
+	if [ "$AUTOQEMU_ARCH" = "x86" ] && [ "$OSTYPE" = "linux-gnu" ]; then
+		if grep -q -E '(vmx|svm)' /proc/cpuinfo; then
 			ret="-enable-kvm"
 		else
 			info VT is not supported by CPU
 		fi
 
-		dmesg | tail | grep "kvm: disabled by bios" > /dev/null
-		if [ $? -eq 0 ]; then
+		if dmesg | tail | grep -q "kvm: disabled by bios"; then
 			info "kvm disabled by bios. You can enable VT in bios"
 			ret=
 		fi
 
-		lsmod | egrep '(kvm_intel|kvm_amd)' > /dev/null
-		if [ $? -ne 0 ]; then
+		if ! lsmod | grep -q -E '(kvm_intel|kvm_amd)'; then
 			info no kvm kernel module loaded
 			ret=
 		fi
 	fi
-	echo $ret;
+	echo "$ret";
 }
 get_user_undef_guess AUTOQEMU_KVM_ARG guess_kvm
 
 guess_load_arg() {
 	NAND_SIZE=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/.*\<AUTOQEMU_UIMAGE_SIZE_MB=\([0-9]\+\).*$/\1/p')
-	if [ ! $NAND_SIZE ]; then
-		if [ "$AUTOQEMU_ARCH" = "riscv" -o "$AUTOQEMU_ARCH" = "riscv64" ]; then
+	if [ ! "$NAND_SIZE" ]; then
+		if [ "$AUTOQEMU_ARCH" = "riscv" ] || [ "$AUTOQEMU_ARCH" = "riscv64" ]; then
 			echo "-bios ${KERNEL:-./build/base/bin/embox}"
 		else
 			echo "-kernel ${KERNEL:-./build/base/bin/embox}"
 		fi
 	else
-		if [ ! $AUTOQEMU_NAND_BUILD_SKIP ];  then
+		if [ ! "$AUTOQEMU_NAND_BUILD_SKIP" ];  then
 			echo "Making uImage..." >&2
 			OMAP_UBOOT_IMAGE_BOARD=overo ./scripts/uboot-uimage >/dev/null
 			if [ 0 -ne $? ]; then
-				exit 1
+			    exit 1
 			fi
 			echo "Making nand image..." >&2
-			./scripts/qemu/beagle/run.sh beagle_nand.img ./uImage $NAND_SIZE >/dev/null 2>/dev/null
+			./scripts/qemu/beagle/run.sh beagle_nand.img ./uImage "$NAND_SIZE" >/dev/null 2>/dev/null
 			rm ./uImage
 		fi
 		echo "-mtdblock beagle_nand.img"
@@ -216,9 +210,9 @@ ARCH2QEMU=(
 
 QEMU=${AUTOQEMU_PREFIX}qemu-system-${ARCH2QEMU[$AUTOQEMU_ARCH]:-$AUTOQEMU_ARCH}
 AWK=$(which gawk >/dev/null && echo gawk || echo awk)
-QEMU_VER=$($QEMU --version | $AWK -f $DATADIR/qemuver.awk)
+QEMU_VER=$($QEMU --version | $AWK -f "$DATADIR"/qemuver.awk)
 
-if [ $QEMU_VER -gt 010200 ]; then
+if [ "$QEMU_VER" -gt 010200 ]; then
 	MB_XEMACLINE="xlnx.xps-ethernetlite"
 else
 	MB_XEMACLINE="xilinx-ethlite"
@@ -240,33 +234,33 @@ NIC2QEMU=(
 	[cadence_gem]="cadence_gem"
 )
 
-IFS=" " read -a qemu_nics <<< "$AUTOQEMU_NICS"
-IFS=" " read -a qemu_nics_config <<< "$AUTOQEMU_NICS_CONFIG"
+IFS=" " read -r -a qemu_nics <<< "$AUTOQEMU_NICS"
+IFS=" " read -r -a qemu_nics_config <<< "$AUTOQEMU_NICS_CONFIG"
 sudo=""
 nic_lines=""
 nic_n=${#qemu_nics[*]}
-if [ $nic_n -gt 0 ]; then
+if [ "$nic_n" -gt 0 ]; then
 	sudo='sudo -E'
 	for ni in "${!qemu_nics[@]}"; do
 
 		nic_model=${NIC2QEMU[${qemu_nics[$ni]}]}
 		echo
-		if [ ! $nic_model ]; then
+		if [ ! "$nic_model" ]; then
 			error "nic model ${qemu_nics[$ni]} is not supported"
 		fi
 
-		if [ ${qemu_nics_config[$ni]} ] && [ ${qemu_nics_config[$ni]} != "-" ]; then
+		if [ "${qemu_nics_config[$ni]}" ] && [ "${qemu_nics_config[$ni]}" != "-" ]; then
 			host_nic_config=${qemu_nics_config[$ni]}
 		else
 			host_nic_config="tap,script=$DATADIR/start_script,downscript=$DATADIR/stop_script"
-			if [ $nic_model = "virtio" ]; then
+			if [ "$nic_model" = "virtio" ]; then
 				host_nic_config="$host_nic_config,vnet_hdr=no"
 			fi
 		fi
 
 		nic_macaddr="AA:BB:CC:DD:EE:0$(($ni + 2))"
 
-		if [ $nic_model = "usb-net" ]; then
+		if [ "$nic_model" = "usb-net" ]; then
 			nic_lines="$nic_lines \
 				-device usb-net,netdev=n$ni,mac=$nic_macaddr"
 		else
@@ -292,20 +286,17 @@ AUDIO2QEMU=(
 	[aaci_pl041]="default"
 )
 
-AUDIO_DEV=" " read -a qemu_sound <<< "$AUTOQEMU_AUDIO"
-AUDIO_DEV=" " read -a qemu_sound_config <<< "$AUTOQEMU_AUDIO_CONFIG"
+AUDIO_DEV=" " read -r -a qemu_sound <<< "$AUTOQEMU_AUDIO"
 
 sound_lines=""
 sound_n=${#qemu_sound[*]}
-if [ $sound_n -gt 0 ]; then
+if [ "$sound_n" -gt 0 ]; then
 
 	for so in "${!qemu_sound[@]}"; do
 		sound_model=${AUDIO2QEMU[${qemu_sound[$so]}]}
 		echo
-		if [ $sound_model = "default" ]; then
-			sound_lines="$sound_lines"
-		else
-			if [ ! $sound_model ]; then
+		if [ "$sound_model" != "default" ]; then
+			if [ ! "$sound_model" ]; then
 				error "sound model ${qemu_sound[$ni]} is not supported"
 			fi
 			sound_lines="$sound_lines -soundhw $sound_model"
@@ -317,7 +308,7 @@ if [ $sound_n -gt 0 ]; then
 		info 'Using host ALSA subsystem. You can change it by setting QEMU_AUDIO_DRV'
 		info 'For example, "export QEMU_AUDIO_DRV=oss"\n'
 	fi
-	info 'QEMU_AUDIO_DRV is now' ${QEMU_AUDIO_DRV} '\n'
+	info 'QEMU_AUDIO_DRV is now' "${QEMU_AUDIO_DRV}" '\n'
 fi
 #############################################
 # END AUDIO
@@ -339,18 +330,17 @@ USB2QEMUID=(
 	[uhci_pci]="uhci"
 )
 
-USB_DEV=" " read -a qemu_usb <<< "$AUTOQEMU_USB"
-USB_DEV=" " read -a qemu_usb_config <<< "$AUTOQEMU_USB_CONFIG"
+USB_DEV=" " read -r -a qemu_usb <<< "$AUTOQEMU_USB"
 
 usb_lines=""
 usb_n=${#qemu_usb[*]}
-if [ $usb_n -gt 0 ]; then
+if [ "$usb_n" -gt 0 ]; then
 
 	for so in "${!qemu_usb[@]}"; do
 		usb_model=${USB2QEMU[${qemu_usb[$so]}]}
 		hci_id=${USB2QEMUID[${qemu_usb[$so]}]}
 		echo
-		if [ ! $usb_model ]; then
+		if [ ! "$usb_model" ]; then
 			error "usb model ${qemu_usb[$ni]} is not supported"
 		else
 			usb_lines="$usb_lines -device $usb_model,id=$hci_id"
@@ -372,14 +362,14 @@ GRAPHIC2QEMU=(
 qemu_graphic=$(guess_graphic)
 graphic_lines="-nographic"
 graphic_n=${#qemu_graphic[*]}
-if [ $graphic_n -gt 0 ]; then
+if [ "$graphic_n" -gt 0 ]; then
 	if [ -z "${AUTOQEMU_NOGRAPHIC_ARG+defined}" ]; then
 		for so in $qemu_graphic; do
 			graphic_model=${GRAPHIC2QEMU[$so]}
-			if [ ! $graphic_model ]; then
+			if [ ! "$graphic_model" ]; then
 				graphic_lines="-nographic"
 			else
-				if [ $graphic_model = "pl110" ]; then
+				if [ "$graphic_model" = "pl110" ]; then
 					graphic_lines="-serial mon:stdio"
 				else
 					graphic_lines="-vga $graphic_model -serial mon:stdio"
@@ -387,8 +377,8 @@ if [ $graphic_n -gt 0 ]; then
 				break
 			fi
 		done
-		if [ $graphic_lines = "-nographic" ]; then
-			if [ $(guess_diag) = "embox__driver__console__vc__vga" ]; then
+		if [ "$graphic_lines" = "-nographic" ]; then
+			if [ "$(guess_diag)" = "embox__driver__console__vc__vga" ]; then
 				graphic_lines="-vga std"
 			fi
 		fi
@@ -401,8 +391,8 @@ fi
 
 RUNAS=""
 # Don't try to drop privileges for root user; qemu fails otherwise
-if [[ `id -u` -ne 0 ]] ; then
-	RUNAS="-runas `whoami`"
+if [[ "$(id -u)" -ne 0 ]] ; then
+	RUNAS="-runas $(whoami)"
 	sudo='sudo -E'
 fi
 

--- a/scripts/qemu/auto_qemu_with_sd_card
+++ b/scripts/qemu/auto_qemu_with_sd_card
@@ -13,7 +13,7 @@ fi
 
 ./scripts/qemu/auto_qemu \
 	-drive if=sd,format=raw,file=$image_file_name \
-	$@
+	"$@"
 #./scripts/qemu/auto_qemu \
 #	-drive id=sd1,format=raw,file=$image_file_name \
 #	-device sd-card,drive=sd1 \

--- a/scripts/qemu/auto_qemu_with_usb_ccid
+++ b/scripts/qemu/auto_qemu_with_usb_ccid
@@ -9,19 +9,24 @@ if [ -d $FAKE_SMARTCARD ]; then
 	echo "$FAKE_SMARTCARD found."
 else
 	echo "$FAKE_SMARTCARD not found. A new one will be created now..."
+	(
+	    # It's taken from QEMU's docs/ccid.txt
+	    mkdir $FAKE_SMARTCARD
+	    cd $FAKE_SMARTCARD || { echo "Failed to cd to $FAKE_SMARTCARD"; exit 1; }
+	    certutil -N -d sql:"$PWD"
+	    certutil -S -d sql:"$PWD" -s "CN=Fake Smart Card CA" -x -t TC,TC,TC -n fake-smartcard-ca
+	    certutil -S -d sql:"$PWD" -t ,, -s "CN=John Doe" -n id-cert -c fake-smartcard-ca
+	    certutil -S -d sql:"$PWD" -t ,, -s "CN=John Doe (signing)" --nsCertType smime -n signing-cert -c fake-smartcard-ca
+	    certutil -S -d sql:"$PWD" -t ,, -s "CN=John Doe (encryption)" --nsCertType sslClient -n encryption-cert -c fake-smartcard-ca
+	) || {
+	    # In case of fail just exit and do not remove $FAKE_SMARTCARD
+	    # to allow to conduct investigation
+	    exit 1
+	}
 
-	# It's taken from QEMU's docs/ccid.txt
-	mkdir $FAKE_SMARTCARD
-	cd $FAKE_SMARTCARD
-	certutil -N -d sql:$PWD
-	certutil -S -d sql:$PWD -s "CN=Fake Smart Card CA" -x -t TC,TC,TC -n fake-smartcard-ca
-	certutil -S -d sql:$PWD -t ,, -s "CN=John Doe" -n id-cert -c fake-smartcard-ca
-	certutil -S -d sql:$PWD -t ,, -s "CN=John Doe (signing)" --nsCertType smime -n signing-cert -c fake-smartcard-ca
-	certutil -S -d sql:$PWD -t ,, -s "CN=John Doe (encryption)" --nsCertType sslClient -n encryption-cert -c fake-smartcard-ca
-	cd -
 fi
 
 ./scripts/qemu/auto_qemu \
 	-device usb-ccid \
 	-device ccid-card-emulated,backend=certificates,db=sql:$FAKE_SMARTCARD,cert1=id-cert,cert2=signing-cert,cert3=encryption-cert \
-	$@
+	"$@"

--- a/scripts/qemu/auto_qemu_with_usb_hub
+++ b/scripts/qemu/auto_qemu_with_usb_hub
@@ -18,4 +18,4 @@ fi
 	-drive if=none,id=usbdisk,file=$image_file_name,format=raw \
 	-device usb-hub,bus=ohci.0,port=$HUB_PORT \
 	-device usb-storage,bus=ohci.0,port=$HUB_PORT.$USBDISK_HUB_PORT,drive=usbdisk \
-	$@
+	"$@"

--- a/scripts/qemu/auto_qemu_with_usb_storage
+++ b/scripts/qemu/auto_qemu_with_usb_storage
@@ -14,4 +14,4 @@ fi
 ./scripts/qemu/auto_qemu \
 	-drive id=my_usb_disk,file=$image_file_name,if=none,format=raw \
 	-device usb-storage,drive=my_usb_disk \
-	$@
+	"$@"

--- a/scripts/qemu/start_script
+++ b/scripts/qemu/start_script
@@ -3,20 +3,20 @@
 TAP=$1
 ip=$(which ip)
 
-$ip tuntap add mode tap $TAP
-$ip link set   dev $TAP address aa:bb:cc:dd:ee:ff
-$ip link set   dev $TAP up
-$ip addr flush dev $TAP
-$ip addr add   dev $TAP 10.0.2.10/24 #broadcast 10.0.2.255
-$ip addr add   dev $TAP fe80::10:0:2:10/64
+$ip tuntap add mode tap "$TAP"
+$ip link set   dev "$TAP" address aa:bb:cc:dd:ee:ff
+$ip link set   dev "$TAP" up
+$ip addr flush dev "$TAP"
+$ip addr add   dev "$TAP" 10.0.2.10/24 #broadcast 10.0.2.255
+$ip addr add   dev "$TAP" fe80::10:0:2:10/64
 
 #Enable IP Forwarding for gateway interface
 GW=$($ip route | sed -n "s/default via .* dev \([0-9a-z_]\+\) .*$/\1/p" | head -n 1)
 if [ "$GW" ]; then
 	echo "Enable IP Forwarding for $GW"
-	iptables -t nat -A POSTROUTING -o $GW -j MASQUERADE
-	iptables -A FORWARD -i $TAP -o $GW -j ACCEPT
-	iptables -A FORWARD -i $GW -o $TAP -j ACCEPT
+	iptables -t nat -A POSTROUTING -o "$GW" -j MASQUERADE
+	iptables -A FORWARD -i "$TAP" -o "$GW" -j ACCEPT
+	iptables -A FORWARD -i "$GW" -o "$TAP" -j ACCEPT
 
 	sysctl net.ipv4.ip_forward=1
 fi

--- a/scripts/qemu/stop_script
+++ b/scripts/qemu/stop_script
@@ -3,6 +3,6 @@
 TAP=$1
 ip=$(which ip)
 
-$ip link set   dev $TAP down
-$ip addr flush dev $TAP
-$ip tuntap del mode tap $TAP
+$ip link set   dev "$TAP" down
+$ip addr flush dev "$TAP"
+$ip tuntap del mode tap "$TAP"

--- a/scripts/trybuild
+++ b/scripts/trybuild
@@ -16,9 +16,9 @@ VC=git
 
 # end of params
 
-if [ -z $TOPDIR ]; then
+if [ -z "$TOPDIR" ]; then
 	TOPDIR=$PWD
 fi
 
 $BUILDBOT try --connect=$CONNECT --master=$MASTER --user=$USER --passwd=$PASSWD \
-	--vc=$VC --topdir=$TOPDIR --who=$TRYWHO "$@"
+	--vc=$VC --topdir="$TOPDIR" --who=$TRYWHO "$@"

--- a/scripts/uboot-uimage
+++ b/scripts/uboot-uimage
@@ -4,7 +4,7 @@ EMBOX_BIN=${1:-"./build/base/bin/embox.bin"}
 UIMAGE=${2:-uImage}
 MKIMAGE=$(which mkimage)
 
-if [ ! $MKIMAGE ]; then
+if [ ! "$MKIMAGE" ]; then
 	echo "!!!!!!!  ERROR !!!!!!!!!!!!! please install mkimage or uboot-tools"   >&2
 	exit 1
 fi
@@ -32,10 +32,10 @@ PADDED_BIN=".embox-padded.bin"
 
 PAD_SIZE=32K
 
-dd if=/dev/zero of=$PAD_FILE_NAME bs=1 count=$PAD_SIZE
+dd if=/dev/zero of="$PAD_FILE_NAME" bs=1 count=$PAD_SIZE
 
-cat $PAD_FILE_NAME $EMBOX_BIN > $PADDED_BIN
+cat "$PAD_FILE_NAME" "$EMBOX_BIN" > "$PADDED_BIN"
 
-$MKIMAGE -A arm -O linux -C none -T kernel -a $LOAD_ADDR -e $ENTRY_ADDR -d $PADDED_BIN $UIMAGE
+"$MKIMAGE" -A arm -O linux -C none -T kernel -a $LOAD_ADDR -e "$ENTRY_ADDR" -d "$PADDED_BIN" "$UIMAGE"
 
-rm $PAD_FILE_NAME $PADDED_BIN
+rm "$PAD_FILE_NAME" "$PADDED_BIN"

--- a/scripts/usermode_start.sh
+++ b/scripts/usermode_start.sh
@@ -1,30 +1,30 @@
 #!/bin/sh
 
 SUDO=sudo
-ROOT=$(dirname $0)/../.
+ROOT=$(dirname "$0")/../.
 
 EMBOX=${ROOT}/build/base/bin/embox
 
 [ -z "$TAP" ] && TAP=tap77
 
 rm_tap() {
-	$SUDO ip tuntap del dev $TAP mode tap
+	$SUDO ip tuntap del dev "$TAP" mode tap
 }
 
 trap rm_tap INT TERM
 
-if [ ! -z "$(ip addr | grep $TAP)" ]; then
+if ip addr | grep -q "$TAP"; then
 	rm_tap
 fi
 
-$SUDO ip tuntap add dev $TAP mode tap
-$SUDO $ROOT/scripts/qemu/start_script $TAP
-export EMBOX_USERMODE_TAP_NAME=$TAP
+$SUDO ip tuntap add dev "$TAP" mode tap
+$SUDO "$ROOT"/scripts/qemu/start_script "$TAP"
+export EMBOX_USERMODE_TAP_NAME="$TAP"
 
-if [ $USERMODE_START_OUTPUT ]; then
-	$EMBOX $TAP >$USERMODE_START_OUTPUT 2>$USERMODE_START_OUTPUT
+if [ "$USERMODE_START_OUTPUT" ]; then
+	$EMBOX "$TAP" >"$USERMODE_START_OUTPUT" 2>"$USERMODE_START_OUTPUT"
 else
-	$EMBOX $TAP
+	$EMBOX "$TAP"
 fi
 
 rm_tap


### PR DESCRIPTION
Hi! This PR resolves #2835 

The most part of the changes is trivial. It is quoting variables with double quotes to protect them from word splitting and globbing. This is especially important for variables containing paths (if a path in such a variable would accidentely contain spaces it would be splited into multiple substrings) and for many other variables too. Bash's word splitting can be very surprising even in obvious-looking commands: http://mywiki.wooledge.org/BashPitfalls#echo_.24foo.

Other changes are:
1. Handling of failed `cd`s, either by wrapping operation requiring `cd` in a subshell, or by explicit `|| exit 1`
2. Joining multiple 'echo string >> file' lines into a group command with a single redirect (https://www.shellcheck.net/wiki/SC2129)
3. Replacing indirect exit-code checks with direct ones, i.e. snippets like this
```
egrep '(vmx|svm)' /proc/cpuinfo > /dev/null
if [ $? -eq 0 ]; then
```
was rewritten like this
```
if grep -q -E '(vmx|svm)' /proc/cpuinfo; then
```
A nice benefit of this is that `grep`s `-q` short-circuits computation, terminating grep after first match.
4. Another changes, like style-related, etc. Most commit messages have a list of them.

Though PR name is «fix according to ShellCheck guidelines», changes introduced by it do not follow _all_ ShellCheck suggestions. I skipped SC suggestions if I wasn't sure that following it wouldn't change code's semantic. But if I followed them thinking that a change was safe, I might have been wrong and the change broke something.