### PR TITLE
mips: correct mips_cache and add Ralink SoC platform

### DIFF
--- a/platform/ralink/templates/rt5350/build.conf
+++ b/platform/ralink/templates/rt5350/build.conf
@@ -1,0 +1,17 @@
+
+TARGET = embox
+
+ARCH = mips
+
+PLATFORM = ralink
+
+CROSS_COMPILE = mips-mti-elf-
+// CROSS_COMPILE = mips-elf-
+// CROSS_COMPILE = mipsel-unknown-linux-gnu-
+
+CFLAGS += -O1 -g3
+CFLAGS += -G0 -march=mips32r2 -mabi=32 -EL -DSOC_RT5350 -DRALINK
+
+CFLAGS += -msoft-float
+
+LDFLAGS += -G0 -EL -melf32ltsmip

--- a/platform/ralink/templates/rt5350/lds.conf
+++ b/platform/ralink/templates/rt5350/lds.conf
@@ -1,0 +1,15 @@
+/*
+ * Linkage configuration.
+ */
+
+/* region (origin, length) */
+RAM (0x80000000, 16M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)
+
+define(OUTPUT_FORMAT_STRING, "elf32-littlemips")
+/* define(OUTPUT_FORMAT_STRING, "elf32-tradlittlemips") */

--- a/platform/ralink/templates/rt5350/mods.conf
+++ b/platform/ralink/templates/rt5350/mods.conf
@@ -1,0 +1,86 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.system(core_freq=360000000)
+	include embox.arch.mips.locore
+	include embox.arch.mips.cpu_idle
+	include embox.arch.mips.context
+	include embox.arch.mips.ipl
+	include embox.arch.mips.libarch
+	include embox.arch.mips.vfork
+	@Runlevel(0) include embox.arch.mips.mm.cache(log_level="LOG_INFO", use_l2_cache=false, use_auto_cache_size=true)
+	include embox.arch.mips.mm.mem_barriers
+
+	include embox.driver.diag.board_diag(base_addr=0xb0000c00, baud_rate=115200)
+	include embox.driver.diag(impl="embox__driver__diag__board_diag")
+	include embox.init.setup_tty_diag
+
+	include embox.driver.interrupt.mips_intc
+	@Runlevel(2) include embox.driver.clock.mips_clk(cyc_per_tick=2)
+	include embox.kernel.time.jiffies(cs_name="mips_clk")
+
+	@Runlevel(2) include embox.kernel.irq
+	include embox.kernel.task.multi
+	include embox.kernel.task.resource.idesc_table(idesc_table_size=32)
+
+	include embox.compat.posix.proc.vfork_exchanged
+	include embox.compat.posix.proc.exec_exchanged
+
+	include embox.kernel.thread.thread_local_none
+	include embox.kernel.thread.thread_cancel_disable
+	include embox.kernel.thread.signal.siginfoq(siginfo_pool_sz=8)
+	include embox.kernel.timer.sleep
+
+	include embox.kernel.sched.sched(log_level="LOG_ERR")
+	include embox.kernel.sched.idle_light
+
+	include embox.kernel.lthread.lthread
+	include embox.kernel.thread.core(thread_pool_size=16)
+
+	/* tty requires */
+	include embox.kernel.thread.mutex
+	include embox.driver.tty.tty(rx_buff_sz=16, io_buff_sz=16)
+	include embox.driver.tty.task_breaking_disable
+
+	include embox.compat.libc.math_simple
+
+	include embox.util.log
+
+	include embox.mem.pool_adapter
+
+	include embox.mem.heap_bm
+	include embox.mem.static_heap(heap_size=0x80000)
+	include embox.mem.bitmask(page_size=4096)
+
+	include embox.compat.posix.util.sleep
+	include embox.framework.LibFramework
+	include embox.compat.libc.stdio.print(support_floating=0)
+
+	include embox.fs.driver.initfs_dvfs
+	include embox.fs.driver.devfs_dvfs
+	include embox.fs.rootfs_dvfs(fstype="initfs")
+
+	include embox.fs.dvfs.core(inode_pool_size=16, dentry_pool_size=16, inode_pool_size=16)
+	include embox.compat.posix.file_system_dvfs
+	include embox.fs.syslib.perm_stub
+	include embox.driver.block_dev
+	include embox.fs.driver.fat_dvfs
+
+	@Runlevel(2) include embox.cmd.sh.tish(builtin_commands = "cd export exit logout httpd dcon")
+	@Runlevel(3) include embox.init.start_script(shell_name="tish", tty_dev="ttyS0", shell_start=1, stop_on_error=false)
+
+	include embox.cmd.help
+	include embox.cmd.sys.version
+	include embox.cmd.sys.uname
+	include embox.cmd.goto
+	include embox.cmd.service
+
+	include embox.cmd.dcon
+	include embox.cmd.hw.mem
+	include embox.cmd.goto
+
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.ls
+
+	include embox.cmd.testing.ticker
+}

--- a/platform/ralink/templates/rt5350/rootfs/network
+++ b/platform/ralink/templates/rt5350/rootfs/network
@@ -1,0 +1,9 @@
+iface eth0 inet static
+	address 192.168.68.230
+	netmask 255.255.255.0
+	gateway 192.168.68.10
+	hwaddress aa:bb:cc:dd:ee:02
+
+iface lo inet static
+	address 127.0.0.1
+	netmask 255.0.0.0

--- a/platform/ralink/templates/rt5350/start_script.inc
+++ b/platform/ralink/templates/rt5350/start_script.inc
@@ -1,0 +1,4 @@
+"version",
+"help",
+"tish",
+

