### PR TITLE
__strong_alias for all the compilers

### DIFF
--- a/src/include/sys/cdefs.h
+++ b/src/include/sys/cdefs.h
@@ -35,10 +35,8 @@
 # define EMPTY_STRUCT_BODY
 #endif
 
-#ifdef __clang__
 #define __strong_alias(alias, sym) \
     __asm__(".global " #alias "\n" \
             #alias " = " #sym);
-#endif
 
 #endif /* SYS_CDEFS_H_ */


### PR DESCRIPTION
Openlib uses non-standard macro `__strong_alias`:

```c
#if  LDBL_MANT_DIG == DBL_MANT_DIG
__strong_alias(cpowl, cpow);
#endif  /* LDBL_MANT_DIG == DBL_MANT_DIG */
```

It's not defined for gcc, so I get compilation error

```
src/s_cpow.c:77:1: warning: data definition has no type or storage class
   77 | __strong_alias(cpowl, cpow);
      | ^~~~~~~~~~~~~~
src/s_cpow.c:77:1: error: type defaults to 'int' in declaration of '__strong_alias' [-Wimplicit-int]
src/s_cpow.c:77:1: error: parameter names (without types) in function declaration **[-Wdeclaration-missing-parameter-type]**
```

Let's juse reuse the same macro for clang