### PR TITLE
riscv: Add support for S mode

### DIFF
--- a/src/arch/riscv/include/asm/entry.h
+++ b/src/arch/riscv/include/asm/entry.h
@@ -11,6 +11,7 @@
 #define RISCV_ENTRY_H_
 
 #include <asm/asm.h>
+#include <asm/regs.h>
 #include <asm/ptrace.h>
 
 #ifdef __ASSEMBLER__
@@ -51,9 +52,9 @@
 	PTR_S   t4, PT_R29(sp)
 	PTR_S   t5, PT_R30(sp)
 
-	csrr    t6, mstatus
+	csrr    t6, STATUS_REG
 	PTR_S   t6, PT_MSTATUS(sp)
-	csrr    t6, mepc
+	csrr    t6, EPC_REG
 	PTR_S   t6, PT_PC(sp)
 .endm
 
@@ -89,10 +90,10 @@
 	PTR_L   t5, PT_R30(sp)
 
 	PTR_L   t6, PT_MSTATUS(sp)
-	csrw    mstatus, t6
+	csrw    STATUS_REG, t6
 
 	PTR_L   t6, PT_PC(sp)
-	csrw    mepc, t6
+	csrw    EPC_REG, t6
 
 	PTR_L   t6, PT_R31(sp)
 

--- a/src/arch/riscv/include/asm/interrupts.h
+++ b/src/arch/riscv/include/asm/interrupts.h
@@ -3,20 +3,20 @@
 
 #include <asm/regs.h>
 
-#define disable_interrupts() clear_csr_bit(mstatus, MSTATUS_MIE)
-#define enable_interrupts()  set_csr_bit(mstatus, MSTATUS_MIE)
+#define disable_interrupts() clear_csr_bit(STATUS_REG, STATUS(IE))
+#define enable_interrupts()  set_csr_bit(STATUS_REG, STATUS(IE))
 
 // #define disable_interrupts()	__asm volatile  ( "csrc mstatus,8" )
 // #define enable_interrupts()	__asm volatile  ( "csrs mstatus,8" )
 
-#define enable_timer_interrupts()  set_csr_bit(mie, MIE_MTIE)
-#define disable_timer_interrupts() clear_csr_bit(mie, MIE_MTIE)
+#define enable_timer_interrupts()  set_csr_bit(INTERRUPT_REG, IE(TIE))
+#define disable_timer_interrupts() clear_csr_bit(INTERRUPT_REG, IE(TIE))
 
-#define enable_external_interrupts()  set_csr_bit(mie, MIE_MEIE)
-#define disable_external_interrupts() clear_csr_bit(mie, MIE_MEIE)
+#define enable_external_interrupts()  set_csr_bit(INTERRUPT_REG, IE(EIE))
+#define disable_external_interrupts() clear_csr_bit(INTERRUPT_REG, IE(EIE))
 
-#define enable_software_interrupts()  set_csr_bit(mie, MIE_MSIE)
-#define disable_software_interrupts() clear_csr_bit(mie, MIE_MSIE)
+#define enable_software_interrupts()  set_csr_bit(INTERRUPT_REG, IE(SIE))
+#define disable_software_interrupts() clear_csr_bit(INTERRUPT_REG, IE(SIE))
 
 #define RISCV_TIMER_IRQ_DEF(timer_handler, pclock_source)               \
 	int (*__riscv_timer_handler)(unsigned int, void *) = timer_handler; \

--- a/src/arch/riscv/include/asm/regs.h
+++ b/src/arch/riscv/include/asm/regs.h
@@ -1,15 +1,53 @@
 #ifndef RISCV_REGISTERS_H_
 #define RISCV_REGISTERS_H_
 
