### PR TITLE
docs: Add python2 installation for Arch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ $ sudo apt-get install build-essential gcc-multilib curl libmpc-dev python
 For Arch Linux:
 ```
 $ sudo pacman -S make gcc-multilib cpio qemu
+$ yay -S python2-bin
 ```
 
 For MAC OS X (requires [MacPorts](https://www.macports.org/install.php) installed):


### PR DESCRIPTION
In 2022 Arch removed python2 from its repository.

I suggest to install precompiled python2 from yay.

I also updated the corresponding lines in the Wiki's Quick Start.