### PR TITLE
fix: Correct base address format in riscv_clint module

### DIFF
--- a/src/drivers/interrupt/riscv_clint/Mybuild
+++ b/src/drivers/interrupt/riscv_clint/Mybuild
@@ -1,7 +1,7 @@
 package embox.driver.interrupt
 
 module riscv_clint extends irqctrl_api {
-	option number base_addr = 0X2000000
+	option number base_addr = 0x2000000
         option number msip_offset = 0x0000
         option number mtimecmp_offset = 0x4000
         option number mtime_offset = 0xBFF8


### PR DESCRIPTION
This PR corrects the base address format in the riscv_clint module. The previous format used '0X2000000', which has been changed to '0x2000000' to adhere to proper hexadecimal notation.