### PR TITLE
Fix gdb* scripts according to ShellCheck

### DIFF
--- a/scripts/gdb_erase_stm32h7.sh
+++ b/scripts/gdb_erase_stm32h7.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32.XXXX)
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "monitor flash banks" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset halt"
+	    echo "monitor flash banks"
 
-	# Erase sector flash0 and flash1
-	echo "monitor stm32h7x mass_erase 0" >> $GDB_CMD_FILE
-	echo "monitor stm32h7x mass_erase 1" >> $GDB_CMD_FILE
+	    # Erase sector flash0 and flash1
+	    echo "monitor stm32h7x mass_erase 0"
+	    echo "monitor stm32h7x mass_erase 1"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 create_gdb_script
 
-$GDB -batch -x $GDB_CMD_FILE
-rm -f $GDB_CMD_FILE
+$GDB -batch -x "$GDB_CMD_FILE"
+rm -f "$GDB_CMD_FILE"

--- a/scripts/gdb_load_stm32.sh
+++ b/scripts/gdb_load_stm32.sh
@@ -1,26 +1,28 @@
 #!/usr/bin/env bash
 
-grep 'QSPI)' ./conf/lds.conf > /dev/null && echo "This script doesn't work with QSPI sections!" && exit -1
+grep 'QSPI)' ./conf/lds.conf > /dev/null && echo "This script doesn't work with QSPI sections!" && exit 1
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32f7_qspi.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32f7_qspi.XXXX)
 EMBOX_ELF=build/base/bin/embox
-EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "load" >> $GDB_CMD_FILE
-	echo "continue" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset halt"
+	    echo "load"
+	    echo "continue"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 create_gdb_script
 
-$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+$GDB -x "$GDB_CMD_FILE" "$EMBOX_ELF"
 
-rm $GDB_CMD_FILE
+rm "$GDB_CMD_FILE"

--- a/scripts/gdb_run_stm32f7_qspi.sh
+++ b/scripts/gdb_run_stm32f7_qspi.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32f7_qspi.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32f7_qspi.XXXX)
 EMBOX_ELF=build/base/bin/embox
-EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
-QSPI_BIN=$(mktemp --tmpdir=$PWD qspi_XXXX.bin)
+EMBOX_BIN=$(mktemp --tmpdir="$PWD" embox_XXXX.bin)
+QSPI_BIN=$(mktemp --tmpdir="$PWD" qspi_XXXX.bin)
 
 prepare_bin() {
 	EMBOX_SECTIONS="--only-section=.text \
@@ -22,41 +22,48 @@ prepare_bin() {
 			       --remove-section=.data \
 			       --remove-section=.bss"
 
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $QSPI_BIN $QSPI_SECTIONS
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $EMBOX_BIN $EMBOX_SECTIONS
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$QSPI_BIN" $QSPI_SECTIONS
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$EMBOX_BIN" $EMBOX_SECTIONS
 }
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "monitor reset init" >> $GDB_CMD_FILE
-	echo "monitor flash banks" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset halt"
+	    echo "monitor reset init"
+	    echo "monitor flash banks"
 
-	# Write embox.bin
-	echo "monitor stm32f2x mass_erase 0" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 0 $EMBOX_BIN" >> $GDB_CMD_FILE
+	    # Write embox.bin
+	    echo "monitor stm32f2x mass_erase 0"
+	    echo "monitor flash write_bank 0 $EMBOX_BIN"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Write qspi.bin
-	sect_size=$(stat -c%s $QSPI_BIN)
+	sect_size=$(stat -c%s "$QSPI_BIN")
 	sectors=$((($sect_size + 65535) / 65536)) # Sector size is 64K for stm32f7 QSPI
