### PR TITLE
test: add unit test for abs in math.h

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -89,3 +89,10 @@ module math_test_sinh {
 	depends embox.framework.LibFramework
 }
 
+module math_test_abs {
+	source "math_test_abs.c"
+
+	depends embox.compat.libc.all
+	depends embox.compat.libc.math
+	depends embox.framework.LibFramework
+}

--- a/src/compat/libc/math/tests/math_test_abs.c
+++ b/src/compat/libc/math/tests/math_test_abs.c
@@ -1,0 +1,39 @@
+/**
+ * @file
+ *
+ * @date May 18, 2024
+ * @aothor Guokai Chen
+ */
+
+
+
+#include <embox/test.h>
+#include <math.h>
+
+EMBOX_TEST_SUITE("abs() tests");
+
+#define abs fabs
+
+TEST_CASE("Test for abs() with negative argument") {
+	test_assert(abs(-1.0) == 1.0);
+}
+
+TEST_CASE("Test for abs() with positive argument") {
+	test_assert(abs(4.0) == 4.0);
+}
+
+TEST_CASE("Test for abs(+0.0)") {
+	test_assert(abs(+0.0) == 0.0);
+}
+
+TEST_CASE("Test for abs(-0.0)") {
+	test_assert(abs(-0.0) == 0.0);
+}
+
+TEST_CASE("Test for abs(+INFINITY)") {
+	test_assert(isinf(abs(INFINITY)));
+}
+
+TEST_CASE("Test for abs(NaN)") {
+	test_assert(isnan(abs(NAN)));
+}

--- a/templates/aarch64/qemu/mods.conf
+++ b/templates/aarch64/qemu/mods.conf
@@ -214,4 +214,6 @@ configuration conf {
 
 	include embox.lib.libds
 	include embox.framework.LibFramework
+	include embox.compat.libc.test.sqrt_test
+	include embox.compat.libc.test.math_test_abs
 }


### PR DESCRIPTION
This solves issue #3266 and enable two math.h tests on aarch64 platform.