### PR TITLE
Add RISC-V PMP Driver for Memory Protection

### DIFF
--- a/src/arch/riscv/pmp/Mybuild
+++ b/src/arch/riscv/pmp/Mybuild
@@ -1,0 +1,5 @@
+package embox.arch.riscv
+
+module pmp {
+  source "pmp.c", "pmp.h"
+}

--- a/src/arch/riscv/pmp/pmp.c
+++ b/src/arch/riscv/pmp/pmp.c
@@ -1,0 +1,122 @@
+/**
+ * @file
+ *
+ * @brief RISC-V Physical Memory Protection (PMP) Driver
+ *
+ * @date 02.08.2024
+ * @author Suraj Ravindra Sonawane
+ */
+
+#include "pmp.h"
+#include <math.h>
+#include <hal/reg.h>
+
+/**
+ * Writes to a PMP configuration register.
+ *
+ * @param reg The index of the PMP configuration register to write to.
+ * @param value The value to write to the register.
+ */
+static inline void write_pmpcfg(uint32_t reg, uint32_t value) {
+    REG32_STORE(PMP_CFG_BASE + reg * 4, value);
+}
+
+/**
+ * Writes to a PMP address register.
+ *
+ * @param reg The index of the PMP address register to write to.
+ * @param value The address value to write to the register.
+ */
+static inline void write_pmpaddr(uint32_t reg, uint32_t value) {
+    REG32_STORE(PMP_ADDR_BASE + reg * 4, value);
+}
+
+/**
+ * Initializes the PMP subsystem by clearing all PMP entries and setting up 
+ * predefined PMP regions based on configuration options.
+ *
+ */
+int pmp_init(void) {
+    unsigned long pmp_addr[PMP_NUM_REGISTERS] = {0};
+    unsigned long pmp_cfg[(PMP_NUM_REGISTERS + 3) / 4] = {0};
+    unsigned int index = 0;
+
+    // Clear all PMP configurations and addresses
+    for (int i = 0; i < PMP_NUM_REGISTERS; i++) {
+        write_pmpaddr(i, 0); 
+        write_pmpcfg(i / 4, 0); 
+    }
+
+    // Set up PMP entries based on configuration options
+    #ifdef CONFIG_ROM_REGION
+    set_pmp_entry(&index, PMP_R | PMP_X | PMP_TOR, ROM_BASE, ROM_SIZE, pmp_addr, pmp_cfg, PMP_NUM_REGISTERS, page_size);
+    #endif
+
+    #ifdef CONFIG_NULL_POINTER_EXCEPTION_DETECTION_PMP
+    set_pmp_entry(&index, PMP_NA, CONFIG_NULL_PTR_BASE, CONFIG_NULL_PTR_SIZE, pmp_addr, pmp_cfg, PMP_NUM_REGISTERS, page_size);
+    #endif
+
+    #ifdef CONFIG_PMP_STACK_GUARD
+    set_pmp_entry(&index, PMP_NA, CONFIG_STACK_GUARD_BASE, CONFIG_STACK_GUARD_SIZE, pmp_addr, pmp_cfg, PMP_NUM_REGISTERS, page_size);
+    set_pmp_entry(&index, PMP_R | PMP_X | PMP_TOR, CONFIG_MPRV_BASE, CONFIG_MPRV_SIZE, pmp_addr, pmp_cfg, PMP_NUM_REGISTERS, page_size);
+    #endif
+
+    // Write configured PMP entries to registers
+    for (unsigned int i = 0; i < index; i++) {
+        write_pmpaddr(i, pmp_addr[i]);
+        write_pmpcfg(i / 4, pmp_cfg[i / 4]);
+    }
+
+    return 0;
+}
+
+/**
+ * Configures a PMP entry with specific parameters.
+ *
+ * @param index Pointer to the current index of the PMP entry to configure.
+ * @param flags The flags that define the permissions and type of the PMP entry.
+ * @param base The base address for the PMP entry.
+ * @param size The size of the memory region to protect.
+ * @param pmp_addr Array of PMP address values to be configured.
+ * @param pmp_cfg Array of PMP configuration values to be set.
+ * @param pmp_count The total number of PMP registers available.
+ * @param page_size The size of a memory page, used to determine entry granularity.
+ */
+void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size_t size,
+                   unsigned long *pmp_addr, unsigned long *pmp_cfg, size_t pmp_count, size_t page_size) {
+    unsigned int i;
+    size_t num_entries = (size + page_size - 1) / page_size;
+
+    // Ensure there are enough PMP registers available
+    if (*index + num_entries > pmp_count) {
+        return; // Not enough PMP registers available
+    }
+
+    if (flags & PMP_TOR) {
+        // TOR: Top of Range
+        pmp_addr[*index] = base >> 2;
+        pmp_cfg[*index / 4] |= flags;
+        (*index)++;
+    } else if (flags & PMP_NA4) {
+        // NA4: Naturally Aligned 4-byte
+        pmp_addr[*index] = base >> 2;
+        pmp_cfg[*index / 4] |= flags;
+        (*index)++;
+    } else if (flags & PMP_NAPOT) {
+        // NAPOT: Naturally Aligned Power of Two
+        size_t napot_size = size;
+        while ((size_t)1 << (uint32_t)log2(napot_size) != napot_size) {
+            napot_size <<= 1;
+        }
+        pmp_addr[*index] = (base >> 2) | (napot_size - 1);
+        pmp_cfg[*index / 4] |= flags;
+        (*index)++;
+    } else {
+        // Default case: Divide the region into pages
+        for (i = 0; i < num_entries; i++) {
+            pmp_addr[*index + i] = base + i * page_size;
+            pmp_cfg[*index + i / 4] |= flags;
+        }
+        *index += num_entries;
+    }
+}

