### PR TITLE
third-party: dropbear: original auth notif. method

### DIFF
--- a/third-party/dropbear/Makefile
+++ b/third-party/dropbear/Makefile
@@ -8,7 +8,7 @@ PKG_SOURCES := https://matt.ucc.asn.au/dropbear/releases/$(PKG_NAME)-$(PKG_VER).
 #PKG_MD5     := c3912f7fcdcc57c99937e4a79480d2c2
 PKG_MD5 := a75a34bcc03cacf71a2db9da3b7c94a5
 
-PKG_PATCHES := dropbear-mpr-pipestub.patch
+PKG_PATCHES := dropbear-mpr.patch
 
 include $(EXTBLD_LIB)
 

--- a/third-party/dropbear/dropbear-mpr.patch
+++ b/third-party/dropbear/dropbear-mpr.patch
@@ -1,6 +1,6 @@
 diff -aur dropbear-2022.83/Makefile.in ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/Makefile.in
 --- dropbear-2022.83/Makefile.in	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/Makefile.in	2023-07-29 18:17:50.993982300 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/Makefile.in	2023-08-09 16:05:01.036016295 +0600
 @@ -9,9 +9,12 @@
  # dbclient functionality, and includes the progress-bar functionality in scp.
  
@@ -35,7 +35,7 @@ diff -aur dropbear-2022.83/Makefile.in ../build/extbld/third_party/dropbear/drop
  	CPPFLAGS+= -DDROPBEAR_CLIENT
 diff -aur dropbear-2022.83/cli-agentfwd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-agentfwd.c
 --- dropbear-2022.83/cli-agentfwd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-agentfwd.c	2023-07-29 18:05:37.242172470 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-agentfwd.c	2023-08-09 16:05:01.036016295 +0600
 @@ -89,7 +89,7 @@
  
  	setnonblocking(fd);
@@ -56,7 +56,7 @@ diff -aur dropbear-2022.83/cli-agentfwd.c ../build/extbld/third_party/dropbear/d
  
 diff -aur dropbear-2022.83/cli-auth.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-auth.c
 --- dropbear-2022.83/cli-auth.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-auth.c	2023-07-29 18:05:37.242172470 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-auth.c	2023-08-09 16:05:01.036016295 +0600
 @@ -36,12 +36,12 @@
  void cli_auth_getmethods() {
  	TRACE(("enter cli_auth_getmethods"))
@@ -208,7 +208,7 @@ diff -aur dropbear-2022.83/cli-auth.c ../build/extbld/third_party/dropbear/dropb
  			cli_auth_password();
 diff -aur dropbear-2022.83/cli-authinteract.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authinteract.c
 --- dropbear-2022.83/cli-authinteract.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authinteract.c	2023-07-29 18:05:37.242172470 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authinteract.c	2023-08-09 16:05:01.036016295 +0600
 @@ -84,13 +84,13 @@
  	}
  	cli_ses.interact_request_received = 1;
@@ -294,7 +294,7 @@ diff -aur dropbear-2022.83/cli-authinteract.c ../build/extbld/third_party/dropbe
  	cli_ses.interact_request_received = 0;
 diff -aur dropbear-2022.83/cli-authpasswd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authpasswd.c
 --- dropbear-2022.83/cli-authpasswd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authpasswd.c	2023-07-29 18:05:37.242172470 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authpasswd.c	2023-08-09 16:05:01.036016295 +0600
 @@ -138,20 +138,20 @@
  		password = getpass_or_cancel(prompt);
  	}
@@ -324,7 +324,7 @@ diff -aur dropbear-2022.83/cli-authpasswd.c ../build/extbld/third_party/dropbear
  	m_burn(password, strlen(password));
 diff -aur dropbear-2022.83/cli-authpubkey.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authpubkey.c
 --- dropbear-2022.83/cli-authpubkey.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authpubkey.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-authpubkey.c	2023-08-09 16:05:01.036016295 +0600
 @@ -64,7 +64,7 @@
  
  	TRACE(("enter recv_msg_userauth_pk_ok"))
@@ -397,7 +397,7 @@ diff -aur dropbear-2022.83/cli-authpubkey.c ../build/extbld/third_party/dropbear
  	}
 diff -aur dropbear-2022.83/cli-channel.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-channel.c
 --- dropbear-2022.83/cli-channel.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-channel.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-channel.c	2023-08-09 16:05:01.036016295 +0600
 @@ -45,7 +45,7 @@
  		return; /* we just ignore it */
  	}
