### PR TITLE
RISC-V: Fix error with static assert 

### DIFF
--- a/src/arch/riscv/include/asm/context.h
+++ b/src/arch/riscv/include/asm/context.h
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <stddef.h>
 
-struct caller_saved_regs {
+struct __attribute__((packed)) caller_saved_regs {
 #if REG_SIZE_F == 4
 	float fa[8];
 	float ft[12];

--- a/templates/riscv/qemu/mods.conf
+++ b/templates/riscv/qemu/mods.conf
@@ -11,7 +11,7 @@ configuration conf {
 	include embox.arch.riscv.mmu_sv39_mode
 
 	include embox.mem.bitmask
-	include embox.driver.periph_memory_stub
+//	include embox.driver.periph_memory_stub
 //	include embox.arch.generic.nommu
 	include embox.mem.sysmalloc_task_based
 	include embox.mem.heap_bm


### PR DESCRIPTION
The build was crashing due to a size mismatch in the caller_saved_regs structure. An instruction has been added that prevents alignment from being added to this structure.