### PR TITLE
Pull Request: Add Tests for `erf()` from `math.h`

### DIFF
--- a/src/compat/libc/math/Mybuild
+++ b/src/compat/libc/math/Mybuild
@@ -17,7 +17,7 @@ module math_builtins extends embox.compat.libc.math {
 	@NoRuntime depends math_builtins_header
 }
 
-+module erf_test {
-+    @Cflags("-fno-builtin")
-+    source "erf_test.c"
-+}
+module erf_test {
+    @Cflags("-fno-builtin")
+    source "erf_test.c"
+}

--- a/src/compat/libc/math/Mybuild
+++ b/src/compat/libc/math/Mybuild
@@ -19,5 +19,5 @@ module math_builtins extends embox.compat.libc.math {
 
 module erf_test {
     @Cflags("-fno-builtin")
-    source "erf_test.c"
+    source "tests/erf_test.c"
 }

--- a/src/compat/libc/math/Mybuild
+++ b/src/compat/libc/math/Mybuild
@@ -16,3 +16,8 @@ abstract module math_openlibm extends embox.compat.libc.math { }
 module math_builtins extends embox.compat.libc.math {
 	@NoRuntime depends math_builtins_header
 }
+
++module erf_test {
++    @Cflags("-fno-builtin")
++    source "erf_test.c"
++}

--- a/src/compat/libc/math/tests/erf_test.c
+++ b/src/compat/libc/math/tests/erf_test.c
@@ -1,0 +1,57 @@
+/**
+ * @file erf_test.c
+ *
+ * @brief Tests for erf() from math.h, as per POSIX/IEEE 754.
+ *        Computes the error function of x, defined as erf(x) = 2/sqrt(pi) * integral from 0 to x of exp(-t^2) dt.
+ *
+ * @date June 21, 2025
+ * @author ShigrafS
+ */
+
+#include <math.h>
+#include <float.h>
+#include <errno.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("erf() tests");
+
+#define EPSILON 1e-10
+
+/* Helper macro for floating-point comparison */
+#define test_assert_float_equal(actual, expected, msg) \
+    test_assert_msg(fabs((actual) - (expected)) < EPSILON, msg, actual)
+
+/* Test normal values */
+TEST_CASE("erf() with positive x") {
+    test_assert_float_equal(erf(1.0), 0.8427007929497149, "erf(1.0) failed: got %f");
+}
+
+TEST_CASE("erf() with negative x") {
+    test_assert_float_equal(erf(-1.0), -0.8427007929497149, "erf(-1.0) failed: got %f");
+}
+
+TEST_CASE("erf() with zero") {
+    test_assert_float_equal(erf(0.0), 0.0, "erf(0.0) failed: got %f");
+}
+
+TEST_CASE("erf() with small x") {
+    test_assert_float_equal(erf(0.1), 0.1124629160182849, "erf(0.1) failed: got %f");
+}
+
+TEST_CASE("erf() with large x") {
+    test_assert_float_equal(erf(5.0), 0.9999999845827421, "erf(5.0) failed: got %f");
+}
+
+TEST_CASE("erf() with infinity and NaN") {
+    test_assert_float_equal(erf(INFINITY), 1.0, "erf(INFINITY) failed: got %f");
+    test_assert_float_equal(erf(-INFINITY), -1.0, "erf(-INFINITY) failed: got %f");
+    test_assert(isnan(erf(NAN)), "erf(NAN) is not NaN");
+}
+
+/* Test overflow or error conditions (erf() typically doesn't overflow, but check errno) */
+TEST_CASE("erf() with large input and errno") {
+    errno = 0;
+    double result = erf(DBL_MAX);
+    test_assert_float_equal(result, 1.0, "erf(DBL_MAX) failed: got %f");
+    test_assert(errno == 0, "erf(DBL_MAX) incorrectly set errno");
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -253,6 +253,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.tanh_test
 	@Runlevel(1) include embox.compat.libc.test.tgamma_test
 	@Runlevel(1) include embox.compat.libc.test.trunc_test
+	@Runlevel(1) include embox.compat.libc.test.erf_test
 
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap_test


### PR DESCRIPTION
Fixes: #3646 

This PR introduces a test suite for the `erf()` (error function) from `math.h`, based on the IEEE 754 and POSIX standards. It verifies the accuracy and robustness of the `erf()` implementation under various scenarios, including regular values, special floating-point inputs (like `INFINITY` and `NAN`), and boundary cases.

---

### 1. Test module added  
**File:** `src/compat/libc/math/Mybuild`

```diff
+module erf_test {
+    @Cflags("-fno-builtin")
+    source "erf_test.c"
+}
````

* Defines a new test module named `erf_test`
* Uses `-fno-builtin` to prevent compiler from optimizing away calls to `erf()`

---

### 2. New test suite implemented

**File:** `src/compat/libc/math/tests/erf_test.c`

* Introduces `EMBOX_TEST_SUITE("erf() tests")`
* Defines `EPSILON = 1e-10` for floating-point comparison
* Covers the following cases:

| Test Case                     | Description                                  |
| ----------------------------- | -------------------------------------------- |
| `erf(1.0)`                    | Positive input                               |
| `erf(-1.0)`                   | Negative input                               |
| `erf(0.0)`                    | Zero                                         |
| `erf(0.1)`                    | Small positive number                        |
| `erf(5.0)`                    | Large positive number                        |
| `erf(INFINITY)` / `-INFINITY` | Special values                               |
| `erf(NAN)`                    | NaN input                                    |
| `erf(DBL_MAX)`                | Largest representable double + `errno` check |

---

### 3. Configuration updated

**File:** `templates/x86/test/units/mods.conf`

```diff
+    @Runlevel(1) include embox.compat.libc.test.erf_test
```

* Registers the `erf_test` module to run as part of the libc test suite at boot

---

## Test Coverage

* Ensures mathematical accuracy within tight bounds using `EPSILON = 1e-10`
* Confirms expected behavior for edge cases
* Validates that `errno` remains unset where appropriate
* Conforms to expected POSIX behavior for `math.h` functions

---