### PR TITLE
arch: Add max_supported_cores option in smp module

### DIFF
--- a/src/arch/Mybuild
+++ b/src/arch/Mybuild
@@ -31,13 +31,13 @@ abstract module syscall { }
 
 @Mandatory
 @DefaultImpl(embox.arch.generic.nousermode)
-abstract module usermode {
-	option number max_supported_cores
-}
+abstract module usermode { }
 
 @Mandatory
 @DefaultImpl(embox.arch.generic.nosmp)
-abstract module smp { }
+abstract module smp {
+	option number max_supported_cores
+}
 
 @Mandatory
 @DefaultImpl(embox.arch.generic.reg_stub)

--- a/src/arch/Mybuild
+++ b/src/arch/Mybuild
@@ -31,7 +31,9 @@ abstract module syscall { }
 
 @Mandatory
 @DefaultImpl(embox.arch.generic.nousermode)
-abstract module usermode { }
+abstract module usermode {
+	option number max_supported_cores
+}
 
 @Mandatory
 @DefaultImpl(embox.arch.generic.nosmp)

--- a/src/arch/generic/Mybuild
+++ b/src/arch/generic/Mybuild
@@ -23,6 +23,7 @@ module nousermode extends embox.arch.usermode {
 
 @NoCode
 module nosmp extends embox.arch.smp {
+	option number max_supported_cores=1
 	source "nosmp.h"
 }
 

--- a/src/arch/x86/include/asm/gdt.h
+++ b/src/arch/x86/include/asm/gdt.h
@@ -11,6 +11,8 @@
 
 #define GDT_ENTRIES            6
 
+#define GDT_ENTRY_SIZE        64
+
 #define GDT_ENTRY_KERNEL_CS    1
 #define GDT_ENTRY_KERNEL_DS    2
 #define GDT_ENTRY_USER_CS      3

--- a/src/arch/x86/include/asm/linkage.h
+++ b/src/arch/x86/include/asm/linkage.h
@@ -5,6 +5,10 @@
  * @author: Anton Bondarev
  */
 
+#include <asm/gdt.h>
+#include <framework/mod/options.h>
+#include <module/embox/arch/x86/kernel/smp.h>
+
 #ifndef LINKAGE_H_
 #define LINKAGE_H_
 
@@ -13,6 +17,8 @@
 #define C_ENTRY(name) .globl name; .align 2; name
 
 #define C_LABEL(name) .globl name; name
+
+#define MAX_SUPPORTED_CORES OPTION_MODULE_GET(embox__arch__x86__kernel__smp, NUMBER, max_supported_cores)
 
 #else
 

--- a/src/arch/x86/kernel/smp/Mybuild
+++ b/src/arch/x86/kernel/smp/Mybuild
@@ -8,6 +8,7 @@ module cpu extends embox.arch.cpu {
 }
 
 module smp extends embox.arch.smp {
+	option number max_supported_cores=2
 	source "smp_traps.S", "ap_trampoline.S", "smp.c"
 
 	depends cpu

--- a/src/arch/x86/kernel/smp/ap_trampoline.S
+++ b/src/arch/x86/kernel/smp/ap_trampoline.S
@@ -33,11 +33,11 @@ C_ENTRY(__ap_trampoline):
 	.align 0x4
 
 C_LABEL(__ap_sp):
-	.space 16
+	.space 4 * MAX_SUPPORTED_CORES
 C_LABEL(__ap_gdtr):
 	.space 8
 C_LABEL(__ap_gdt):
-	.space 384 /* TODO: Fix size */
+	.space GDT_ENTRIES * GDT_ENTRY_SIZE
 C_LABEL(__ap_trampoline_end):
 
 	.section .text

--- a/src/arch/x86/kernel/smp/smp.c
+++ b/src/arch/x86/kernel/smp/smp.c
@@ -29,7 +29,6 @@
 	OPTION_MODULE_GET(embox__kernel__thread__core, NUMBER, thread_stack_size)
 
 EMBOX_UNIT_INIT(unit_init);
-#define X86_MAXAPS 4
 #define TRAMPOLINE_ADDR 0x20000UL
 extern void idt_load(void);
 


### PR DESCRIPTION
add max_sipported_cores option to allocate __AP_SP size for user to config