### PR TITLE
Added tests for math.h fabs, floor, round and tanh

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -135,3 +135,35 @@ module asin_tests {
 	depends embox.compat.libc.math
 	depends embox.framework.LibFramework
 }
+
+module round_tests {
+	source "round_tests.c"
+
+
+	depends embox.compat.libc.math
+	depends embox.framework.LibFramework
+}
+
+module tanh_tests {
+	source "tanh_tests.c"
+
+
+	depends embox.compat.libc.math
+	depends embox.framework.LibFramework
+}
+
+module floor_tests {
+	source "floor_tests.c"
+
+
+	depends embox.compat.libc.math
+	depends embox.framework.LibFramework
+}
+
+module fabs_tests {
+	source "fabs_tests.c"
+
+
+	depends embox.compat.libc.math
+	depends embox.framework.LibFramework
+}

--- a/src/compat/libc/math/tests/fabs_tests.c
+++ b/src/compat/libc/math/tests/fabs_tests.c
@@ -1,0 +1,45 @@
+/**
+ * @file
+ *
+ * @date July 07, 2024
+ * @author Ankith Veldandi
+ */
+
+
+
+#include <embox/test.h>
+#include <math.h>
+
+EMBOX_TEST_SUITE("fabs() tests");
+
+TEST_CASE("Test for fabs(2.33)"){
+    test_assert(fabs(2.33) == 2.33);
+}
+
+TEST_CASE("Test for fabs(-2.33)"){
+    test_assert(fabs(-2.33) == 2.33);
+}
+
+TEST_CASE("Test for fabs(-233)"){
+    test_assert(fabs(-233) == 233);
+}
+
+TEST_CASE("Test for fabs(0.0)"){
+    test_assert(fabs(0.00) == 0.0);
+}
+
+TEST_CASE("Test for fabs(-0.0)"){
+    test_assert(fabs(-0.00) == 0.0);
+}
+
+TEST_CASE("Test for fabs(+INFINITY)"){
+    test_assert(isinf(fabs(INFINITY)));
+}
+
+TEST_CASE("Test for fabs(-INFINITY)"){
+    test_assert(isinf(fabs(-INFINITY)));
+}
+
+TEST_CASE("Test for fabs(NAN)"){
+    test_assert(isnan(fabs(NAN)));
+}

--- a/src/compat/libc/math/tests/floor_tests.c
+++ b/src/compat/libc/math/tests/floor_tests.c
@@ -1,0 +1,46 @@
+/**
+ * @file
+ *
+ * @date July 07, 2024
+ * @author Ankith Veldandi
+ */
+
+
+
+#include <embox/test.h>
+#include <math.h>
+
+EMBOX_TEST_SUITE("floor() tests");
+
+
+TEST_CASE("Test for floor(0.23)") {
+	test_assert(floor(0.23) == 0.0);
+}
+
+TEST_CASE("Test for floor(5.73)") {
+	test_assert(floor(5.73) == 5.0);
+}
+
+TEST_CASE("Test for floor(6.0)") {
+	test_assert(floor(6.0) == 6.0);
+}
+
+TEST_CASE("Test for floor(-3.4)") {
+	test_assert(floor(-3.4) == -4.0);
+}
+
+TEST_CASE("Test for floor(-3.0)") {
+	test_assert(floor(-3.0) == -3.0);
+}
+
+TEST_CASE("Test for floor(+INFINITY)") {
+	test_assert(isinf(floor(INFINITY)));
+}
+
+TEST_CASE("Test for floor(-INFINITY)") {
+	test_assert(isinf(floor(-INFINITY)));
+}
+
+TEST_CASE("Test for floor(NAN)") {
+	test_assert(isnan(floor(NAN)));
+}

