### PR TITLE
templates: x86/test/net mods.conf-vfork depr mods

### DIFF
--- a/templates/x86/test/net/mods.conf
+++ b/templates/x86/test/net/mods.conf
@@ -124,8 +124,6 @@ configuration conf {
 	@Runlevel(2) include embox.framework.LibFramework
 	@Runlevel(2) include embox.compat.libc.all
 	include embox.compat.libc.math_openlibm
-	include embox.compat.posix.proc.exec_stop_parent
-	include embox.compat.posix.proc.vfork_stop_parent
 
 
 	include embox.net.lib.dns_fixed(nameserver="8.8.8.8")


### PR DESCRIPTION
Clean out x86/test/net template of old modules hindering vfork functioning. Because of them Dropbear in multi-process mode didn't function properly