### PR TITLE
net: tcp FINWAIT2 state timeout added

### DIFF
--- a/src/net/l4/Mybuild
+++ b/src/net/l4/Mybuild
@@ -3,6 +3,8 @@ package embox.net
 module tcp {
 	option boolean verify_chksum=true
 	option number log_level = 0
+    /* finwait2 timoeout in ms / 0=wait forever */
+    option number tcp_finwait2_timeout_ms = 60000
 	source "tcp.c"
 
 	depends embox.kernel.task.idesc_event


### PR DESCRIPTION
Socket may be stuck in FINWAIT_2 state waiting for fin from the remote host forever, so although it violates specification, seems reasonable to have timeout for it
Anyway it is possible to set timeout option in Mybuild to 0, so that it will wait for fin forever