@@ -409,7 +409,7 @@ diff -aur dropbear-2022.83/cli-channel.c ../build/extbld/third_party/dropbear/dr
  		TRACE(("leave recv_msg_channel_extended_data: wrong datatype: %d",
 diff -aur dropbear-2022.83/cli-chansession.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-chansession.c
 --- dropbear-2022.83/cli-chansession.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-chansession.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-chansession.c	2023-08-09 16:05:01.036016295 +0600
 @@ -61,11 +61,11 @@
  
  	TRACE(("enter cli_chansessreq"))
@@ -572,7 +572,7 @@ diff -aur dropbear-2022.83/cli-chansession.c ../build/extbld/third_party/dropbea
  	TRACE(("leave cli_send_netcat_request"))
 diff -aur dropbear-2022.83/cli-kex.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-kex.c
 --- dropbear-2022.83/cli-kex.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-kex.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-kex.c	2023-08-09 16:05:01.036016295 +0600
 @@ -53,47 +53,47 @@
  	}
  #endif
@@ -750,7 +750,7 @@ diff -aur dropbear-2022.83/cli-kex.c ../build/extbld/third_party/dropbear/dropbe
  	}
 diff -aur dropbear-2022.83/cli-main.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-main.c
 --- dropbear-2022.83/cli-main.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-main.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-main.c	2023-08-09 16:05:01.040016228 +0600
 @@ -60,7 +60,7 @@
  	cli_getopts(argc, argv);
  
@@ -771,7 +771,7 @@ diff -aur dropbear-2022.83/cli-main.c ../build/extbld/third_party/dropbear/dropb
  
 diff -aur dropbear-2022.83/cli-runopts.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-runopts.c
 --- dropbear-2022.83/cli-runopts.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-runopts.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-runopts.c	2023-08-09 16:05:01.040016228 +0600
 @@ -158,7 +158,7 @@
  	cli_opts.disable_trivial_auth = 0;
  #if DROPBEAR_CLI_LOCALTCPFWD
@@ -893,7 +893,7 @@ diff -aur dropbear-2022.83/cli-runopts.c ../build/extbld/third_party/dropbear/dr
  #endif
 diff -aur dropbear-2022.83/cli-session.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-session.c
 --- dropbear-2022.83/cli-session.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-session.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-session.c	2023-08-09 16:05:01.040016228 +0600
 @@ -103,7 +103,7 @@
  	}
  	myses->sock_in = myses->sock_out = sock;
@@ -1065,7 +1065,7 @@ diff -aur dropbear-2022.83/cli-session.c ../build/extbld/third_party/dropbear/dr
  #endif
 diff -aur dropbear-2022.83/cli-tcpfwd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-tcpfwd.c
 --- dropbear-2022.83/cli-tcpfwd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-tcpfwd.c	2023-07-29 18:05:37.246172404 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/cli-tcpfwd.c	2023-08-09 16:05:01.040016228 +0600
 @@ -124,7 +124,7 @@
  	}
  	else
@@ -1123,7 +1123,7 @@ diff -aur dropbear-2022.83/cli-tcpfwd.c ../build/extbld/third_party/dropbear/dro
  	in case they want to forward different ports separately ... */
 diff -aur dropbear-2022.83/common-channel.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-channel.c
 --- dropbear-2022.83/common-channel.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-channel.c	2023-07-29 18:05:37.250172338 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-channel.c	2023-08-09 16:05:01.040016228 +0600
 @@ -70,12 +70,12 @@
  void chaninitialise(const struct ChanType *chantypes[]) {
  
@@ -1643,7 +1643,7 @@ diff -aur dropbear-2022.83/common-channel.c ../build/extbld/third_party/dropbear
  }
 diff -aur dropbear-2022.83/common-kex.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-kex.c
 --- dropbear-2022.83/common-kex.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-kex.c	2023-07-29 18:05:37.250172338 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-kex.c	2023-08-09 16:05:01.044016161 +0600
 @@ -55,65 +55,65 @@
  void send_msg_kexinit() {
  
@@ -2587,7 +2587,7 @@ diff -aur dropbear-2022.83/common-kex.c ../build/extbld/third_party/dropbear/dro
  
 diff -aur dropbear-2022.83/common-runopts.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-runopts.c
 --- dropbear-2022.83/common-runopts.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-runopts.c	2023-07-29 18:05:37.250172338 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-runopts.c	2023-08-09 16:05:01.044016161 +0600
 @@ -31,7 +31,7 @@
  #include "algo.h"
  #include "dbrandom.h"
@@ -2649,7 +2649,7 @@ diff -aur dropbear-2022.83/common-runopts.c ../build/extbld/third_party/dropbear
  }
 diff -aur dropbear-2022.83/common-session.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-session.c
 --- dropbear-2022.83/common-session.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-session.c	2023-07-29 18:05:37.250172338 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/common-session.c	2023-08-09 16:05:01.044016161 +0600
 @@ -22,6 +22,7 @@
   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   * SOFTWARE. */
