### PR TITLE
[Minor]: Fix spelling error in printf statement.

### DIFF
--- a/src/cmds/service/service.c
+++ b/src/cmds/service/service.c
@@ -230,6 +230,6 @@ int main(int argc, char **argv) {
     if(service_run(command, &argv[arg_offset]) < 0)
         printf("Couldn't start service %s\n", argv[1]);
     else
-        printf("Succefully started\n");
+        printf("Successfully started\n");
     return 0;
 }


### PR DESCRIPTION
This pull request corrects a small typo in a `printf` output string to improve clarity. No functional changes were made.