### PR TITLE
Improve system timer strategy for smp

### DIFF
--- a/src/arch/x86/kernel/smp/smp.c
+++ b/src/arch/x86/kernel/smp/smp.c
@@ -21,6 +21,7 @@
 #include <kernel/task.h>
 #include <kernel/task/kernel_task.h>
 #include <kernel/thread.h>
+#include <kernel/sched.h>
 
 #include <module/embox/driver/interrupt/lapic.h>
 #include <module/embox/kernel/thread/core.h>
@@ -99,6 +100,8 @@ static int unit_init(void) {
 
 	/* Initialize trampoline for the APs */
 	init_trampoline();
+
+	sched_ticker_set_shared();
 
 	/* Start all CPUs */
 	self_id = cpu_get_id();

--- a/src/include/kernel/sched.h
+++ b/src/include/kernel/sched.h
@@ -114,6 +114,10 @@ extern void sched_set_current(struct schedee *schedee);
 
 extern void sched_ticker_add(void);
 extern void sched_ticker_del(void);
+extern void* sched_ticker_get_timer(void);
+
+extern void sched_ticker_set_shared(void);
+extern void sched_ticker_set_private(void);
 
 extern int sched_active(struct schedee *s);
 

--- a/src/kernel/sched/Mybuild
+++ b/src/kernel/sched/Mybuild
@@ -18,6 +18,7 @@ module sched {
 
 	depends wait_queue
 
+	depends embox.kernel.timer.strategy.api
 	depends embox.kernel.sched.current.api
 }
 

--- a/src/kernel/sched/sched_ticker.c
+++ b/src/kernel/sched/sched_ticker.c
@@ -22,6 +22,10 @@
 
 static struct sys_timer sched_tick_timer;
 
+#ifdef SMP
+static struct sys_timer_sharing sched_tick_sharing;
+#endif
+
 static void sched_tick(sys_timer_t *timer, void *param) {
 #ifdef SMP
 	for (int i = 0; i < NCPU; i++) {
@@ -46,4 +50,33 @@ void sched_ticker_del(void) {
 	if (timer_is_started(&sched_tick_timer)) {
 		timer_stop(&sched_tick_timer);
 	}
+}
+
+void sched_ticker_set_shared(void) {
+#ifdef SMP
+	if (!timer_is_shared(&sched_tick_timer)) {
+		sched_tick_timer.timer_sharing = &sched_tick_sharing;
+		if(timer_is_started(&sched_tick_timer))
+			sched_tick_timer.timer_sharing->shared_cpu = (0x1 << cpu_get_id());
+		timer_set_shared(&sched_tick_timer);
+	}else{
+		panic("Once-called function, check up\n");
+	}
+#else
+	panic("Single CPU system should not call this\n");
+#endif
+}
+
+void sched_ticker_set_private(void) {
+#ifdef SMP
+	if (timer_is_shared(&sched_tick_timer)) {
+		timer_set_private(&sched_tick_timer);
+	}
+#else
+	panic("Single CPU system should not call this\n");
+#endif
+}
+
+void* sched_ticker_get_timer(void){
+	return (void*)&sched_tick_timer;
 }

--- a/src/kernel/time/timer/strategy/Mybuild
+++ b/src/kernel/time/timer/strategy/Mybuild
@@ -10,3 +10,7 @@ module list_timer extends api {
 module head_timer extends api {
 	source "head_timer.c", "head_timer.h"
 }
+
+module head_timer_smp extends api {
+	source "head_timer_smp.c", "head_timer.h"
+}

--- a/src/kernel/time/timer/strategy/head_timer_smp.c
+++ b/src/kernel/time/timer/strategy/head_timer_smp.c
@@ -1,0 +1,172 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 22.07.10
+ * @author Andrey Baboshin
+ * @author Ilia Vaprol
+ * @author Fedor Burdun
+ * @date 26.08.2024
+ * @author Zeng Zixian
+ */
+
+#include <kernel/time/timer.h>
+#include <kernel/sched.h>
+#include <hal/clock.h>
+#include <hal/ipl.h>
+#include <hal/cpu.h>
+
+#include <embox/unit.h>
+
+/* init at run time */
+static struct dlist_head sys_timers_list[NCPU];
+
+EMBOX_UNIT_INIT(sys_timers_list_init);
+
+static int sys_timers_list_init(void) {
+	for(int i = 0; i < NCPU; i++)
+		dlist_head_init(&sys_timers_list[i]);
+	return 0;
+}
+
+void timer_strat_start(struct sys_timer *tmr) {
+	int cpuid;
+	struct sys_timer *it_tmr = NULL;
+	struct dlist_head *next_tmr_lnk;
+	ipl_t ipl;
+
+	tmr->cnt = clock_sys_ticks() + tmr->load;
+
+	ipl = ipl_save();
+	cpuid = cpu_get_id();
+	ipl_restore(ipl);
+
+	if(sched_ticker_get_timer() == (void*)tmr) {
+		dlist_head_init(&tmr->multi_lnk[cpuid]);
+	}else{
+		dlist_head_init(&tmr->lnk);
+	}
+	next_tmr_lnk = &sys_timers_list[cpuid];
+
+	for (struct dlist_head *__next = sys_timers_list[cpuid].next; \
+		__next != &sys_timers_list[cpuid]; __next = __next->next) {
+
+		it_tmr =  dlist_entry(__next, struct sys_timer, multi_lnk[cpuid]);
+		if(sched_ticker_get_timer() != (void*)it_tmr) {
+			it_tmr =  dlist_entry(__next, struct sys_timer, lnk);
+		}
+
+		if (it_tmr->cnt >= tmr->cnt) {
+			/* decrease value of next timer after inserting */
+			it_tmr->cnt -= tmr->cnt;
+
+			if(sched_ticker_get_timer() == (void*)it_tmr) {
+				next_tmr_lnk = &it_tmr->multi_lnk[cpuid];
+			}else{
+				next_tmr_lnk = &it_tmr->lnk;
+			}
+			break;
+		}
+		tmr->cnt -= it_tmr->cnt;
+	}
+
+	timer_set_started(tmr);
+	if(sched_ticker_get_timer() == (void*)tmr) {
+		dlist_add_prev(&tmr->multi_lnk[cpuid], next_tmr_lnk);
+	}else{
+		dlist_add_prev(&tmr->lnk, next_tmr_lnk);
+	}
+}
+
+void timer_strat_stop(struct sys_timer *tmr) {
+	int cpuid;
+	struct sys_timer *next_tmr;
+	ipl_t ipl;
+
+	ipl = ipl_save();
+	cpuid = cpu_get_id();
+	ipl_restore(ipl);
+
+	timer_set_stopped(tmr);
+
+	if(sched_ticker_get_timer() == (void*)tmr) {
+		if (tmr->multi_lnk[cpuid].next != &sys_timers_list[cpuid]) {
+			next_tmr = dlist_entry(tmr->multi_lnk[cpuid].next, struct sys_timer, lnk);
+			next_tmr->cnt += tmr->cnt;
+		}
+	}else{
+		if (tmr->lnk.next != &sys_timers_list[cpuid]) {
+			next_tmr = dlist_entry(tmr->lnk.next, struct sys_timer, lnk);
+			next_tmr->cnt += tmr->cnt;
+		}
+	}
+
+
+	if(sched_ticker_get_timer() == (void*)tmr) {
+		assert(tmr != next_tmr); /* At most one sched_ticker in list */
+		dlist_del(&tmr->multi_lnk[cpuid]);
+	}else{
+		dlist_del(&tmr->lnk);
+	}
+
+}
+
+int timer_strat_get_next_event(clock_t *next_event) {
+	int cpuid;
+	ipl_t ipl;
+	int ret = -1;
+	struct sys_timer *tmr;
+
+	ipl = ipl_save();
+	cpuid = cpu_get_id();
+	ipl_restore(ipl);
+
+	if (!dlist_empty(&sys_timers_list[cpuid])) {
+		/* have a try to check whether the next timer is sched_ticker */
+		tmr = dlist_first_entry(&sys_timers_list[cpuid], struct sys_timer, multi_lnk[cpuid]);
+		if(sched_ticker_get_timer() != (void*)tmr) {
+			tmr = dlist_first_entry(&sys_timers_list[cpuid], struct sys_timer, lnk);
+		}
+		*next_event = tmr->cnt;
+		ret = 0;
+	}
+
+	return ret;
+}
+
+/**
+ * For each timer in the timers array do the following: if the timer is enable
+ * and the counter of this timer is the zero then its initial value is assigned
+ * to the counter and the function is executed.
+ */
+void timer_strat_sched(clock_t jiffies) {
+	int cpuid;
+	struct sys_timer *it_tmr = NULL;
+	ipl_t ipl;
+
+	ipl = ipl_save();
+	cpuid = cpu_get_id();
+	ipl_restore(ipl);
+
+	for (struct dlist_head *__next = sys_timers_list[cpuid].next; \
+		__next != &sys_timers_list[cpuid]; __next = __next->next) {
+
+		it_tmr =  dlist_entry(__next, struct sys_timer, multi_lnk[cpuid]);
+		if(sched_ticker_get_timer() != (void*)it_tmr) {
+			it_tmr =  dlist_entry(__next, struct sys_timer, lnk);
+		}
+
+		if (jiffies < it_tmr->cnt) {
+			break;
+		}
+		jiffies -= it_tmr->cnt;
+
+		timer_strat_stop(it_tmr);
+		if (timer_is_periodic(it_tmr)) {
+			timer_strat_start(it_tmr);
+		}
+
+		it_tmr->handle(it_tmr, it_tmr->param);
+	}
+
+}

--- a/src/kernel/time/timer/sys_timer.c
+++ b/src/kernel/time/timer/sys_timer.c
@@ -14,6 +14,7 @@
 #include <kernel/time/timer.h>
 #include <kernel/time/time.h>
 #include <kernel/sched/sched_lock.h>
+#include <kernel/sched.h>
 #include <hal/clock.h>
 
 POOL_DEF(timer_pool, sys_timer_t, OPTION_GET(NUMBER,timer_quantity));
@@ -24,10 +25,19 @@ int timer_init(struct sys_timer *tmr, unsigned int flags,
 		return -EINVAL;
 	}
 
-	tmr->state = 0;
+	/**
+	 * No need to init timer_sharing and state file for
+	 * sched_tick_timer
+	 */
+	if(sched_ticker_get_timer() != (void*)tmr){
+		tmr->timer_sharing = NULL;
+		tmr->state = 0;
+	}
+
 	tmr->handle = handler;
 	tmr->param = param;
 	tmr->flags = flags;
+
 	return ENOERR;
 }
 


### PR DESCRIPTION
In the previous situation, each CPU would interfere with each other during timer scheduling. Timer sharing was introduced in this PR to solve this problem.