### PR TITLE
tests: Minor changes to net tests

### DIFF
--- a/scripts/autotest/testsuite/modbus/modbus_bits_read/test_client/mb_test_client.c
+++ b/scripts/autotest/testsuite/modbus/modbus_bits_read/test_client/mb_test_client.c
@@ -64,11 +64,12 @@ int main(int argc, char **argv) {
         modbus_close(mb_);
         modbus_free(mb_);
 
-        printf("Packet number %d\n", p);
+        printf("Packet number %d bits:\n", p);
+        printf("( ");
         for (int k=0; k<8; k++) {
-            printf("[0x%02x] ", tab_bits[k] );
+            printf("%d ", tab_bits[k] );
         }
-        printf("\n");
+        printf(")\n");
         p=p+1;
     }
     printf("Finished reading. Failed %d/%d\n", N_fails, N_times);

--- a/src/tests/net/inet_stream_socket_test.c
+++ b/src/tests/net/inet_stream_socket_test.c
@@ -151,6 +151,7 @@ TEST_CASE("accept() returns first connected client") {
 	test_assert_equal(1, recv(a, buf, 2, 0));
 	test_assert_equal('a', buf[0]);
 
+    close(a);
 	close(other_c);
 }
 


### PR DESCRIPTION
On of the sock_stream tests hung an unclosed socket, close() added
In modbus test client output formatting slightly changed