### PR TITLE
Fix NULL pointer dereference in fflush()

### DIFF
--- a/src/compat/libc/stdio/fflush.c
+++ b/src/compat/libc/stdio/fflush.c
@@ -9,11 +9,19 @@
 #include <fcntl.h>
 #include "file_struct.h"
 
+#include <errno.h>
 #include <stdio.h>
 
 extern int libc_ob_forceflush(FILE *file);
 
 int fflush(FILE *stream) {
+	if (stream == NULL) {
+		// If the argument is NULL we must flush all open output
+		// streams. For now, just fail and do not attempt to
+		// dereference NULL pointer.
+		errno = ENOSYS;
+		return EOF;
+	}
 
 	if (stream->flags & O_WRONLY) {
 		libc_ob_forceflush(stream);


### PR DESCRIPTION
fflush(0) is absolutely valid invocation and it means "flush all output streams". Since embox does not track output streams right now, it takes some effort to implement it properly. But at least it should not dereference NULL.

fflush(0) is heavily used in iperf third-party tool.