### PR TITLE
add flag for 16 byte register address alignment

### DIFF
--- a/templates/aarch64/qemu/build.conf
+++ b/templates/aarch64/qemu/build.conf
@@ -10,3 +10,4 @@ CFLAGS += -O0 -g3
 // CFLAGS += -march=armv8-a+nosimd+nosve -mtune=cortex-a53
 CFLAGS += -march=armv8-a -mtune=cortex-a53
 CFLAGS += -mabi=lp64
+CFLAGS += -mstrict-align


### PR DESCRIPTION
There was problem (Alignment Fault) with starting embox with qemu-system-aarch64 (on mac m1). 
Added flag -mstrict-align in build.conf for 16 byte register address alignment. 