### PR TITLE
kernel:time: Add SMP jiffies tick increasing rule

### DIFF
--- a/src/arch/Mybuild
+++ b/src/arch/Mybuild
@@ -36,7 +36,7 @@ abstract module usermode { }
 @Mandatory
 @DefaultImpl(embox.arch.generic.nosmp)
 abstract module smp {
-	option number max_supported_cores
+	option boolean independent_clock = false
 }
 
 @Mandatory

--- a/src/arch/generic/Mybuild
+++ b/src/arch/generic/Mybuild
@@ -18,7 +18,7 @@ module nousermode extends embox.arch.usermode {
 }
 
 module nosmp extends embox.arch.smp {
-	option number max_supported_cores=1
+	option boolean independent_clock = false
 	source "nosmp.h"
 }
 

--- a/src/arch/riscv/kernel/smp/Mybuild
+++ b/src/arch/riscv/kernel/smp/Mybuild
@@ -1,0 +1,30 @@
+package embox.arch.riscv.kernel
+
+module cpu extends embox.arch.cpu {
+	option number cpu_count
+	source "cpu_get_id.c"
+
+}
+
+module ipi {
+	@IncludeExport(path="riscv")
+	source "ipi.h"
+
+	source "ipi.c"
+
+}
+
+module smp extends embox.arch.smp {
+	source "ap_trampoline.S", "smp.c", "ap_timer_handler.c"
+
+	option boolean independent_clock = true
+
+	depends cpu
+	depends ipi
+
+	depends embox.driver.interrupt.riscv_plic
+	depends embox.driver.interrupt.riscv_clint
+	depends embox.kernel.thread.core
+	@NoRuntime depends embox.kernel.sched.affinity.smp
+	depends embox.driver.periph_memory
+}

--- a/src/arch/x86/kernel/smp/Mybuild
+++ b/src/arch/x86/kernel/smp/Mybuild
@@ -10,6 +10,8 @@ module cpu extends embox.arch.cpu {
 module smp extends embox.arch.smp {
 	source "smp_traps.S", "ap_trampoline.S", "smp.c"
 
+	option boolean independent_clock = false
+
 	depends cpu
 	/* i.e. depends from embox.arch.x86.kernel.cpu */
 


### PR DESCRIPTION
In some SMP cases, each CPU has a complete independent clock. In order to prevent scheduling frequency changes as the number of CPUs increase.