### PR TITLE
Enforce POSIX SIGKILL/SIGSTOP rules

### DIFF
--- a/src/compat/posix/include/signal.h
+++ b/src/compat/posix/include/signal.h
@@ -75,6 +75,8 @@
 #define SA_NODEFER   (0x1ul << 5)
 #define SA_RESETHAND (0x1ul << 6)
 
+#define IS_UNMODIFIABLE_SIGNAL(sig) ((sig) == SIGKILL || (sig) == SIGSTOP)
+
 __BEGIN_DECLS
 
 #ifdef __clang__

--- a/src/compat/posix/proc/signal/signal.c
+++ b/src/compat/posix/proc/signal/signal.c
@@ -32,7 +32,7 @@ int sigaction(int sig, const struct sigaction *restrict act,
 		struct sigaction *restrict oact) {
 	struct sigaction *sig_table = task_self_resource_sig_table();
 
-	if (!check_range(sig, 0, _SIG_TOTAL))
+	if (!check_range(sig, 0, _SIG_TOTAL) || IS_UNMODIFIABLE_SIGNAL(sig))
 		return SET_ERRNO(EINVAL);
 
 	if (oact) {
@@ -73,7 +73,6 @@ sighandler_t signal(int sig, sighandler_t func) {
 
 	err = sigaction(sig, &act, &oact);
 	if (err) {
-		SET_ERRNO(err);
 		return SIG_ERR;
 	}
 


### PR DESCRIPTION
signal: enforce POSIX SIGKILL/SIGSTOP rules

- Reject handler setup for SIGKILL/SIGSTOP with EINVAL
- Remove incorrect errno setting in signal()

Fixes #3532
