### PR TITLE
tty: add workaround fix in tty_ioctl()

### DIFF
--- a/src/drivers/tty/serial/ttys_term.c
+++ b/src/drivers/tty/serial/ttys_term.c
@@ -39,6 +39,8 @@ static void uart_term_setup(struct tty *tty, struct termios *termios) {
 		params.baud_rate = termios->c_ospeed;
 		uart_set_params(uart_dev, &params);
 	}
+
+    tty->init = 1;
 }
 
 struct tty_ops uart_tty_ops = {

--- a/src/drivers/tty/tty.c
+++ b/src/drivers/tty/tty.c
@@ -212,7 +212,10 @@ int tty_ioctl(struct tty *t, int request, void *data) {
 	case TIOCSETA:
 		memcpy(&t->termios, data, sizeof(struct termios));
 		termios_update_ring(&t->termios, &t->i_ring, &t->i_canon_ring);
-		if (t->ops->setup) {
+        /* This check for init is a workaround to make current realization
+         * work and not cause shutdown if it tries to initialize several times.
+         * That probably needs a clean solution in the future*/
+		if ((t->ops->setup)&&(!t->init)) {
 			t->ops->setup(t, &t->termios);
 		}
 		break;
@@ -263,6 +266,7 @@ struct tty *tty_init(struct tty *t, const struct tty_ops *ops) {
 
 	t->idesc = NULL;
 	t->ops = ops;
+    t->init = 0;
 
 	termios_init(&t->termios);
 

--- a/src/include/drivers/tty.h
+++ b/src/include/drivers/tty.h
@@ -48,6 +48,8 @@ struct tty {
 	struct ring       o_ring;
 	char              o_buff[TTY_IO_BUFF_SZ];
 	pid_t             pgrp; /* process group (TODO: lonely process now) */
+
+    uint8_t init;   /* see comment in tty_ioctl() in tty.c */
 };
 
 struct tty_ops {


### PR DESCRIPTION
workaround for tty device not cause shutdown if it tries to setup several times