### PR TITLE
TST: Add test for ceil() in libc tests

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -104,3 +104,11 @@ module math_test_abs {
 	depends embox.compat.libc.math
 	depends embox.framework.LibFramework
 }
+
+module math_test_ceil {
+    source "math_test_ceil.c"
+
+    depends embox.compat.libc.all
+    depends embox.compat.libc.math
+    depends embox.framework.LibFramework
+}

--- a/src/compat/libc/math/tests/math_test_ceil.c
+++ b/src/compat/libc/math/tests/math_test_ceil.c
@@ -1,0 +1,37 @@
+/**
+ * @file
+ *
+ * @date May 18, 2024
+ * @author Jason Mok
+ */
+
+
+
+#include <embox/test.h>
+#include <math.h>
+
+EMBOX_TEST_SUITE("ceil() tests");
+
+TEST_CASE("Test for ceil() with positive argument") {
+    test_assert(ceil(4.3) == 5.0);
+}
+
+TEST_CASE("Test for ceil() with negative argument") {
+    test_assert(ceil(-4.3) == -4.0);
+}
+
+TEST_CASE("Test for ceil(0.0)") {
+    test_assert(ceil(+0.0) == 0.0);
+}
+
+TEST_CASE("Test for ceil(-0.0)") {
+    test_assert(ceil(-0.0) == 0.0);
+}
+
+TEST_CASE("Test for ceil(+INFINITY)") {
+    test_assert(isinf(ceil(INFINITY)));
+}
+
+TEST_CASE("Test for ceil(NaN)") {
+    test_assert(isnan(ceil(NAN)));
+}

--- a/templates/aarch64/qemu/mods.conf
+++ b/templates/aarch64/qemu/mods.conf
@@ -216,4 +216,5 @@ configuration conf {
 	include embox.framework.LibFramework
 	include embox.compat.libc.test.sqrt_test
 	include embox.compat.libc.test.math_test_abs
+	include embox.compat.libc.test.math_test_ceil
 }

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -134,6 +134,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.sqrt_test
 	@Runlevel(1) include embox.compat.libc.test.exp_test
 	@Runlevel(1) include embox.compat.libc.test.math_test_cos
+	@Runlevel(1) include embox.compat.libc.test.math_test_ceil
 
 	@Runlevel(1) include embox.lib.libcrypt.des_test
 


### PR DESCRIPTION
Added unit tests for ceil() in `libc/math/tests`. Closes #3269 