### PR TITLE
drivers: clock: make riscv_clk an abstract module

### DIFF
--- a/src/drivers/clock/riscv_clk/Mybuild
+++ b/src/drivers/clock/riscv_clk/Mybuild
@@ -1,9 +1,12 @@
 package embox.driver.clock
 
-module riscv_clk {
+@DefaultImpl(embox.driver.clock.riscv_timer_clint)
+abstract module riscv_clk {
 	option number rtc_freq=1000000
-	
-	source "riscv_clk.c"
+}
+
+module riscv_timer_clint extends riscv_clk {
+	source "riscv_timer_clint.c"
 
 	depends embox.kernel.time.clock_source
 	depends embox.driver.interrupt.riscv_clint

--- a/src/drivers/clock/riscv_clk/riscv_timer_clint.c
+++ b/src/drivers/clock/riscv_clk/riscv_timer_clint.c
@@ -29,7 +29,7 @@
 
 static int clock_handler(unsigned int irq_nr, void *dev_id) {
 #if SMODE
-    
+
 	register uintptr_t a7 asm("a7") = (uintptr_t)(OPENSBI_TIMER);
 	register uintptr_t a6 asm("a6") = (uintptr_t)(0);
 	register uintptr_t a0 asm("a0") = 0;
@@ -67,7 +67,7 @@ static int riscv_clock_setup(struct clock_source *cs) {
 
 static struct time_event_device riscv_event_device = {
     .set_periodic = riscv_clock_setup,
-    .name = "riscv_clk",
+    .name = "riscv_timer_clint",
     .irq_nr = IRQ_TIMER,
 };
 


### PR DESCRIPTION
Some vendors get riscv clocksource from CSR TIME, better to make an abstraction.