### PR TITLE
templates: x86/test/net templ fix(ci crashed)

### DIFF
--- a/templates/x86/test/net/mods.conf
+++ b/templates/x86/test/net/mods.conf
@@ -36,6 +36,7 @@ configuration conf {
 	@Runlevel(1) include embox.kernel.thread.core(thread_pool_size=512, thread_stack_size=0x4000)
 	include embox.kernel.thread.signal.sigstate
 	include embox.kernel.thread.signal.siginfoq
+    include embox.kernel.task.resource.env(env_str_len=64)
 
 	@Runlevel(2) include embox.cmd.sh.tish(prompt="%u@%h:%w%$", rich_prompt_support=1, builtin_commands="exit logout cd export mount umount")
 	@Runlevel(3) include embox.init.start_script(shell_name="tish",shell_start=1,stop_on_error=true, tty_dev="ttyS0")


### PR DESCRIPTION
In x86/test/net template configuration environment structure for a task(struct task_env) had default env_str_len value equal to 32. Because of that new version of dropbear crashed trying to write long environment variable.