### PR TITLE
Refactor: Move ip_forward() declaration from ip.h to ip_input.c

### DIFF
--- a/src/include/net/l3/ipv4/ip.h
+++ b/src/include/net/l3/ipv4/ip.h
@@ -72,8 +72,6 @@ struct net_pack_out_ops;
 extern const struct net_pack_out_ops *const ip_out_ops
 		__attribute__ ((weak));
 
-/* TODO remve this */
-
 struct sock;
 extern int ip_header_size(struct sock *sock);
 

--- a/src/include/net/l3/ipv4/ip.h
+++ b/src/include/net/l3/ipv4/ip.h
@@ -73,7 +73,6 @@ extern const struct net_pack_out_ops *const ip_out_ops
 		__attribute__ ((weak));
 
 /* TODO remve this */
-extern int ip_forward(struct sk_buff *skb);
 
 struct sock;
 extern int ip_header_size(struct sock *sock);

--- a/src/net/l3/ipv4/ip_input.c
+++ b/src/net/l3/ipv4/ip_input.c
@@ -32,6 +32,8 @@
 
 EMBOX_NET_PACK(ETH_P_IP, ip_rcv);
 
+extern int ip_forward(struct sk_buff *skb);
+
 static int ip_rcv(struct sk_buff *skb, struct net_device *dev) {
 	net_device_stats_t *stats = &dev->stats;
 	const struct net_proto *nproto;


### PR DESCRIPTION
Completes a TODO task in the Embox RTOS networking stack by refactoring the declaration of `ip_forward()`:

- Removed `ip_forward()` declaration from `ip.h`.
- Added the correct declaration in `ip_input.c`, where the function is used.
- Avoids confusion and redundancy since `ip_output.c` already includes a different declaration with more parameters.