### PR TITLE
kernel:sched: Give each CPU a sched_tick_timer

### DIFF
--- a/src/include/kernel/sched.h
+++ b/src/include/kernel/sched.h
@@ -112,8 +112,8 @@ extern int schedee_init(struct schedee *schedee, int priority,
 
 extern void sched_set_current(struct schedee *schedee);
 
-extern void sched_ticker_add(void);
-extern void sched_ticker_del(void);
+extern void sched_ticker_add(unsigned int cpuid);
+extern void sched_ticker_del(unsigned int cpuid);
 
 extern int sched_active(struct schedee *s);
 

--- a/src/kernel/sched/sched.c
+++ b/src/kernel/sched/sched.c
@@ -423,9 +423,15 @@ static void sched_ticker_update(void) {
 	/* We only need re-schedule by ticker only if there is
 	 * an active schedee with the same priority in runq. */
 	if (cur != next && cur_prio == next_prio) {
-		sched_ticker_add();
+#ifdef SMP
+		for(unsigned int cpuid = 0; cpuid < NCPU; cpuid++)
+			if(0x1 << cpuid & next->affinity.mask)
+#else
+			unsigned int cpuid = cpu_get_id();
+#endif /* SMP */
+				sched_ticker_add(cpuid);
 	} else {
-		sched_ticker_del();
+		sched_ticker_del(cpu_get_id());
 	}
 }
 

--- a/src/kernel/sched/sched_ticker.c
+++ b/src/kernel/sched/sched_ticker.c
@@ -9,6 +9,7 @@
 
 #include <hal/cpu.h>
 #include <kernel/sched.h>
+#include <kernel/thread.h>
 
 #include <kernel/time/timer.h>
 #include <kernel/cpu/cpu.h>
@@ -20,7 +21,7 @@
 #define SCHED_TICK_INTERVAL \
 	OPTION_GET(NUMBER, tick_interval)
 
-static struct sys_timer sched_tick_timer;
+static struct sys_timer sched_tick_timer[NCPU];
 
 static void sched_tick(sys_timer_t *timer, void *param) {
 	sched_post_switch();
@@ -33,15 +34,15 @@ static void sched_tick(sys_timer_t *timer, void *param) {
 #endif /* SMP */
 }
 
-void sched_ticker_add(void) {
-	if (!timer_is_started(&sched_tick_timer)) {
-		timer_init_start_msec(&sched_tick_timer, TIMER_PERIODIC,
+void sched_ticker_add(unsigned int cpuid) {
+	if (!timer_is_started(&sched_tick_timer[cpuid])) {
+		timer_init_start_msec(&sched_tick_timer[cpuid], TIMER_PERIODIC,
 				SCHED_TICK_INTERVAL, sched_tick, NULL);
 	}
 }
 
-void sched_ticker_del(void) {
-	if (timer_is_started(&sched_tick_timer)) {
-		timer_stop(&sched_tick_timer);
+void sched_ticker_del(unsigned int cpuid) {
+	if (timer_is_started(&sched_tick_timer[cpuid])) {
+		timer_stop(&sched_tick_timer[cpuid]);
 	}
 }

--- a/src/kernel/sched/sched_ticker_stub.c
+++ b/src/kernel/sched/sched_ticker_stub.c
@@ -6,8 +6,8 @@
  * @date    08.12.2014
  */
 
-void sched_ticker_add(void) {
+void sched_ticker_add(unsigned int cpuid) {
 }
 
-void sched_ticker_del(void) {
+void sched_ticker_del(unsigned int cpuid) {
 }

--- a/src/kernel/thread/thread_switch.c
+++ b/src/kernel/thread/thread_switch.c
@@ -28,7 +28,7 @@ void thread_ack_switched(void) {
 	log_debug("first switch on cpu :%d",cpu_get_id());
 	ipl_enable();
 	/* we add first timer the same behavious as sched_ticker_update*/
-	sched_ticker_add();
+	sched_ticker_add(cpu_get_id());
 	sched_timing_start(&thread_self()->schedee);	
 	sched_unlock();
 }


### PR DESCRIPTION
In SMP case, we use affinity to specify which cpu that a thread belongs to. When we put all threads to one CPU, the rest of it do nothing, IDLE_state cpu will delete the sched_tick_timer. So it's necessary to give each cpu a timer in order to not disturb each other