--- a/src/arch/riscv/pmp/pmp.c
+++ b/src/arch/riscv/pmp/pmp.c
@@ -8,8 +8,8 @@
  */
 
 #include "pmp.h"
-#include <math.h>
 #include <hal/reg.h>
+#include <embox/unit.h>
 
 /**
  * Writes to a PMP configuration register.
@@ -36,7 +36,7 @@ static inline void write_pmpaddr(uint32_t reg, uint32_t value) {
  * predefined PMP regions based on configuration options.
  *
  */
-int pmp_init(void) {
+static int pmp_init(void) {
     unsigned long pmp_addr[PMP_NUM_REGISTERS] = {0};
     unsigned long pmp_cfg[(PMP_NUM_REGISTERS + 3) / 4] = {0};
     unsigned int index = 0;
@@ -104,8 +104,9 @@ void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size
         (*index)++;
     } else if (flags & PMP_NAPOT) {
         // NAPOT: Naturally Aligned Power of Two
-        size_t napot_size = size;
-        while ((size_t)1 << (uint32_t)log2(napot_size) != napot_size) {
+        napot_size = size;
+        napot_size = 1;
+        while (napot_size < size) {
             napot_size <<= 1;
         }
         pmp_addr[*index] = (base >> 2) | (napot_size - 1);
@@ -120,3 +121,5 @@ void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size
         *index += num_entries;
     }
 }
+
+EMBOX_UNIT_INIT(pmp_init);

--- a/src/arch/riscv/pmp/pmp.h
+++ b/src/arch/riscv/pmp/pmp.h
@@ -1,0 +1,73 @@
+/**
+ * @file
+ *
+ * @brief RISC-V Physical Memory Protection (PMP) Driver Header
+ *
+ * @date 02.08.2024
+ * @author Suraj Ravindra Sonawane
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef PMP_H_
+#define PMP_H_
+
+// PMP Configuration Base Address and Number of Registers
+#define PMP_CFG_BASE  0x3A0
+#define PMP_ADDR_BASE 0x3B0
+#define PMP_NUM_REGISTERS 16 // Number of PMP registers available
+
+// PMP Access Flags
+#define PMP_R 0x1  // Read Access
+#define PMP_W 0x2  // Write Access
+#define PMP_X 0x4  // Execute Access
+#define PMP_NA 0x0 // No Access
+#define PMP_TOR 0x8 // Top of Range
+#define PMP_NA4 0x10 // Naturally Aligned 4-byte Region
+#define PMP_NAPOT 0x20 // Naturally Aligned Power of Two Region
+
+typedef struct {
+    uintptr_t address;
+    uint32_t config;
+} pmp_region_t;
+
+/**
+ * Initializes the PMP subsystem by clearing all PMP entries and setting up 
+ * predefined PMP regions based on configuration options.
+ *
+ */
+int pmp_init(void);
+
+/**
+ * Configures a PMP entry with specific parameters.
+ *
+ * @param index Pointer to the current index of the PMP entry to configure.
+ * @param flags The flags that define the permissions and type of the PMP entry.
+ * @param base The base address for the PMP entry.
+ * @param size The size of the memory region to protect.
+ * @param pmp_addr Array of PMP address values to be configured.
+ * @param pmp_cfg Array of PMP configuration values to be set.
+ * @param pmp_count The total number of PMP registers available.
+ * @param page_size The size of a memory page, used to determine entry granularity.
+ */
+void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size_t size,
+                   unsigned long *pmp_addr, unsigned long *pmp_cfg, size_t pmp_count, size_t page_size);
+
+/**
+ * Writes to a PMP configuration register.
+ *
+ * @param reg The index of the PMP configuration register to write to.
+ * @param value The value to write to the register.
+ */
+static inline void write_pmpcfg(uint32_t reg, uint32_t value);
+
+/**
+ * Writes to a PMP address register.
+ *
+ * @param reg The index of the PMP address register to write to.
+ * @param value The address value to write to the register.
+ */
+static inline void write_pmpaddr(uint32_t reg, uint32_t value);
+
+#endif /* PMP_H_ */

--- a/src/arch/riscv/pmp/pmp.h
+++ b/src/arch/riscv/pmp/pmp.h
@@ -37,7 +37,7 @@ typedef struct {
  * predefined PMP regions based on configuration options.
  *
  */
-int pmp_init(void);
+static int pmp_init(void);
 
 /**
  * Configures a PMP entry with specific parameters.

--- a/templates/riscv/qemu/mods.conf
+++ b/templates/riscv/qemu/mods.conf
@@ -8,6 +8,7 @@ configuration conf {
 	include embox.arch.riscv.kernel.context
 	include embox.arch.riscv.libarch
 	include embox.arch.riscv.vfork
+	include embox.arch.riscv.pmp
 
 	include embox.mem.bitmask
 	include embox.driver.periph_memory_stub


### PR DESCRIPTION
- Implement PMP initialization and configuration functions
- Support for TOR, NA4, and NAPOT entry types
- Provide utility functions for PMP register access

This driver enables memory protection on RISC-V systems to enhance security. Tested with the riscv/qemu template.

Please review and suggest any required changes.