### PR TITLE
third_party : add kissfft for tensorflow third party dependency

### DIFF
--- a/third-party/lib/kissfft/Makefile
+++ b/third-party/lib/kissfft/Makefile
@@ -1,0 +1,24 @@
+PKG_NAME := kissfft
+PKG_VER  := v130
+
+PKG_SOURCES := https://github.com/mborgerding/kissfft/archive/refs/tags/$(PKG_VER).zip
+PKG_MD5 := 438ba1fef5783cc5f5f201395cc477ca
+
+$(CONFIGURE) :
+	touch $@
+
+$(BUILD) :
+	touch $@
+
+$(INSTALL) :
+	
+	ln -sfn $(PKG_SOURCE_DIR) $(PKG_INSTALL_DIR)/include
+
+	
+	if [ -f "$(PKG_SOURCE_DIR)/_kiss_fft_guts.h" ]; then \
+	    grep -q '_KISS_FFT_GUTS_H' $(PKG_SOURCE_DIR)/_kiss_fft_guts.h || { \
+	        sed -i '1i#ifndef _KISS_FFT_GUTS_H\n#define _KISS_FFT_GUTS_H\n' $(PKG_SOURCE_DIR)/_kiss_fft_guts.h; \
+	        echo "\n#endif /* _KISS_FFT_GUTS_H */" >> $(PKG_SOURCE_DIR)/_kiss_fft_guts.h; \
+	    }; \
+	fi
+	touch $@

--- a/third-party/lib/kissfft/Mybuild
+++ b/third-party/lib/kissfft/Mybuild
@@ -1,0 +1,16 @@
+package third_party.lib.kissfft
+
+@Build(stage=1, script="$(EXTERNAL_MAKE)")
+static module kissfft_download {
+
+}
+
+@BuildDepends(kissfft_download)
+static module libkissfft {
+//	@AddPrefix("^BUILD/extbld/^MOD_PATH/install")
+
+	@NoRuntime depends kissfft_download
+}
+
+
+


### PR DESCRIPTION
This commit integrates KissFFT as an independent third-party library in Embox.

The library has been patched to support the Micro Speech example, using the external KissFFT wrappers from TensorFlow Lite Micro’s signal processing code.

This enables FFT functionality in embedded builds without relying on platform-specific DSP libraries, improving portability for audio and signal processing tasks.