### PR TITLE
Fix ld_map_info & usermode_start according to ShellCheck

### DIFF
--- a/scripts/ld_map_info.sh
+++ b/scripts/ld_map_info.sh
@@ -11,7 +11,7 @@ print_help() {
 MAP=$1
 PATTERN=$2
 
-if [ -z $MAP ] || [ -z $PATTERN ]; then
+if [ -z "$MAP" ] || [ -z "$PATTERN" ]; then
 	print_help
 	exit 1
 fi
@@ -24,9 +24,41 @@ fi
 
 export PATTERN_VAR="$PATTERN"
 
-cat $MAP | \
-	$AWK '($0 ~ ENVIRON["PATTERN_VAR"] || prev ~ ENVIRON["PATTERN_VAR"]) && /\.o/ \
-	     { printf "%-20x%-20d%s\n", $(NF-1), $(NF-1), $NF }; { prev=$0 }' | sort -n -k2 | \
-	$AWK 'BEGIN { printf "%-20s%-20s%s\n", "Size (hex)", "Size (dec)", "File" }
-	     { s += $2; print }
-	     END { printf "Total: %x (hex) / %d (dec)\n", s, s }'
+# Short reference on awk to ease understanding the scripts below:
+# - awk is controlled by instructions of the form 'pattern { action }'
+# - pattern defines when action is performed
+# - pattern or action may be omitted, but not both
+# - pattern value may be BEGIN, END or <expression>
+# - omitted pattern means 'match all'
+# - omitted action  means '{ print }'
+# - awk splits input lines and stores resulting parts in variables $1, $2, $3, …
+#   $0 holds current input line
+
+
+# $0               current input line
+# ~                regular expression matching
+# ENVIRON["NAME"]  access to environment variables
+# /r/              checks if current input line matches regular expression 'r'
+# NF               number of fields obtained after splitting the input line
+#
+# This script basically does the following: "if current or previous line matches pattern,
+# and also current line matches another pattern, then use some fields of this line
+# to fill a template and print the result. Always store current line in 'prev' variable."
+SELECT_MATCHING_AWK_SCRIPT='
+	($0 ~ ENVIRON["PATTERN_VAR"] || prev ~ ENVIRON["PATTERN_VAR"]) && /\.o/ { printf "%-20x%-20d%s\n", $(NF-1), $(NF-1), $NF };
+	{ prev=$0 }
+'
+
+# BEGIN  matches begining of input
+# END    matches end of input
+#
+# This script prints a line at first, then while consuming input lines it caculates
+# some running sum, and at the end it prints another line using calculated sum as
+# part of it.
+HEADER_FOOTER_AWK_SCRIPT='
+	BEGIN { printf "%-20s%-20s%s\n", "Size (hex)", "Size (dec)", "File" }
+	{ s += $2; print }
+	END { printf "Total: %x (hex) / %d (dec)\n", s, s }
+'
+
+$AWK "$SELECT_MATCHING_AWK_SCRIPT" "$MAP" | sort -n -k2 | $AWK "$HEADER_FOOTER_AWK_SCRIPT"

--- a/scripts/usermode_start.sh
+++ b/scripts/usermode_start.sh
@@ -1,30 +1,30 @@
 #!/bin/sh
 
 SUDO=sudo
-ROOT=$(dirname $0)/../.
+ROOT=$(dirname "$0")/../.
 
 EMBOX=${ROOT}/build/base/bin/embox
 
 [ -z "$TAP" ] && TAP=tap77
 
 rm_tap() {
-	$SUDO ip tuntap del dev $TAP mode tap
+	$SUDO ip tuntap del dev "$TAP" mode tap
 }
 
 trap rm_tap INT TERM
 
-if [ ! -z "$(ip addr | grep $TAP)" ]; then
+if ip addr | grep -q "$TAP"; then
 	rm_tap
 fi
 
-$SUDO ip tuntap add dev $TAP mode tap
-$SUDO $ROOT/scripts/qemu/start_script $TAP
-export EMBOX_USERMODE_TAP_NAME=$TAP
+$SUDO ip tuntap add dev "$TAP" mode tap
+$SUDO "$ROOT/scripts/qemu/start_script" "$TAP"
+export EMBOX_USERMODE_TAP_NAME="$TAP"
 
-if [ $USERMODE_START_OUTPUT ]; then
-	$EMBOX $TAP >$USERMODE_START_OUTPUT 2>$USERMODE_START_OUTPUT
+if [ "$USERMODE_START_OUTPUT" ]; then
+	$EMBOX "$TAP" >"$USERMODE_START_OUTPUT" 2>"$USERMODE_START_OUTPUT"
 else
-	$EMBOX $TAP
+	$EMBOX "$TAP"
 fi
 
 rm_tap


### PR DESCRIPTION
Hi @anton-bondarev! Yet another PR in the series. 

Changes are not very complicated:
1. Wrapping in double quotes here and there
2. Simpler condition in `usermode_start.sh`:
```diff
-if [ ! -z "$(ip addr | grep $TAP)" ]; then
+if ip addr | grep -q "$TAP"; then
```
This is direct check if `ip addr` contains `$TAP` — `grep -q` terminates on first match with zero exit-code.

3. Extensive comments on embedded AWK scripts in `ld_map_info.sh`. 