### PR TITLE
Fix relocation issues caused by mcmodel mismatch on RISC-V

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ MAKEFLAGS += --warn-undefined-variables
 # Avoids bogus 'undefined variable' warnings.
 export PS1 :=
 
+# Check for mcmodel compatibility before building
+.PHONY: check-mcmodel
+check-mcmodel:
+	@bash ./scripts/check_mcmodel.sh || { echo "mcmodel check failed. Please check the error above and consider using -mcmodel=medany."; exit 1; }
+
+# Make 'all' depend on check-mcmodel
+all: check-mcmodel
+
 .DEFAULT_GOAL := all
 
 # Force multiple targets listed in the command line to run independently,

--- a/scripts/check_mcmodel.sh
+++ b/scripts/check_mcmodel.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# scripts/check_mcmodel.sh
+# Test script to detect -mcmodel=medlow relocation issues
+
+# Use the compiler from the environment or default to riscv64-unknown-elf-gcc
+CC=${CC:-riscv64-unknown-elf-gcc}
+
+# Test compilation and linking with -mcmodel=medlow
+echo "Checking -mcmodel=medlow compatibility..."
+if ! $CC -mcmodel=medlow -o mcmodel_test scripts/mcmodel_test.c 2>/dev/null; then
+    echo "Warning: Linking with -mcmodel=medlow failed. This indicates your toolchain or libraries may not support large code/data sizes (>1 MiB)."
+    echo "Recommendation: Rebuild your toolchain with --with-cmodel=medany or use -mcmodel=medany for your application."
+    echo "To rebuild the toolchain, run: ./configure --with-cmodel=medany && make"
+    exit 1
+else
+    echo "Success: -mcmodel=medlow is compatible with large code/data sizes."
+    rm -f mcmodel_test
+    exit 0
+fi

--- a/scripts/mcmodel_test.c
+++ b/scripts/mcmodel_test.c
@@ -1,0 +1,7 @@
+// scripts/mcmodel_test.c
+     // Test program to detect -mcmodel=medlow relocation issues
+     char large_array[2 * 1024 * 1024]; // 2 MiB array to force large relocation
+
+     char *get_ptr() {
+         return &large_array[0];
+     }


### PR DESCRIPTION
#3654 

This PR introduces a **pre-build check** to detect `mcmodel` incompatibility early in the build process and provide clear guidance to users.

#### Changes introduced:

1. **`Makefile` Updates**

   * Adds a new target `check-mcmodel` that builds and links a dummy C program using `-mcmodel=medlow`.
   * Hooks this check into the default `all` target to ensure it runs automatically before the main build.

2. **New Script: `scripts/check_mcmodel.sh`**

   * Attempts to compile a small C program (`mcmodel_test.c`) with `-mcmodel=medlow`.
   * If it fails, the script outputs a helpful diagnostic message and recommends rebuilding the toolchain with `--with-cmodel=medany`.

3. **New Test File: `scripts/mcmodel_test.c`**

   * Contains a 2 MiB global array to force large memory usage, simulating conditions under which `HI20` relocation issues occur.
   * This helps reliably trigger the error if the toolchain is not properly configured.

### 🧪 Example Output (if failing):

```
Checking -mcmodel=medlow compatibility...
Warning: Linking with -mcmodel=medlow failed. This indicates your toolchain or libraries may not support large code/data sizes (>1 MiB).
Recommendation: Rebuild your toolchain with --with-cmodel=medany or use -mcmodel=medany for your application.
To rebuild the toolchain, run: ./configure --with-cmodel=medany && make
```

### 📚 Documentation Note

[TO-DO] It’s also recommended to add a note in the `riscv64-qemu` tutorial or toolchain build guide, reminding users to configure the toolchain with:

```
./configure --with-cmodel=medany
```

if they expect to use large code/data segments or plan to build applications with `-mcmodel=medany`.

### 🧩 Related Discussions

* [[apache/nuttx#10594](https://github.com/apache/nuttx/pull/10594)](https://github.com/apache/nuttx/pull/10594) — similar relocation issue discussion
