### PR TITLE
Tun: fix memory leak and race condition

### DIFF
--- a/src/drivers/net/tun/tun.c
+++ b/src/drivers/net/tun/tun.c
@@ -73,8 +73,13 @@ static int tun_xmit(struct net_device *dev, struct sk_buff *skb) {
 	memcpy(ethh->h_source, skb->dev->dev_addr, ETH_ALEN);
 	memset(ethh->h_dest, 0, ETH_ALEN);
 
-	skb_queue_push(&tun->rx_q, skb);
-	waitq_wakeup(&tun->wq, 1);
+	tun_krnl_lock(tun);
+	{
+		skb_queue_push(&tun->rx_q, skb);
+		waitq_wakeup(&tun->wq, 1);
+	}
+	tun_krnl_unlock(tun);
+
 	return 0;
 }
 

--- a/src/drivers/net/tun/tun.c
+++ b/src/drivers/net/tun/tun.c
@@ -142,6 +142,7 @@ static ssize_t tun_dev_read(struct char_dev *cdev, void *buf, size_t nbyte) {
 		}
 	} while (ret == 0);
 	waitq_wait_cleanup(&tun->wq, wql);
+	skb_free(skb);
 
 	return ret;
 }


### PR DESCRIPTION
fix the memory leak in tun_dev_read by adding skb_free and race condition in tun_xmit by adding lock to the code that accesses queue 