### PR TITLE
riscv: Fix kernel sbi defconfig reversing

### DIFF
--- a/src/arch/riscv/kernel/Mybuild
+++ b/src/arch/riscv/kernel/Mybuild
@@ -7,14 +7,14 @@ abstract module conf {
 }
 
 module conf_nosbi extends  conf {
-        option boolean smode = true
+        option boolean smode = false
 	source "sbi.c"
 	source "sbi_ecall.c"
 }
 
 
 module conf_sbi extends  conf {
-        option boolean smode = false
+        option boolean smode = true
 
 }
 


### PR DESCRIPTION
This fixed:
https://github.com/embox/embox/actions/runs/15211776776/job/42787425755