### PR TITLE
sched: Add API of get schedee with no affinity

### DIFF
--- a/src/include/kernel/sched/runq.h
+++ b/src/include/kernel/sched/runq.h
@@ -18,6 +18,7 @@ extern void runq_insert(runq_t *queue, struct schedee *schedee);
 extern void runq_remove(runq_t *queue, struct schedee *schedee);
 extern struct schedee *runq_extract(runq_t *queue);
 extern struct schedee *runq_get_next(runq_t *queue);
+extern struct schedee *runq_get_next_ignore_affinity(runq_t *queue);
 
 extern void runq_item_init(runq_item_t *runq_link);
 

--- a/src/kernel/sched/strategy/runq/list_array.c
+++ b/src/kernel/sched/strategy/runq/list_array.c
@@ -89,3 +89,24 @@ struct schedee *runq_extract(runq_t *queue) {
 
 	return schedee;
 }
+
+struct schedee *runq_get_next_ignore_affinity(runq_t *queue) {
+	struct schedee *schedee = NULL;
+	int i;
+
+	for (i = SCHED_PRIORITY_MAX; i >= SCHED_PRIORITY_MIN; i--) {
+		struct schedee *s;
+
+		dlist_foreach_entry(s, &queue->list[i], runq_link) {
+			/* Not checking the affinity */
+			schedee = s;
+			break;
+		}
+
+		if (schedee) {
+			break;
+		}
+	}
+
+	return schedee;
+}


### PR DESCRIPTION
In smp system, it's useful to know whether is really empty in rq or just because of affinity to get an NULL result