+#include <framework/mod/options.h>
+
+#include "config/embox/arch/riscv/kernel/arch.h"
+#include "util/macro.h"
+
+#define SMODE \
+	OPTION_MODULE_GET(embox__arch__riscv__kernel__arch, BOOLEAN, smode)
+#if SMODE
+#define MODE_LOWER_CASE s
+#define MODE_UPPER_CASE S
+#else
+#define MODE_LOWER_CASE m
+#define MODE_UPPER_CASE M
+#endif
+#define RET_INSTR       MACRO_CONCAT(MODE_LOWER_CASE, ret)
+#define CAUSE_REG       MACRO_CONCAT(MODE_LOWER_CASE, cause)
+#define STATUS_REG      MACRO_CONCAT(MODE_LOWER_CASE, status)
+#define INTERRUPT_REG   MACRO_CONCAT(MODE_LOWER_CASE, ie)
+#define EPC_REG         MACRO_CONCAT(MODE_LOWER_CASE, epc)
+#define TRAP_VECTOR_REG MACRO_CONCAT(MODE_LOWER_CASE, tvec)
+
 /* Machine mode Status Register (mstatus) */
 #define MSTATUS_MIE  (1UL << 3)  /* Machine Interrupt Enable */
 #define MSTATUS_MPIE (1UL << 7)  /* Machine Previous Interrupt Enable */
 #define MSTATUS_MPP  (3UL << 11) /* Machine Previous Privilege Mode */
 
+#define SSTATUS_SIE  (1UL << 1) /* Supervisor Interrupt Enable */
+#define SSTATUS_SPIE (1UL << 5) /* Supervisor Previous Interrupt Enable */
+#define SSTATUS_SPP  (1UL << 8) /* Supervisor Previous Privilege Mode */
+
+#define STATUS(x)                                        \
+	MACRO_CONCAT(MACRO_CONCAT(MODE_UPPER_CASE, STATUS_), \
+	    MACRO_CONCAT(MODE_UPPER_CASE, x))
+
 /* Machine Mode Interrupt Register (mie)*/
 #define MIE_MSIE (1UL << 3)  /* Machine Software Interrupt Enable */
 #define MIE_MTIE (1UL << 7)  /* Machine Timer Interrupt Enable */
 #define MIE_MEIE (1UL << 11) /* Machine External Interrupt Enable */
+
+/* Supervisor Mode Interrupt Register (sie)*/
+#define SIE_SSIE (1UL << 1) /* Supervisor Software Interrupt Enable */
+#define SIE_STIE (1UL << 5) /* Supervisor Timer Interrupt Enable */
+#define SIE_SEIE (1UL << 9) /* Supervisor External Interrupt Enable */
+
+#define IE(x)                                        \
+	MACRO_CONCAT(MACRO_CONCAT(MODE_UPPER_CASE, IE_), \
+	    MACRO_CONCAT(MODE_UPPER_CASE, x))
 
 /* Machine Interrupt Pending (mip) */
 #define MIP_MSIP (1UL << 3)  /* Machine Software Interrupt Pending */
@@ -60,22 +98,38 @@
 #define EXC_STORE_ALIGN  6
 #define EXC_STORE_ACCESS 7
 
+/* Supervisor Cause (scause) */
+/* Asynchronous causes */
+#define IRQ_SUPERVISOR_SOFTWARE 1
+#define IRQ_SUPERVISOR_TIMER    5
+#define IRQ_SUPERVISOR_EXTERNAL 9
+
+#if SMODE
+#define IRQ_SOFTWARE IRQ_SUPERVISOR_SOFTWARE
+#define IRQ_TIMER    IRQ_SUPERVISOR_TIMER
+#define IRQ_EXTERNAL IRQ_SUPERVISOR_EXTERNAL
+#else
+#define IRQ_SOFTWARE IRQ_MACHINE_SOFTWARE
+#define IRQ_TIMER    IRQ_MACHINE_TIMER
+#define IRQ_EXTERNAL IRQ_MACHINE_EXTERNAL
+#endif
+
 #define __ENABLE_TIMER_INTERRUPTS __asm volatile("csrs mie,%0" ::"r"(MIE_MTIE));
 