@@ -3280,7 +3280,7 @@ diff -aur dropbear-2022.83/common-session.c ../build/extbld/third_party/dropbear
  
 diff -aur dropbear-2022.83/debug.h ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/debug.h
 --- dropbear-2022.83/debug.h	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/debug.h	2023-07-29 18:05:37.250172338 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/debug.h	2023-08-09 16:05:01.044016161 +0600
 @@ -36,8 +36,8 @@
  /* All functions writing to the cleartext payload buffer call
   * CHECKCLEARTOWRITE() before writing. This is only really useful if you're
@@ -3294,7 +3294,7 @@ diff -aur dropbear-2022.83/debug.h ../build/extbld/third_party/dropbear/dropbear
  #define CHECKCLEARTOWRITE()
 diff -aur dropbear-2022.83/fuzz/fuzz-common.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzz-common.c
 --- dropbear-2022.83/fuzz/fuzz-common.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzz-common.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzz-common.c	2023-08-09 16:05:01.044016161 +0600
 @@ -104,7 +104,7 @@
  
  void fuzz_svr_hook_preloop() {
@@ -3382,7 +3382,7 @@ diff -aur dropbear-2022.83/fuzz/fuzz-common.c ../build/extbld/third_party/dropbe
      genrandom((void*)&wrapseed, sizeof(wrapseed));
 diff -aur dropbear-2022.83/fuzz/fuzzer-kexcurve25519.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexcurve25519.c
 --- dropbear-2022.83/fuzz/fuzzer-kexcurve25519.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexcurve25519.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexcurve25519.c	2023-08-09 16:05:01.044016161 +0600
 @@ -20,7 +20,7 @@
  	keep_newkeys = (struct key_context*)m_malloc(sizeof(struct key_context));
  	keep_newkeys->algo_kex = fuzz_get_algo(sshkex, "curve25519-sha256");
@@ -3425,7 +3425,7 @@ diff -aur dropbear-2022.83/fuzz/fuzzer-kexcurve25519.c ../build/extbld/third_par
  		m_malloc_free_epoch(1, 0);
 diff -aur dropbear-2022.83/fuzz/fuzzer-kexdh.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexdh.c
 --- dropbear-2022.83/fuzz/fuzzer-kexdh.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexdh.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexdh.c	2023-08-09 16:05:01.044016161 +0600
 @@ -19,7 +19,7 @@
  	keep_newkeys = (struct key_context*)m_malloc(sizeof(struct key_context));
  	keep_newkeys->algo_kex = fuzz_get_algo(sshkex, "diffie-hellman-group14-sha256");
@@ -3468,7 +3468,7 @@ diff -aur dropbear-2022.83/fuzz/fuzzer-kexdh.c ../build/extbld/third_party/dropb
  		m_malloc_free_epoch(1, 0);
 diff -aur dropbear-2022.83/fuzz/fuzzer-kexecdh.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexecdh.c
 --- dropbear-2022.83/fuzz/fuzzer-kexecdh.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexecdh.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/fuzz/fuzzer-kexecdh.c	2023-08-09 16:05:01.044016161 +0600
 @@ -27,12 +27,12 @@
  	assert(ecdh[1]);
  	assert(ecdh[2]);
@@ -3522,7 +3522,7 @@ diff -aur dropbear-2022.83/fuzz/fuzzer-kexecdh.c ../build/extbld/third_party/dro
  		m_malloc_free_epoch(1, 0);
 diff -aur dropbear-2022.83/includes.h ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/includes.h
 --- dropbear-2022.83/includes.h	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/includes.h	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/includes.h	2023-08-09 16:05:01.048016094 +0600
 @@ -28,9 +28,15 @@
  #include "options.h"
  #include "debug.h"
@@ -3561,7 +3561,7 @@ diff -aur dropbear-2022.83/includes.h ../build/extbld/third_party/dropbear/dropb
  #include <netinet/tcp.h>
 diff -aur dropbear-2022.83/listener.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/listener.c
 --- dropbear-2022.83/listener.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/listener.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/listener.c	2023-08-09 16:05:01.048016094 +0600
 @@ -30,9 +30,9 @@
  void listeners_initialise() {
  
@@ -3685,7 +3685,7 @@ diff -aur dropbear-2022.83/listener.c ../build/extbld/third_party/dropbear/dropb
  }
 diff -aur dropbear-2022.83/netio.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/netio.c
 --- dropbear-2022.83/netio.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/netio.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/netio.c	2023-08-09 16:05:01.048016094 +0600
 @@ -110,7 +110,7 @@
  			}
  		}
@@ -3745,7 +3745,7 @@ diff -aur dropbear-2022.83/netio.c ../build/extbld/third_party/dropbear/dropbear
  	rfc4594 has some guidance to meanings.
 diff -aur dropbear-2022.83/packet.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/packet.c
 --- dropbear-2022.83/packet.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/packet.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/packet.c	2023-08-09 16:05:01.048016094 +0600
 @@ -68,11 +68,11 @@
  #endif
  	
@@ -4345,7 +4345,7 @@ diff -aur dropbear-2022.83/packet.c ../build/extbld/third_party/dropbear/dropbea
  #endif
 diff -aur dropbear-2022.83/process-packet.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/process-packet.c
 --- dropbear-2022.83/process-packet.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/process-packet.c	2023-07-29 18:05:37.254172272 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/process-packet.c	2023-08-09 16:05:01.048016094 +0600
 @@ -48,11 +48,11 @@
  
  	TRACE2(("enter process_packet"))
@@ -4465,7 +4465,7 @@ diff -aur dropbear-2022.83/process-packet.c ../build/extbld/third_party/dropbear
  }
 diff -aur dropbear-2022.83/runopts.h ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/runopts.h
 --- dropbear-2022.83/runopts.h	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/runopts.h	2023-07-29 18:05:37.258172206 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/runopts.h	2023-08-09 16:05:01.048016094 +0600
 @@ -61,7 +61,7 @@
  
  } runopts;
@@ -4486,7 +4486,7 @@ diff -aur dropbear-2022.83/runopts.h ../build/extbld/third_party/dropbear/dropbe
  void loadhostkeys(void);
 diff -aur dropbear-2022.83/session.h ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/session.h
 --- dropbear-2022.83/session.h	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/session.h	2023-07-29 18:05:37.258172206 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/session.h	2023-08-09 16:05:01.048016094 +0600
 @@ -339,10 +339,10 @@
  };
  
@@ -4502,7 +4502,7 @@ diff -aur dropbear-2022.83/session.h ../build/extbld/third_party/dropbear/dropbe
  #if DROPBEAR_CLIENT
 diff -aur dropbear-2022.83/svr-agentfwd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-agentfwd.c
 --- dropbear-2022.83/svr-agentfwd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-agentfwd.c	2023-07-29 18:05:37.258172206 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-agentfwd.c	2023-08-09 16:05:01.052016027 +0600
 @@ -156,8 +156,8 @@
  		 * for themselves */
  		uid = getuid();
