### PR TITLE
updated readme preparing environment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Required environment:
 ### Preparing environment
 For Debian-based systems (most packages are installed out of box though):
 ```
-$ sudo apt-get install build-essential gcc-multilib curl libmpc-dev python
+$ sudo apt-get install build-essential gcc-multilib curl libmpc-dev python3
 ```
 
 For Arch Linux:


### PR DESCRIPTION
Python 2 has reached end-of-life and is no longer supported. Most modern tools and scripts require Python 3 for compatibility and security. Updating to python3 avoids issues with unsupported dependencies and keeps the development environment up-to-date.

