### PR TITLE
start_script: use @ before command to suppress output

### DIFF
--- a/src/init/start_script.c
+++ b/src/init/start_script.c
@@ -47,7 +47,11 @@ static int run_script(void) {
 	array_foreach(command, script_commands, ARRAY_SIZE(script_commands)) {
 		int ret;
 
-		printf("> %s \n", command);
+		if (command[0]=='@'){
+			command++;
+		} else{
+			printf("> %s \n", command);
+		}
 
 		ret = shell_exec(shell, command);
 


### PR DESCRIPTION
now posiible to write in start_script.inc like this:
```
"@mkdir -v /conf",
"@mount -t DumbFS /dev/stm32flash0 /conf",
"conf_setup",
"netmanager",
```

first two commands will execute without printing to tty