### PR TITLE
tests: remove unused header file

### DIFF
--- a/src/tests/smp/simult_thread_test.c
+++ b/src/tests/smp/simult_thread_test.c
@@ -11,8 +11,6 @@
 
 #include <util/log.h>
 
-#include <asm/ap.h>
-
 #include <kernel/thread.h>
 #include <kernel/task.h>
 #include <kernel/thread/thread_stack.h>


### PR DESCRIPTION
`<asm/ap.h>` is only exsit in x86 currently