@@ -4527,7 +4527,7 @@ diff -aur dropbear-2022.83/svr-agentfwd.c ../build/extbld/third_party/dropbear/d
  #endif
 diff -aur dropbear-2022.83/svr-auth.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-auth.c
 --- dropbear-2022.83/svr-auth.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-auth.c	2023-07-29 18:05:37.258172206 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-auth.c	2023-08-09 16:13:57.942000560 +0600
 @@ -40,13 +40,13 @@
  
  /* initialise the first time for a session, resetting all parameters */
@@ -4826,7 +4826,7 @@ diff -aur dropbear-2022.83/svr-auth.c ../build/extbld/third_party/dropbear/dropb
  		}
  		dropbear_exit("Max auth tries reached - user '%s'",
  				userstr);
-@@ -449,23 +449,24 @@
+@@ -449,23 +449,23 @@
  
  	CHECKCLEARTOWRITE();
  
@@ -4852,14 +4852,13 @@ diff -aur dropbear-2022.83/svr-auth.c ../build/extbld/third_party/dropbear/dropb
  	 * we fail, we might end up leaking connection slots, and disallow new
  	 * logins - a nasty situation. */							
 -	m_close(svr_ses.childpipe);
-+    write(svr_ses->childpipe, "done", 4);
 +	m_close(svr_ses->childpipe);
  
  	TRACE(("leave send_msg_userauth_success"))
  
 diff -aur dropbear-2022.83/svr-authpam.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpam.c
 --- dropbear-2022.83/svr-authpam.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpam.c	2023-07-29 18:05:37.258172206 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpam.c	2023-08-09 16:05:01.052016027 +0600
 @@ -197,28 +197,28 @@
  	unsigned char changepw;
  
