### PR TITLE
kernel:irq: Add function of enable attached IRQs

### DIFF
--- a/src/include/kernel/irq.h
+++ b/src/include/kernel/irq.h
@@ -117,6 +117,12 @@ extern int irq_detach(unsigned int irq_nr, void *data);
  */
 extern void irq_dispatch(unsigned int interrupt_nr);
 
+/**
+ * Enable interrupt of all attached IRQs. Mainly used in SMP for
+ * APs initialization. This allows AP to handler interrupt independently
+ */
+extern void irq_enable_attached(void);
+
 #ifndef STATIC_IRQ_EXTENTION
 #define STATIC_IRQ_ATTACH(_irq_nr, _hnd, _data)
 #endif

--- a/src/kernel/irq/irq.c
+++ b/src/kernel/irq/irq.c
@@ -181,3 +181,11 @@ void irq_dispatch(unsigned int irq_nr) {
 		ipl_restore(ipl);
 	}
 }
+
+void irq_enable_attached(void) {
+	for(int irq_nr = 0; irq_nr < IRQ_NRS_TOTAL; irq_nr++) {
+		if(irq_table[irq_nr]) {
+			irqctrl_enable(irq_nr);
+		}
+	}
+}

--- a/src/kernel/irq/static_irq/irq_static.c
+++ b/src/kernel/irq/static_irq/irq_static.c
@@ -35,3 +35,11 @@ int irq_detach(unsigned int irq_nr, void *dev_id) {
 void irq_dispatch(unsigned int irq_nr) {
 
 }
+
+void irq_enable_attached(void) {
+	for(int irq_nr = 0; irq_nr < IRQ_NRS_TOTAL; irq_nr++) {
+		if(irq_table[irq_nr]) {
+			irqctrl_enable(irq_nr);
+		}
+	}
+}


### PR DESCRIPTION
This is one way to enable all registered interrput source in AP. I'm not sure if the method is good, if someone  come up better  way, please give me a suggestion