### PR TITLE
template: riscv: Uncomment test_pmp in riscv/qemu template

### DIFF
--- a/templates/riscv/qemu/mods.conf
+++ b/templates/riscv/qemu/mods.conf
@@ -9,7 +9,6 @@ configuration conf {
 	include embox.arch.riscv.libarch
 	include embox.arch.riscv.vfork
 	include embox.arch.riscv.pmp
-	include embox.arch.riscv.pmp.test_pmp
 
 	include embox.mem.bitmask
 	include embox.driver.periph_memory_stub
@@ -90,7 +89,7 @@ configuration conf {
 	include embox.lib.libds
 	include embox.framework.LibFramework
 
-	// FIXME @Runlevel(2) include embox.arch.riscv.pmp.test_pmp
+	@Runlevel(2) include embox.arch.riscv.pmp.test_pmp
 
 	@Runlevel(2) include embox.cmd.sh.tish(
 				prompt="%u@%h:%w%$", rich_prompt_support=1,


### PR DESCRIPTION
- Removed `test_pmp` from the `riscv/qemu` template, which I had previously fixed in a prior PR [PR #3392](https://github.com/embox/embox/pull/3392) but forgot to remove.
- Tested and confirmed that the template working perfectly.