### PR TITLE
kernel: Add case that runq_get_next returns 0

### DIFF
--- a/src/kernel/sched/sched.c
+++ b/src/kernel/sched/sched.c
@@ -416,6 +416,14 @@ static void sched_ticker_update(void) {
 	cur = schedee_get_current();
 
 	next = runq_get_next(&rq.queue);
+	/**
+	 * If runq_get_next() returns NULL which means the rq is empty at all.
+	 * There is no need for thread switching, just delete the sched_tick
+	 */
+	if(next == NULL) {
+		sched_ticker_del();
+		return;
+	}
 
 	cur_prio = schedee_priority_get(cur);
 	next_prio = schedee_priority_get(next);
@@ -456,7 +464,9 @@ static void __schedule(int preempt) {
 	sched_timing_stop(prev);
 
 	while (1) {
+		/* when called from here, it must NOT be empty*/
 		next = runq_get_next(&rq.queue);
+		assert(next);
 
 		if (schedee_is_thread(prev) && schedee_is_thread(next) &&
 			    schedee_priority_get(prev) == schedee_priority_get(next)) {


### PR DESCRIPTION
In some archs such as RISCV, dereferencing NULL will crash. But in some case, x86 will not.
When `runq_get_next()` returns NULL,  which means there is no other threads in `rq` queue. So we can just delete the `sched_timer` for the only thread to run.