### PR TITLE
kernel:lthread: Add static lthread schedee type

### DIFF
--- a/src/kernel/lthread/lthread.h
+++ b/src/kernel/lthread/lthread.h
@@ -141,6 +141,7 @@ extern struct schedee *lthread_process(struct schedee *prev,
 		.schedee = { \
 			.runq_link = RUNQ_ITEM_INIT(_lth.schedee.runq_link), \
 			.lock = SPIN_UNLOCKED, \
+			.type = SCHEDEE_LTHREAD, \
 			.process = lthread_process, \
 			.ready = false, \
 			.active = false, \


### PR DESCRIPTION
if not set type explicitly, the default type is SCHEDEE_THREAD
In that case, it always attemp to context_switch