### PR TITLE
Fix continuous/* shell-scripts according to ShellCheck

### DIFF
--- a/scripts/continuous/prepare.sh
+++ b/scripts/continuous/prepare.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Replaces every / with __ in $1 and assigns result
 target=${1//\//__}
 
 x86__test__net() {
@@ -8,8 +9,8 @@ x86__test__net() {
 	cp build/base/bin/embox ./ping-target
 }
 
-if ! [ $target ] || ! type -t $target > /dev/null; then
-	echo nothing to prepare for \"$1\"
+if ! [ "$target" ] || ! type -t "$target" > /dev/null; then
+	echo nothing to prepare for \""$1"\"
 	exit 0
 fi
-$target "$@"
+"$target" "$@"

--- a/scripts/continuous/touch-mk-cache.sh
+++ b/scripts/continuous/touch-mk-cache.sh
@@ -3,7 +3,7 @@
 C=./mk/.cache
 
 touch $C/mk/*
-find  $C/mybuild/files | xargs touch
+find  $C/mybuild/files -exec touch ';'
 touch $C/mybuild/myfiles-model.mk
 touch $C/mybuild/myfiles-list.mk
 exit 0

--- a/scripts/continuous/tsim_run.sh
+++ b/scripts/continuous/tsim_run.sh
@@ -3,4 +3,4 @@
 OUTPUT_FILE=$1
 shift
 
-echo "c" | tsim-leon3 $@ > $OUTPUT_FILE
+echo "c" | tsim-leon3 "$@" > $OUTPUT_FILE


### PR DESCRIPTION
Hi @anton-bondarev

This PR offers double-quoting mostly, but also it has a couple of changes which possibly can change code semantics.

Here I've added an extra case when default variable value is used:
```diff
-TIMEOUT=${CONTINIOUS_RUN_TIMEOUT-60}
+TIMEOUT=${CONTINIOUS_RUN_TIMEOUT:-60}
```
Explanation in Bash manual:
>When not performing substring expansion, using the form described below (e.g., ‘:-’), Bash tests for a parameter that is unset or null. Omitting the colon results in a test only for a parameter that is unset. Put another way, if the colon is included, the operator tests for both parameter’s existence and that its value is not null; if the colon is omitted, the operator tests only for existence. 

Here I renamed a variable to make its name reflect its purpose and also changed the way it is initialized:
```diff
 ATML="$1"
 SIM_ARG="$2"
-shift 2
-OTHER_ARGS="$@"
+PID_FILE="$3"
…
-       echo $sim_bg > $OTHER_ARGS
+       echo $sim_bg > "$PID_FILE"
…
-       sim_bg=$(cat $OTHER_ARGS)
+       sim_bg=$(cat "$PID_FILE")
```
```
embox/scripts/continuous $ grep OTHER_ARGS run.sh 
14:OTHER_ARGS="$@"
167:	echo $sim_bg > $OTHER_ARGS
172:	sim_bg=$(cat $OTHER_ARGS)
```
As you can see its used only to store a name of a file. I struggle to understand why it is initialized with concatenation of array values (assigning `"$@"` to a variable in Bash does exactly this). If the script has ever worked, then it must have been called in a way that `$@` held a single value without spaces. So I think it safe to assign `$3` to this variable.

This is merely a more elegant key existence checking (https://onlinegdb.com/lx6zQXza5):
```diff
-if ! echo ${!atml2run[@]} | grep $ATML &>/dev/null; then
+if ! [ -v "atml2run[$ATML]" ]; then
```

Other changes I believe shouldn't affect code semantics.