### PR TITLE
add check qemu-version  for RUNAS flag (-runas (removed in 10.0))

### DIFF
--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -417,7 +417,11 @@ fi
 RUNAS=""
 # Don't try to drop privileges for root user; qemu fails otherwise
 if [[ "$(id -u)" -ne 0 ]] ; then
-	RUNAS="-runas $(whoami)"
+	if [ "$QEMU_VER" > 100000 ]; then
+		RUNAS="-run-with user=$(whoami)"
+	else 
+		RUNAS="-runas $(whoami)"
+	fi
 	sudo='sudo -E'
 fi
 


### PR DESCRIPTION
There is problem with running script auto_qemu because the flag -runas for qemu-system was removed in 10.0.
In the script It was added check for version of qemu for RUNAS instruction and if it is lower 10 version than used  flag "-runas" else "-run-with user".