### PR TITLE
TST: Add test for `expm1()` in libc tests

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -50,6 +50,11 @@ module exp2_test {
 	source "exp2_test.c"
 }
 
+module expm1_test {
+	@Cflags("-fno-builtin")
+	source "expm1_test.c"
+}
+
 module sin_test {
 	@Cflags("-fno-builtin")
 	source "sin_test.c"

--- a/src/compat/libc/math/tests/expm1_test.c
+++ b/src/compat/libc/math/tests/expm1_test.c
@@ -1,0 +1,39 @@
+/**
+ * @file
+ *
+ * @date Nov 10, 2024
+ * @author Jason Mok
+ */
+
+#include <math.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("expm1() tests");
+
+TEST_CASE("Test for expm1(0.0)") {
+    test_assert(expm1(0.0) == 0.0);
+}
+
+TEST_CASE("Test for expm1(3.0)") {
+    test_assert(expm1(3.0) == (exp(3.0) - 1.0));
+}
+
+TEST_CASE("Test for expm1(1.0)") {
+    test_assert(expm1(1.0) == (M_E - 1.0));
+}
+
+TEST_CASE("Test for expm1(-1.0)") {
+    test_assert(expm1(-1.0) == (-1.0 / M_E));
+}
+
+TEST_CASE("Test for expm1(+INFINITY)") {
+    test_assert(isinf(expm1(INFINITY)));
+}
+
+TEST_CASE("Test for expm1(-INFINITY)") {
+    test_assert(expm1(-INFINITY) == -1.0);
+}
+
+TEST_CASE("Test for expm1(NaN)") {
+    test_assert(isnan(expm1(NAN)));
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -190,6 +190,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.pow_test
 	@Runlevel(1) include embox.compat.libc.test.exp_test
 	@Runlevel(1) include embox.compat.libc.test.exp2_test
+	@Runlevel(1) include embox.compat.libc.test.expm1_test
 	@Runlevel(1) include embox.compat.libc.test.sin_test
 	@Runlevel(1) include embox.compat.libc.test.cos_test
 	@Runlevel(1) include embox.compat.libc.test.atan_test


### PR DESCRIPTION
Added unit tests for `expm1()` in `src/compat/libc/math/tests`. Closes https://github.com/embox/embox/issues/3454