### PR TITLE
kernel:sched: Improve sched_tick function in smp

### DIFF
--- a/src/kernel/sched/sched_ticker.c
+++ b/src/kernel/sched/sched_ticker.c
@@ -23,14 +23,16 @@
 static struct sys_timer sched_tick_timer;
 
 static void sched_tick(sys_timer_t *timer, void *param) {
-	sched_post_switch();
-
 #ifdef SMP
 	for (int i = 0; i < NCPU; i++) {
 		extern void smp_send_resched(int cpu_id);
+		if(i == cpu_get_id()) {
+			continue;
+		}
 		smp_send_resched(i);
 	}
 #endif /* SMP */
+	sched_post_switch();
 }
 
 void sched_ticker_add(void) {


### PR DESCRIPTION
Put sched_post_switch after sending resched signal because sched_post_switch may switch to another thread which delays the resched signal.
It's no need to send resched signal to self_cpu