### PR TITLE
template: CI test/fs template cifs fix

### DIFF
--- a/scripts/continuous/fs/run.sh
+++ b/scripts/continuous/fs/run.sh
@@ -61,8 +61,11 @@ run_qemu_fs() {
 		iso9660)
 			img_mount="\"mount -t $FS /dev/cd0 /mnt/fs_test\","
 			;;
-		cifs | nfs)
+		nfs)
 			img_mount="\"mount -t $FS 10.0.2.10:$IMG /mnt/fs_test\","
+			;;
+		cifs)
+			img_mount="\"mount -t $FS 10.0.2.10$IMG /mnt/fs_test\","
 			;;
 	esac
 


### PR DESCRIPTION
This pull-request should fix failure of the test/fs template in CI when testing cifs file system, that appeared after improving the behavior of inet_*ton functions. The assumption that failure is caused by erroneous colon in mount command for cifs file system in scripts/continuous/run.sh