### PR TITLE
Fix: PMP Module (Update PMP Register Management and API Declaration)

### DIFF
--- a/src/arch/riscv/pmp/pmp.c
+++ b/src/arch/riscv/pmp/pmp.c
@@ -17,7 +17,7 @@
  * @param reg The index of the PMP configuration register to write to.
  * @param value The value to write to the register.
  */
-static inline void write_pmpcfg(uint32_t reg, uint32_t value) {
+void write_pmpcfg(uint32_t reg, uint32_t value) {
     REG32_STORE(PMP_CFG_BASE + reg * 4, value);
 }
 
@@ -27,7 +27,7 @@ static inline void write_pmpcfg(uint32_t reg, uint32_t value) {
  * @param reg The index of the PMP address register to write to.
  * @param value The address value to write to the register.
  */
-static inline void write_pmpaddr(uint32_t reg, uint32_t value) {
+void write_pmpaddr(uint32_t reg, uint32_t value) {
     REG32_STORE(PMP_ADDR_BASE + reg * 4, value);
 }
 
@@ -40,12 +40,6 @@ static int pmp_init(void) {
     unsigned long pmp_addr[PMP_NUM_REGISTERS] = {0};
     unsigned long pmp_cfg[(PMP_NUM_REGISTERS + 3) / 4] = {0};
     unsigned int index = 0;
-
-    // Clear all PMP configurations and addresses
-    for (int i = 0; i < PMP_NUM_REGISTERS; i++) {
-        write_pmpaddr(i, 0); 
-        write_pmpcfg(i / 4, 0); 
-    }
 
     // Set up PMP entries based on configuration options
     #ifdef CONFIG_ROM_REGION
@@ -86,6 +80,7 @@ void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size
                    unsigned long *pmp_addr, unsigned long *pmp_cfg, size_t pmp_count, size_t page_size) {
     unsigned int i;
     size_t num_entries = (size + page_size - 1) / page_size;
+    size_t napot_size;
 
     // Ensure there are enough PMP registers available
     if (*index + num_entries > pmp_count) {

--- a/src/arch/riscv/pmp/pmp.h
+++ b/src/arch/riscv/pmp/pmp.h
@@ -44,7 +44,7 @@ typedef struct {
  * @param pmp_count The total number of PMP registers available.
  * @param page_size The size of a memory page, used to determine entry granularity.
  */
-void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size_t size,
+extern void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size_t size,
                    unsigned long *pmp_addr, unsigned long *pmp_cfg, size_t pmp_count, size_t page_size);
 
 /**
@@ -53,7 +53,7 @@ void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size
  * @param reg The index of the PMP configuration register to write to.
  * @param value The value to write to the register.
  */
-void write_pmpcfg(uint32_t reg, uint32_t value);
+extern void write_pmpcfg(uint32_t reg, uint32_t value);
 
 /**
  * Writes to a PMP address register.
@@ -61,6 +61,6 @@ void write_pmpcfg(uint32_t reg, uint32_t value);
  * @param reg The index of the PMP address register to write to.
  * @param value The address value to write to the register.
  */
-void write_pmpaddr(uint32_t reg, uint32_t value);
+extern void write_pmpaddr(uint32_t reg, uint32_t value);
 
 #endif /* PMP_H_ */

--- a/src/arch/riscv/pmp/pmp.h
+++ b/src/arch/riscv/pmp/pmp.h
@@ -33,13 +33,6 @@ typedef struct {
 } pmp_region_t;
 
 /**
- * Initializes the PMP subsystem by clearing all PMP entries and setting up 
- * predefined PMP regions based on configuration options.
- *
- */
-static int pmp_init(void);
-
-/**
  * Configures a PMP entry with specific parameters.
  *
  * @param index Pointer to the current index of the PMP entry to configure.
@@ -60,7 +53,7 @@ void set_pmp_entry(unsigned int *index, unsigned int flags, uintptr_t base, size
  * @param reg The index of the PMP configuration register to write to.
  * @param value The value to write to the register.
  */
-static inline void write_pmpcfg(uint32_t reg, uint32_t value);
+void write_pmpcfg(uint32_t reg, uint32_t value);
 
 /**
  * Writes to a PMP address register.
@@ -68,6 +61,6 @@ static inline void write_pmpcfg(uint32_t reg, uint32_t value);
  * @param reg The index of the PMP address register to write to.
  * @param value The address value to write to the register.
  */
-static inline void write_pmpaddr(uint32_t reg, uint32_t value);
+void write_pmpaddr(uint32_t reg, uint32_t value);
 
 #endif /* PMP_H_ */


### PR DESCRIPTION
1. Removed the unnecessary code for manually clearing PMP registers, as it disrupted existing configurations and was found to be redundant.
2. Deleted the pmp_init function declaration from the header file, since it is initialized using EMBOX_UNIT_INIT(pmp_init) and does not need to be exposed in the header.
3. Changed the functions definition of write_pmpcfg and write_pmpaddr from static inline to public to enable its use outside the .c file by including the .h file.