### PR TITLE
riscv:Fix PMP_Test suite

### DIFF
--- a/src/arch/riscv/pmp/test_pmp/test_pmp.c
+++ b/src/arch/riscv/pmp/test_pmp/test_pmp.c
@@ -28,12 +28,6 @@ TEST_CASE("Set PMP Entry") {
     // Verify that the configured PMP address and configuration match the expected values
     test_assert_equal(pmp_addr[0], base >> 2); // Check if the address is correctly shifted
     test_assert_equal(pmp_cfg[0], flags); // Verify that the flags match the expected configuration
-
-    // Additional verification to ensure that the PMP registers have been set correctly
-    for (unsigned int i = 0; i < index; i++) {
-        test_assert_equal(REG32_LOAD(PMP_ADDR_BASE + i * 4), pmp_addr[i]); // Verify the address register
-        test_assert_equal(REG32_LOAD(PMP_CFG_BASE + i * 4), pmp_cfg[i / 4]); // Verify the configuration register
-    }
 }
 
 /**
@@ -55,12 +49,6 @@ TEST_CASE("Invalid PMP Entry") {
 
     // Call the function to test with an invalid index
     set_pmp_entry(&index, flags, base, size, pmp_addr, pmp_cfg, pmp_count, page_size);
-
-    // Verify that no PMP entries were written due to the invalid index
-    for (unsigned int i = 0; i < PMP_NUM_REGISTERS; i++) {
-        test_assert_equal(REG32_LOAD(PMP_ADDR_BASE + i * 4), 0); // Ensure address registers are zero
-        test_assert_equal(REG32_LOAD(PMP_CFG_BASE + i * 4), 0); // Ensure configuration registers are zero
-    }
 }
 
 /**

--- a/templates/riscv/qemu/mods.conf
+++ b/templates/riscv/qemu/mods.conf
@@ -9,6 +9,7 @@ configuration conf {
 	include embox.arch.riscv.libarch
 	include embox.arch.riscv.vfork
 	include embox.arch.riscv.pmp
+	include embox.arch.riscv.pmp.test_pmp
 
 	include embox.mem.bitmask
 	include embox.driver.periph_memory_stub


### PR DESCRIPTION
This PR addresses an issue in the PMP test case where checks involving registers (REG32_LOAD) were causing errors. Since the set_pmp_entry function only computes values for pmp_addr and pmp_cfg without setting the registers, the checks for register values are redundant and unnecessary.

The existing assertions (test_assert_equal(pmp_addr[0], base >> 2); and test_assert_equal(pmp_cfg[0], flags);) are sufficient for validating the function's behavior. This PR removes the redundant checks to prevent errors.

Changes:

    Removed unnecessary REG32_LOAD checks in the PMP test case.
    Re-added test suite into riscv/qemu template 
    
Changes have been tested using the riscv/qemu template to ensure correctness:
![Screenshot from 2024-08-20 20-54-22](https://github.com/user-attachments/assets/7b171dd8-f148-459e-b1c4-acfea1b71d82)
    