### PR TITLE
Add unit tests for math.h remainder() function

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -174,3 +174,8 @@ module frexp_test {
 	@Cflags("-fno-builtin")
 	source "frexp_test.c"
 }
+
+module remainder_test {
+       @Cflags("-fno-builtin")
+        source "remainder_test.c"
+}

--- a/src/compat/libc/math/tests/remainder_test.c
+++ b/src/compat/libc/math/tests/remainder_test.c
@@ -1,0 +1,36 @@
+/**
+ * @file
+ *
+ * @date May 11, 2025
+ * @author Shankari Anand
+ */
+
+#include <math.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("remainder() tests");
+
+TEST_CASE("Test for remainder() with positive numerator") {
+    double result = remainder(5.0, 2.0);
+    test_assert(result == 1.0);
+}
+
+TEST_CASE("Test for remainder() with negative numerator") {
+    double result = remainder(-5.0, 2.0);
+    test_assert(result == -1.0);
+}
+
+TEST_CASE("Test for remainder() with negative denominator") {
+    double result = remainder(5.0, -2.0);
+    test_assert(result == 1.0);
+}
+
+TEST_CASE("Test for remainder() when both are negative") {
+    double result = remainder(-5.0, -2.0);
+    test_assert(result == -1.0);
+}
+
+TEST_CASE("Test for remainder() with zero numerator") {
+    double result = remainder(0.0, 2.0);
+    test_assert(result == 0.0);
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -229,6 +229,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.llrint_test
 	@Runlevel(1) include embox.compat.libc.test.log1p_test
 	@Runlevel(1) include embox.compat.libc.test.frexp_test
+	@Runlevel(1) include embox.compat.libc.test.remainder_test
 
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap_test


### PR DESCRIPTION
This pull request implements unit tests for the `remainder()` function from `math.h`, addressing issue [#3594](https://github.com/embox/embox/issues/3594).

Changes Introduced -

- Created a new test file: `remainder_test.c`
- Added test cases covering:
  - Positive and negative input values
  - Zero as the dividend
- Registered the test in `mods.conf` under the `x86` architecture