### PR TITLE
arch:riscv: Fix context_switch bug

### DIFF
--- a/src/arch/riscv/kernel/context_switch.S
+++ b/src/arch/riscv/kernel/context_switch.S
@@ -17,7 +17,6 @@
 
 .align 2
 context_switch:
-	addi    sp, sp, -CTX_SIZE
 	PTR_S   sp, CTX_SP(a0)
 	PTR_S   ra, CTX_RA(a0)
 	PTR_S   s0, CTX_S0(a0)
@@ -52,6 +51,5 @@ context_switch:
 	PTR_L   s11, CTX_S11(a1)
 	PTR_L   t6, CTX_MSTATUS(a1)
 	csrw    STATUS_REG, t6
-	addi    sp, sp, CTX_SIZE
 
 	ret


### PR DESCRIPTION
When thread is created, original context contains a sp which points to next thread. The addtional modification to sp register will cause memory leaking when context switching, which will change the data belongs to next thread.