### PR TITLE
cmd: thread utility add kill functionality

### DIFF
--- a/src/cmds/proc/Thread.my
+++ b/src/cmds/proc/Thread.my
@@ -13,8 +13,8 @@ package embox.cmd.proc
 			Prints usage
 		-s
 			Prints threads statistics
-		-k id
-			Stops the thread with the specified id
+		-k thread_id
+			Stops the task to which this thread belongs
 		AUTHORS
 			Gleb Efimov, Alina Kramar, Roman Oderov
 	''')


### PR DESCRIPTION
Strangely thread -k didn't have any functionality
This PR adds functionality to kill task to which specified thread belongs with -k option