### PR TITLE
Fix shell scripts in scripts/docker according to ShellCheck

### DIFF
--- a/scripts/docker/container/bin/gdbwrapper2
+++ b/scripts/docker/container/bin/gdbwrapper2
@@ -1,18 +1,17 @@
 #!/bin/sh
 
-. $(dirname $0)/../gdbwrapper_lib.sh
+. "$(dirname "$0")/../gdbwrapper_lib.sh"
 
 # make alias from host path to container path. After this no
 # path substitution will be reqired (like gdb substitute-path)
-if [ $PROJECT_LOC ]; then
-	sudo mkdir -p $PROJECT_LOC
-	mount | grep -q $PROJECT_LOC
-	if [ $? != 0 ]; then
-		sudo mount --bind $EMBOX_DIR $PROJECT_LOC
+if [ "$PROJECT_LOC" ]; then
+	sudo mkdir -p "$PROJECT_LOC"
+	if ! mount | grep -q "$PROJECT_LOC"; then
+		sudo mount --bind "$EMBOX_DIR" "$PROJECT_LOC"
 	fi
 fi
 
-echo $$ > $GDBPID
+echo $$ > "$GDBPID"
 
 # TODO add gdb cross-compile prefix detection
 exec gdb "$@"

--- a/scripts/docker/container/bin/killgdbwrapper
+++ b/scripts/docker/container/bin/killgdbwrapper
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-. $(dirname $0)/../gdbwrapper_lib.sh
+. "$(dirname "$0")/../gdbwrapper_lib.sh"
 
 SIG=$1
 
-[ -f $GDBPID ] && PID=$(cat $GDBPID)
+[ -f "$GDBPID" ] && PID=$(cat "$GDBPID")
 
-[ $PID ] && kill -s $SIG $PID
+[ "$PID" ] && kill -s "$SIG" "$PID"

--- a/scripts/docker/docker_start.sh
+++ b/scripts/docker/docker_start.sh
@@ -20,11 +20,11 @@ expose_ports_args() {
 
 docker run -d --privileged \
 	--name emdocker \
-	-v $PWD:/embox \
+	-v "$PWD":/embox \
 	$(expose_ports_args $(localport $EMBOX_PORTS)) \
-	${dockerimage:-embox/emdocker}
+	"${dockerimage:-embox/emdocker}"
 
-. $(dirname $0)/docker_rc.sh
+. "$(dirname "$0")/docker_rc.sh"
 
 # wait till docker started, otherwise getting "No 'user' user found"
 waittries=${DOCKER_START_WAIT_TIME_SEC:-10}
@@ -38,7 +38,7 @@ while [ 0 -lt $waittries ]; do
 	waittries=$(($waittries - 1))
 done
 
-if [ x0 = x$started ]; then
+if [ 0 = $started ]; then
 	echo "Container is not stated for some time, trying one more time in verbose mode" >&2
 	echo "If it fail, try to change timeout specifying DOCKER_START_WAIT_TIME_SEC env, like" >&2
 	echo "" >&2
@@ -46,7 +46,7 @@ if [ x0 = x$started ]; then
 	dr true && started=1
 fi
 
-if [ x0 = x$started ]; then
+if [ 0 = $started ]; then
 	echo "Can't start container" >&2
 	exit 1
 fi

--- a/scripts/docker/gdbhostwrapper
+++ b/scripts/docker/gdbhostwrapper
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 function myreadlink() {
-	(cd "$1" && echo "$(pwd -P)")
+	(cd "$1" && pwd -P)
 }
 
-dr=$(dirname $0)/docker_run.sh
-EMBOX_LOC=$(myreadlink $(dirname $0)/../../)
+dr=$(dirname "$0")/docker_run.sh
+EMBOX_LOC=$(myreadlink "$(dirname "$0")/../../")
 
 on_sig() {
 	intr=1
@@ -16,7 +16,7 @@ for i in 1 2 3 9 14 15; do
 	trap "on_sig $i;" $i
 done
 
-$dr PROJECT_LOC=$EMBOX_LOC gdbwrapper2 <&0 "$@" &
+$dr PROJECT_LOC="$EMBOX_LOC" gdbwrapper2 <&0 "$@" &
 
 PID=$!
 


### PR DESCRIPTION
Hi @anton-bondarev!

As usual, most of the changes is wrapping variables containing paths in double quotes and also

1. Checking the exit-code of a command directly
```diff
-       mount | grep -q $PROJECT_LOC
-       if [ $? != 0 ]; then
+       if ! mount | grep -q "$PROJECT_LOC"; then
```

2. Removing obsolete trick (https://www.shellcheck.net/wiki/SC2268)
```diff
-if [ x0 = x$started ]; then
+if [ 0 = $started ]; then
```

3. Removing useless command substitution. There is no need to catch `pwd`'s output and pass it as argument to `echo`. We can use `pwd`'s output as is.
```diff
-       (cd "$1" && echo "$(pwd -P)")
+       (cd "$1" && pwd -P)
```