### PR TITLE
riscv: Fix conf_sbi module not sources sbi.c

### DIFF
--- a/src/arch/riscv/kernel/Mybuild
+++ b/src/arch/riscv/kernel/Mybuild
@@ -8,14 +8,13 @@ abstract module conf {
 
 module conf_nosbi extends  conf {
 	option boolean smode = false
-	source "sbi.c"
-	source "sbi_ecall.c"
 }
 
 
 module conf_sbi extends  conf {
 	option boolean smode = true
-
+	source "sbi.c"
+	source "sbi_ecall.c"
 }
 
 module locore extends embox.arch.locore {


### PR DESCRIPTION
This is my dump mistake of reviewing code. Sorry for taking up maintainers' time for merging PRs.
Uh.. It's hard to write code correctly, I will be more careful next time.