### PR TITLE
drivers: interrupt: Implement RISC-V CLINT for Interrupt Control and Timer Management.

### DIFF
--- a/src/drivers/interrupt/riscv_clint/Mybuild
+++ b/src/drivers/interrupt/riscv_clint/Mybuild
@@ -1,0 +1,10 @@
+package embox.driver.interrupt
+
+module riscv_clint extends irqctrl_api {
+	option number base_addr = 0X2000000
+        option number msip_offset = 0x0000
+        option number mtimecmp_offset = 0x4000
+        option number mtime_offset = 0xBFF8
+
+	source "riscv_clint.c", "riscv_clint.h"
+}

--- a/src/drivers/interrupt/riscv_clint/riscv_clint.c
+++ b/src/drivers/interrupt/riscv_clint/riscv_clint.c
@@ -1,0 +1,72 @@
+/**
+ * @file
+ *
+ * @brief Implementation of the RISC-V Core Local Interruptor (CLINT) for interrupt control and timer management.
+ *
+ * @date 05.07.2024
+ * @authored by Suraj Ravindra Sonawane
+ */
+
+#include <stdint.h>
+#include <drivers/irqctrl.h>
+#include <hal/reg.h>
+
+#define CLINT_ADDR      OPTION_GET(NUMBER, base_addr)
+#define MSIP_OFFSET     OPTION_GET(NUMBER, msip_offset)
+#define MTIMECMP_OFFSET OPTION_GET(NUMBER, mtimecmp_offset)
+#define MTIME_OFFSET    OPTION_GET(NUMBER, mtime_offset)
+
+#define MSIP_ADDR       (CLINT_ADDR + MSIP_OFFSET)
+#define MTIMECMP_ADDR   (CLINT_ADDR + MTIMECMP_OFFSET)
+#define MTIME_ADDR      (CLINT_ADDR + MTIME_OFFSET)
+
+/**
+ * Initializes the CLINT.
+ *
+ * This function initializes the CLINT by clearing the MSIP (Software Interrupt) and setting MTIMECMP
+ * to its maximum value (0xFFFFFFFFFFFFFFFF).
+ *
+ * @return 0 on success.
+ */
+static int clint_init(void) {
+    // Initial configuration: clear MSIP and set MTIMECMP to max value
+    REG32_STORE(MSIP_ADDR, 0);                      // Clear MSIP by writing 0 to its address
+    REG64_STORE(MTIMECMP_ADDR, 0xFFFFFFFFFFFFFFFF); // Set MTIMECMP to max value
+    REG64_STORE(MTIME_ADDR, 0);                     // Initialize MTIME to 0
+    return 0;
+}
+
+/**
+ * Configures the Software Interrupt (MSIP).
+ *
+ * This function configures the MSIP by writing a specific value (0 or 1) to its address.
+ *
+ * @param value The value (0 or 1) to set for MSIP.
+ */
+void clint_configure_msip(uint8_t value) {
+    REG32_STORE(MSIP_ADDR, value & 1); // Write the least significant bit of 'value' to MSIP_ADDR
+}
+
+/**
+ * Sets the MTIMECMP register value.
+ *
+ * This function sets the MTIMECMP register to the provided 64-bit value.
+ *
+ * @param value The value to set for MTIMECMP.
+ */
+void clint_set_mtimecmp(uint64_t value) {
+    REG64_STORE(MTIMECMP_ADDR, value); // Write 'value' to MTIMECMP_ADDR
+}
+
+/**
+ * Retrieves the current value of MTIME.
+ *
+ * This function reads and returns the current value of MTIME.
+ *
+ * @return The current value of MTIME.
+ */
+uint64_t clint_get_mtime(void) {
+    return REG64_LOAD(MTIME_ADDR); // Read and return the value at MTIME_ADDR
+}
+
+IRQCTRL_DEF(riscv_clint, clint_init);

--- a/src/drivers/interrupt/riscv_clint/riscv_clint.h
+++ b/src/drivers/interrupt/riscv_clint/riscv_clint.h
@@ -1,0 +1,11 @@
+/**
+ * @file
+ *
+ * @date 05.07.2024
+ * @author Suraj Ravindra Sonawane
+ */
+
+#ifndef IRQCTRL_RISCV_CLINT_IMPL_H_
+#define IRQCTRL_RISCV_CLINT_IMPL_H_
+
+#endif /* IRQCTRL_RISCV_CLINT_IMPL_H_ */


### PR DESCRIPTION
This PR introduces the implementation of the RISC-V Core Local Interruptor (CLINT) for interrupt control and timer management. By referring to this [**document**](https://chromitem-soc.readthedocs.io/en/latest/clint.html). Please review it and advise on any additional elements that need to be added?

I have implemented the following features:
- **CLINT Initialization:** Clears the MSIP (Software Interrupt) and sets MTIMECMP to its maximum value.
Software Interrupt Configuration: Allows configuration of the MSIP by writing a specific value (0 or 1) to its address.
- **MTIMECMP Register:** Sets the MTIMECMP register to the provided 64-bit value.
- **MTIME Retrieval**: Reads and returns the current value of MTIME.