--- a/src/arch/mips/mm/mips_cache.c
+++ b/src/arch/mips/mm/mips_cache.c
@@ -12,7 +12,6 @@
 #include <asm/io.h>
 #include <asm/mipsregs.h>
 #include <asm/system.h>
-#include <drivers/mips/global_control_block.h>
 #include <embox/unit.h>
 #include <framework/mod/options.h>
 #include <kernel/panic.h>
@@ -23,17 +22,31 @@
 
 EMBOX_UNIT_INIT(mips_cache_init);
 
+#ifndef CONFIG_SYS_ICACHE_LINE_SIZE
+#define CONFIG_SYS_ICACHE_LINE_SIZE	32
+#endif
+
+#ifndef CONFIG_SYS_DCACHE_LINE_SIZE
+#define CONFIG_SYS_DCACHE_LINE_SIZE	32
+#endif
+
+#ifndef CONFIG_SYS_SCACHE_LINE_SIZE
+#define CONFIG_SYS_SCACHE_LINE_SIZE	0
+#endif
+
 #if USE_L2_CACHE
-static uint32_t l2_line_size;
+extern uint32_t mips_cm_l2_line_size(void);
+
+static uint32_t l2_line_size = CONFIG_SYS_SCACHE_LINE_SIZE;
 #endif
 
 #if USE_CACHE_SIZE_AUTO
-static uint32_t l1i_line_size;
-static uint32_t l1d_line_size;
+static uint32_t l1i_line_size = CONFIG_SYS_ICACHE_LINE_SIZE;
+static uint32_t l1d_line_size = CONFIG_SYS_DCACHE_LINE_SIZE;
 #endif
 
 static inline unsigned long icache_line_size(void) {
-#ifdef USE_CACHE_SIZE_AUTO
+#if USE_CACHE_SIZE_AUTO
 	return l1i_line_size;
 #else
 	return CONFIG_SYS_ICACHE_LINE_SIZE;
@@ -41,7 +54,7 @@ static inline unsigned long icache_line_size(void) {
 }
 
 static inline unsigned long dcache_line_size(void) {
-#ifdef USE_CACHE_SIZE_AUTO
+#if USE_CACHE_SIZE_AUTO
 	return l1d_line_size;
 #else
 	return CONFIG_SYS_DCACHE_LINE_SIZE;
@@ -49,7 +62,7 @@ static inline unsigned long dcache_line_size(void) {
 }
 
 static inline unsigned long scache_line_size(void) {
-#ifdef USE_L2_CACHE
+#if USE_L2_CACHE
 	return l2_line_size;
 #else
 	return CONFIG_SYS_SCACHE_LINE_SIZE;
@@ -91,7 +104,7 @@ static void probe_l2(void) {
 #endif
 
 static int mips_cache_init(void) {
-#ifdef USE_CACHE_SIZE_AUTO
+#if USE_CACHE_SIZE_AUTO
 	unsigned long conf1, il, dl;
 
 	conf1 = mips_read_c0_config1();

--- a/src/drivers/diag/ralink_diag/Mybuild
+++ b/src/drivers/diag/ralink_diag/Mybuild
@@ -1,0 +1,7 @@
+package embox.driver.diag
+
+module board_diag extends diag_api {
+	option number base_addr = 0xb0000c00
+	option number baud_rate = 115200
+	source "board_diag.c"
+}

--- a/src/drivers/diag/ralink_diag/board_diag.c
+++ b/src/drivers/diag/ralink_diag/board_diag.c
@@ -1,0 +1,72 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date 04.12.2024
+ * @author Serge Vasilugin
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include <framework/mod/options.h>
+#include <drivers/diag.h>
+
+#define UART_BASE_ADDR  OPTION_GET(NUMBER,base_addr)
+#define BAUD_RATE OPTION_GET(NUMBER,baud_rate)
+
+
+#define READREG(r)		*(volatile unsigned int *)(r)
+#define WRITEREG(r,v)		*(volatile unsigned int *)(r) = v
+
+#define KSEG1ADDR(_x)		(((_x) & 0x1fffffff) | 0xa0000000)
+
+#ifdef UART_BASE_ADDR
+#define	UART_BASE KSEG1ADDR(UART_BASE_ADDR)
+#else
+
+#ifdef SOC_RT288X
+#define UART_BASE		0xb0300c00
+#else
+#define UART_BASE		0xb0000c00
+#endif
+
+#endif
+
+#define UART_RX			0
+#define UART_TX			1<<2
+#define UART_LSR		7<<2
+
+#define UART_LSR_DR		1
+#define UART_LSR_THRE		0x20
+
+#define UART_READ(r)		READREG(UART_BASE + (r))
+#define UART_WRITE(r,v)		WRITEREG(UART_BASE + (r), (v))
+
+static int board_init(const struct diag *diag)
+{
+	return 0;
+}
+
+static void board_putc(const struct diag *diag, char ch)
+{
+	while (((UART_READ(UART_LSR)) & UART_LSR_THRE) == 0);
+	UART_WRITE(UART_TX, ch);
+	while (((UART_READ(UART_LSR)) & UART_LSR_THRE) == 0);
+}
+
+static int board_kbhit(const struct diag *diag)
+{
+	return UART_READ(UART_LSR) & UART_LSR_DR;
+}
+
+static char board_getc(const struct diag *diag)
+{
+	return UART_READ(UART_RX);
+}
+
+DIAG_OPS_DEF(
+	.init = board_init,
+	.putc = board_putc,
+	.getc = board_getc,
+	.kbhit = board_kbhit,
+);


### PR DESCRIPTION
1. Module *mips_cache* was corrected to use predefined values for data and instruction cache line size.
2. Added ralink diag port driver and new platform **ralink**