### PR TITLE
Add image scripts for creating uImage and ISO Image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ embox.includes
 
 ## Build
 /*.img
+*.dtb
 
 ## Other
 /.dep.inc

--- a/board_config/dts/dummy.dts
+++ b/board_config/dts/dummy.dts
@@ -1,0 +1,10 @@
+/dts-v1/;
+
+/ {
+	compatible = "embox";
+	model = "embox-fake";
+	#address-cells = <2>;
+	#size-cells = <1>;
+	cpus {
+	};
+};

--- a/scripts/mkiso.sh
+++ b/scripts/mkiso.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+if ! command -v dtc >/dev/null 2>&1; then
+  echo "Error: dtc not found !"
+  exit 1
+fi
+
+if ! command -v mkfs.vfat >/dev/null 2>&1; then
+  echo "Error: mkfs.vfat not found !"
+  exit 1
+fi
+
+EMBOX_ELF="build/base/bin/embox"
+EMBOX_BIN="build/base/bin/embox.bin"
+ISONAME="embox.img"
+MOUNT_DIR="embox-iso-tmp"
+DEVICE_TREE="board_config/dts/dummy"
+UBOOT_ARGS=()
+
+help_info() {
+	echo "Usage: $0 [options] [positional_args...]"
+	echo
+	echo "Options:"
+	echo "  -o, --output <file>     Specify the output uImage file name"
+	echo "  -i, --iso <name>        Specify the iso image name"
+	echo "  -b, --bin <bin>         Specify the binary name"
+	echo "  -e, --elf <elf>         Specify the elf name"
+	echo "  -d, --dir <dir>         Specify the tmp mount dir name"
+	echo "  -h, --help              Show this help message and exit"
+	echo "  --u-boot <args>         All following args are passed to uboot-uimage script"
+	echo
+	echo "Example:"
+	echo "  $0 -i embox.img -d embox-iso-tmp --u-boot -o uImage -a riscv"
+	echo
+}
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--u-boot)
+			shift
+			while [[ $# -gt 0 && $1 != --* ]]; do
+			UBOOT_ARGS+=("$1")
+			shift
+			done
+			;;
+		-i|--iso)
+			ISONAME="$2"
+			shift
+			shift
+			;;
+		-d|--dir)
+			MOUNT_DIR="$2"
+			shift
+			shift
+			;;
+		-h|--help)
+			help_info
+			exit 0
+			;;
+		*)
+			echo "Unknown option: $1"
+			help_info
+			exit 1
+			;;
+	esac
+done
+
+echo "ISO           = ${ISONAME}"
+echo "DTB           = ${DEVICE_TREE}.dtb"
+
+UIMAGE_VALUE=$(./scripts/uboot-uimage ${UBOOT_ARGS[@]} | tee >(cat >&2) |  grep '^UIMAGE' | awk -F'= ' '{print $2}')
+
+mkdir ${MOUNT_DIR} || { echo "${MOUNT_DIR} directory exist !!"; exit 1; }
+dd if=/dev/zero of=${ISONAME} bs=1M count=64
+mkfs.vfat -F 32 ${ISONAME}
+dtc -I dts -O dtb -o $DEVICE_TREE.dtb $DEVICE_TREE.dts
+
+mount -o loop ${ISONAME} ${MOUNT_DIR}
+cp ${EMBOX_ELF} ${MOUNT_DIR}
+cp ${EMBOX_BIN} ${MOUNT_DIR}
+cp ${UIMAGE_VALUE} ${MOUNT_DIR}
+cp $DEVICE_TREE.dtb ${MOUNT_DIR}
+chmod 664 ${ISONAME}
+
+umount ${MOUNT_DIR}
+rmdir ${MOUNT_DIR}

--- a/scripts/uboot-uimage
+++ b/scripts/uboot-uimage
@@ -1,12 +1,70 @@
 #!/bin/sh
 
-EMBOX_BIN=${1:-"./build/base/bin/embox.bin"}
-UIMAGE=${2:-uImage}
+EMBOX_BIN="./build/base/bin/embox.bin"
+IMAGENAME="Embox RTOS Image"
+UIMAGE="uImage"
+ARCH="riscv"
 MKIMAGE=$(which mkimage)
+POSITIONAL_ARGS=()
 
 if [ ! "$MKIMAGE" ]; then
 	echo "!!!!!!!  ERROR !!!!!!!!!!!!! please install mkimage or uboot-tools"   >&2
 	exit 1
+fi
+
+help_info() {
+	echo "Usage: $0 [options] [positional_args...]"
+	echo
+	echo "Options:"
+	echo "  -o, --output <file>     Specify the output uImage file name"
+	echo "  -A, --arch <arch>       Specify the target architecture (e.g., arm, riscv)"
+	echo "  -n, --name <name>       Specify the image name scription"
+	echo "  -n, --name <name>       Specify the image name scription"
+	echo "  -h, --help              Show this help message and exit"
+	echo
+	echo "Example:"
+	echo "  $0 -o uImage -a riscv -n \"Embox RTOS Image\" ./build/base/bin/embox.bin"
+	echo "  $0 ./build/base/bin/embox.bin -o uImage -a riscv -n \"Embox RTOS Image\""
+	echo
+}
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		-o|--output)
+			UIMAGE="$2"
+			shift # past argument
+			shift # past value
+			;;
+		-a|--arch)
+			ARCH="$2"
+			shift
+			shift
+			;;
+		-n|--name)
+			IMAGENAME="$2"
+			shift
+			shift
+			;;
+		-h|--help)
+			help_info
+			exit 0
+			;;
+		-*|--*)
+			echo "Unknown option $1"
+			help_info
+			exit 1
+			;;
+		*)
+			POSITIONAL_ARGS+=("$1") # save positional arg
+			shift # past argument
+			;;
+	esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
+
+if [[ -n $1 ]]; then
+    EMBOX_BIN="$1"
 fi
 
 case $OMAP_UBOOT_IMAGE_BOARD in
@@ -20,22 +78,19 @@ case $OMAP_UBOOT_IMAGE_BOARD in
 		LOAD_ADDR=0x43000000
 		;;
 	*)
-		LOAD_ADDR=0x80000000
+		LOAD_ADDR=0x84000000
 		;;
 esac
-ENTRY_ADDR=$(printf "0x%x" $(($LOAD_ADDR + 0x8040)))
 
-echo LOAD_ADDR=$LOAD_ADDR ENTRY_ADDR=$ENTRY_ADDR
+ENTRY_ADDR=${LOAD_ADDR}
 
-PAD_FILE_NAME=".pad.zero"
-PADDED_BIN=".embox-padded.bin"
+echo "UIMAGE        = ${UIMAGE}"
+echo "ARCH          = ${ARCH}"
+echo "EMBOX_BIN     = ${EMBOX_BIN}"
+echo "IMAGENAME     = ${IMAGENAME}"
 
-PAD_SIZE=32K
+echo "LOAD_ADDR     = ${LOAD_ADDR}"
+echo "ENTRY_ADDR    = ${ENTRY_ADDR}"
 
-dd if=/dev/zero of="$PAD_FILE_NAME" bs=1 count=$PAD_SIZE
-
-cat "$PAD_FILE_NAME" "$EMBOX_BIN" > "$PADDED_BIN"
-
-"$MKIMAGE" -A arm -O linux -C none -T kernel -a $LOAD_ADDR -e "$ENTRY_ADDR" -d "$PADDED_BIN" "$UIMAGE"
-
-rm "$PAD_FILE_NAME" "$PADDED_BIN"
+${MKIMAGE} -A ${ARCH} -O linux -C none -T kernel -a ${LOAD_ADDR} \
+	-e ${ENTRY_ADDR} -n "${IMAGENAME}" -d ${EMBOX_BIN} ${UIMAGE}


### PR DESCRIPTION
uboot-uimage is mainly used for u-boot `bootm` command
mkiso.sh is mainly used to enable qemu to identify and load the kernel and dtb in ISO through virtio.