-	echo "monitor flash erase_sector 3 0 $sectors" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 3 $QSPI_BIN" >> $GDB_CMD_FILE
-	## Check qspi.bin is written correctly
-	echo "monitor flash verify_bank 3 $QSPI_BIN" >> $GDB_CMD_FILE
 
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "continue" >> $GDB_CMD_FILE
+	{
+	    echo "monitor flash erase_sector 3 0 $sectors"
+	    echo "monitor flash write_bank 3 $QSPI_BIN"
+	    ## Check qspi.bin is written correctly
+	    echo "monitor flash verify_bank 3 $QSPI_BIN"
+
+	    echo "monitor reset halt"
+	    echo "continue"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 prepare_bin
 create_gdb_script
 
-$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+$GDB -x "$GDB_CMD_FILE" "$EMBOX_ELF"
 
-rm $GDB_CMD_FILE
-rm $EMBOX_BIN $QSPI_BIN
+rm "$GDB_CMD_FILE"
+rm "$EMBOX_BIN" "$QSPI_BIN"

--- a/scripts/gdb_run_stm32h7_qspi.sh
+++ b/scripts/gdb_run_stm32h7_qspi.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 GDB=arm-none-eabi-gdb
-GDB_CMD_FILE=$(mktemp --tmpdir=$PWD embox_gdb_stm32h7_qspi.XXXX)
+GDB_CMD_FILE=$(mktemp --tmpdir="$PWD" embox_gdb_stm32h7_qspi.XXXX)
 EMBOX_ELF=build/base/bin/embox
-EMBOX_BIN=$(mktemp --tmpdir=$PWD embox_XXXX.bin)
-EMBOX_BIN0=$(mktemp --tmpdir=$PWD embox_bank0_XXXX.bin)
-EMBOX_BIN1=$(mktemp --tmpdir=$PWD embox_bank1_XXXX.bin)
-QSPI_BIN=$(mktemp --tmpdir=$PWD qspi_XXXX.bin)
+EMBOX_BIN=$(mktemp --tmpdir="$PWD" embox_XXXX.bin)
+EMBOX_BIN0=$(mktemp --tmpdir="$PWD" embox_bank0_XXXX.bin)
+EMBOX_BIN1=$(mktemp --tmpdir="$PWD" embox_bank1_XXXX.bin)
+QSPI_BIN=$(mktemp --tmpdir="$PWD" qspi_XXXX.bin)
 
 prepare_bin() {
 	EMBOX_SECTIONS="--only-section=.text \
@@ -24,45 +24,52 @@ prepare_bin() {
 			       --remove-section=.data \
 			       --remove-section=.bss"
 
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $QSPI_BIN $QSPI_SECTIONS
-	arm-none-eabi-objcopy -O binary build/base/bin/embox $EMBOX_BIN $EMBOX_SECTIONS
-	dd if=$EMBOX_BIN of=$EMBOX_BIN0 bs=1 count=$((1024 * 1024))
-	dd if=$EMBOX_BIN of=$EMBOX_BIN1 bs=1 skip=$((1024 * 1024))	
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$QSPI_BIN" $QSPI_SECTIONS
+	arm-none-eabi-objcopy -O binary build/base/bin/embox "$EMBOX_BIN" $EMBOX_SECTIONS
+	dd if="$EMBOX_BIN" of="$EMBOX_BIN0" bs=1 count=$((1024 * 1024))
+	dd if="$EMBOX_BIN" of="$EMBOX_BIN1" bs=1 skip=$((1024 * 1024))
 }
 
 create_gdb_script() {
-	rm -f $GDB_CMD_FILE
+	rm -f "$GDB_CMD_FILE"
 
-	echo "target ext :3333" >> $GDB_CMD_FILE
-	echo "monitor reset init" >> $GDB_CMD_FILE
-	echo "monitor flash banks" >> $GDB_CMD_FILE
+	{
+	    echo "target ext :3333"
+	    echo "monitor reset init"
+	    echo "monitor flash banks"
 
-	# Write embox.bin
-	echo "monitor stm32h7x mass_erase 0" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 0 $EMBOX_BIN0" >> $GDB_CMD_FILE
+	    # Write embox.bin
+	    echo "monitor stm32h7x mass_erase 0"
+	    echo "monitor flash write_bank 0 $EMBOX_BIN0"
 
-	echo "monitor stm32h7x mass_erase 1" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 1 $EMBOX_BIN1" >> $GDB_CMD_FILE
+	    echo "monitor stm32h7x mass_erase 1"
+	    echo "monitor flash write_bank 1 $EMBOX_BIN1"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Write qspi.bin
-	sect_size=$(stat -c%s $QSPI_BIN)
+	sect_size=$(stat -c%s "$QSPI_BIN")
 	sectors=$((($sect_size + 65535) / 65536)) # Sector size is 64K for stm32h7 QSPI
-	echo "monitor flash erase_sector 2 0 $sectors" >> $GDB_CMD_FILE
-	echo "monitor flash write_bank 2 $QSPI_BIN" >> $GDB_CMD_FILE
-	## Check qspi.bin is written correctly
-	echo "monitor flash verify_bank 2 $QSPI_BIN" >> $GDB_CMD_FILE
 
-	echo "monitor reset halt" >> $GDB_CMD_FILE
-	echo "continue" >> $GDB_CMD_FILE
+	{
+	    echo "monitor flash erase_sector 2 0 $sectors"
+	    echo "monitor flash write_bank 2 $QSPI_BIN"
+	    ## Check qspi.bin is written correctly
+	    echo "monitor flash verify_bank 2 $QSPI_BIN"
+
+	    echo "monitor reset halt"
+	    echo "continue"
+
+	} >> "$GDB_CMD_FILE"
 
 	# Show generated GDB sctipt
-	echo "GDB script:" && cat $GDB_CMD_FILE && echo ""
+	echo "GDB script:" && cat "$GDB_CMD_FILE" && echo ""
 }
 
 prepare_bin
 create_gdb_script
 
-$GDB -x $GDB_CMD_FILE $EMBOX_ELF
+$GDB -x "$GDB_CMD_FILE" "$EMBOX_ELF"
 
-rm $GDB_CMD_FILE
-rm $EMBOX_BIN $QSPI_BIN $EMBOX_BIN0 $EMBOX_BIN1
+rm "$GDB_CMD_FILE"
+rm "$EMBOX_BIN" "$QSPI_BIN" "$EMBOX_BIN0" "$EMBOX_BIN1"


### PR DESCRIPTION
Hi @anton-bondarev! Another portion of the #2835. This PR is about `gdb*.sh` scripts.

Changes are of two types:
1. Wrapping in double quotes the variables containing paths 
2. Replacing patterns like this:
```bash
echo "…" >> some-file
echo "…" >> some-file
echo "…" >> some-file
```
with group commands:
```bash
{
    echo "…"
    echo "…"
    echo "…" 
} >> some-file
```
It gives the same result but looks cleaner (an example of group command's output redirect and pipelining: https://onlinegdb.com/7dQabeEcoF).

These changes don't modify code semantics, so I think there is no need to check the scripts with real hardware.