@@ -4950,7 +4949,7 @@ diff -aur dropbear-2022.83/svr-authpam.c ../build/extbld/third_party/dropbear/dr
  		
 diff -aur dropbear-2022.83/svr-authpasswd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpasswd.c
 --- dropbear-2022.83/svr-authpasswd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpasswd.c	2023-07-29 18:05:37.258172206 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpasswd.c	2023-08-09 16:05:01.052016027 +0600
 @@ -57,17 +57,17 @@
  	unsigned int changepw;
  
@@ -5037,7 +5036,7 @@ diff -aur dropbear-2022.83/svr-authpasswd.c ../build/extbld/third_party/dropbear
  }
 diff -aur dropbear-2022.83/svr-authpubkey.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpubkey.c
 --- dropbear-2022.83/svr-authpubkey.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpubkey.c	2023-07-29 18:05:37.262172140 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpubkey.c	2023-08-09 16:05:01.052016027 +0600
 @@ -101,11 +101,11 @@
  
  	/* 0 indicates user just wants to check if key can be used, 1 is an
@@ -5273,7 +5272,7 @@ diff -aur dropbear-2022.83/svr-authpubkey.c ../build/extbld/third_party/dropbear
  		TRACE(("leave checkfileperm: failure perms/owner"))
 diff -aur dropbear-2022.83/svr-authpubkeyoptions.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpubkeyoptions.c
 --- dropbear-2022.83/svr-authpubkeyoptions.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpubkeyoptions.c	2023-07-29 18:05:37.262172140 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-authpubkeyoptions.c	2023-08-09 16:05:01.056015960 +0600
 @@ -53,8 +53,8 @@
  /* Returns 1 if pubkey allows agent forwarding,
   * 0 otherwise */
@@ -5509,7 +5508,7 @@ diff -aur dropbear-2022.83/svr-authpubkeyoptions.c ../build/extbld/third_party/d
  		}
 diff -aur dropbear-2022.83/svr-chansession.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-chansession.c
 --- dropbear-2022.83/svr-chansession.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-chansession.c	2023-07-29 18:05:37.262172140 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-chansession.c	2023-08-09 16:05:01.056015960 +0600
 @@ -89,14 +89,14 @@
  /* There's a particular race we have to watch out for: if the forked child
   * executes, exits, and this signal-handler is called, all before the parent
@@ -5959,7 +5958,7 @@ diff -aur dropbear-2022.83/svr-chansession.c ../build/extbld/third_party/dropbea
  	sigemptyset(&sa_chld.sa_mask);
 diff -aur dropbear-2022.83/svr-kex.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-kex.c
 --- dropbear-2022.83/svr-kex.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-kex.c	2023-07-29 18:05:37.266172074 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-kex.c	2023-08-09 16:05:01.056015960 +0600
 @@ -51,15 +51,15 @@
  	buffer *ecdh_qs = NULL;
  
@@ -6133,7 +6132,7 @@ diff -aur dropbear-2022.83/svr-kex.c ../build/extbld/third_party/dropbear/dropbe
  
 diff -aur dropbear-2022.83/svr-main.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-main.c
 --- dropbear-2022.83/svr-main.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-main.c	2023-07-29 18:05:37.302171480 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-main.c	2023-08-09 16:05:01.056015960 +0600
 @@ -22,6 +22,7 @@
   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   * SOFTWARE. */
