### PR TITLE
test: pipe close() test more correct interpretation

### DIFF
--- a/src/compat/posix/idx/tests/pipe_close_notify_test.c
+++ b/src/compat/posix/idx/tests/pipe_close_notify_test.c
@@ -19,14 +19,14 @@ EMBOX_TEST_SUITE("Pipe's close() notification test");
 
 TEST_CASE("When pipe's writing end is closed, reading end should get notified") {
     int childpipe[2];
-    fd_set readfs;
+    fd_set readfds;
     char *buff;
     int res;
     struct timeval timeout;
     timeout.tv_sec = 0;
     timeout.tv_usec = 500;
 
-    FD_ZERO(&readfs);
+    FD_ZERO(&readfds);
     buff = malloc(5*sizeof(char));
     memset(buff, 0, 5*sizeof(char));
 
@@ -34,10 +34,10 @@ TEST_CASE("When pipe's writing end is closed, reading end should get notified") 
     if(res!=0)
         test_fail("Couldn't create pipe");
 
-    FD_SET(childpipe[0], &readfs);
+    FD_SET(childpipe[0], &readfds);
     write(childpipe[1], "test", 4);
 
-    res = select(10, &readfs, NULL, NULL, &timeout);
+    res = select(10, &readfds, NULL, NULL, &timeout);
     if(res<=0)
         test_fail("Error or timeout waiting for test string from pipe");
     res = read(childpipe[0], buff, 4);
@@ -46,11 +46,14 @@ TEST_CASE("When pipe's writing end is closed, reading end should get notified") 
         
     close(childpipe[1]);
 
-    res = select(10, &readfs, NULL, NULL, &timeout);
+    res = select(10, &readfds, NULL, NULL, &timeout);
     if(res<0)
         test_fail("Error in select() after pipe write end close()");
     if(res==0)
         test_fail("Select() timeout waiting for close() event notification");
+    if(res>0)
+        if(!FD_ISSET(childpipe[0],&readfds))
+            test_fail("After select file descriptor isn't in readfds");
 
     close(childpipe[0]);
     free(buff);


### PR DESCRIPTION
More correct result interpretation and a minor naming typo correction