### PR TITLE
fix stm32/nucleo_f410rb template

### DIFF
--- a/platform/stm32/templates/f4/nucleo_f410rb/build.conf
+++ b/platform/stm32/templates/f4/nucleo_f410rb/build.conf
@@ -6,7 +6,7 @@ ARCH = arm
 
 CROSS_COMPILE = arm-none-eabi-
 
-CFLAGS += -O0 -g3
+CFLAGS += -O1 -g3
 
 CFLAGS += -mthumb -mlittle-endian
 CFLAGS += -march=armv7e-m -mtune=cortex-m4

--- a/platform/stm32/templates/f4/nucleo_f410rb/lds.conf
+++ b/platform/stm32/templates/f4/nucleo_f410rb/lds.conf
@@ -3,10 +3,10 @@
  */
 
 /* region (origin, length) */
-ROM (0x08000000, 512K)
-RAM (0x20000000, 128K)
+ROM (0x08000000, 128K)
+RAM (0x20000000, 32K)
 
-region(SRAM_CCM, 0x10000000, 64K)
+// region(SRAM_CCM, 0x10000000, 64K)
 
 /* section (region[, lma_region]) */
 text   (ROM)
@@ -14,5 +14,5 @@ rodata (ROM)
 data   (RAM, ROM)
 bss    (RAM)
 
-section(heap, SRAM_CCM, SRAM_CCM)
-phdr   (heap, PT_LOAD, FLAGS(6))
+// section(heap, SRAM_CCM, SRAM_CCM)
+// phdr   (heap, PT_LOAD, FLAGS(6))

--- a/platform/stm32/templates/f4/nucleo_f410rb/mods.conf
+++ b/platform/stm32/templates/f4/nucleo_f410rb/mods.conf
@@ -5,7 +5,7 @@ configuration conf {
 	include embox.arch.arm.cortexm3.bundle
 	include platform.stm32.f4.nucleo_f410rb.bsp
 	include embox.arch.arm.libarch
-	include embox.arch.arm.vfork
+//	include embox.arch.arm.vfork
 
 	include embox.kernel.stack(stack_size=4096,alignment=4)
 
@@ -20,10 +20,10 @@ configuration conf {
 	@Runlevel(1) include embox.driver.serial.stm_usart_f4
 	@Runlevel(1) include embox.driver.serial.stm_diag(baud_rate=115200, usartx=2)
 	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__stm_diag")
-	@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=2)
+	//@Runlevel(1) include embox.driver.serial.stm_ttyS0(baud_rate=115200, usartx=2)
 
-	include embox.driver.flash.stm32f4cube(flash_size=0x4000)
-	include embox.driver.flash.flash_fs
+//	include embox.driver.flash.stm32f4cube(flash_size=0x4000)
+//	include embox.driver.flash.flash_fs
 
 	include embox.driver.gpio.stm32_gpio_f4
 
@@ -34,62 +34,54 @@ configuration conf {
 // 	include embox.driver.spi.stm32cube_spi(log_level=0)
 // 	include embox.driver.spi.stm32sube_spi1(log_level=0) /* Note: SPI1 overlaps some USART2 pins */
 
-	include embox.driver.virtual.null
-	include embox.driver.virtual.zero
-
-	include embox.driver.char_dev
-	include embox.driver.block_dev(dev_quantity=4)
-
-	include embox.kernel.critical
-	include embox.kernel.irq_static
-	include embox.kernel.irq_stack_protection
-
-	include embox.kernel.task.multi
-	include embox.kernel.task.resource.idesc_table(idesc_table_size=6)
-
-	include embox.kernel.thread.thread_local_none
-	include embox.kernel.thread.thread_cancel_disable
-	include embox.kernel.thread.signal_stub
-//	include embox.kernel.thread.signal.siginfoq(siginfo_pool_sz=4)
-	include embox.kernel.timer.sleep
-	include embox.kernel.sched.sched
-	include embox.kernel.sched.idle_light
-	include embox.kernel.lthread.lthread
-	include embox.kernel.thread.core(thread_pool_size=1)
-
-	/* tty requires */
-	include embox.kernel.thread.mutex
-	include embox.driver.tty.tty(rx_buff_sz=16, io_buff_sz=16)
-	include embox.driver.tty.task_breaking_disable
-
-	include embox.compat.posix.proc.vfork_exchanged
-	include embox.compat.posix.proc.exec_exchanged
-
-//	include embox.util.hashtable
-//	include embox.util.log
-
-	include embox.util.LibUtil
-	/*include embox.framework.embuild_light*/
-	include embox.framework.LibFramework
 	include embox.compat.libc.stdio.print(support_floating=0)
+	include embox.compat.libc.stdio.printf
+	include embox.compat.libc.stdio.scanf_without_file
+	include embox.compat.libc.strerror(strerror_short=1)
+	include embox.compat.posix.util.sleep
+	include embox.compat.posix.util.time
 	include embox.compat.posix.util.getopt
 
-	include embox.mem.pool_adapter
-	include embox.mem.heap_bm
-	include embox.mem.static_heap(heap_size=0x400)
-	include embox.mem.bitmask(page_size=64)
+	include embox.driver.char_dev_stub
 
-	include embox.fs.driver.initfs_dvfs(file_quantity=32)
-	include embox.fs.driver.devfs_dvfs
-	include embox.fs.rootfs_dvfs(fstype="initfs")
-	include embox.fs.dvfs.core
-	include embox.compat.posix.fs.all_dvfs
-	include embox.fs.syslib.perm_stub
+	include embox.driver.periph_memory_stub
+	include embox.driver.serial.core_notty
 
-	@Runlevel(2) include embox.cmd.sh.tish(
-		builtin_commands = "cd export exit logout pin ls"
-	)
+	include embox.driver.tty.task_breaking_disable
+
+	include embox.framework.embuild_light(use_mod_names=true)
+
+	include embox.fs.driver.devfs_stub
+
+	include embox.kernel.irq_static
+	include embox.kernel.sched.sched_ticker_stub
+	include embox.kernel.spinlock(spin_debug=false)
+	include embox.kernel.task.resource.idesc_table(idesc_table_size=3)
+	include embox.kernel.task.single
+	include embox.kernel.task.task_no_table
+	include embox.kernel.thread.signal_stub
+	include embox.kernel.thread.stack_none
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.thread.thread_local_none
+	include embox.kernel.thread.thread_none
+	include embox.kernel.critical
+
+	include embox.lib.Tokenizer
+
+	include embox.util.Bit
+	include embox.util.dlist
+
+	include embox.kernel.timer.sleep_nosched
+    @Runlevel(1) include embox.kernel.time.kernel_time
+    @Runlevel(1) include embox.kernel.timer.itimer(itimer_quantity=0)
+    @Runlevel(1) include embox.kernel.timer.strategy.head_timer
+    @Runlevel(1) include embox.kernel.timer.sys_timer(timer_quantity=2)
+
+    @Runlevel(1) include embox.kernel.sched.boot_light
+    @Runlevel(1) include embox.kernel.sched.timing.none
+
 	include embox.init.setup_tty_diag
-	@Runlevel(3) include embox.init.start_script(shell_name="tish")
+    @Runlevel(2) include embox.cmd.shell
+    @Runlevel(3) include embox.init.start_script(shell_name="diag_shell")
 
 }


### PR DESCRIPTION
**platform/stm32/f4/nucleo_f410rb:** `(template)` Fix non-working out-of-box config template for `nucleo_f410rb`