-#define read_csr(reg)                                   \
-	({                                                  \
-		unsigned long __tmp;                            \
-		__asm volatile("csrr %0, " #reg : "=r"(__tmp)); \
-		__tmp;                                          \
+#define read_csr(reg)                                                \
+	({                                                               \
+		unsigned long __tmp;                                         \
+		__asm volatile("csrr %0, " MACRO_STRING(reg) : "=r"(__tmp)); \
+		__tmp;                                                       \
 	})
 
 #define write_csr(reg, val) \
-	({ __asm volatile("csrw " #reg ", %0" ::"rK"((val))); })
+	({ __asm volatile("csrw " MACRO_STRING(reg) ", %0" ::"rK"((val))); })
 
 #define set_csr_bit(reg, mask) \
-	({ __asm volatile("csrs " #reg ", %0" ::"rK"((mask))); })
+	({ __asm volatile("csrs " MACRO_STRING(reg) ", %0" ::"rK"((mask))); })
 
 #define clear_csr_bit(reg, mask) \
-	({ __asm volatile("csrc " #reg ", %0" ::"rK"((mask))); })
+	({ __asm volatile("csrc " MACRO_STRING(reg) ", %0" ::"rK"((mask))); })
 
 #endif /* RISCV_REGISTERS_H_ */

--- a/src/arch/riscv/kernel/Mybuild
+++ b/src/arch/riscv/kernel/Mybuild
@@ -6,6 +6,7 @@ module boot extends embox.arch.boot {
 
 module arch extends embox.arch.arch {
 	source "arch.c"
+    option boolean smode = false
 }
 
 module locore extends embox.arch.locore {

--- a/src/arch/riscv/kernel/boot.S
+++ b/src/arch/riscv/kernel/boot.S
@@ -6,6 +6,7 @@
  * @date 06.07.23
  */
 #include <asm/asm.h>
+#include <asm/regs.h>
 #include <hal/cpu.h>
 
 .section .init, "ax"
@@ -36,13 +37,17 @@ _start:
 	 * register.
 	 */
 	la      t0, riscv_trap_handler
-	csrw    mtvec, t0
+	csrw    TRAP_VECTOR_REG, t0
 
 	/**
 	 * Continue on hart lottery winner, others branch to
 	 * secondary_hart_loop.
 	 */
+#if SMODE
+	add     t0, a0, 0
+#else
 	csrr    t0, mhartid
+#endif
 	bnez    t0, secondary_hart_loop
 
 	/* Set up stack pointer. */

--- a/src/arch/riscv/kernel/context.c
+++ b/src/arch/riscv/kernel/context.c
@@ -19,9 +19,9 @@ void context_init(struct context *ctx, unsigned int flags,
 
 	ctx->sp = (unsigned long) sp;
 	ctx->ra = (unsigned long) routine_fn;
-	ctx->mstatus = read_csr(mstatus);
+	ctx->mstatus = read_csr(STATUS_REG);
 
 	if (flags & CONTEXT_IRQDISABLE) {
-		ctx->mstatus &= ~(MSTATUS_MIE);
+		ctx->mstatus &= ~(STATUS(IE));
 	}
 }

--- a/src/arch/riscv/kernel/context_switch.S
+++ b/src/arch/riscv/kernel/context_switch.S
@@ -7,6 +7,7 @@
  * @author Nastya Nizharadze
  */
 #include <asm/asm.h>
+#include <asm/regs.h>
 
 #include "context.h"
 
@@ -31,7 +32,7 @@ context_switch:
 	PTR_S   s9, CTX_S9(a0)
 	PTR_S   s10, CTX_S10(a0)
 	PTR_S   s11, CTX_S11(a0)
-	csrr    t6, mstatus
+	csrr    t6, STATUS_REG
 	PTR_S   t6, CTX_MSTATUS(a0)
 
 	PTR_L   sp, CTX_SP(a1)
@@ -50,7 +51,7 @@ context_switch:
 	PTR_L   s10, CTX_S10(a1)
 	PTR_L   s11, CTX_S11(a1)
 	PTR_L   t6, CTX_MSTATUS(a1)
-	csrw    mstatus, t6
+	csrw    STATUS_REG, t6
 	addi    sp, sp, CTX_SIZE
 
 	ret

--- a/src/arch/riscv/kernel/entry.S
+++ b/src/arch/riscv/kernel/entry.S
@@ -17,7 +17,7 @@
 .align 2
 riscv_trap_handler:
 	SAVE_ALL
-	csrr    a1, mcause
+	csrr    a1, CAUSE_REG
 	srli    t0, a1, (__riscv_xlen - 1)
 	bnez    t0, 1f
 
@@ -31,4 +31,4 @@ riscv_trap_handler:
 
 riscv_trap_exit:
 	RESTORE_ALL
-	mret
+	RET_INSTR

--- a/src/arch/riscv/kernel/exception.h
+++ b/src/arch/riscv/kernel/exception.h
@@ -6,6 +6,7 @@
  * @date 28.07.23
  */
 #include <asm/ptrace.h>
+#include <asm/regs.h>
 #include <kernel/printk.h>
 #include <hal/test/traps_core.h>
 
@@ -20,7 +21,7 @@ extern trap_handler_t riscv_excpt_table[0x10];
 	       "sp      = %#lx\n"                                   \
 	       "gp      = %#lx\n"                                   \
 	       "tp      = %#lx\n"                                   \
-	       "mstatus = %#lx\n"                                   \
+	       MACRO_STRING(STATUS_REG) " = %#lx\n"                 \
 	       "pc      = %#lx\n",                                  \
 	    (ptregs)->ra, (ptregs)->sp, (ptregs)->gp, (ptregs)->tp, \
 	    (ptregs)->mstatus, (ptregs)->pc)

--- a/src/arch/riscv/kernel/interrupt.c
+++ b/src/arch/riscv/kernel/interrupt.c
@@ -32,10 +32,10 @@ void riscv_interrupt_handler(void) {
 		long pending;
 		long interrupt_id;
 
-		pending = (read_csr(mcause)) & CLEAN_IRQ_BIT;
+		pending = (read_csr(CAUSE_REG)) & CLEAN_IRQ_BIT;
 		interrupt_id = pending;
 
-		if (pending == IRQ_MACHINE_TIMER) {
+		if (pending == IRQ_TIMER) {
 			disable_timer_interrupts();
 			//ipl_enable();               /* enable mstatus.MIE */
 			if (__riscv_timer_handler) {
@@ -43,7 +43,7 @@ void riscv_interrupt_handler(void) {
 			}
 			//ipl_disable();              /* disable mstatus.MIE */
 			enable_timer_interrupts();
-		} else if (pending == IRQ_MACHINE_EXTERNAL) {
+		} else if (pending == IRQ_EXTERNAL) {
 			/* the ID of the highest-priority pending interrupt */
 			interrupt_id = irqctrl_get_num();
 			if (interrupt_id == 0) {

--- a/src/arch/riscv/kernel/ipl_impl.c
+++ b/src/arch/riscv/kernel/ipl_impl.c
@@ -16,11 +16,11 @@ void ipl_init(void) {
 
 ipl_t ipl_save(void) {
 	ipl_t csr;
-	csr = read_csr(mstatus);
-	write_csr(mstatus, csr & ~(MSTATUS_MIE));
+	csr = read_csr(STATUS_REG);
+	write_csr(STATUS_REG, csr & ~(STATUS(IE)));
 	return csr;
 }
 
 void ipl_restore(ipl_t ipl) {
-	write_csr(mstatus, ipl);
+	write_csr(STATUS_REG, ipl);
 }

--- a/src/drivers/interrupt/riscv_plic/Mybuild
+++ b/src/drivers/interrupt/riscv_plic/Mybuild
@@ -2,6 +2,8 @@ package embox.driver.interrupt
 
 module riscv_plic extends irqctrl_api {
 	option number base_addr = 0x0C000000
+	option number threshold_offset = 0x200000
+	option number interrupt_enable_offset = 0x2000
 
 	source "riscv_plic.c", "riscv_plic.h"
 }

--- a/src/drivers/interrupt/riscv_plic/riscv_plic.c
+++ b/src/drivers/interrupt/riscv_plic/riscv_plic.c
@@ -20,13 +20,15 @@
 #include <embox/unit.h>
 
 #define PLIC_ADDR                 OPTION_GET(NUMBER, base_addr)
+#define PRIORITY_THRESHOLD_OFFSET OPTION_GET(NUMBER, threshold_offset)
+#define INTERRUPT_ENABLE_OFFSRT   OPTION_GET(NUMBER, interrupt_enable_offset)
 
 #define IPL_ADDR(num)            (PLIC_ADDR + (num * 4))
 
-#define PRIORITY_THRESHOLD_ADDR  (PLIC_ADDR + 0x200000U)
-#define CLAIM_COMPLETE_ADDR      (PLIC_ADDR + 0x200004U) /* offset for hart 0 claim/complere reg */
-#define INTERRUPT_ENABLE_REG_1   (PLIC_ADDR + 0x2000U)
-#define INTERRUPT_ENABLE_REG_2   (PLIC_ADDR + 0x2004U)
+#define PRIORITY_THRESHOLD_ADDR  (PLIC_ADDR + PRIORITY_THRESHOLD_OFFSET)
+#define CLAIM_COMPLETE_ADDR      (PLIC_ADDR + PRIORITY_THRESHOLD_OFFSET + 0x4U) /* offset for hart 0 claim/complere reg */
+#define INTERRUPT_ENABLE_REG_1   (PLIC_ADDR + INTERRUPT_ENABLE_OFFSRT)
+#define INTERRUPT_ENABLE_REG_2   (PLIC_ADDR + INTERRUPT_ENABLE_OFFSRT + 0x4U)
 
 
 static int plic_init(void) {

--- a/templates/riscv64/qemu-smode/build.conf
+++ b/templates/riscv64/qemu-smode/build.conf
@@ -1,0 +1,14 @@
+TARGET = embox
+
+PLATFORM = virt
+
+ARCH = riscv64
+
+CROSS_COMPILE = riscv64-unknown-elf-
+
+CFLAGS += -g -O0
+CFLAGS += -march=rv64gc -mabi=lp64d -mcmodel=medany
+CFLAGS += -falign-functions -falign-jumps -falign-labels -falign-loops
+CFLAGS += -ffreestanding
+
+LDFLAGS += -melf64lriscv

--- a/templates/riscv64/qemu-smode/lds.conf
+++ b/templates/riscv64/qemu-smode/lds.conf
@@ -1,0 +1,14 @@
+/*
+ * Linkage configuration.
+ */
+
+/* region (origin, length) */
+ROM (0x00001000, 8K)
+/* region (origin, length) */
+RAM (0x84000000, 512M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/templates/riscv64/qemu-smode/mods.conf
+++ b/templates/riscv64/qemu-smode/mods.conf
@@ -1,0 +1,144 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.system(core_freq=1000000000)
+	include embox.arch.riscv.kernel.boot
+	include embox.arch.riscv.kernel.arch(smode=true)
+	include embox.arch.riscv.kernel.locore
+	include embox.arch.riscv.kernel.context
+	include embox.arch.riscv.libarch
+	include embox.arch.riscv.vfork
+
+	include embox.mem.bitmask
+	include embox.driver.periph_memory_stub
+	include embox.arch.generic.nommu
+	include embox.mem.sysmalloc_task_based
+	include embox.mem.heap_bm
+
+	include embox.kernel.task.resource.errno
+
+	include embox.driver.serial.ns16550(reg_width=1)
+	include embox.driver.serial.ns16550_diag(base_addr=0x10000000)
+	include embox.driver.serial.ns16550_ttyS0(base_addr=0x10000000, irq_num=10)
+	include embox.driver.diag(impl="embox__driver__serial__ns16550_diag")
+
+	include embox.driver.interrupt.riscv_plic(threshold_offset=0x201000, interrupt_enable_offset=0x2080)
+	include embox.driver.clock.riscv_clk(base_mtime=0x200bff8, base_mtimecmp=0x2004000, rtc_freq=10000000)
+	include embox.kernel.time.jiffies(cs_name="riscv_clk")
+
+	/* Tell printf() do not support floating point */
+	include embox.compat.libc.stdio.print(support_floating=0)
+
+	@Runlevel(0) include embox.mem.phymem
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
+	@Runlevel(2) include embox.kernel.time.kernel_time
+	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(2) include embox.kernel.thread.core
+	include embox.kernel.stack
+	include embox.kernel.sched.strategy.priority_based
+	include embox.kernel.thread.signal.sigstate
+	include embox.kernel.thread.signal.siginfoq
+
+	include embox.mem.pool_adapter
+	@Runlevel(2) include embox.mem.static_heap
+	include embox.mem.heap_bm
+	include embox.mem.bitmask
+
+	@Runlevel(2) include embox.fs.node(fnode_quantity=1024)
+	@Runlevel(2) include embox.fs.rootfs_oldfs
+	@Runlevel(2) include embox.fs.driver.initfs
+	@Runlevel(2) include embox.fs.driver.ramfs
+	@Runlevel(2) include embox.fs.driver.ext2
+	@Runlevel(2) include embox.fs.driver.fat
+	include embox.fs.driver.devfs_old
+
+	include embox.driver.block_dev
+	include embox.fs.file_desc_oldfs
+
+	@Runlevel(2) include embox.cmd.sh.tish(
+				prompt="%u@%h:%w%$", rich_prompt_support=1,
+				builtin_commands="exit logout cd export mount umount")
+	include embox.init.system_start_service(log_level=3, tty_dev="ttyS0")
+	include embox.cmd.service
+
+	include embox.cmd.testing.ticker
+
+	include embox.arch.riscv.breakpoint
+	include embox.arch.riscv.sw_breakpoint_ops
+	@Runlevel(2) include embox.lib.breakpoint_test.sw_breakpoint_test
+
+	include embox.cmd.wc
+	include embox.cmd.fs.head
+
+	include embox.cmd.fs.dd
+	include embox.cmd.fs.md5sum
+	include embox.cmd.fs.uniq
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.cd
+	include embox.cmd.fs.pwd
+	include embox.cmd.fs.ls
+	include embox.cmd.fs.rm
+	include embox.cmd.fs.mkfs
+	include embox.cmd.fs.mount
+	include embox.cmd.fs.more
+	include embox.cmd.fs.umount
+	include embox.cmd.fs.stat
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.mkdir
+	include embox.cmd.fs.cp
+	include embox.cmd.fs.mv
+
+	include embox.cmd.help
+	include embox.cmd.man
+
+	include embox.cmd.sys.uname
+	include embox.cmd.sys.env
+	include embox.cmd.sys.export
+	include embox.cmd.sys.version
+	include embox.cmd.sys.date
+	include embox.cmd.sys.time
+	include embox.cmd.sys.shutdown
+
+	include embox.cmd.lsmod
+	include embox.cmd.test
+
+	include embox.cmd.proc.nice
+	include embox.cmd.proc.renice
+
+	include embox.cmd.proc.thread
+	include embox.cmd.proc.top
+
+//	include embox.cmd.mmuinfo
+//	include embox.cmd.hw.mmutrans
+	include embox.cmd.mem
+
+	include embox.compat.libc.math_simple
+	include embox.kernel.spinlock(spin_debug = false)
+
+	include embox.kernel.task.resource.vfork
+	include embox.compat.posix.proc.exec
+	include embox.compat.posix.proc.pid
+	include embox.compat.posix.proc.waitpid
+	include embox.compat.posix.fs.close
+
+	include embox.kernel.task.resource.errno
+
+	include embox.compat.libc.all
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.libc.math_simple
+	include embox.compat.posix.pthread_key
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.fs.rewinddir_stub
+
+	include embox.compat.atomic.pseudo_atomic
+
+	include embox.util.LibUtil
+	include embox.framework.LibFramework
+}

--- a/templates/riscv64/qemu-smode/system_start.inc
+++ b/templates/riscv64/qemu-smode/system_start.inc
@@ -1,0 +1,6 @@
+"export PWD=/",
+"export HOME=/",
+//"netmanager",
+//"service telnetd",
+//"service httpd",
+"tish",


### PR DESCRIPTION
Add support for building embox for running in S mode
Tested with OpenSBI under `virt` platform in QEMU
Exact command: `qemu-system-riscv64 -nographic -M virt -kernel embox`