### PR TITLE
improve x86 in smp case one step further

### DIFF
--- a/src/arch/x86/kernel/smp/ap_trampoline.S
+++ b/src/arch/x86/kernel/smp/ap_trampoline.S
@@ -39,6 +39,9 @@ C_LABEL(__ap_gdtr):
 	.space 8
 C_LABEL(__ap_gdt):
 	.space GDT_ENTRIES * GDT_ENTRY_SIZE
+C_LABEL(__tmp_small_stack):
+	/* this stack in only for calling cpu_get_id */
+	.space 0x40
 C_LABEL(__ap_trampoline_end):
 
 	.section .text
@@ -54,7 +57,14 @@ __ap_trampoline_32:
 	movw %ax, %ss
 
 	/* Setting up stack */
-	mov	__ap_sp, %esp
+	lea	__tmp_small_stack, %esp
+	addl $0x40, %esp
+	call cpu_get_id
+
+	/* eax get the returned cpuid value */
+	dec	%eax
+	lea	__ap_sp(,%eax,4), %esp
+	mov	(%esp), %esp
 
 	/* Jumping forward */
 	jmp startup_ap

--- a/src/arch/x86/kernel/smp/smp.c
+++ b/src/arch/x86/kernel/smp/smp.c
@@ -83,7 +83,7 @@ static inline void init_trampoline(void) {
 /* TODO: FIX THIS! */
 static inline void cpu_start(int cpu_id) {
 	/* Setting up stack and boot */
-	__ap_sp[cpu_id - 1] = ap_stack[cpu_id] + KERNEL_AP_STACK_SZ;
+	__ap_sp[cpu_id - 1] = (char *)&ap_stack[cpu_id - 1] + KERNEL_AP_STACK_SZ;
 
 	lapic_send_init_ipi(cpu_id);
 

--- a/src/arch/x86/kernel/smp/smp.c
+++ b/src/arch/x86/kernel/smp/smp.c
@@ -22,6 +22,7 @@
 #include <kernel/task/kernel_task.h>
 #include <kernel/thread.h>
 #include <kernel/sched.h>
+#include <kernel/irq.h>
 
 #include <module/embox/driver/interrupt/lapic.h>
 #include <module/embox/kernel/thread/core.h>
@@ -52,7 +53,7 @@ void startup_ap(void) {
 
 	idt_load();
 	apic_init();
-	irqctrl_enable(2);
+	irq_enable_attached();
 
 	bs_idle = thread_init_stack(__ap_sp[self_id - 1] - THREAD_STACK_SIZE, THREAD_STACK_SIZE,
 	    SCHED_PRIORITY_MIN, bs_idle_run, NULL);


### PR DESCRIPTION
1. Allow more than two cpus
2. Allow each cpu handles all events independently after calling `irq_enable_attached()`