### PR TITLE
Improve stm32/nucleo_f410rb template - add ticker command and heap

### DIFF
--- a/platform/stm32/templates/f4/nucleo_f410rb/mods.conf
+++ b/platform/stm32/templates/f4/nucleo_f410rb/mods.conf
@@ -34,8 +34,9 @@ configuration conf {
 // 	include embox.driver.spi.stm32cube_spi(log_level=0)
 // 	include embox.driver.spi.stm32sube_spi1(log_level=0) /* Note: SPI1 overlaps some USART2 pins */
 
-	include embox.compat.libc.stdio.print(support_floating=0)
+	include embox.compat.libc.stdio.print(support_floating=1)
 	include embox.compat.libc.stdio.scanf_without_file
+	include embox.compat.libc.math_simple
 	include embox.compat.libc.strerror(strerror_short=1)
 	include embox.compat.posix.util.sleep
 	include embox.compat.posix.util.time
@@ -79,17 +80,18 @@ configuration conf {
 
     @Runlevel(1) include embox.kernel.sched.timing.none
 
-//	include embox.mem.pool_adapter
-//	include embox.mem.heap_bm
-//	include embox.mem.static_heap(heap_size=0x40)
-//	include embox.mem.bitmask(page_size=64)
+	include embox.mem.pool_adapter
+	include embox.mem.heap_bm
+	include embox.mem.static_heap(heap_size=0x400)
+	include embox.mem.bitmask(page_size=64)
 
 	include embox.init.setup_tty_diag
-    @Runlevel(2) include embox.cmd.shell(prompt="f410rb # ", welcome_msg="Welcome to Embox!!")
+    @Runlevel(2) include embox.cmd.shell(prompt="f410rb>", welcome_msg="Welcome to Embox!!")
     @Runlevel(3) include embox.init.start_script(shell_name="diag_shell")
 
 	include embox.cmd.help
 	include embox.cmd.sys.version
 	include embox.cmd.sys.uname
-//	include embox.cmd.proc.thread
+	include embox.cmd.hardware.pin
+	include embox.cmd.testing.ticker
 }


### PR DESCRIPTION
Add ticker command to stm32/nucleo_f410rb template, also add some compat.libc stuff and static heap