### PR TITLE
Fix codestyle/*.sh according to ShellCheck guidelines

### DIFF
--- a/scripts/codestyle/format_files.sh
+++ b/scripts/codestyle/format_files.sh
@@ -7,17 +7,14 @@ if [ -z "$1" ]; then
 	exit
 fi
 
-files=$(cat $1)
-
 mkdir -p out
 
-for item in $files ; do
-
-	dn=$(dirname $item)
-	mkdir -p out/$dn
-	uncrustify -f $item -c uncrustify_cfg.ini > out/$item
-
-done
+while read -r item;
+do
+	dn=$(dirname "$item")
+	mkdir -p "out/$dn"
+	uncrustify -f "$item" -c uncrustify_cfg.ini > "out/$item"
+done < "$1"
 
 find out -type f -empty -delete
 rsync -ah out/ ./

--- a/scripts/codestyle/install_uncrustify.sh
+++ b/scripts/codestyle/install_uncrustify.sh
@@ -4,15 +4,15 @@ set -xe
 
 RELEASE=0.65
 
-mkdir -p $SRC
-cd $SRC
+mkdir -p "$SRC"
+cd "$SRC"
 
-wget -c https://github.com/uncrustify/uncrustify/archive/uncrustify-${RELEASE}.tar.gz
-tar axf uncrustify-${RELEASE}.tar.gz
+wget -c "https://github.com/uncrustify/uncrustify/archive/uncrustify-${RELEASE}.tar.gz"
+tar axf "uncrustify-${RELEASE}.tar.gz"
 
 mkdir build
 cd build
 
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL ../uncrustify-uncrustify-${RELEASE}
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$INSTALL" ../uncrustify-uncrustify-"${RELEASE}"
 
 make install

--- a/scripts/codestyle/run_uncrustify.sh
+++ b/scripts/codestyle/run_uncrustify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TEMPDIR="out"
-UNCRUSTIFY_BASE=$(dirname $0)
+UNCRUSTIFY_BASE=$(dirname "$0")
 
 verbose="true"
 
@@ -35,12 +35,12 @@ done
 
 # the rest will go to git diff directly
 shift $(($OPTIND - 1))
-diffargs="$@"
+diffargs=( "$@" )
 
 tmpundiff=$TEMPDIR/diff
 mkdir -p $tmpundiff
 
-git diff --no-prefix $diffargs -- 'src/*.[ch]' | awk -v outpref=$tmpundiff -f $UNCRUSTIFY_BASE/undiff.awk
+git diff --no-prefix "${diffargs[@]}" -- 'src/*.[ch]' | awk -v outpref="$tmpundiff" -f "$UNCRUSTIFY_BASE"/undiff.awk
 
 result=0
 
@@ -50,19 +50,19 @@ else
 	fixdiffarg="--quiet"
 fi
 
-for f in $(cd $tmpundiff; find -type f); do
-	from=$tmpundiff/$f 
+for f in $(cd $tmpundiff; find . -type f); do
+	from=$tmpundiff/$f
 	to=$TEMPDIR/fixed/$f
-	mkdir -p $(dirname $to)
+	mkdir -p "$(dirname "$to")"
 
-	uncrustify --frag -c $UNCRUSTIFY_BASE/uncrustify_cfg.ini -f $from > $to 2>/dev/null
-	if [ ! -s $to ]; then 
+	uncrustify --frag -c "$UNCRUSTIFY_BASE"/uncrustify_cfg.ini -f "$from" > "$to" 2>/dev/null
+	if [ ! -s "$to" ]; then
 		continue
 	fi
 
 
-	git diff $fixdiffarg --no-index -- $from $to | tail -n +3
-	if [ ${PIPESTATUS[0]} != 0 ]; then
+	git diff $fixdiffarg --no-index -- "$from" "$to" | tail -n +3
+	if [ "${PIPESTATUS[0]}" != 0 ]; then
 		[ $verbose ] || echo "Codestyle issue: $f"
 		result=1
 	fi

--- a/scripts/codestyle/travis_uncrustify.sh
+++ b/scripts/codestyle/travis_uncrustify.sh
@@ -5,12 +5,12 @@ git fetch --depth=1000 # unlikely the branch will have more than 1000 commits
 
 revs="$(git rev-parse --short master)...$(git rev-parse --short HEAD)"
 
-echo Checking $revs for code style conformance
+echo Checking "$revs" for code style conformance
 
-$(dirname $0)/run_uncrustify.sh $revs
+"$(dirname "$0")"/run_uncrustify.sh $revs
 result=$?
 
-if [ $result != 0 ] && [ x"$TRAVIS_PULL_REQUEST" = xfalse ]; then
+if [ $result != 0 ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
 	echo "Ignoring code style violations (non-PR job)"
 	result=0
 fi


### PR DESCRIPTION
Hi @anton-bondarev! Another part of #2835. This PR:

1. Quotes variables in paths, links and echo args to protect them from globbing and word splitting
2. Rewrites loop with reading a file line by line instead of cat'ing its contents into variable
```diff
-files=$(cat $1)
-
-for item in $files ; do
-
-       dn=$(dirname $item)
-       mkdir -p out/$dn
-       uncrustify -f $item -c uncrustify_cfg.ini > out/$item
-
-done
+while read -r item;
+do
+       dn=$(dirname "$item")
+       mkdir -p "out/$dn"
+       uncrustify -f "$item" -c uncrustify_cfg.ini > "out/$item"
+done < "$1"

```
3. Rewrites implicit arrays-of-strings-to-string conversion with explicit array expansion
```diff
-diffargs="$@"
+diffargs=( "$@" )
…
-git diff --no-prefix $diffargs …
+git diff --no-prefix "${diffargs[@]}" …
```
4. Removes obsolete `[ x$VAR = xvalue ]` trick, see https://www.shellcheck.net/wiki/SC2268
```diff
-if [ $result != 0 ] && [ x"$TRAVIS_PULL_REQUEST" = xfalse ]; then
+if [ $result != 0 ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
```