### PR TITLE
Add unit-tests for atan() functions (math.h) 

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -112,3 +112,11 @@ module math_test_ceil {
     depends embox.compat.libc.math
     depends embox.framework.LibFramework
 }
+
+module atan_test {
+  source "atan_tests.c"
+
+  depends embox.compat.libc.all
+	depends embox.compat.libc.math
+	depends embox.framework.LibFramework
+}

--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -113,7 +113,7 @@ module math_test_ceil {
     depends embox.framework.LibFramework
 }
 
-module atan_test {
+module atan_tests {
   source "atan_tests.c"
 
   depends embox.compat.libc.all

--- a/src/compat/libc/math/tests/atan_tests.c
+++ b/src/compat/libc/math/tests/atan_tests.c
@@ -1,0 +1,45 @@
+/**
+ * @file
+ *
+ * @date May 20, 2024
+ * @author liu kang bing
+ */
+
+#include <math.h>
+
+#include <embox/test.h>
+EMBOX_TEST_SUITE("atan() tests");
+
+static bool is_equal(double x, double y) {
+	return fabs(x - y) < 1e-9;
+}
+
+TEST_CASE("Test for simple value") {
+	test_assert(is_equal(atan(0.0), 0.0));
+	test_assert(is_equal(atan(1.0), M_PI_4));
+	test_assert(is_equal(atan(-1.0), -M_PI_4));
+}
+
+TEST_CASE("Test for atan(tan(x)) == x") {
+	double lower = -M_PI_2;
+	double uper = M_PI_2;
+	double step = 1e-3;
+	for (double x = lower; x < uper; x += step) {
+		test_assert(is_equal(atan(tan(x)), x));
+	}
+}
+
+TEST_CASE("Test for tan(atan(x)) == x") {
+	double lower = -1e5;
+	double uper = 1e5;
+	double step = 1;
+	for (double x = lower; x < uper; x += step) {
+		test_assert(is_equal(tan(atan(x)), x));
+	}
+}
+
+TEST_CASE("Test for corner cases and failure case") {
+	test_assert(is_equal(M_PI_2, atan(INFINITY)));
+	test_assert(is_equal(-M_PI_2, atan(-INFINITY)));
+	isnan(atan(NAN));
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -135,6 +135,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.exp_test
 	@Runlevel(1) include embox.compat.libc.test.math_test_cos
 	@Runlevel(1) include embox.compat.libc.test.math_test_ceil
+  @Runlevel(1) include embox.compat.libc.test.atan_tests
 
 	@Runlevel(1) include embox.lib.libcrypt.des_test
 


### PR DESCRIPTION
This test module is also added to the x86 template
closes #3268 