### PR TITLE
Add tests for tgamma() from math.h

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -176,6 +176,11 @@ module frexp_test {
 }
 
 module remainder_test {
-       @Cflags("-fno-builtin")
-        source "remainder_test.c"
+  @Cflags("-fno-builtin")
+  source "remainder_test.c"
+}
+
+module tgamma_test {
+	@Cflags("-fno-builtin")
+	source "tgamma_test.c"
 }

--- a/src/compat/libc/math/tests/tgamma_test.c
+++ b/src/compat/libc/math/tests/tgamma_test.c
@@ -1,0 +1,93 @@
+/**
+ * @file
+ * 
+ * @date May 19, 2025
+ * @author Peize Li
+ */
+#include <math.h>
+#include <float.h>
+#include <errno.h>
+
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("tgamma() tests");
+
+#define _ISOC99_SOURCE
+#define _POSIX_C_SOURCE 200112L
+#define TGAMMA_EPSILON_FACTORIAL (DBL_EPSILON * 1000)
+#define TGAMMA_EPSILON_PI_RELATED (DBL_EPSILON * 100)
+#define TGAMMA_EPSILON_GENERAL (1e-6)
+
+static int approx_equal(double calc, double expect, double epsilon) {
+  if (isnan(calc) && isnan(expect)) {
+    return 1;
+  }
+  if (isinf(calc) && isinf(expect) && ((calc > 0) == (expect > 0))) {
+    return 1;
+  }
+  if (fabs(expect) < epsilon) {
+    return fabs(calc - expect) < epsilon;
+  }
+  return fabs(calc - expect) / fabs(expect) < epsilon;
+}
+
+TEST_CASE("tgamma() with positive integers") {
+  test_assert(approx_equal(tgamma(1.0), 1.0, TGAMMA_EPSILON_FACTORIAL));
+  test_assert(approx_equal(tgamma(2.0), 1.0, TGAMMA_EPSILON_FACTORIAL));
+  test_assert(approx_equal(tgamma(5.0), 24.0, TGAMMA_EPSILON_FACTORIAL));
+}
+
+TEST_CASE("tgamma() with positive non-integers") {
+  test_assert(approx_equal(tgamma(0.5), sqrt(M_PI), TGAMMA_EPSILON_PI_RELATED));
+  test_assert(approx_equal(tgamma(1.5), 0.5 * sqrt(M_PI), TGAMMA_EPSILON_PI_RELATED));
+}
+
+TEST_CASE("tgamma() with zero input") {
+  test_assert(isinf(tgamma(+0.0)) && tgamma(+0.0) > 0);
+  test_assert(isinf(tgamma(-0.0)) && tgamma(-0.0) < 0);
+}
+
+TEST_CASE("tgamma() with infinite input") {
+  test_assert(isinf(tgamma(INFINITY)) && tgamma(INFINITY) > 0);
+  test_assert(isnan(tgamma(-INFINITY)));
+}
+
+TEST_CASE("tgamma() with NaN input") {
+  test_assert(isnan(tgamma(NAN)));
+}
+
+TEST_CASE("tgamma() with negative integers") {
+  test_assert(isnan(tgamma(-1.0)));
+  test_assert(isnan(tgamma(-2.0)));
+}
+
+TEST_CASE("tgamma() with negative non-integers") {
+  test_assert(approx_equal(tgamma(-0.5), -2.0 * sqrt(M_PI), TGAMMA_EPSILON_PI_RELATED));
+}
+
+TEST_CASE("tgamma() near overflow") {
+  test_assert(!isinf(tgamma(171.0)) && !isnan(tgamma(171.0)));
+  test_assert(isinf(tgamma(172.0)) && tgamma(172.0) > 0);
+}
+
+TEST_CASE("tgamma() recursion property") {
+  double x = 1.14;
+  test_assert(approx_equal(tgamma(x+1), x*tgamma(x), TGAMMA_EPSILON_GENERAL));
+}
+
+TEST_CASE("tgamma() and lgamma() consistency") {
+  double x = 5.14;
+  test_assert(approx_equal(log(tgamma(x)), lgamma(x), TGAMMA_EPSILON_GENERAL));
+}
+
+TEST_CASE("tgamma() overflow sets errno") {
+  // errno = 0;
+  // tgamma(172.0);
+  // test_assert(errno == ERANGE);
+}
+
+TEST_CASE("tgamma() invalid input sets errno") {
+  // errno = 0;
+  // tgamma(-1.0);
+  // test_assert(errno == EDOM);
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -230,6 +230,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.log1p_test
 	@Runlevel(1) include embox.compat.libc.test.frexp_test
 	@Runlevel(1) include embox.compat.libc.test.remainder_test
+	@Runlevel(1) include embox.compat.libc.test.tgamma_test
 
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap_test


### PR DESCRIPTION
Hi, this is my first PR, please advise me if there are any deficiencies. 

Completed testing of tgamma() based on x86. 

I've noticed that the openlibm currently used by embox seems to be a bit undefined.

``` 
Errors are reported as specified in math_errhandling.
For IEEE-compatible type double, overflow happens if 0 < x < 1/[DBL_MAX] or if x > 171.7.  
  
If a range error due to overflow occurs, [±HUGE_VAL], ±HUGE_VALF, or ±HUGE_VALL is returned.
POSIX requires that a pole error occurs if the argument is zero, but a domain error occurs when the argument is a negative integer
```
However, errno is not set to ERANGE in the case of an overflow, nor is it set to EDOM when the parameter is a negative integer.

Considering RTOS might trim some standard library features for performance, I commented out these two tests. 

Thank you for your reviewing:)
