### PR TITLE
riscv:Add RISC-V MMU Support

### DIFF
--- a/src/arch/riscv/mmu/Mybuild
+++ b/src/arch/riscv/mmu/Mybuild
@@ -1,0 +1,9 @@
+package embox.arch.riscv
+
+module mmu extends embox.mem.vmem{
+	source "mmu.c", "mmu.h"
+	
+	option number page_size=4096
+	
+	depends embox.mem.vmem_depends
+}

--- a/src/arch/riscv/mmu/mmu.c
+++ b/src/arch/riscv/mmu/mmu.c
@@ -1,0 +1,117 @@
+/**
+ * @file
+ * @brief RISC-V MMU Implementation
+ *
+ * @date 04.09.2024
+ */
+
+#include "mmu.h"
+#include <asm/regs.h> 
+#include <mem/vmem.h>  
+
+#include <stdint.h>
+
+#include <hal/mmu.h>
+#include <mem/vmem.h>
+
+#define MMU_PTE_FLAG    (MMU_PAGE_WRITABLE | MMU_PAGE_USERMODE)
+
+static uintptr_t *ctx_table[0x100] __attribute__((aligned(MMU_PAGE_SIZE)));
+
+static int ctx_counter = 0;
+
+void mmu_on(void) {
+    uint64_t satp_val = (read_csr(satp) | ((uint64_t)SATP_MODE_SV39 << 60)); // Enable MMU for SV39
+    write_csr(satp, satp_val);
+    //asm volatile ("sfence.vma" : : : "memory"); // Flush TLB after enabling MMU
+}
+
+void mmu_off(void) {
+    uintptr_t satp_val = 0;  // Disable paging
+    write_csr(satp, satp_val);
+    //asm volatile ("sfence.vma" : : : "memory"); // Flush TLB after disabling MMU
+}
+                   
+void mmu_flush_tlb_single(unsigned long addr) {
+    //asm volatile("sfence.vma %0, zero" : : "r"(addr) : "memory");
+}
+
+void mmu_flush_tlb(void) {
+    //asm volatile("sfence.vma zero, zero" : : : "memory");
+}
+
+mmu_vaddr_t mmu_get_fault_address(void) {
+    return read_csr(stval); // Returns the fault address from stval
+}
+
+void mmu_set_context(mmu_ctx_t ctx) {
+    write_csr(satp, ((read_csr(satp) & ~0xFFFFFFFFFFUL) | (uintptr_t) mmu_get_root(ctx)));
+    //asm volatile ("sfence.vma" : : : "memory"); // Flush TLB
+}
+
+mmu_ctx_t mmu_create_context(uintptr_t *pgd) {
+    mmu_ctx_t ctx = (mmu_ctx_t) (++ctx_counter);
+    ctx_table[ctx] = pgd;
+    return ctx;
+}
+
+uintptr_t *mmu_get_root(mmu_ctx_t ctx) {
+    return ctx_table[ctx];
+}
+
+int mmu_present(int lvl, uintptr_t *entry)  {
+	switch(lvl) {
+	case 0:
+		return (uint32_t)*entry & MMU_PAGE_PRESENT;
+	case 1:
+		return (uint32_t)*entry & MMU_PAGE_PRESENT;
+	}
+	return 0;
+}
+
+void mmu_set(int lvl, uintptr_t *entry, uintptr_t value) {
+    *entry = (value & MMU_PAGE_MASK) | MMU_PTE_FLAG | MMU_PAGE_PRESENT;
+}
+
+uintptr_t *mmu_get(int lvl, uintptr_t *entry) {
+    return (uintptr_t *) (*entry & MMU_PAGE_MASK);
+}
+
+void mmu_unset(int lvl, uintptr_t *entry) {
+    *entry = 0;
+}
+
+uintptr_t mmu_pte_pack(uintptr_t addr, int prot) {
+    int flags = 0;
+    if (prot & PROT_WRITE) {
+        flags |= MMU_PAGE_WRITABLE;
+    }
+    if (prot & PROT_EXEC) {
+        flags |= MMU_PAGE_EXECUTABLE;
+    }
+    if (prot & VMEM_PAGE_USERMODE) {
+        flags |= MMU_PAGE_USERMODE;
+    }
+    return addr | flags | MMU_PAGE_PRESENT;
+}
+
+int mmu_pte_set(uintptr_t *entry, uintptr_t value) {
+	*entry = value;
+	return 0;
+}
+
+uintptr_t mmu_pte_get(uintptr_t *entry) {
+	return *entry;
+}
+
+uintptr_t mmu_pte_unpack(uintptr_t pte, int *flags) {
+    int prot = 0;
+    if (pte & MMU_PAGE_WRITABLE) {
+        prot |= PROT_WRITE;
+    }
+    if (pte & MMU_PAGE_EXECUTABLE) {
+        prot |= PROT_EXEC;
+    }
+    *flags = prot;
+    return pte & MMU_PAGE_MASK;
+}

--- a/src/arch/riscv/mmu/mmu.h
+++ b/src/arch/riscv/mmu/mmu.h
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * @brief RISC-V MMU Header File
+ *
+ * @date 04.09.2024
+ */
+
+#ifndef RISCV_MMU_H_
+#define RISCV_MMU_H_
+
+#include <stdint.h>
+#include <inttypes.h>
+
+#define MMU_LEVELS              2
+
+// Define PTE flags
+#define MMU_PAGE_PRESENT        (1UL << 0)   // Page Table Entry Present flag
+#define MMU_PAGE_WRITABLE       (1UL << 1)   // Page Table Entry Writable flag
+#define MMU_PAGE_USERMODE       (1UL << 2)   // Page Table Entry Usermode flag
+#define MMU_PAGE_DISABLE_CACHE  (1UL << 3)   // Page Table Entry Disable Cache flag (if applicable)
+#define MMU_PAGE_EXECUTABLE     (1UL << 5)   // Page Table Entry Executable flag
+
+typedef uintptr_t __mmu_paddr_t;   // Physical address type
+typedef uintptr_t __mmu_vaddr_t;   // Virtual address type
+
+typedef uint32_t __mmu_ctx_t;      // MMU context type
+typedef uint64_t __mmu_reg_t;      // 64-bit PTE for RISC-V
+
+#define __PRIxMMUREG PRIx64       // For 64-bit PTE format specifier
+
+// Page entry shifts for each level in the paging hierarchy
+
+#define __MMU_SHIFT_0 22
+#define __MMU_SHIFT_1 12
+#define __MMU_SHIFT_2 21
+#define __MMU_SHIFT_3 12
+
+#define SATP_MODE_SV32    1
+#define SATP_MODE_SV39    8
+#endif /* RISCV_MMU_H_ */


### PR DESCRIPTION
This PR introduces initial version of MMU support for the RISC-V architecture, implementing key functions for virtual memory management. It includes context creation, enabling/disabling the MMU, and TLB flushing. The implementation uses the SV39 mode for 39-bit virtual addressing. It's important to note that this is not the final implementation, as the MMU is a complex component with various functionalities. I plan to continue improving and expanding its capabilities in future updates/PR's.