### PR TITLE
fix Time.my depends

### DIFF
--- a/src/cmds/sys/time/Time.my
+++ b/src/cmds/sys/time/Time.my
@@ -16,4 +16,6 @@ package embox.cmd.sys
 	''')
 module time {
 	source "time.c"
+
+	depends embox.compat.libc.stdlib.system
 }


### PR DESCRIPTION
Fix time.my depends on `embox.compat.libc.stdlib.system` because time.c uses `system()`