### PR TITLE
Prepare Multiprocessor on x86 arch with testing modules

### DIFF
--- a/src/arch/x86/kernel/irq_handler.c
+++ b/src/arch/x86/kernel/irq_handler.c
@@ -14,11 +14,12 @@
 #include <kernel/irq.h>
 
 fastcall void irq_handler(pt_regs_t *regs) {
+	int irq = regs->trapno - 0x20;
 	assert(!critical_inside(CRITICAL_IRQ_LOCK));
 
 	critical_enter(CRITICAL_IRQ_HANDLER);
 	{
-		int irq = regs->trapno - 0x20;
+		irqctrl_disable(irq);
 
 		ipl_enable();
 
@@ -35,6 +36,7 @@ fastcall void irq_handler(pt_regs_t *regs) {
 
 		irqctrl_eoi(irq);
 
+		irqctrl_enable(irq);
 	}
 	critical_leave(CRITICAL_IRQ_HANDLER);
 	critical_dispatch_pending();

--- a/src/tests/smp/Mybuild
+++ b/src/tests/smp/Mybuild
@@ -4,4 +4,11 @@ package embox.test.smp
 @Cmd(name = "test_smp", help="Running multiple cores")
 module test_smp {
     source "test_smp.c"
+	depends embox.arch.smp
+}
+
+module simult_thread_test {
+	option string log_level="LOG_NONE"
+	source "simult_thread_test.c"
+	depends embox.arch.smp
 }

--- a/src/tests/smp/simult_thread_test.c
+++ b/src/tests/smp/simult_thread_test.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @date 2024.8.7
+ * @author Zeng Zixian
+ */
+
+#include <embox/test.h>
+
+#include <util/log.h>
+
+#include <asm/ap.h>
+
+#include <kernel/thread.h>
+#include <kernel/task.h>
+#include <kernel/thread/thread_stack.h>
+
+#include <module/embox/kernel/stack.h>
+
+#define MAX_TRYTIMES    ((unsigned int)(-1) - 1)
+
+EMBOX_TEST_SUITE("test simultaneous thread on CPUs");
+
+static unsigned int try_time = 0;
+static unsigned int thread_status[4] = {0};
+
+static int search_threads(void) {
+	struct thread * th;
+	struct task *task;
+	int ret = 0;
+
+	task_foreach(task) {
+		task_foreach_thread(th, task) {
+			if(th->schedee.active == 1 && th != thread_self()){
+				ret = 1;
+				thread_status[0] = th->schedee.active;
+				thread_status[1] = th->schedee.ready;
+				thread_status[2] = th->schedee.waiting;
+				thread_status[3] = (unsigned int)th;
+				return ret;
+			}
+		}
+	}
+
+	return ret;
+}
+
+
+void * test_thread_1(void *arg){
+	struct thread * self = thread_self();
+	int founded = 0;
+	test_assert(self->schedee.active);
+
+	while(try_time++ < MAX_TRYTIMES) {
+		founded = search_threads();
+		if(founded) break;
+	}
+
+	log_debug("found %d try_time %u",founded,try_time);
+	if(founded){
+		log_debug("Self thread %#x A %u R %u W %u", (unsigned int)self, self->schedee.active, self->schedee.ready, self->schedee.waiting);
+		log_debug("Found thread %#x A %u R %u W %u", thread_status[3], thread_status[0], thread_status[1], thread_status[2]);
+	}
+
+	test_assert_not_zero(founded);
+	return 0;
+}
+
+void * test_thread_2(void * arg){
+	test_assert_zero(thread_join((struct thread *)arg,NULL));
+	return 0;
+}
+
+
+TEST_CASE("two threads exsit simultaneously") {
+	struct thread * thread1, * thread2;
+	thread1 = thread_create(THREAD_FLAG_PRIORITY_HIGHER,test_thread_1,NULL);
+	thread2 = thread_create(0,test_thread_2,thread1);
+	thread_join(thread2,NULL);
+}

--- a/src/tests/smp/test_smp.c
+++ b/src/tests/smp/test_smp.c
@@ -1,7 +1,10 @@
 #include <kernel/thread.h>
 #include <kernel/cpu/cpu.h>
 #include <kernel/spinlock.h>
+#include <kernel/thread/thread_alloc.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 static volatile int shared_counter = 0;
 static spinlock_t lock = SPIN_STATIC_UNLOCKED;
@@ -27,4 +30,52 @@ void start_thread_on_cpu(int cpu_id) {
 
     cpu_bind(cpu_id, t);
     thread_launch(t);
+}
+
+int count, all_chars;
+char b = '\n';
+void * thd_1(void *arg){
+	for(int i = 0;count < all_chars; i++){
+		if((i % 10000000) == 0){
+			count++;
+			if(count % 70 == 0) write(2,&b,1);
+
+			write(2,(char *)arg,1);
+		}
+	}
+	return 0;
+}
+
+int main(int argc, char *argv[]) {
+	struct thread * tid1, *tid2, *tid3, *tid4, *tid5;
+	char string[]="0123456789";
+
+	if(argc > 1){
+		all_chars = atoi(argv[1]);
+		count = 0;
+	} else{
+		all_chars = 200;
+		count = 0;
+	}
+
+	sched_lock();
+	tid1 = thread_create(0,thd_1,string+1);
+	tid2 = thread_create(0,thd_1,string+2);
+	tid3 = thread_create(0,thd_1,string+3);
+	tid4 = thread_create(0,thd_1,string+4);
+	tid5 = thread_create(0,thd_1,string+5);
+
+	sched_affinity_set(&tid1->schedee.affinity,1);
+	sched_affinity_set(&tid2->schedee.affinity,1);
+	sched_affinity_set(&tid3->schedee.affinity,1);
+	sched_affinity_set(&tid4->schedee.affinity,2);
+	sched_affinity_set(&tid5->schedee.affinity,2);
+
+	sched_unlock();
+
+	thread_join(tid1,NULL);
+	thread_join(tid2,NULL);
+	thread_join(tid3,NULL);
+	thread_join(tid4,NULL);
+	thread_join(tid5,NULL);
 }

--- a/templates/x86/smp/build.conf
+++ b/templates/x86/smp/build.conf
@@ -1,6 +1,8 @@
 TARGET = embox
 ARCH = x86
 
+//CROSS_COMPILE = i686-elf-
+
 CFLAGS += -O0 -g
 CFLAGS += -march=i386 -m32
 

--- a/templates/x86/smp/mods.conf
+++ b/templates/x86/smp/mods.conf
@@ -2,81 +2,92 @@
 package genconfig
 
 configuration conf {
-	@Runlevel(2) include embox.arch.x86.kernel.cpu_idle
-	@Runlevel(2) include embox.arch.x86.kernel.locore
-	@Runlevel(2) include embox.arch.x86.kernel.context
-	@Runlevel(2) include embox.arch.x86.kernel.interrupt
-	@Runlevel(2) include embox.arch.x86.kernel.smp
-	@Runlevel(2) include embox.arch.x86.kernel.cpu(cpu_count=2)
-	@Runlevel(2) include embox.arch.x86.vfork
+	@Runlevel(1) include embox.arch.x86.kernel.cpu_idle
+	@Runlevel(1) include embox.arch.x86.kernel.locore
+	@Runlevel(1) include embox.arch.x86.kernel.context
+	@Runlevel(1) include embox.arch.x86.kernel.interrupt
+	@Runlevel(1) include embox.arch.x86.kernel.cpu(cpu_count=2)
+	@Runlevel(1) include embox.arch.x86.vfork
 
 	include embox.arch.x86.libarch
-	include embox.arch.x86.cpu_info_x86
 
 	include embox.driver.interrupt.i8259_headers
 	include embox.driver.interrupt.lapic
 	include embox.driver.interrupt.ioapic
 	include embox.driver.clock.pit(irq_num=2)
 	include embox.kernel.time.jiffies(cs_name="pit")
-	@Runlevel(2) include embox.driver.clock.lapic_timer
+	//include embox.driver.clock.lapic_timer
+	//include embox.kernel.time.jiffies(cs_name="lapic_timer")
 
-	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(0) include embox.kernel.timer.sys_timer
+	@Runlevel(0) include embox.kernel.time.kernel_time
+	@Runlevel(1) include embox.kernel.sched.strategy.priority_based_smp
+	@Runlevel(1) include embox.kernel.timer.sleep
+	@Runlevel(1) include embox.kernel.timer.strategy.head_timer
 	@Runlevel(1) include embox.kernel.time.kernel_time
-	@Runlevel(2) include embox.kernel.sched.strategy.priority_based_smp
-	@Runlevel(2) include embox.kernel.timer.sleep
-	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
-	@Runlevel(2) include embox.kernel.time.kernel_time
-	@Runlevel(2) include embox.kernel.irq
-	@Runlevel(2) include embox.kernel.critical
-	@Runlevel(2) include embox.kernel.task.multi
-	@Runlevel(2) include embox.kernel.cpu.smp
+	@Runlevel(1) include embox.kernel.irq
+	@Runlevel(1) include embox.kernel.critical
+	@Runlevel(1) include embox.kernel.task.multi
 	include embox.kernel.sched.idle_thread
+	include embox.kernel.sched.sched(log_level="LOG_NONE")
+	include embox.kernel.thread.core(log_level="LOG_NONE")
 
-	@Runlevel(2) include embox.mem.pool_adapter
-	@Runlevel(2) include embox.mem.static_heap(heap_size=16777216)
-	@Runlevel(2) include embox.mem.heap_bm(heap_size=8388608)
-	@Runlevel(2) include embox.mem.bitmask
+	@Runlevel(1) include embox.mem.pool_adapter
+	@Runlevel(1) include embox.mem.static_heap(heap_size=16777216)
+	@Runlevel(1) include embox.mem.heap_bm(heap_size=8388608)
+	@Runlevel(1) include embox.mem.bitmask
 
-	@Runlevel(2) include embox.driver.serial.i8250_diag(baud_rate=38400)
-	@Runlevel(2) include embox.driver.diag(impl="embox__driver__serial__i8250_diag")
-	@Runlevel(2) include embox.driver.serial.i8250_ttyS0(baud_rate=38400)
+	@Runlevel(1) include embox.driver.serial.i8250_diag(baud_rate=38400)
+	@Runlevel(1) include embox.driver.diag(impl="embox__driver__serial__i8250_diag")
+	@Runlevel(1) include embox.driver.serial.i8250_ttyS0(baud_rate=38400)
 
-	@Runlevel(2) include embox.driver.tty.tty
-	@Runlevel(2) include embox.driver.tty.vterm
-	@Runlevel(2) include embox.driver.input.keyboard.i8042_keyboard
+	@Runlevel(1) include embox.driver.tty.tty
+	@Runlevel(1) include embox.driver.tty.vterm
+	@Runlevel(1) include embox.driver.input.keyboard.i8042_keyboard
 
-	@Runlevel(2) include embox.driver.virtual.null
-	@Runlevel(2) include embox.driver.virtual.zero
+	@Runlevel(1) include embox.driver.virtual.null
+	@Runlevel(1) include embox.driver.virtual.zero
 
 
 /*enable back tracing for panic (asserts)*/
-	@Runlevel(2) include embox.arch.x86.stackframe
-	@Runlevel(2) include embox.lib.debug.whereami
+	@Runlevel(1) include embox.arch.x86.stackframe
+	@Runlevel(1) include embox.lib.debug.whereami
 
-	@Runlevel(2) include embox.driver.net.loopback
-	@Runlevel(2) include embox.driver.net.ne2k_pci
+	@Runlevel(1) include embox.driver.net.loopback
+	@Runlevel(1) include embox.driver.net.ne2k_pci
 
-	@Runlevel(2) include embox.fs.driver.initfs
-	@Runlevel(2) include embox.fs.rootfs_oldfs
-	@Runlevel(2) include embox.fs.driver.devfs
-	include embox.compat.posix.file_system_oldfs
+	@Runlevel(1) include embox.fs.driver.initfs
+	@Runlevel(1) include embox.fs.rootfs_oldfs
+	@Runlevel(1) include embox.fs.driver.devfs
+	@Runlevel(1) include embox.compat.posix.file_system_oldfs
 
-	@Runlevel(1) include embox.driver.ide
+	@Runlevel(0) include embox.driver.ide
 
-	@Runlevel(1) include embox.test.critical
-	@Runlevel(1) include embox.test.framework.mod.member.ops_test
-	@Runlevel(1) include embox.test.kernel.timer_test
-	@Runlevel(1) include embox.test.recursion
-	@Runlevel(1) include embox.test.posix.sleep_test
-	@Runlevel(1) include embox.test.stdlib.bsearch_test
-	@Runlevel(1) include embox.test.stdlib.qsort_test
-	@Runlevel(1) include embox.test.util.array_test
-	@Runlevel(1) include embox.test.util.bit_test
-	@Runlevel(1) include embox.test.util.slist_test
-	@Runlevel(1) include embox.test.util.tree_test
+	/**
+	* SMP module init before test module for accuracy
+	* And after unit initializing to prevent bootstrap
+	* thread be scheduled to APs
+	*/
+	@Runlevel(3) include embox.arch.x86.kernel.smp
+	@Runlevel(3) include embox.kernel.cpu.smp
 
-	@Runlevel(2) include embox.cmd.sh.tish
-	@Runlevel(3) include embox.init.start_script(shell_name="tish",tty_dev="ttyS0",shell_start=1)
+	@Runlevel(3) include embox.test.smp.test_smp
+	@Runlevel(3) include embox.test.smp.simult_thread_test(log_level="LOG_DEBUG")
+	@Runlevel(3) include embox.test.util.tree_test
+	@Runlevel(3) include embox.test.util.slist_test
+	@Runlevel(3) include embox.test.util.bit_test
+	@Runlevel(3) include embox.test.util.array_test
+	@Runlevel(3) include embox.test.stdlib.qsort_test
+	@Runlevel(3) include embox.test.stdlib.bsearch_test
+	@Runlevel(3) include embox.test.posix.sleep_test
+	@Runlevel(3) include embox.test.recursion
+	@Runlevel(3) include embox.test.kernel.timer_test
+	@Runlevel(3) include embox.test.framework.mod.member.ops_test
+	@Runlevel(3) include embox.test.critical
+
+	@Runlevel(3) include embox.cmd.sh.tish
+	@Runlevel(3) include embox.init.system_start_service(log_level="LOG_INFO", tty_dev="ttyS0")
+	//include embox.init.system_start_service(shell_name="tish",tty_dev="ttyS0",shell_start=1)
 
 	include embox.cmd.net.arp
 	include embox.cmd.net.arping
@@ -127,23 +138,23 @@ configuration conf {
 
 	include embox.cmd.testing.ticker
 
-	@Runlevel(2) include embox.net.core
-	@Runlevel(2) include embox.net.socket
-	@Runlevel(2) include embox.net.dev
-	@Runlevel(2) include embox.net.af_inet
-	@Runlevel(2) include embox.net.ipv4
-	@Runlevel(2) include embox.net.arp
-	@Runlevel(2) include embox.net.icmpv4
-	@Runlevel(2) include embox.net.udp
-	@Runlevel(2) include embox.net.tcp
-	@Runlevel(2) include embox.net.udp_sock
-	@Runlevel(2) include embox.net.tcp_sock
-	@Runlevel(2) include embox.net.raw_sock
-	@Runlevel(2) include embox.net.net_entry
+	@Runlevel(1) include embox.net.core
+	@Runlevel(1) include embox.net.socket
+	@Runlevel(1) include embox.net.dev
+	@Runlevel(1) include embox.net.af_inet
+	@Runlevel(1) include embox.net.ipv4
+	@Runlevel(1) include embox.net.arp
+	@Runlevel(1) include embox.net.icmpv4
+	@Runlevel(1) include embox.net.udp
+	@Runlevel(1) include embox.net.tcp
+	@Runlevel(1) include embox.net.udp_sock
+	@Runlevel(1) include embox.net.tcp_sock
+	@Runlevel(1) include embox.net.raw_sock
+	@Runlevel(1) include embox.net.net_entry
 
-	@Runlevel(2) include embox.lib.libds
-	@Runlevel(2) include embox.framework.LibFramework
-	@Runlevel(2) include embox.compat.posix.LibPosix
-	@Runlevel(2) include embox.compat.libc.all
+	@Runlevel(1) include embox.lib.libds
+	@Runlevel(1) include embox.framework.LibFramework
+	@Runlevel(1) include embox.compat.posix.LibPosix
+	@Runlevel(1) include embox.compat.libc.all
 	include embox.compat.libc.math_openlibm
 }

--- a/templates/x86/smp/system_start.inc
+++ b/templates/x86/smp/system_start.inc
@@ -1,0 +1,7 @@
+"ifconfig lo 127.0.0.1 netmask 255.0.0.0 up",
+"route add 127.0.0.0 netmask 255.0.0.0 lo",
+"ifconfig eth0 10.0.2.16 netmask 255.255.255.0 up",
+"route add 10.0.2.0 netmask 255.255.255.0 eth0",
+"route add default gw 10.0.2.10 eth0",
+"date -s 201206011922.40",
+"tish",


### PR DESCRIPTION
- Currently SMP on x86 arch can set affinity to specify which CPU to execute. Two may running simultaneously and individually or one is in `idle` and another is running thread. The latter may occur when set all threads' affinities to one CPU.
- Each CPU can handle interrupt individually, which can be set in `startup_ap()`. Only clock interrupt is be set in this PR. 

Comments on any commit are welcome!