### PR TITLE
mips: correct general exception vector setting and some improvement in interrupt processing

### DIFF
--- a/src/arch/mips/kernel/exc_init.c
+++ b/src/arch/mips/kernel/exc_init.c
@@ -24,6 +24,9 @@ void mips_exception_init(void) {
 
 	flush_cache((unsigned long)(KSEG0 + 0x180), 0x80);
 
+	/* explicitly set ebase */
+	mips_write_c0_ebase(KSEG0);
+
 	execution_hazard_barrier();
 
 	/* Configure status register */

--- a/src/drivers/interrupt/mips_intc/mips_intc.c
+++ b/src/drivers/interrupt/mips_intc/mips_intc.c
@@ -48,7 +48,7 @@ unsigned int irqctrl_get_intid(void) {
 	unsigned int irq;
 	uint32_t pending;
 
-	pending = (mips_read_c0_cause() & CAUSE_IM) >> ST0_IRQ_MASK_OFFSET;
+	pending = (mips_read_c0_cause() & mips_read_c0_status() & CAUSE_IM) >> ST0_IRQ_MASK_OFFSET;
 
 	for (irq = 0; irq < IRQCTRL_IRQS_TOTAL; irq++) {
 		if (pending & (1U << irq)) {

--- a/src/drivers/interrupt/mips_intc/mips_intc.c
+++ b/src/drivers/interrupt/mips_intc/mips_intc.c
@@ -50,7 +50,7 @@ unsigned int irqctrl_get_intid(void) {
 
 	pending = (mips_read_c0_cause() & mips_read_c0_status() & CAUSE_IM) >> ST0_IRQ_MASK_OFFSET;
 
-	for (irq = 0; irq < IRQCTRL_IRQS_TOTAL; irq++) {
+	for (irq = IRQCTRL_IRQS_TOTAL - 1; irq >=0 ; irq--) {
 		if (pending & (1U << irq)) {
 			return irq;
 		}


### PR DESCRIPTION
1. c0 EBase may be remapped by bootloader, so explisctly set it to KSEG0.
2. Improvement in interrupt handling:
  - mask out unwanted interrupts;
  - set higher priority for higher interrupt number. 