### PR TITLE
Fix disk/* shell scripts according to ShellCheck

### DIFF
--- a/scripts/disk/img2vdi.sh
+++ b/scripts/disk/img2vdi.sh
@@ -2,8 +2,8 @@
 #
 
 if [ $# -ne 1 ]; then
-	echo "Usage: `basename $0` path/to/file.img"
-	exit $E_BADARGS
+	echo "Usage: $(basename "$0") path/to/file.img"
+	exit "$E_BADARGS"
 fi
 
 IMG_DIR=$(dirname "$1")
@@ -13,7 +13,7 @@ VDI_DIR=$IMG_DIR
 VDI_NAME=${IMG_NAME%.*}.vdi
 VDI_UUID="d713cd0d-0dfc-415c-931e-61ab199d4817"
 
-rm -rf $VDI_DIR/$VDI_NAME
-VBoxManage convertfromraw --format VDI $IMG_DIR/$IMG_NAME $VDI_DIR/$VDI_NAME
-VBoxManage internalcommands sethduuid $VDI_DIR/$VDI_NAME $VDI_UUID
-chmod 777 $VDI_DIR/$VDI_NAME
+rm -rf "${VDI_DIR:?}"/"${VDI_NAME:?}"
+VBoxManage convertfromraw --format VDI "$IMG_DIR"/"$IMG_NAME" "$VDI_DIR"/"$VDI_NAME"
+VBoxManage internalcommands sethduuid "$VDI_DIR"/"$VDI_NAME" $VDI_UUID
+chmod 777 "$VDI_DIR"/"$VDI_NAME"

--- a/scripts/disk/make_img.sh
+++ b/scripts/disk/make_img.sh
@@ -2,7 +2,7 @@
 # Gotta have a grub 0.97-like installed on your system
 #
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || { echo "Failed to cd to $(dirname "$0")"; exit 1; }
 
 KERNEL_NAME="embox"
 BIN_DIR="../../build/base/bin"


### PR DESCRIPTION
Hi @anton-bondarev!

As the name of PR states it changes files in `scripts/disk` folder. The file `partitions.sh` has the majority of changes while others mostly have two or three lines changed. Below I will comment on some parts from `partitions.sh`

### default values
```diff
-PARTS=$2 
-FS=$3
-SIZE=$4
+PARTS=${2:-4}
+FS=${3:-fat}
+SIZE=${4:-128}
 
-[ "$PARTS" == "" ] && PARTS=4
-[ "$FS" == "" ] && FS="fat"
-[ "$SIZE" == "" ] && SIZE=128
```
I've replaced explicit check-and-assignment of default values with parameter expansion feature
>${parameter:-word}
>
>    If parameter is unset or null, the expansion of word is substituted. Otherwise, the value of parameter is substituted. 
>(https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)

### input values validity checks
Simplified bounds-check:
```diff
-if [[ ! $PARTS = 1 && ! $PARTS = 2 && ! $PARTS = 3 && ! $PARTS = 4 ]]; then
+# Check that the number of partitions is correct
+if [[ $PARTS -lt 1 ]] || [[ $PARTS -gt 4 ]]; then
```

Here the existence of command was checked by finding command's path using `which`. If `which` output wasn't empty, then command was considered existing. I've rewritten it using Bash builtin `command`: with `-v` switch it exits with 0 if command has been found, with 1 otherwise. `MKFS_PATH` was not used anywhere else in the script.
```diff
-MKFS_PATH=`sudo which mkfs.$FS 2> /dev/null`
-[ "$MKFS_PATH" == "" ] && echo "Command mkfs.$FS not found" && exit
+# Check that $FS refers to known filesystem
+if ! command -v "mkfs.$FS" >/dev/null; then
+    echo "Command mkfs.$FS not found"
+    exit 1
+fi
```

### the loop
This loop creates partitions in image file. It had quite complicated expression for partition boundaries, which I attempted to simplify.
```diff
+PARTITION_SIZE=$(( SIZE / PARTS ))
+OFFSET=0
 for i in $(seq 1 $PARTS)
 do
-       sudo parted $IMG -s mkpart primary fat32 \
-               $(( $i * $SIZE / ($PARTS + 1) )) $(( (1 + $i) * $SIZE / ($PARTS + 1) ))
+       # 'mkpart' subcommand  usage (from 'man parted'):
+       #     mkpart [part-type name fs-type] start end
+
+       sudo parted "$IMG" -s mkpart primary fat32 $OFFSET $(( OFFSET + PARTITION_SIZE ))
+       OFFSET=$(( OFFSET + PARTITION_SIZE ))
 done
```

Also I believe that original expression for partition boundaries had a bug. Here is what partitions created by original loop look like (with default values for partition number and file size):
```
Number  Start   End     Size    Type     File system  Flags
 1      25,2MB  51,4MB  26,2MB  primary               lba
 2      51,4MB  76,0MB  24,6MB  primary               lba
 3      76,0MB  102MB   26,0MB  primary               lba
 4      102MB   128MB   26,0MB  primary               lba
```
As you can see, they didn't start near the beginning of a file. It looks very much like a bug to me. With new expression partitions look like this:
```
Number  Start   End     Size    Type     File system  Flags
 1      512B    32,0MB  32,0MB  primary               lba
 2      32,0MB  64,0MB  32,0MB  primary               lba
 3      64,0MB  96,0MB  32,0MB  primary               lba
 4      96,5MB  128MB   31,5MB  primary               lba
```

The only place `partitions.sh` is used is here:
```
embox/scripts$ grep -r -F 'partitions.sh' .
./autotest/run_scripts/run_qemu_mmc.sh:./scripts/disk/partitions.sh "$IMG"
```