--- a/src/compat/libc/math/tests/round_tests.c
+++ b/src/compat/libc/math/tests/round_tests.c
@@ -1,0 +1,42 @@
+/**
+ * @file
+ *
+ * @date July 07, 2024
+ * @author Ankith Veldandi
+ */
+
+
+
+#include <embox/test.h>
+#include <math.h>
+
+EMBOX_TEST_SUITE("round() tests");
+
+
+TEST_CASE("Test for round(0.23)") {
+	test_assert(round(0.23) == 0.0);
+}
+
+TEST_CASE("Test for round(0.73)") {
+	test_assert(round(0.73) == 1.0);
+}
+
+TEST_CASE("Test for round(0.0)") {
+	test_assert(round(0.0) == 0.0);
+}
+
+TEST_CASE("Test for round(3.5)") {
+	test_assert(round(3.5) == 4.0);
+}
+
+TEST_CASE("Test for round(-3.5)") {
+	test_assert(round(-3.5) == -4.0);
+}
+
+TEST_CASE("Test for round(+INFINITY)") {
+	test_assert(isinf(round(INFINITY)));
+}
+
+TEST_CASE("Test for round(NAN)") {
+	test_assert(isnan(round(NAN)));
+}

--- a/src/compat/libc/math/tests/tanh_tests.c
+++ b/src/compat/libc/math/tests/tanh_tests.c
@@ -1,0 +1,37 @@
+/**
+ * @file
+ *
+ * @date July 07, 2024
+ * @author Ankith Veldandi
+ */
+
+
+
+#include <embox/test.h>
+#include <math.h>
+
+EMBOX_TEST_SUITE("tanh() tests");
+
+TEST_CASE("Test for tanh(INFINITY)"){
+    test_assert(tanh(INFINITY) == 1);
+}
+
+TEST_CASE("Test for tanh(-INFINITY)"){
+    test_assert(tanh(-INFINITY) == -1);
+}
+
+TEST_CASE("Test for tanh(NAN)"){
+    test_assert(isnan(tanh(NAN)));
+}
+
+TEST_CASE("Test for tanh(0)"){
+    test_assert(tanh(0) == 0);
+}
+
+TEST_CASE("Test for tanh(45)"){
+    test_assert(tanh(45) == 1);
+}
+
+TEST_CASE("Test for tanh(-45)"){
+    test_assert(tanh(-45) == -1);
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -193,7 +193,10 @@ configuration conf {
 	//@Runlevel(1) include embox.compat.libc.test.atan_tests
 	@Runlevel(1) include embox.compat.libc.test.atan2_tests
 	@Runlevel(1) include embox.compat.libc.test.acos_tests
-
+	@Runlevel(1) include embox.compat.libc.test.fabs_tests
+	@Runlevel(1) include embox.compat.libc.test.floor_tests
+	@Runlevel(1) include embox.compat.libc.test.round_tests
+	@Runlevel(1) include embox.compat.libc.test.tanh_tests
 	@Runlevel(1) include embox.compat.libc.test.math_test_cosh
 
 	@Runlevel(1) include embox.lib.crypt.des_test


### PR DESCRIPTION
Added test cases to tanh(), round(), floor() and fabs() as per issues #3337 , #3336 , #3331 and #3330 respectively. 
After adding test cases also added them in the Mybuild inside `src/compat/libc/math/tests/Mybuild` as per the sqrt_tests.

Then to test I added these in mods.conf (this is not included in the commit as I assumed the master won't include them)
```
@Runlevel(1) include embox.compat.libc.test.round_tests
@Runlevel(1) include embox.compat.libc.test.fabs_tests
@Runlevel(1) include embox.compat.libc.test.floor_tests
@Runlevel(1) include embox.compat.libc.test.tanh_tests
```
And when I build `make` and run `./scripts/qemu/auto_qemu` I see all the tests pass.
Below is the screenshot showing that.

![embox](https://github.com/embox/embox/assets/143205588/8ba2aa7d-0c68-43fe-bc3f-851de671b4d8)

This is my first issue, if anything more is required like if the test cases are not enough, I can add more. Please let me know. 