### PR TITLE
date: In set_date() read correct tm_mon field

### DIFF
--- a/src/cmds/sys/date.c
+++ b/src/cmds/sys/date.c
@@ -63,6 +63,7 @@ static void set_date(char *new_date) {
 
 	end -= 2;
 	sscanf(end, "%d", &date.tm_mon);
+	date.tm_mon -= 1;
 	*end = '\0';
 
 	end -= 4;


### PR DESCRIPTION
Fix https://github.com/embox/embox/issues/2492
```
date -s 202307251757.40
date -s 202301251757.40
date -s 202312251757.40
date -s 202307301757.40
date -s 202307311757.40
date -s 202307321757.40
```
```
2023-07-25 17:57:40

2023-01-25 17:57:40

2023-12-25 17:57:40

2023-07-30 17:57:40

2023-07-31 17:57:40

2023-08-01 17:57:40
```