### PR TITLE
Refactor autotest/run.sh

### DIFF
--- a/scripts/autotest/run.sh
+++ b/scripts/autotest/run.sh
@@ -1,49 +1,115 @@
 #!/bin/bash
 
+# - BASH_SOURCE is an array variable whose members are source filenames.
+# - '%/*' — is a parameter expansion feature which uses everything after
+#   %-sign as a pattern and removes the shortest match to this pattern
+#   from the parameter.
+# This magic spell gives a path to a dir where current source file
+# is located.
 BASEDIR=$(realpath ${BASH_SOURCE%/*})
 TESTSUITE_DIR=$BASEDIR/testsuite
-TESTSUITE_LIST=$(ls $TESTSUITE_DIR)
 
-TESTCASE_DIR=
-TESTCASE_LIST=
 
+print_usage() {
+	echo "Usage: $0 <testsuite> <test case 1> <test case 2> …"
+	echo "  You can 'export TEST_PRINT_ALL=1' to make tests echo to console"
+
+}
+
+
+# Prints available testsuites
+# Usage:
+#    show_available_testsuites
+#
+# This function depends on a variable $TESTSUITE_DIR which is defined
+# in global scope.
 show_available_testsuites() {
 	echo "Available testsuites:"
-	echo $TESTSUITE_LIST
+	ls "$TESTSUITE_DIR"
 }
 
+
+# Prints testcases of the testsuite passed to function
+#
+# Usage:
+#    show_available_testcases <testsuite name>, e.g.:
+#      show_available_testcases block_dev
+#      show_available_testcases fs-ramfs
+#      show_available_testcases "$TESTSUITE_NAME"
+#      ...
+#
+# This function depends on a variable $TESTSUITE_DIR which is defined
+# in global scope.
 show_available_testcases() {
-	echo "Availables testcase for testsuite $TESTSUITE:"
-	echo $TESTCASE_LIST
+	local TESTSUITE=$1
+	echo "Availables testcase for testsuite '$TESTSUITE':"
+
+	# Print testcase names on one line separated with spaces.
+	# '-n' omits trailing newline
+	for testcase in "$TESTSUITE_DIR/$TESTSUITE"/*/; do
+	    echo -n "$(basename "$testcase") "
+	done
+	echo
 }
+
 
 if [ "$1" = "-h" ]; then
-	echo "Usage: $0 <testsuite> <test cases>"
-	echo "  You can 'export TEST_PRINT_ALL=1' to make tests echo to console"
+	print_usage
 	exit 1
 fi
 
-TESTSUITE=$1
 
-if [ -z $TESTSUITE ]; then
+# Check what caller has passed as a test suite name
+TESTSUITE=$1
+if [ -z "$TESTSUITE" ]; then
+	echo 'You have to select a test suite!'
+	echo
+	show_available_testsuites
+	echo
+	print_usage
+	exit 1
+fi
+
+if [ ! -d "$TESTSUITE_DIR/$TESTSUITE" ]; then
+	echo "'$TESTSUITE' is not a valid test suite name!"
+	echo
 	show_available_testsuites
 	exit 1
 fi
 
-TESTCASE_DIR=$BASEDIR/testsuite/$TESTSUITE
-TESTCASE_LIST=$(for i in $(ls -d $TESTCASE_DIR/*/); do basename $i; done)
 
+# At this point we've successfully checked that the first argument to this script
+# was a valid testsuite name. We've saved it in $TESTSUITE variable.
+#
+# Rest of the args are considered to be testcase names. We want to store them in an array.
+# To do this:
+# 1. Shift arguments to the left by one to strip the first argument
+# 2. Assign values of $@ array to a new array
 shift
-TESTCASES=$@
+TESTCASES=( "$@" )
 
-if [ -z "$TESTCASES" ]; then
-	show_available_testcases
+
+# Check if a caller has supplied at least one testcase name
+if [[ "${#TESTCASES[@]}" -eq 0 ]]; then
+	echo "You have to select at least one testcase!"
+	echo
+	show_available_testcases "$TESTSUITE"
+	echo
+	print_usage
 	exit 1
 fi
 
-for testcase in $TESTCASES; do
-	if [ -z "$(echo $TESTCASE_LIST | fgrep -w $testcase)" ]; then
+# Check if every value in TESTCASES array is a valid testcase name.
+#
+# Test definitions are organazed on disk in hierarchy of directories:
+#   ./testsuite/<testsuite name>/<testcase name>/
+#
+# If such a path exists, then testsuite and testcase names are correct.
+for testcase in "${TESTCASES[@]}"; do
+	if [ ! -d "$TESTSUITE_DIR/$TESTSUITE/$testcase" ]; then
 		echo "Test '$testcase' is not part of testsuite '$TESTSUITE'"
+		echo
+		show_available_testcases "$TESTSUITE"
 		exit 1
 	fi
 done
@@ -64,7 +130,7 @@ if [ -z "$TEST_CURRENT_CONFIG" ]; then
 	exit 1
 fi
 
-printf "\nCurrent configuration: \"$TEST_CURRENT_CONFIG\"\n"
+printf '\nCurrent configuration: "%s"\n' "$TEST_CURRENT_CONFIG"
 
 if [ -z "$TEST_PRINT_ALL" ]; then
 	TEST_PRINT_ALL=1
@@ -72,19 +138,19 @@ fi
 
 echo "Starting testsuite $TESTSUITE ..."
 
-rm -f $TESTSUITE.log
+rm -f "$TESTSUITE.log"
 
 testsuite_res=0
 summary=
-for testcase in $TESTCASES; do
+for testcase in "${TESTCASES[@]}"; do
 	echo "  Starting test $TESTSUITE/$testcase ..."
 
-	if [ ${TEST_PRINT_ALL} -eq 0 ]; then
-		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
-			$EMBOX_IP $HOST_IP $EMBOX_PROMPT > ${TESTSUITE}_$testcase.log
+	if [ "$TEST_PRINT_ALL" -eq 0 ]; then
+		expect "$BASEDIR/framework/core.exp" "$BASEDIR/testsuite/$TESTSUITE" "$testcase" \
+			$EMBOX_IP $HOST_IP "$EMBOX_PROMPT" > "${TESTSUITE}_$testcase.log"
 	else
-		expect $BASEDIR/framework/core.exp $BASEDIR/testsuite/$TESTSUITE $testcase \
-			$EMBOX_IP $HOST_IP $EMBOX_PROMPT
+		expect "$BASEDIR/framework/core.exp" "$BASEDIR/testsuite/$TESTSUITE" "$testcase" \
+			$EMBOX_IP $HOST_IP "$EMBOX_PROMPT"
 	fi
 	rc=$?
 


### PR DESCRIPTION
Hi @anton-bondarev! This PR continues the series of PRs related to #2835. It introduces a lot of changes in a single file:

1. Adds comments here and there
2. Rewrites listing of testsuites and testcases. Original approach used global variables to initialize and store lists of testsuite and testcase names which in turn were printed out by special functions. Thus these functions depended heavily on global state. I've tried to reduce this dependence and moved all listing logic into the body of this functions. So this
```diff
-TESTSUITE_LIST=$(ls $TESTSUITE_DIR)
```
has moved here
```diff
 show_available_testsuites() {
        echo "Available testsuites:"
-       echo $TESTSUITE_LIST
+       ls "$TESTSUITE_DIR"
 }
```
And this
```diff
-TESTCASE_DIR=
-TESTCASE_LIST=
…
-TESTCASE_DIR=$BASEDIR/testsuite/$TESTSUITE
-TESTCASE_LIST=$(for i in $(ls -d $TESTCASE_DIR/*/); do basename $i; done)
```
has moved there
```diff
 show_available_testcases() {
-       echo "Availables testcase for testsuite $TESTSUITE:"
-       echo $TESTCASE_LIST
+       local TESTSUITE=$1
+       echo "Availables testcase for testsuite '$TESTSUITE':"
+
+       # Print testcase names on one line separated with spaces.
+       # '-n' omits trailing newline
+       for testcase in "$TESTSUITE_DIR/$TESTSUITE"/*/; do
+           echo -n "$(basename "$testcase") "
+       done
+       echo
 }
```
3. Testcase names now stored as an array instead of a string
```diff
-TESTCASES=$@
+TESTCASES=( "$@" )
```
And its usage is now explicitly states that it is a group of values. No implicit conversions like "split string on spaces" etc.
```diff
-if [ -z "$TESTCASES" ]; then
+if [[ "${#TESTCASES[@]}" -eq 0 ]]; then
…
-for testcase in $TESTCASES; do
+for testcase in "${TESTCASES[@]}"; do
```
4. Other changes are mostly quoting.

I've performed a simple regression test to make sure I haven't broken something: I ran every available testsuite with original script and then with refactored one. Test runs had the same outcome: the test which failed with original version failed with refactored too, which passed with original version passed with refactored too (Embox used in the test runs was started as `./scripts/qemu/qemu_with_disk.sh`)