### PR TITLE
third_party: Add initial TensorFlow Lite Micro build integration

### DIFF
--- a/project/tensorflow/templates/x86_qemu/build.conf
+++ b/project/tensorflow/templates/x86_qemu/build.conf
@@ -1,0 +1,12 @@
+TARGET = embox
+ARCH = x86
+
+// For MAC OS X
+//CROSS_COMPILE = i386-elf-
+
+CFLAGS += -O0 -gdwarf-2
+CFLAGS += -fsanitize=undefined
+CFLAGS += -m32
+CFLAGS += -mno-mmx -mno-sse -mno-sse2 -mno-sse3
+
+LDFLAGS += -m elf_i386

--- a/project/tensorflow/templates/x86_qemu/lds.conf
+++ b/project/tensorflow/templates/x86_qemu/lds.conf
@@ -1,0 +1,8 @@
+/* region (origin, length) */
+RAM (0x00100000, 256M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/project/tensorflow/templates/x86_qemu/mods.conf
+++ b/project/tensorflow/templates/x86_qemu/mods.conf
@@ -1,0 +1,238 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.x86.kernel.cpu_idle
+	include embox.arch.x86.kernel.locore
+	include embox.arch.x86.kernel.context
+	include embox.arch.x86.kernel.interrupt
+
+	include embox.arch.x86.vfork
+	include embox.arch.x86.stackframe
+	include embox.arch.x86.libarch
+	include embox.arch.x86.mmu
+	include embox.arch.x86.mmuinfo
+	include embox.arch.x86.cpu_info_x86
+
+	include embox.arch.x86.kernel.acpi_shutdown
+
+	@Runlevel(0) include embox.driver.interrupt.i8259
+	@Runlevel(0) include embox.driver.clock.pit
+	include embox.kernel.time.jiffies(cs_name="pit")
+	@Runlevel(2) include embox.driver.clock.tsc
+	@Runlevel(2) include embox.driver.clock.hpet
+
+	@Runlevel(2) include embox.driver.serial.i8250_diag(baud_rate=38400)
+	@Runlevel(2) include embox.driver.diag(impl="embox__driver__serial__i8250_diag")
+	@Runlevel(2) include embox.driver.serial.i8250_ttyS0(baud_rate=38400)
+
+	include embox.driver.serial.i8250_ttyS1(baud_rate=11520)
+	// include embox.driver.serial.i8250_ttyS2(baud_rate=11520)
+	// include embox.driver.serial.i8250_ttyS3(baud_rate=11520)
+
+	@Runlevel(2) include embox.driver.virtual.null
+	@Runlevel(2) include embox.driver.virtual.zero
+
+	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(2) include embox.driver.net.virtio
+	@Runlevel(1) include embox.driver.net.usbnet
+
+	@Runlevel(1) include embox.driver.ide
+
+	@Runlevel(1) include embox.driver.usb.class.mass_storage
+	@Runlevel(1) include embox.driver.usb.class.ccid(log_level="LOG_DEBUG")
+	@Runlevel(1) include embox.driver.usb.class.hid
+	@Runlevel(2) include embox.driver.usb.hc.ohci_pci
+
+	@Runlevel(2) include embox.lib.debug.whereami
+	@Runlevel(2) include embox.lib.debug.ubsan(stop_on_handle=false)
+	@Runlevel(2) include embox.profiler.tracing
+
+	@Runlevel(0) include embox.mem.phymem
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
+	@Runlevel(2) include embox.kernel.time.kernel_time
+	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000)
+	include embox.kernel.stack(stack_size=0x20000)
+	include embox.kernel.sched.strategy.priority_based
+	include embox.kernel.thread.signal.sigstate
+	include embox.kernel.thread.signal.siginfoq
+	include embox.kernel.task.resource.env(env_str_len=64)
+
+	include embox.mem.pool_adapter
+	@Runlevel(2) include embox.mem.static_heap(heap_size=0x8000000)
+	include embox.mem.heap_bm(heap_size=0x4000000)
+	include embox.mem.bitmask
+
+	include embox.compat.libc.all
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.libc.math_openlibm
+	include embox.compat.posix.pthread_key
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.util.nanosleep
+	include embox.compat.posix.sys.mman.mmap_stub
+
+	include embox.compat.atomic.pseudo_atomic
+
+	include embox.lib.libds
+	include embox.framework.LibFramework
+
+/* for old fs comment dvfs part */
+	include embox.fs.node(fnode_quantity=1024)
+	@Runlevel(2) include embox.fs.rootfs_oldfs
+	include embox.fs.driver.initfs
+	include embox.fs.driver.binfs
+	include embox.fs.driver.devfs_old
+	include embox.fs.driver.ramfs
+	include embox.fs.driver.fat
+	include embox.fs.driver.cdfs
+	include embox.fs.driver.ext2
+	// include embox.fs.driver.ext3fs_oldfs //__ubsan_handle_vla_bound_not_positive
+	include embox.fs.driver.nfs
+	include embox.compat.posix.file_system_oldfs
+
+/* for dvfs comment old fs part */
+/*
+	@Runlevel(2) include embox.fs.dvfs.core
+	@Runlevel(2) include embox.fs.rootfs_dvfs
+	include embox.fs.driver.initfs_dvfs
+	include embox.fs.driver.binfs_dvfs
+	include embox.fs.driver.devfs_dvfs
+	include embox.fs.driver.ramfs_dvfs
+	include embox.fs.driver.fat_dvfs
+	include embox.fs.driver.cdfs_dvfs
+	include embox.fs.driver.ext2_dvfs
+	// include embox.fs.driver.ext3fs_dvfs //__ubsan_handle_vla_bound_not_positive
+	include embox.compat.posix.file_system_dvfs
+*/
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=4000)
+	@Runlevel(2) include embox.net.skbuff_data(
+			amount_skb_data=4000, data_size=1514,
+			data_align=1, data_padto=1,ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(
+			amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.tcp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.tcp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.net_entry
+	/* AF_INET, SOCK_STREAM, default */
+	include embox.net.lib.dns_file
+
+	include embox.init.system_start_service(log_level="LOG_INFO", tty_dev="ttyS0")
+	include embox.cmd.source_cmd
+	include embox.cmd.sh.tish(
+				prompt="%u@%h:%w%$", rich_prompt_support=1,
+				builtin_commands="exit logout cd export mount umount")
+	include embox.cmd.service
+
+	include embox.cmd.net.arp
+	include embox.cmd.net.netstat
+	include embox.cmd.net.arping
+	include embox.cmd.net.rarping
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.ping
+	include embox.cmd.net.iptables
+	include embox.cmd.net.route
+	include embox.cmd.net.ftp
+	include embox.cmd.net.tftp
+	include embox.cmd.net.snmpd
+	include embox.cmd.net.ntpdate
+	include embox.cmd.net.ntpd
+	include embox.cmd.net.telnetd
+	include embox.cmd.net.nslookup
+	include embox.cmd.net.getmail
+	include embox.cmd.net.sendmail
+	include embox.cmd.net.httpd
+	include embox.cmd.net.httpd_cgi(use_real_cmd=true, use_parallel_cgi=false)
+	include embox.service.http_admin
+	include embox.service.http_admin_iface_list(is_readonly=true)
+	include embox.service.http_admin_iface_html
+	include embox.demo.website
+	include embox.cmd.net.netmanager
+	include embox.cmd.net.net_service
+
+	include embox.cmd.wc
+	include embox.cmd.fs.head
+
+	include embox.cmd.fs.dd
+	include embox.cmd.fs.md5sum
+	include embox.cmd.fs.uniq
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.cd
+	include embox.cmd.fs.pwd
+	include embox.cmd.fs.ls
+	include embox.cmd.fs.du
+	include embox.cmd.fs.rm
+	include embox.cmd.fs.mkfs
+	include embox.cmd.fs.mount
+	include embox.cmd.fs.more
+	include embox.cmd.fs.umount
+	include embox.cmd.fs.stat
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.mkdir
+	include embox.cmd.fs.cp
+	include embox.cmd.fs.mv
+	include embox.cmd.fs.xattr
+
+	include embox.cmd.help
+	include embox.cmd.man
+
+	include embox.cmd.sys.uname
+	include embox.cmd.sys.env
+	include embox.cmd.sys.export
+	include embox.cmd.sys.version
+	include embox.cmd.sys.date
+	include embox.cmd.sys.time
+	include embox.cmd.sys.shutdown
+
+	include embox.cmd.lsmod
+	include embox.cmd.test
+
+	include embox.cmd.proc.nice
+	include embox.cmd.proc.renice
+
+	include embox.cmd.proc.thread
+	include embox.cmd.proc.top
+
+	include embox.cmd.mmuinfo
+	include embox.cmd.hw.mmutrans
+	include embox.cmd.hw.mem
+	include embox.cmd.memmap
+
+	include embox.cmd.ide
+	include embox.cmd.lspci
+	include embox.cmd.blockdev
+	include embox.cmd.hw.lsusb
+	include embox.cmd.hw.lsblk
+	include embox.cmd.hw.lshw
+	include embox.cmd.hw.partition
+	include embox.cmd.hw.ccid_cmd
+
+	include embox.cmd.cpuinfo
+
+	include embox.cmd.testing.block_dev_test
+	include embox.cmd.testing.ticker
+
+	include embox.cmd.testing.preemption
+	include third_party.tensorflow.libtflm
+	include third_party.tensorflow.all
+	include third_party.lib.tensorflow.build
+
+
+}

--- a/project/tensorflow/templates/x86_qemu/rootfs/network
+++ b/project/tensorflow/templates/x86_qemu/rootfs/network
@@ -1,0 +1,9 @@
+iface eth0 inet static
+	address 10.0.2.16
+	netmask 255.255.255.0
+	gateway 10.0.2.10
+	hwaddress aa:bb:cc:dd:ee:02
+
+iface lo inet static
+	address 127.0.0.1
+	netmask 255.0.0.0

--- a/project/tensorflow/templates/x86_qemu/rootfs/resolv.conf
+++ b/project/tensorflow/templates/x86_qemu/rootfs/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 8.8.8.8

--- a/project/tensorflow/templates/x86_qemu/rootfs/time_setup.sh
+++ b/project/tensorflow/templates/x86_qemu/rootfs/time_setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+date -s 202108311902.40
+#ntpdate 0.europe.pool.ntp.org
+ntpdate 54.36.110.36

--- a/project/tensorflow/templates/x86_qemu/system_start.inc
+++ b/project/tensorflow/templates/x86_qemu/system_start.inc
@@ -1,0 +1,8 @@
+"export PWD=/",
+"export HOME=/",
+"partition",
+"service net_service",
+"service telnetd",
+"service httpd",
+"source time_setup.sh",
+"tish",

--- a/third-party/lib/tensorflow/Makefile
+++ b/third-party/lib/tensorflow/Makefile
@@ -1,0 +1,136 @@
+PKG_NAME          := tflite-micro
+PKG_VER           := main
+PKG_REPO          := https://github.com/tensorflow/$(PKG_NAME).git
+PKG_SOURCE_DIR    := $(PKG_NAME)
+PKG_BUILD_DIR     := build/$(PKG_NAME)
+
+TFLM_FLATBUFFERS_VER := 23.5.26
+TFLM_GEMMLOWP_VER     := 719139ce755a0f31cbf1c37f7f98adcc7fc9f425
+TFLM_RUY_VER          := d37128311b445e758136b8602d1bbd2a755e115d
+TFLM_KISSFFT_VER      := v130
+
+
+FLATBUFFERS_URL := https://github.com/google/flatbuffers/archive/v$(TFLM_FLATBUFFERS_VER).zip
+GEMMLOWP_URL    := https://github.com/google/gemmlowp/archive/$(TFLM_GEMMLOWP_VER).zip
+RUY_URL         := https://github.com/google/ruy/archive/$(TFLM_RUY_VER).zip
+KISSFFT_URL     := https://github.com/mborgerding/kissfft/archive/refs/tags/$(TFLM_KISSFFT_VER).zip
+
+MD5_FLATBUFFERS := e87e8acd8e2d53653387ad78720316e2
+MD5_GEMMLOWP    := 7e8191b24853d75de2af87622ad293ba
+MD5_RUY         := abf7a91eb90d195f016ebe0be885bb6e
+MD5_KISSFFT     := 438ba1fef5783cc5f5f201395cc477ca
+
+
+CXX := g++
+CXXFLAGS := -std=c++17 -O3 -Wall -Wno-narrowing
+
+
+INCLUDE_DIRS := \
+  -I$(PKG_SOURCE_DIR) \
+  -Ithird_party_static/flatbuffers/include \
+  -Ithird_party_static/gemmlowp \
+  -Ithird_party_static/kissfft \
+  -Ithird_party_static/ruy
+
+THIRD_PARTY := third_party_static
+
+.PHONY: all clone third_party configure build install clean
+
+
+CONFIGURE := .configured
+BUILD     := .built
+INSTALL   := .installed
+
+all: install
+
+clone:
+	@if [ ! -d "$(PKG_SOURCE_DIR)" ]; then \
+		echo "Cloning TensorFlow Lite Micro..."; \
+		git clone --depth=1 -b $(PKG_VER) $(PKG_REPO) $(PKG_SOURCE_DIR); \
+	else \
+		echo "Already cloned."; \
+	fi
+
+
+define download_zip
+	@echo "Downloading: $(1)"
+	@mkdir -p temp && cd temp && \
+	curl -L -o archive.zip $(1) && \
+	echo "$(2)  archive.zip" | md5sum -c - && \
+	unzip -q archive.zip && \
+	mkdir -p "$(abspath $(3))" && \
+	mv */* "$(abspath $(3))" && \
+	cd ../.. && rm -rf temp
+endef
+
+
+third_party: clone
+	mkdir -p $(THIRD_PARTY)
+	$(call download_zip,$(GEMMLOWP_URL),$(MD5_GEMMLOWP),$(THIRD_PARTY)/gemmlowp)
+	$(call download_zip,$(RUY_URL),$(MD5_RUY),$(THIRD_PARTY)/ruy)
+	$(call download_zip,$(KISSFFT_URL),$(MD5_KISSFFT),$(THIRD_PARTY)/kissfft)
+	$(call download_zip,$(FLATBUFFERS_URL),$(MD5_FLATBUFFERS),$(THIRD_PARTY)/flatbuffers)
+THIRD_PARTY_SRCS := \
+  $(wildcard $(THIRD_PARTY)/ruy/*.cc) \
+  $(wildcard $(THIRD_PARTY)/gemmlowp/*.cc) \
+  $(wildcard $(THIRD_PARTY)/kissfft/*.c) \
+  $(wildcard $(THIRD_PARTY)/flatbuffers/*.c)
+
+SRCS := \
+  $(shell find $(PKG_SOURCE_DIR)/tensorflow/lite/micro -maxdepth 1 -name '*.cc' ! -name '*test.cc') \
+  $(shell find $(PKG_SOURCE_DIR)/tensorflow/lite/core/api -name '*.cc') \
+  $(shell find $(PKG_SOURCE_DIR)/tensorflow/lite/schema -name '*.cc') \
+  $(shell find $(PKG_SOURCE_DIR)/tensorflow/lite/kernels/internal -name '*.cc') \
+  $(shell find $(PKG_SOURCE_DIR)/tensorflow/lite/kernels -name '*.cc') \
+  $(shell find $(PKG_SOURCE_DIR)/tensorflow/lite/c -name '*.c') \
+  $(THIRD_PARTY_SRCS)
+
+OBJS := $(patsubst $(PKG_SOURCE_DIR)/%.cc, $(PKG_BUILD_DIR)/%.o, $(filter %.cc,$(SRCS))) \
+        $(patsubst $(PKG_SOURCE_DIR)/%.c,  $(PKG_BUILD_DIR)/%.o, $(filter %.c,$(SRCS)))
+
+$(PKG_BUILD_DIR)/libtflm.a: $(OBJS)
+	@mkdir -p $(dir $@)
+	ar rcs $@ $^
+
+$(PKG_BUILD_DIR)/%.o: $(PKG_SOURCE_DIR)/%.cc
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDE_DIRS) -c "$<" -o "$@"
+
+$(PKG_BUILD_DIR)/%.o: $(PKG_SOURCE_DIR)/%.c
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDE_DIRS) -x c -c "$<" -o "$@"
+
+
+$(CONFIGURE):
+	$(MAKE) clone
+	$(MAKE) third_party
+	touch $@
+
+$(BUILD): $(CONFIGURE)
+	$(MAKE) $(PKG_BUILD_DIR)/libtflm.a
+	touch $@
+
+$(INSTALL): $(BUILD)
+	@echo "Installing libtflm.a and headers..."
+
+
+	@mkdir -p install/lib install/include
+	@cp $(PKG_BUILD_DIR)/libtflm.a install/lib/
+
+
+	@mkdir -p $(EXTERNAL_BUILD_DIR)/third_party/lib/tensorflow/build/tflite-micro
+	@cp $(PKG_BUILD_DIR)/libtflm.a $(EXTERNAL_BUILD_DIR)/third_party/lib/tensorflow/build/tflite-micro/
+
+
+	@find $(PKG_SOURCE_DIR)/tensorflow/lite -name '*.h' -exec cp --parents {} install/include/ \;
+
+	touch $@
+
+
+configure: $(CONFIGURE)
+build:     $(BUILD)
+install:   $(INSTALL)
+
+
+clean:
+	rm -rf $(PKG_SOURCE_DIR) $(PKG_BUILD_DIR) $(THIRD_PARTY) install .configured .built .installed

--- a/third-party/lib/tensorflow/Mybuild
+++ b/third-party/lib/tensorflow/Mybuild
@@ -1,0 +1,48 @@
+package third_party.lib.tensorflow
+
+module backend {
+	option string tflm_version="main"
+}
+
+@Build(stage=2, script="$(EXTERNAL_MAKE)")
+@BuildArtifactPath(cppflags="-I$(EXTERNAL_BUILD_DIR)/third_party/lib/tensorflow/install/include")
+@BuildDepends(backend)
+@BuildDepends(embox.lib.libstdcxx)
+@BuildDepends(third_party.compiler_headers)
+static module build {
+	option string flatbuffers_version="23.5.26"
+	option string gemmlowp_commit="719139ce755a0f31cbf1c37f7f98adcc7fc9f425"
+	option string ruy_commit="d37128311b445e758136b8602d1bbd2a755e115d"
+	option string kissfft_version="v130"
+
+	@NoRuntime depends backend
+	@NoRuntime depends third_party.compiler_headers
+	@NoRuntime depends embox.compat.libc.all
+	@NoRuntime depends embox.compat.atomic.pseudo_atomic
+	@NoRuntime depends embox.compat.posix.pthread_key
+
+	source "^BUILD/extbld/third_party/lib/tensorflow/tflite-micro/tensorflow/lite/c"
+	source "^BUILD/extbld/third_party/lib/tensorflow/tflite-micro/tensorflow/lite/core/api"
+	source "^BUILD/extbld/third_party/lib/tensorflow/tflite-micro/tensorflow/lite/kernels"
+	source "^BUILD/extbld/third_party/lib/tensorflow/tflite-micro/tensorflow/lite/kernels/internal"
+	source "^BUILD/extbld/third_party/lib/tensorflow/tflite-micro/tensorflow/lite/micro"
+	source "^BUILD/extbld/third_party/lib/tensorflow/tflite-micro/tensorflow/lite/schema"
+    source "^BUILD/extbld/third_party/lib/tensorflow/third_party_static/flatbuffers"
+	source "^BUILD/extbld/third_party/lib/tensorflow/third_party_static/ruy"
+	source "^BUILD/extbld/third_party/lib/tensorflow/third_party_static/gemmlowp"
+	source "^BUILD/extbld/third_party/lib/tensorflow/third_party_static/kissfft"
+
+}
+
+@LinkerSection(text="tflm_text", rodata="tflm_rodata", data="tflm_data", bss="tflm_bss")
+@BuildDepends(third_party.lib.tensorflow.build)
+@Build(script="true")
+static module libtflm {
+        source "^BUILD/extbld/third_party/lib/tensorflow/build/tflite-micro/libtflm.a"
+	@NoRuntime depends build
+}
+
+@BuildDepends(libtflm)
+static module all {
+	@NoRuntime depends libtflm
+}


### PR DESCRIPTION
Integrate TensorFlow Lite Micro into Embox Build System
This PR adds initial support for integrating TensorFlow Lite Micro (TFLM) as a third-party library in Embox.

Summary of Changes:
1. Added a custom Makefile to build libtflm.a as a static library.
2. Introduced a Mybuild module to manage compilation and declare module dependencies.
3. Modified mods.conf under the x86/qemu template to enable TensorFlow Lite Micro support.

Build Instructions:
1. Run `make confload-x86/qemu`
2. Run `make` to build the TensorFlow Lite Micro library and integrate it into the Embox image

This PR serves as an initial integration point for TensorFlow Lite Micro into the Embox build system. To include additional source files for custom models, you must update the Makefile accordingly and register the necessary modules within Mybuild.

It is recommended to use the libtflm.a static module when performing model inference to ensure consistency with the build system and reuse of precompiled core components.

Thanks,
Abhinav Ananthu