### PR TITLE
docs: add debian dependency python-is-python3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Required environment:
 ### Preparing environment
 For Debian-based systems (most packages are installed out of box though):
 ```
-$ sudo apt-get install build-essential gcc-multilib curl libmpc-dev python3
+$ sudo apt-get install build-essential gcc-multilib curl libmpc-dev python3 python-is-python3
 ```
 
 For Arch Linux:


### PR DESCRIPTION
When building on debian an error occur because the compilation script wants to use `python` but under debian `python` is not present. 
To fix this i added the `python-is-python3` dependency that creates a symlink to point the `/usr/bin/python` interpreter at the current default `python3`.
with this the compilation is successful.

Another way to fix this is to change the compilation scripts but is more invasive.