@@ -6386,7 +6385,7 @@ diff -aur dropbear-2022.83/svr-main.c ../build/extbld/third_party/dropbear/dropb
  		}
 diff -aur dropbear-2022.83/svr-runopts.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-runopts.c
 --- dropbear-2022.83/svr-runopts.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-runopts.c	2023-07-29 18:05:37.302171480 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-runopts.c	2023-08-09 16:05:01.056015960 +0600
 @@ -32,7 +32,7 @@
  
  #include <grp.h>
@@ -6917,7 +6916,7 @@ diff -aur dropbear-2022.83/svr-runopts.c ../build/extbld/third_party/dropbear/dr
  		any_keys = 1;
 diff -aur dropbear-2022.83/svr-service.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-service.c
 --- dropbear-2022.83/svr-service.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-service.c	2023-07-29 18:05:37.302171480 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-service.c	2023-08-09 16:05:01.056015960 +0600
 @@ -41,7 +41,7 @@
  
  	TRACE(("enter recv_msg_service_request"))
@@ -6949,7 +6948,7 @@ diff -aur dropbear-2022.83/svr-service.c ../build/extbld/third_party/dropbear/dr
  
 diff -aur dropbear-2022.83/svr-session.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-session.c
 --- dropbear-2022.83/svr-session.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-session.c	2023-07-29 18:05:37.302171480 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-session.c	2023-08-09 16:05:01.056015960 +0600
 @@ -45,7 +45,7 @@
  static void svr_remoteclosed(void);
  static void svr_algos_initialise(void);
@@ -7224,7 +7223,7 @@ diff -aur dropbear-2022.83/svr-session.c ../build/extbld/third_party/dropbear/dr
  }
 diff -aur dropbear-2022.83/svr-tcpfwd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-tcpfwd.c
 --- dropbear-2022.83/svr-tcpfwd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-tcpfwd.c	2023-07-29 18:05:37.306171414 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-tcpfwd.c	2023-08-09 16:05:01.060015893 +0600
 @@ -43,8 +43,8 @@
  
  	TRACE(("recv_msg_global_request_remotetcp: remote tcp forwarding not compiled in"))
@@ -7348,7 +7347,7 @@ diff -aur dropbear-2022.83/svr-tcpfwd.c ../build/extbld/third_party/dropbear/dro
  	if (origport > 65535 || destport > 65535) {
 diff -aur dropbear-2022.83/svr-x11fwd.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-x11fwd.c
 --- dropbear-2022.83/svr-x11fwd.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-x11fwd.c	2023-07-29 18:05:37.306171414 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/svr-x11fwd.c	2023-08-09 16:05:01.060015893 +0600
 @@ -75,10 +75,10 @@
  		return DROPBEAR_FAILURE;
  	}
@@ -7377,7 +7376,7 @@ diff -aur dropbear-2022.83/svr-x11fwd.c ../build/extbld/third_party/dropbear/dro
  		return DROPBEAR_SUCCESS;
 diff -aur dropbear-2022.83/sysoptions.h ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/sysoptions.h
 --- dropbear-2022.83/sysoptions.h	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/sysoptions.h	2023-07-29 18:05:37.306171414 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/sysoptions.h	2023-08-09 16:05:01.060015893 +0600
 @@ -32,6 +32,8 @@
  /* Would probably work on freebsd but hasn't been tested */
  #if defined(HAVE_FEXECVE) && DROPBEAR_REEXEC && defined(__linux__)
@@ -7435,7 +7434,7 @@ diff -aur dropbear-2022.83/sysoptions.h ../build/extbld/third_party/dropbear/dro
  
 diff -aur dropbear-2022.83/tcp-accept.c ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/tcp-accept.c
 --- dropbear-2022.83/tcp-accept.c	2022-11-14 20:30:00.000000000 +0600
-+++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/tcp-accept.c	2023-07-29 18:05:37.306171414 +0600
++++ ../build/extbld/third_party/dropbear/dropbear/dropbear-2022.83/tcp-accept.c	2023-08-09 16:05:01.060015893 +0600
 @@ -87,13 +87,13 @@
  		if (addr == NULL) {
  			addr = "localhost";


### PR DESCRIPTION
After #2873 fixed pipe close notification, return to the dropbear original authentication success notification method by closing corresponding pipeline