### PR TITLE
platform: ralink: add support into uart ns16550 driver

### DIFF
--- a/platform/ralink/templates/rt5350/mods.conf
+++ b/platform/ralink/templates/rt5350/mods.conf
@@ -11,9 +11,13 @@ configuration conf {
 	@Runlevel(0) include embox.arch.mips.mm.cache(log_level="LOG_INFO", use_l2_cache=false, use_auto_cache_size=true)
 	include embox.arch.mips.mm.mem_barriers
 
-	include embox.driver.diag.board_diag(base_addr=0xb0000c00, baud_rate=115200)
-	include embox.driver.diag(impl="embox__driver__diag__board_diag")
-	include embox.init.setup_tty_diag
+//	include embox.driver.diag.board_diag(base_addr=0xb0000c00, baud_rate=115200)
+//	include embox.driver.diag(impl="embox__driver__diag__board_diag")
+//	include embox.init.setup_tty_diag
+	include embox.driver.serial.ns16550(mem32_access=true, reg_width=4)
+	include embox.driver.serial.ns16550_diag(base_addr=0xb0000c00, baud_rate=115200)
+	include embox.driver.serial.ns16550_ttyS0(base_addr=0xb0000c00, irq_num=20)
+	include embox.driver.diag(impl="embox__driver__serial__ns16550_diag")
 
 //	include embox.driver.interrupt.mips_intc
 	include embox.driver.interrupt.ralink_intc

--- a/src/arch/mips/kernel/reg/mmap_reg.h
+++ b/src/arch/mips/kernel/reg/mmap_reg.h
@@ -14,10 +14,10 @@
 
 #define __MMAP_REG_STORE(inttype, addr, val)                      \
 	do {                                                          \
-		*((volatile inttype *)((uintptr_t)addr + KSEG1)) = (val); \
+		*((volatile inttype *)((uintptr_t)(addr & 0x1fffffff) | KSEG1)) = (val); \
 	} while (0)
 
 #define __MMAP_REG_LOAD(inttype, addr) \
-	*((volatile inttype *)((uintptr_t)addr + KSEG1))
+	*((volatile inttype *)((uintptr_t)(addr & 0x1fffffff) | KSEG1))
 
 #endif /* MIPS_KERNEL_REG_REG_H_ */

--- a/src/drivers/serial/ns16550/ns16550.c
+++ b/src/drivers/serial/ns16550/ns16550.c
@@ -18,6 +18,38 @@
 #define REG_WIDTH    OPTION_GET(NUMBER, reg_width)
 #define MEM32_ACCESS OPTION_GET(BOOLEAN, mem32_access)
 
+#ifdef RALINK
+/**
+ * Redefinition for Ralink layout
+ * (R) - read only
+ * (W) - write only
+ * (R/W) - read/write
+ * (RC) - read/clear
+ */
+#define UART_RHR(base) (base + REG_WIDTH * 0) /* (R) Receiver Holding Reg */
+#define UART_THR(base) (base + REG_WIDTH * 1) /* (W) Transmitter Holding Reg */
+#define UART_IER(base) (base + REG_WIDTH * 2) /* (R/W) Interrupt Enable Reg */
+#define UART_ISR(base) (base + REG_WIDTH * 3) /* (R) Interrupt Status Reg */
+#define UART_FCR(base) (base + REG_WIDTH * 4) /* (R/W) FIFO Control Reg */
+#define UART_LCR(base) (base + REG_WIDTH * 5) /* (R/W) Line Control Reg */
+#define UART_MCR(base) (base + REG_WIDTH * 6) /* (R/W) Modem Control Reg */
+#define UART_LSR(base) (base + REG_WIDTH * 7) /* (RC) Line Status Reg */
+#define UART_MSR(base) (base + REG_WIDTH * 8) /* (RC) Modem Status Reg - not for uartlite*/
+#define UART_SPR(base) (base + REG_WIDTH * 9) /* (R/W) Scratch Pad Reg */
+
+/**
+ * Ralink ignore DLAB = 1 settting (for ns16550 compatibility)
+ * but use its' own registers
+ */
+/* (R/W) Baudrate Divisor’s as 16-bit value */
+#define UART_DL(base) (base + REG_WIDTH * 10)
+/* (R/W) Baudrate Divisor’s Constant Least Significant Byte */
+#define UART_DLL(base) (base + REG_WIDTH * 11)
+/* (R/W) Baudrate Divisor’s Constant Most Significant Byte */
+#define UART_DLM(base) (base + REG_WIDTH * 12)
+//#define UART_PSD(base) (base + REG_WIDTH * 5) /* (W) Prescaler Division */
+/* End of RALINK specific regs */
+#else
 /**
  * General Register Set
  * 
@@ -35,6 +67,20 @@
 #define UART_LSR(base) (base + REG_WIDTH * 5) /* (R) Line Status Reg */
 #define UART_MSR(base) (base + REG_WIDTH * 6) /* (R) Modem Status Reg */
 #define UART_SPR(base) (base + REG_WIDTH * 7) /* (R/W) Scratch Pad Reg */
+
+/**
+ * Registers accesible only when DLAB = 1
+ * 
+ * (R) - read only
+ * (W) - write only
+ * (R/W) - read/write
+ */
+/* (R/W) Baudrate Divisor’s Constant Least Significant Byte */
+#define UART_DLL(base) (base + REG_WIDTH * 0)
+/* (R/W) Baudrate Divisor’s Constant Most Significant Byte */
+#define UART_DLM(base) (base + REG_WIDTH * 1)
+#define UART_PSD(base) (base + REG_WIDTH * 5) /* (W) Prescaler Division */
+#endif	/*End of #ifdef RALINK */
 
 #define UART_IER_DR   (1U << 0) /* Data Ready */
 #define UART_IER_THRE (1U << 1) /* Transmit-hold-register empty */
@@ -57,19 +103,6 @@
 #define UART_LSR_THRE (1U << 5) /* Transmit-hold-register empty */
 #define UART_LSR_TE   (1U << 6) /* Transmitter empty */
 #define UART_LSR_FDE  (1U << 7) /* FIFO data Error */
-
-/**
- * Registers accesible only when DLAB = 1
- * 
- * (R) - read only
- * (W) - write only
- * (R/W) - read/write
- */
-/* (R/W) Baudrate Divisor’s Constant Least Significant Byte */
-#define UART_DLL(base) (base + REG_WIDTH * 0)
-/* (R/W) Baudrate Divisor’s Constant Most Significant Byte */
-#define UART_DLM(base) (base + REG_WIDTH * 1)
-#define UART_PSD(base) (base + REG_WIDTH * 5) /* (W) Prescaler Division */
 
 #if MEM32_ACCESS
 static_assert(REG_WIDTH == 4, "");


### PR DESCRIPTION
1. Fix load/store macros to work correctly for addr from any segment.
2. Add Ralink register layout into uart ns16550 driver.
3. Switch to standard uart ns16550 driver in config.