### PR TITLE
Change the UART 6 pins and clock source

### DIFF
--- a/board_config/nucleo_f429zi.conf.h
+++ b/board_config/nucleo_f429zi.conf.h
@@ -51,12 +51,12 @@ struct uart_conf uarts[] = {
 				VAL("", 71),
 			},
 			.pins = {
-				PIN("TX", PC, PIN_6, AF8),
-				PIN("RX", PC, PIN_7, AF8),
+				PIN("TX", PG, PIN_14, AF8),
+				PIN("RX", PG, PIN_9, AF8),
 			},
 			.clocks = {
-				VAL("TX",   CLK_GPIOC),
-				VAL("RX",   CLK_GPIOC),
+				VAL("TX",   CLK_GPIOG),
+				VAL("RX",   CLK_GPIOG),
 				VAL("UART", CLK_USART6),
 			}
 		},


### PR DESCRIPTION
For #2842 
Firstly, According to the user manual [https://www.st.com/resource/en/user_manual/um1974-stm32-nucleo144-boards-mb1137-stmicroelectronics.pdf](url), A total of 7 USART6 field information were queried, with USART_SA_TX pointing to PG14 and USART_SA_RX pointing to PG14.
![L0}6@$}XRH PUID@%5}IHK](https://github.com/user-attachments/assets/bed47878-106f-42db-93da-f507138894af)

Secondly, [https://www.st.com/resource/en/datasheet/stm32f429zi.pdf](url) query  shows:PG14: AF8 = USART6_TX, PG9: AF8 = USART6_RX
![S3MA``62SCN9% GG{`DKSL8](https://github.com/user-attachments/assets/b3a42f74-4123-472c-889d-ff9712285f03)

Finally, my personal thoughts are that in the future, if device trees are supported, pin and clock information can be directly modified in DTS files without recompiling, and the scalability will be better.

Thank you for your guidance. I will continue to follow Embox