### PR TITLE
arch:x86: change the smp_send_resched function

### DIFF
--- a/src/arch/x86/kernel/smp/smp.c
+++ b/src/arch/x86/kernel/smp/smp.c
@@ -116,10 +116,12 @@ void smp_send_resched(int cpu_id) {
 
 void resched(void) {
 	extern void sched_post_switch(void);
+	extern void sched_post_switch_noyield(void);
 
 	lapic_send_eoi();
 
-	sched_post_switch();
+	//sched_post_switch();
+	sched_post_switch_noyield();
 }
 
 /* FIXME this is a code (not device memory) region */


### PR DESCRIPTION
The smp_send_resched function is mainly used in sched_tick handler which gives up current thread by force and find a new thread to run. But when one cpu want to give up current thread by itself doesn't means other cpus also want to give up current thread that runs on other cpus