### PR TITLE
test: pipe() close should notify read-end

### DIFF
--- a/src/compat/posix/idx/tests/Mybuild
+++ b/src/compat/posix/idx/tests/Mybuild
@@ -1,0 +1,5 @@
+package embox.compat.posix.idx.tests
+
+module pipe_close_notify_test {
+	source "pipe_close_notify_test.c"
+}

--- a/src/compat/posix/idx/tests/pipe_close_notify_test.c
+++ b/src/compat/posix/idx/tests/pipe_close_notify_test.c
@@ -1,0 +1,57 @@
+
+/**
+ * @file
+ *
+ * @date July 31, 2023
+ * @author 
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/select.h>
+#include <unistd.h>
+
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("Pipe's close() notification test");
+
+TEST_CASE("When pipe's writing end is closed, reading end should get notified") {
+    int childpipe[2];
+    fd_set readfs;
+    char *buff;
+    int res;
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 500;
+
+    FD_ZERO(&readfs);
+    buff = malloc(5*sizeof(char));
+    memset(buff, 0, 5*sizeof(char));
+
+    res = pipe(childpipe);
+    if(res!=0)
+        test_fail("Couldn't create pipe");
+
+    FD_SET(childpipe[0], &readfs);
+    write(childpipe[1], "test", 4);
+
+    res = select(10, &readfs, NULL, NULL, &timeout);
+    if(res<=0)
+        test_fail("Error or timeout waiting for test string from pipe");
+    res = read(childpipe[0], buff, 4);
+    if(res<=0)
+        test_fail("Didn't get test string");
+        
+    close(childpipe[1]);
+
+    res = select(10, &readfs, NULL, NULL, &timeout);
+    if(res<0)
+        test_fail("Error in select() after pipe write end close()");
+    if(res==0)
+        test_fail("Select() timeout waiting for close() event notification");
+
+    close(childpipe[0]);
+    free(buff);
+}


### PR DESCRIPTION
Although POSIX doesn't seem to pose it directly, we find that third-party programs might be relying on it. As it happens in case of dropbear. Linux man page on select() do mention, that on end-of-file readfs descriptors in select() should be ready to read. So it might be a good idea to stick to it.
This test should pass in case select()'s readfs descriptors are notified on close() event