### PR TITLE
driver: Add ESP32 WiFi driver

### DIFF
--- a/project/at/src/cmds/wireless/wifi_test.c
+++ b/project/at/src/cmds/wireless/wifi_test.c
@@ -1,0 +1,358 @@
+/**
+ * @file
+ * @brief WiFi Module Test Command
+ * 
+ * @date Aug 6, 2025
+ * @author Peize Li
+ */
+
+#include <arpa/inet.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include <at/at_client.h>
+#include <at/at_parser.h>
+#include <at/emulator/at_emulator.h>
+#include <net/netdevice.h>
+#include <net/wlan/wireless_ioctl.h>
+#include <wifi/esp32c3/emulator/esp32c3_emulator.h>
+#include <wifi/esp32c3/esp32c3_wifi.h>
+#include <wifi/wifi_core.h>
+
+/* PTY support */
+extern int ppty(int ptyfds[2]);
+
+/* Emulator thread data */
+struct emulator_thread_data {
+	int fd;
+	at_emulator_t *emulator;
+	volatile bool running;
+};
+
+static void print_usage(void) {
+	printf("Usage: wifi_test [options]\n");
+	printf("Options:\n");
+	printf("  -t         Run WiFi integration tests\n");
+	printf("  -h         Show this help\n");
+}
+
+/* Emulator thread function for PTY testing */
+static void *emulator_thread_func(void *arg) {
+	struct emulator_thread_data *data = (struct emulator_thread_data *)arg;
+	char buffer[256];
+
+	printf("[EMU] Emulator thread started on fd=%d\n", data->fd);
+
+	while (data->running) {
+		int n = read(data->fd, buffer, sizeof(buffer));
+		if (n > 0) {
+			printf("[EMU] Received %d bytes: ", n);
+			for (int i = 0; i < n && i < 50; i++) {
+				if (buffer[i] >= 32 && buffer[i] < 127) {
+					printf("%c", buffer[i]);
+				}
+				else if (buffer[i] == '\r') {
+					printf("\\r");
+				}
+				else if (buffer[i] == '\n') {
+					printf("\\n");
+				}
+				else {
+					printf("\\x%02X", (unsigned char)buffer[i]);
+				}
+			}
+			if (n > 50) {
+				printf("...");
+			}
+			printf("\n");
+
+			for (int i = 0; i < n; i++) {
+				const char *response = at_emulator_process(data->emulator,
+				    &buffer[i], 1);
+				if (response && *response) {
+					size_t resp_len = strlen(response);
+					printf("[EMU] Sending response (%zu bytes)\n", resp_len);
+
+					// For large responses, send in chunks to avoid PTY buffer limits
+					if (resp_len > 100) {
+						size_t sent = 0;
+						while (sent < resp_len) {
+							// Find next line boundary
+							size_t chunk_end = sent + 64;
+							if (chunk_end < resp_len) {
+								// Look for nearest \n
+								while (chunk_end > sent
+								       && response[chunk_end] != '\n') {
+									chunk_end--;
+								}
+								if (chunk_end > sent
+								    && response[chunk_end] == '\n') {
+									chunk_end++; // Include \n
+								}
+								else {
+									chunk_end = sent + 64; // Use fixed size if no \n found
+								}
+							}
+							else {
+								chunk_end = resp_len;
+							}
+
+							size_t to_send = chunk_end - sent;
+							if (write(data->fd, response + sent, to_send) < 0) {
+								printf("[EMU] Write error: %s\n", strerror(errno));
+								break;
+							}
+							sent = chunk_end;
+
+							if (sent < resp_len) {
+								usleep(10000); // 10ms delay between chunks
+							}
+						}
+					}
+					else {
+						// Small responses can be sent at once
+						if (write(data->fd, response, resp_len) < 0) {
+							printf("[EMU] Write error: %s\n", strerror(errno));
+							break;
+						}
+					}
+				}
+			}
+		}
+		else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			printf("[EMU] Read error: %s\n", strerror(errno));
+			break;
+		}
+
+		usleep(1000);
+	}
+
+	printf("[EMU] Emulator thread exiting\n");
+	return NULL;
+}
+
+static void *emulator_poll_thread(void *arg) {
+	struct emulator_thread_data *data = (struct emulator_thread_data *)arg;
+
+	while (data->running) {
+		const char *urc = at_emulator_poll(data->emulator);
+		if (urc && *urc) {
+			write(data->fd, urc, strlen(urc));
+		}
+		usleep(50000); /* 50ms */
+	}
+
+	return NULL;
+}
+
+static int run_wifi_test(void) {
+	int ptyfds[2];
+	pthread_t emu_thread, poll_thread;
+	struct emulator_thread_data emu_data;
+	struct net_device netdev = {0};
+
+	printf("=== WiFi Integration Test ===\n");
+
+	/* Create PTY and emulator */
+	if (ppty(ptyfds) != 0) {
+		printf("Failed to create PTY\n");
+		return -1;
+	}
+
+	fcntl(ptyfds[1], F_SETFL, fcntl(ptyfds[1], F_GETFL, 0) | O_NONBLOCK);
+
+	emu_data.emulator = esp32c3_emulator_create();
+	if (!emu_data.emulator) {
+		printf("Failed to create ESP32-C3 emulator\n");
+		close(ptyfds[0]);
+		close(ptyfds[1]);
+		return -1;
+	}
+
+	emu_data.fd = ptyfds[1];
+	emu_data.running = true;
+
+	pthread_create(&emu_thread, NULL, emulator_thread_func, &emu_data);
+	pthread_create(&poll_thread, NULL, emulator_poll_thread, &emu_data);
+
+	usleep(100000);
+
+	/* Initialize network device */
+	strcpy(netdev.name, "wlan0");
+	netdev.flags = 0;
+
+	/* Test 1: Initialize driver */
+	printf("\n1. Initialize WiFi driver\n");
+	if (esp32c3_wifi_init_fd(&netdev, ptyfds[0]) == 0) {
+		printf("✓ Driver initialized successfully\n");
+	}
+	else {
+		printf("✗ Driver initialization failed\n");
+		goto cleanup;
+	}
+
+	struct wlan_device *wdev = netdev.wireless_priv;
+	struct wifi_core *wifi = wdev ? wdev->priv : NULL;
+
+	/* Test 2: Scan for APs */
+	printf("\n2. Scan for access points\n");
+
+	if (netdev.wireless_ops && netdev.wireless_ops->scan) {
+		int scan_ret = netdev.wireless_ops->scan(&netdev);
+		printf("Scan operation returned: %d\n", scan_ret);
+
+		if (scan_ret == 0 && wdev) {
+			printf("Found %d access points\n", wdev->scan_result.count);
+
+			if (wdev->scan_result.count > 0) {
+				printf("\nAvailable networks:\n");
+				for (int i = 0; i < wdev->scan_result.count; i++) {
+					struct wlan_scan_ap *ap = &wdev->scan_result.aps[i];
+					printf("  [%d] SSID: %-20s RSSI: %3d dBm  CH: %2d  "
+					       "Security: %s\n",
+					    i, ap->ssid, ap->rssi, ap->channel,
+					    ap->security ? "WPA2" : "Open");
+				}
+			}
+		}
+		else {
+			printf("✗ Scan failed\n");
+		}
+	}
+
+	/* Test 3: Connect to AP */
+	printf("\n3. Connect to access point\n");
+	if (wdev && wdev->scan_result.count > 0 && netdev.wireless_ops->connect) {
+		const char *ssid = wdev->scan_result.aps[0].ssid;
+		printf("Attempting connection to '%s'...\n", ssid);
+
+		int conn_ret = netdev.wireless_ops->connect(&netdev, ssid, "password");
+		printf("Connect operation returned: %d\n", conn_ret);
+
+		if (conn_ret == 0) {
+			printf("✓ Connected successfully\n");
+
+			/* Check connection info */
+			if (wifi && wifi_core_has_ip(wifi)) {
+				char ip[16] = {0};
+				char connected_ssid[33] = {0};
+				int8_t rssi = 0;
+
+				if (wifi_core_get_connection_info(wifi, connected_ssid, ip, &rssi)
+				    == 0) {
+					printf("\nConnection details:\n");
+					printf("  SSID: %s\n", connected_ssid);
+					printf("  IP Address: %s\n", ip);
+					printf("  Signal Strength: %d dBm\n", rssi);
+				}
+			}
+		}
+		else {
+			printf("✗ Connection failed\n");
+		}
+	}
+
+	/* Test 4: Power Management */
+	printf("\n4. Test Power Management\n");
+	if (wifi && wifi_core_is_connected(wifi)) {
+		int current_mode;
+
+		// get current power mode
+		if (esp32c3_get_power_mode(wifi, &current_mode) == 0) {
+			printf("Current power mode: %s\n",
+			    current_mode == WLAN_PWR_ACTIVE ? "Active"
+			    : current_mode == WLAN_PWR_SAVE ? "Power Save"
+			                                    : "Deep Save");
+		}
+
+		// test switching to power save mode
+		printf("Switching to Power Save mode...\n");
+		if (esp32c3_set_power_mode(wifi, WLAN_PWR_SAVE) == 0) {
+			printf("✓ Power mode changed successfully\n");
+
+			// verify connection is still active
+			if (wifi_core_is_connected(wifi)) {
+				printf("✓ Connection maintained in Power Save mode\n");
+			}
+		}
+
+		// restore to active mode
+		esp32c3_set_power_mode(wifi, WLAN_PWR_ACTIVE);
+	}
+
+	/* Test 5: Disconnect */
+	printf("\n5. Disconnect from network\n");
+	if (netdev.wireless_ops && netdev.wireless_ops->disconnect) {
+		int disc_ret = netdev.wireless_ops->disconnect(&netdev);
+		printf("Disconnect operation returned: %d\n", disc_ret);
+		if (disc_ret == 0) {
+			printf("✓ Disconnected successfully\n");
+		}
+	}
+
+cleanup:
+	printf("\n=== Cleanup ===\n");
+
+	/* 1. Cleanup WiFi driver (while emulator is still alive) */
+	if (netdev.wireless_ops) {
+		esp32c3_wifi_cleanup(&netdev);
+		printf("✓ WiFi driver cleaned up\n");
+	}
+
+	/* 2. Stop emulator threads */
+	emu_data.running = false;
+	pthread_join(emu_thread, NULL);
+	pthread_join(poll_thread, NULL);
+	printf("✓ Emulator threads stopped\n");
+
+	/* 3. Cleanup emulator */
+	esp32c3_emulator_destroy(emu_data.emulator);
+	printf("✓ Emulator destroyed\n");
+
+	/* 4. Close PTY */
+	if (ptyfds[0] >= 0)
+		close(ptyfds[0]);
+	if (ptyfds[1] >= 0)
+		close(ptyfds[1]);
+	printf("✓ PTY closed\n");
+
+	printf("\n=== Test Complete ===\n");
+	return 0;
+}
+
+int main(int argc, char *argv[]) {
+	int opt;
+
+	/* No options provided, show usage */
+	if (argc == 1) {
+		print_usage();
+		return 0;
+	}
+
+	while ((opt = getopt(argc, argv, "th")) != -1) {
+		switch (opt) {
+		case 't':
+			return run_wifi_test();
+		case 'h':
+			print_usage();
+			return 0;
+		default:
+			print_usage();
+			return -1;
+		}
+	}
+
+	print_usage();
+	return -1;
+}

--- a/project/at/src/cmds/wireless/wifi_test.my
+++ b/project/at/src/cmds/wireless/wifi_test.my
@@ -1,0 +1,26 @@
+package project.at.cmd
+
+@AutoCmd
+@Cmd(name = "wifi_test",
+	help = "esp32c3 wifi intergrate test utility",
+	man = '''
+		NAME
+			wifi_test - esp32c3 wifi intergrate test utility
+		SYNOPSIS
+			wifi_test [options]
+		OPTIONS
+			-t          Run integration tests using PTY
+			-h          Show help message
+		AUTHORS
+			Peize Li
+	''')
+module wifi_test {
+	source "wifi_test.c"
+	
+	depends project.at.driver.at.at_parser  
+	depends project.at.driver.at.at_emulator  
+	depends project.at.driver.at.at_client
+  depends project.at.net.wlan.wlan_core
+  depends project.at.driver.net.wifi.wifi_core
+  depends project.at.driver.net.wifi.esp32c3_wifi
+}

--- a/project/at/src/drivers/at/Mybuild
+++ b/project/at/src/drivers/at/Mybuild
@@ -23,5 +23,7 @@ module at_client {
 	source "at_client.h"
 
 	depends at_parser 
-	depends embox.compat.posix.LibPosix  
+	depends embox.compat.posix.LibPosix
+	depends embox.kernel.time.jiffies  
 }
+

--- a/project/at/src/drivers/at/at_client.c
+++ b/project/at/src/drivers/at/at_client.c
@@ -15,9 +15,29 @@
 
 #include <at/at_client.h>
 #include <at/at_parser.h>
+#include <hal/clock.h>
 #include <kernel/time/time.h>
 
 int at_client_init_fd(at_client_t *client, int fd);
+
+#define AT_DEBUG(client, fmt, ...)                         \
+	do {                                                   \
+		if ((client)->flags & AT_CLIENT_FLAG_DEBUG) {      \
+			printf("[AT_DEBUG] " fmt "\n", ##__VA_ARGS__); \
+		}                                                  \
+	} while (0)
+
+/* Get current time in milliseconds */
+static uint32_t get_current_ms(void) {
+	return jiffies2ms(clock_sys_ticks());
+}
+
+/* Check if timeout occurred */
+static bool is_timeout(uint32_t start_ms, uint32_t timeout_ms) {
+	uint32_t current = get_current_ms();
+	/* Handle wraparound */
+	return (current - start_ms) >= timeout_ms;
+}
 
 /* Initialize AT client with device path */
 int at_client_init(at_client_t *client, const char *device_path) {
@@ -55,7 +75,9 @@ int at_client_init_fd(at_client_t *client, int fd) {
 
 	memset(client, 0, sizeof(*client));
 	client->fd = fd;
-	client->owns_fd = false;  /* We don't own this fd */
+	client->owns_fd = false; /* We don't own this fd */
+	client->mode = AT_CLIENT_MODE_TEST;
+	client->flags = 0;
 
 	/* Set non-blocking mode */
 	int flags = fcntl(fd, F_GETFL, 0);
@@ -91,23 +113,25 @@ void at_client_close(at_client_t *client) {
 		return;
 	}
 
-	if (client->fd >= 0) {
-		/* Only close fd if we opened it ourselves */
-		if (client->owns_fd) {
-			close(client->fd);
-		}
-		client->fd = -1;
+	/* Prevent double close */
+	if (client->fd < 0) {
+		return; // already closed
 	}
 
-	/* Clear the structure */
+	if (client->owns_fd) {
+		close(client->fd);
+	}
+
+	/* clean up struct but keep fd invalid */
 	memset(client, 0, sizeof(*client));
-	
-	/* Set fd to invalid value */
 	client->fd = -1;
+	client->mode = AT_CLIENT_MODE_TEST;
 }
 
 static void process_line(at_client_t *client, const char *line) {
 	at_resp_type_t type;
+
+	AT_DEBUG(client, "process_line: '%s'", line);
 
 	/* Ignore empty lines */
 	if (!line[0]) {
@@ -115,32 +139,65 @@ static void process_line(at_client_t *client, const char *line) {
 	}
 
 	type = at_get_response_type(line);
+	AT_DEBUG(client, "line type: %d", type);
 
 	/* If waiting for response */
 	if (client->waiting_resp) {
-		/* Save response data */
 		if (client->resp_buf && client->resp_size > 0
 		    && (type == AT_RESP_DATA || type == AT_RESP_UNKNOWN)) {
-			size_t len = strlen(line);
+			/* Append new line before the response */
+			size_t line_len = strlen(line);
 			size_t current_len = strlen(client->resp_buf);
 
-			if (current_len + len + 3 < client->resp_size) {
+			AT_DEBUG(client, "appending to resp_buf, current_len=%zu", current_len);
+
+			/* Calculate needed size: current + separator + new line + terminator */
+			size_t separator_len = (current_len > 0) ? 2 : 0; /* "\r\n" */
+			size_t needed = current_len + separator_len + line_len + 1;
+
+			if (needed <= client->resp_size) {
 				if (current_len > 0) {
 					strcat(client->resp_buf, "\r\n");
 				}
 				strcat(client->resp_buf, line);
+			}
+			else {
+				/* buffer overflow, truncate response */
+				size_t available = client->resp_size - current_len
+				                   - separator_len - 1;
+				if (available > 0
+				    && current_len + separator_len < client->resp_size) {
+					if (current_len > 0) {
+						strcat(client->resp_buf, "\r\n");
+					}
+					strncat(client->resp_buf, line, available);
+					/* Ensure null-termination */
+					client->resp_buf[client->resp_size - 1] = '\0';
+				}
+				/* Set truncated flag */
+				client->flags |= AT_CLIENT_FLAG_RESP_TRUNCATED;
 			}
 		}
 
 		/* Check if response complete */
 		switch (type) {
 		case AT_RESP_OK:
+			AT_DEBUG(client, "Got OK, ending response");
 			client->result = AT_OK;
 			client->waiting_resp = false;
 			break;
 
 		case AT_RESP_ERROR:
-			client->result = AT_ERROR;
+			/* Extract CME/CMS error code */
+			if (strncmp(line, "+CME ERROR:", 11) == 0) {
+				client->result = AT_CME_ERROR;
+			}
+			else if (strncmp(line, "+CMS ERROR:", 11) == 0) {
+				client->result = AT_CMS_ERROR;
+			}
+			else {
+				client->result = AT_ERROR;
+			}
 			client->waiting_resp = false;
 			break;
 
@@ -155,7 +212,7 @@ static void process_line(at_client_t *client, const char *line) {
 			break;
 
 		default:
-			/* Check for numeric response (numeric mode) */
+			/* Check for numeric response (verbose mode disabled) */
 			if (strlen(line) == 1 && line[0] >= '0' && line[0] <= '9') {
 				switch (line[0]) {
 				case '0': /* OK */
@@ -190,68 +247,144 @@ static void process_line(at_client_t *client, const char *line) {
 		}
 	}
 	/* Otherwise might be URC */
-	else if (client->urc_handler && at_is_urc(line)) {
+	else if (client->urc_handler) {
+		/* Call URC handler */
 		client->urc_handler(line, client->urc_arg);
 	}
 }
 
 void at_client_process_rx(at_client_t *client) {
-	unsigned char ch;
+	unsigned char buffer[256]; /* Buffer for reading data */
 	ssize_t n;
+	int i;
+	int consecutive_empty = 0;
+	const int max_empty_reads = (client->mode == AT_CLIENT_MODE_NORMAL) ? 3 : 1;
+	const int read_delay_us = (client->mode == AT_CLIENT_MODE_NORMAL) ? 5000 : 0;
+	const int empty_delay_us = (client->mode == AT_CLIENT_MODE_NORMAL) ? 10000 : 0;
 
 	if (!client || client->fd < 0) {
 		return;
 	}
 
-	/* Read all available characters */
-	while ((n = read(client->fd, &ch, 1)) > 0) {
-		/* Handle line ending */
-		if (ch == '\r' || ch == '\n') {
-			if (client->rx_pos > 0) {
-				client->rx_buf[client->rx_pos] = '\0';
-				process_line(client, client->rx_buf);
-				client->rx_pos = 0;
+	/* Continuous reading until several empty reads */
+	while (consecutive_empty < max_empty_reads) {
+		n = read(client->fd, buffer, sizeof(buffer));
+
+		if (n > 0) {
+			consecutive_empty = 0;
+			AT_DEBUG(client, "Received %zd bytes", n);
+
+			for (i = 0; i < n; i++) {
+				unsigned char ch = buffer[i];
+
+				if (ch == '\r' || ch == '\n') {
+					if (client->rx_pos > 0) {
+						client->rx_buf[client->rx_pos] = '\0';
+						AT_DEBUG(client, "Complete line: '%s'", client->rx_buf);
+						process_line(client, client->rx_buf);
+						client->rx_pos = 0;
+					}
+				}
+				else if (client->rx_pos < AT_CLIENT_RX_BUFFER_SIZE - 1) {
+					client->rx_buf[client->rx_pos++] = ch;
+				}
+				else {
+					/* Buffer overflow - process current line */
+					AT_DEBUG(client, "RX buffer overflow!");
+					client->rx_buf[client->rx_pos] = '\0';
+					process_line(client, client->rx_buf);
+					client->rx_pos = 0;
+					client->rx_buf[client->rx_pos++] = ch;
+				}
+			}
+
+			if (read_delay_us > 0) {
+				usleep(read_delay_us);
 			}
 		}
-		/* Accumulate characters */
-		else if (client->rx_pos < sizeof(client->rx_buf) - 1) {
-			client->rx_buf[client->rx_pos++] = ch;
+		else if (n == 0 || (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))) {
+			consecutive_empty++;
+			if (consecutive_empty < max_empty_reads && empty_delay_us > 0) {
+				usleep(empty_delay_us);
+			}
 		}
-		/* Buffer overflow, discard */
 		else {
-			client->rx_pos = 0;
+			AT_DEBUG(client, "Read error: %s", strerror(errno));
+			break;
 		}
+	}
+
+	/* Handle incomplete line for URC */
+	if (client->rx_pos > 0 && !client->waiting_resp) {
+		client->rx_buf[client->rx_pos] = '\0';
+		if (client->urc_handler) {
+			client->urc_handler(client->rx_buf, client->urc_arg);
+		}
+		client->rx_pos = 0;
 	}
 }
 
 at_result_t at_client_send(at_client_t *client, const char *cmd, char *resp_buf,
     size_t resp_size, uint32_t timeout_ms) {
-	uint32_t start_time, elapsed;
-	ssize_t written;
-	size_t total_written = 0;
-	size_t cmd_len;
-
 	if (!client || !cmd || client->fd < 0) {
 		return AT_INVALID_PARAM;
 	}
 
-	/* Prepare to receive response */
+	uint32_t start_time;
+	ssize_t written;
+	size_t total_written = 0;
+	size_t cmd_len;
+	at_client_mode_t mode = client->mode;
+	const bool is_normal_mode = (mode == AT_CLIENT_MODE_NORMAL);
+	const int retry_count = is_normal_mode ? 3 : 1;
+	const int retry_delay_us = is_normal_mode ? 2000 : 0;
+	const int post_send_delay_us = is_normal_mode ? 10000 : 0;
+
+	AT_DEBUG(client, "Sending: %s", cmd);
+
+	/* Drain receive buffer in NORMAL mode */
+	if (client->mode == AT_CLIENT_MODE_NORMAL) {
+		int old_flags = fcntl(client->fd, F_GETFL, 0);
+		fcntl(client->fd, F_SETFL, old_flags | O_NONBLOCK);
+
+		char drain_buf[256];
+		int drain_count = 0;
+		while (read(client->fd, drain_buf, sizeof(drain_buf)) > 0) {
+			drain_count++;
+			if (drain_count > 10)
+				break;
+		}
+
+		fcntl(client->fd, F_SETFL, old_flags);
+	}
+
+	/* Clear line buffer */
+	client->rx_pos = 0;
+
+	/* Prepare for response */
 	client->waiting_resp = true;
 	client->result = AT_TIMEOUT;
 	client->resp_buf = resp_buf;
 	client->resp_size = resp_size;
+	client->flags &= ~AT_CLIENT_FLAG_RESP_TRUNCATED;
 
 	if (resp_buf && resp_size > 0) {
 		resp_buf[0] = '\0';
 	}
 
+	start_time = get_current_ms();
+
 	/* Send command */
 	cmd_len = strlen(cmd);
 	while (total_written < cmd_len) {
+		if (is_timeout(start_time, timeout_ms)) {
+			client->waiting_resp = false;
+			return AT_TIMEOUT;
+		}
+
 		written = write(client->fd, cmd + total_written, cmd_len - total_written);
 		if (written < 0) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
-				/* Non-blocking write, retry */
 				usleep(1000);
 				continue;
 			}
@@ -261,10 +394,15 @@ at_result_t at_client_send(at_client_t *client, const char *cmd, char *resp_buf,
 		total_written += written;
 	}
 
-	/* Send \r\n */
+	/* Send CRLF */
 	const char *crlf = "\r\n";
 	total_written = 0;
 	while (total_written < 2) {
+		if (is_timeout(start_time, timeout_ms)) {
+			client->waiting_resp = false;
+			return AT_TIMEOUT;
+		}
+
 		written = write(client->fd, crlf + total_written, 2 - total_written);
 		if (written < 0) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -277,19 +415,47 @@ at_result_t at_client_send(at_client_t *client, const char *cmd, char *resp_buf,
 		total_written += written;
 	}
 
-	/* Wait for response */
-	start_time = clock();
-	while (client->waiting_resp) {
-		at_client_process_rx(client);
+	if (post_send_delay_us > 0) {
+		usleep(post_send_delay_us);
+	}
 
-		/* Check timeout */
-		elapsed = clock() - start_time;
-		if (elapsed > (timeout_ms * CLOCKS_PER_SEC / 1000)) {
+	/* Wait for response */
+	int no_progress_count = 0;
+	size_t last_resp_len = 0;
+
+	while (client->waiting_resp) {
+		for (int i = 0; i < retry_count && client->waiting_resp; i++) {
+			at_client_process_rx(client);
+			if (!client->waiting_resp)
+				break;
+			if (retry_delay_us > 0) {
+				usleep(retry_delay_us);
+			}
+		}
+
+		/* Check progress */
+		size_t current_resp_len = (resp_buf && resp_size > 0) ? strlen(resp_buf)
+		                                                      : 0;
+		if (current_resp_len > last_resp_len) {
+			no_progress_count = 0;
+			last_resp_len = current_resp_len;
+		}
+		else {
+			no_progress_count++;
+		}
+
+		if (is_timeout(start_time, timeout_ms)) {
 			client->waiting_resp = false;
+			AT_DEBUG(client, "TIMEOUT after %u ms", timeout_ms);
 			return AT_TIMEOUT;
 		}
 
-		usleep(1000); /* 1ms */
+		usleep(5000);
+	}
+
+	AT_DEBUG(client, "Response complete: result=%d", client->result);
+	if (resp_buf && resp_size > 0) {
+		AT_DEBUG(client, "Response buffer has %zu chars", strlen(resp_buf));
 	}
 
 	return client->result;
@@ -300,5 +466,22 @@ void at_client_set_urc_handler(at_client_t *client,
 	if (client) {
 		client->urc_handler = handler;
 		client->urc_arg = arg;
+	}
+}
+
+void at_client_set_mode(at_client_t *client, at_client_mode_t mode) {
+	if (client) {
+		client->mode = mode;
+	}
+}
+
+void at_client_enable_debug(at_client_t *client, bool enable) {
+	if (client) {
+		if (enable) {
+			client->flags |= AT_CLIENT_FLAG_DEBUG;
+		}
+		else {
+			client->flags &= ~AT_CLIENT_FLAG_DEBUG;
+		}
 	}
 }

--- a/project/at/src/drivers/at/emulator/at_emulator.h
+++ b/project/at/src/drivers/at/emulator/at_emulator.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <kernel/thread/sync/mutex.h>
 #include <at/at_parser.h>
 
 /* Forward declarations */
@@ -68,6 +69,14 @@ struct at_emulator {
 
 	/* User data pointer */
 	void *user_data;
+
+	/* URC management */
+	char pending_urc[256];
+	bool has_pending_urc;
+	struct mutex urc_mutex;
+
+	/* Device poll function */
+	const char *(*device_poll)(struct at_emulator *emu);
 };
 
 /**
@@ -199,5 +208,25 @@ void at_emulator_set_user_data(at_emulator_t *emu, void *data);
  * @return User data pointer, NULL if not set
  */
 void *at_emulator_get_user_data(at_emulator_t *emu);
+
+/**
+ * @brief Push URC message to emulator
+ * 
+ * @param emu Emulator instance
+ * @param urc URC message string
+ */
+void at_emulator_push_urc(at_emulator_t *emu, const char *urc);
+
+
+/**
+ * @brief Poll for pending URC messages
+ * 
+ * Checks for device-specific events and pending URC messages.
+ * Should be called periodically for asynchronous event handling.
+ *
+ * @param emu Emulator instance
+ * @return URC string if available, NULL otherwise
+ */
+const char *at_emulator_poll(at_emulator_t *emu);
 
 #endif /* AT_EMULATOR_H */

--- a/project/at/src/drivers/net/wifi/Mybuild
+++ b/project/at/src/drivers/net/wifi/Mybuild
@@ -8,3 +8,12 @@ module wifi_core {
 
 	depends project.at.net.wlan.wlan_core
 }
+
+module esp32c3_emulator {
+	source "esp32c3/emulator/esp32c3_emulator.c"
+
+	@IncludeExport(path="wifi")
+	source "esp32c3/emulator/esp32c3_emulator.h"
+
+	depends project.at.driver.at.at_emulator
+}

--- a/project/at/src/drivers/net/wifi/Mybuild
+++ b/project/at/src/drivers/net/wifi/Mybuild
@@ -17,3 +17,12 @@ module esp32c3_emulator {
 
 	depends project.at.driver.at.at_emulator
 }
+
+module esp32c3_wifi {
+  source "esp32c3/esp32c3_wifi.c"
+
+	@IncludeExport(path="wifi")
+	source "esp32c3/esp32c3_wifi.h"
+
+  depends project.at.driver.net.wifi.wifi_core
+}

--- a/project/at/src/drivers/net/wifi/Mybuild
+++ b/project/at/src/drivers/net/wifi/Mybuild
@@ -1,0 +1,10 @@
+package project.at.driver.net.wifi
+
+module wifi_core {
+	source "wifi_core.c"
+
+	@IncludeExport(path="wifi")
+	source "wifi_core.h"
+
+	depends project.at.net.wlan.wlan_core
+}

--- a/project/at/src/drivers/net/wifi/esp32c3/emulator/esp32c3_emulator.c
+++ b/project/at/src/drivers/net/wifi/esp32c3/emulator/esp32c3_emulator.c
@@ -1,0 +1,509 @@
+/**
+ * @file
+ * @brief ESP32-C3 AT Emulator Implementation 
+ * 
+ * @date July 31, 2025
+ * @author Peize Li
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <kernel/thread/sync/mutex.h>
+#include <kernel/time/timer.h>
+#include <wifi/esp32c3/emulator/esp32c3_emulator.h>
+
+/* WiFi connection simulation delay (ms) */
+#define WIFI_CONNECT_DELAY_MS 200
+#define WIFI_IP_DELAY_MS      50
+
+static esp32c3_emu_data_t *get_esp32_data(at_emulator_t *emu) {
+	return (esp32c3_emu_data_t *)at_emulator_get_user_data(emu);
+}
+
+/* Device-specific poll callback for ESP32-C3 */
+static const char *esp32c3_device_poll(at_emulator_t *emu) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+	static char buffer[256];
+
+	if (!data) {
+		return NULL;
+	}
+
+	/* Handle post-reset "READY" message */
+	mutex_lock(&data->state_mutex);
+	if (data->rst_pending) {
+		data->rst_pending = false;
+		strcpy(buffer, "\r\nREADY\r\n");
+		mutex_unlock(&data->state_mutex);
+		return buffer;
+	}
+	mutex_unlock(&data->state_mutex);
+
+	return NULL;
+}
+
+/* Safe timer stop with mutex protection */
+static void emu_timer_stop(esp32c3_emu_data_t *data) {
+	mutex_lock(&data->timer_mutex);
+
+	if (data->timer_active) {
+		timer_stop(&data->conn_timer);
+		data->timer_active = false;
+	}
+	if (data->ip_timer_active) {
+		timer_stop(&data->ip_timer);
+		data->ip_timer_active = false;
+	}
+
+	mutex_unlock(&data->timer_mutex);
+}
+
+/* Timer callback for WiFi connection stages */
+static void wifi_connect_timer_handler(struct sys_timer *timer, void *param) {
+	esp32c3_emu_data_t *data = (esp32c3_emu_data_t *)param;
+
+	(void)timer;
+
+	mutex_lock(&data->timer_mutex);
+	mutex_lock(&data->state_mutex);
+
+	switch (data->wifi_state) {
+	case ESP32_WIFI_CONNECTING:
+		data->wifi_state = ESP32_WIFI_CONNECTED;
+		at_emulator_push_urc(data->base_emu, "\r\nWIFI CONNECTED\r\n");
+
+		/* Schedule IP acquisition */
+		if (!data->ip_timer_active) {
+			timer_init_start_msec(&data->ip_timer, TIMER_ONESHOT,
+			    WIFI_IP_DELAY_MS, wifi_connect_timer_handler, data);
+			data->ip_timer_active = true;
+		}
+		data->timer_active = false;
+		break;
+
+	case ESP32_WIFI_CONNECTED:
+		data->wifi_state = ESP32_WIFI_GOT_IP;
+		strcpy(data->ip_addr, "192.168.1.100");
+		strcpy(data->gateway, "192.168.1.1");
+		strcpy(data->netmask, "255.255.255.0");
+
+		at_emulator_push_urc(data->base_emu, "\r\nWIFI GOT IP\r\n");
+		data->ip_timer_active = false;
+		break;
+
+	default:
+		data->timer_active = false;
+		data->ip_timer_active = false;
+		break;
+	}
+
+	mutex_unlock(&data->state_mutex);
+	mutex_unlock(&data->timer_mutex);
+}
+
+/* AT+RST - Reset module */
+static at_result_t cmd_rst(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	(void)type;
+	(void)params;
+	(void)response;
+	(void)resp_size;
+
+	emu_timer_stop(data);
+
+	mutex_lock(&data->state_mutex);
+	data->wifi_state = ESP32_WIFI_IDLE;
+	data->wifi_mode = 1; /* Default STA mode */
+	memset(data->current_ssid, 0, sizeof(data->current_ssid));
+	memset(data->current_password, 0, sizeof(data->current_password));
+	memset(data->ip_addr, 0, sizeof(data->ip_addr));
+	memset(data->gateway, 0, sizeof(data->gateway));
+	memset(data->netmask, 0, sizeof(data->netmask));
+	data->tcp_state.connected = false;
+	mutex_unlock(&data->state_mutex);
+
+	data->rst_pending = true;
+
+	return AT_OK;
+}
+
+/* AT+CWMODE - Set/Query WiFi mode */
+static at_result_t cmd_cwmode(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	switch (type) {
+	case AT_CMD_SET:
+		if (params && *params) {
+			int mode = atoi(params);
+			if (mode >= 1 && mode <= 3) {
+				mutex_lock(&data->state_mutex);
+				data->wifi_mode = mode;
+				mutex_unlock(&data->state_mutex);
+				return AT_OK;
+			}
+		}
+		return AT_ERROR;
+
+	case AT_CMD_READ:
+		mutex_lock(&data->state_mutex);
+		snprintf(response, resp_size, "+CWMODE:%d", data->wifi_mode);
+		mutex_unlock(&data->state_mutex);
+		return AT_OK;
+
+	case AT_CMD_TEST:
+		snprintf(response, resp_size, "+CWMODE:(1-3)");
+		return AT_OK;
+
+	case AT_CMD_EXEC:
+		return AT_ERROR;
+
+	default:
+		return AT_ERROR;
+	}
+}
+
+/* AT+CWJAP - Connect to AP */
+static at_result_t cmd_cwjap(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	switch (type) {
+	case AT_CMD_SET:
+		if (params) {
+			char ssid[33] = {0};
+			char pwd[65] = {0};
+			char temp[128];
+
+			strncpy(temp, params, sizeof(temp) - 1);
+			temp[sizeof(temp) - 1] = '\0';
+
+			/* Parse SSID and password from quoted parameters */
+			char *p1 = strtok(temp, "\"");
+			if (p1) {
+				strncpy(ssid, p1, sizeof(ssid) - 1);
+
+				strtok(NULL, "\"");
+				char *p2 = strtok(NULL, "\"");
+				if (p2) {
+					strncpy(pwd, p2, sizeof(pwd) - 1);
+				}
+			}
+
+			if (strlen(ssid) > 0) {
+				/* Check if SSID exists in scan results */
+				bool ssid_found = false;
+				mutex_lock(&data->state_mutex);
+				for (int i = 0; i < data->scan_count; i++) {
+					if (strcmp(data->scan_results[i].ssid, ssid) == 0) {
+						ssid_found = true;
+						break;
+					}
+				}
+				mutex_unlock(&data->state_mutex);
+
+				/* Accept any SSID starting with "Test" for simulation */
+				if (!ssid_found && strncmp(ssid, "Test", 4) == 0) {
+					ssid_found = true;
+				}
+
+				if (!ssid_found) {
+					return AT_ERROR;
+				}
+
+				/* Disconnect if already connected */
+				mutex_lock(&data->state_mutex);
+				if (data->wifi_state >= ESP32_WIFI_CONNECTED) {
+					data->wifi_state = ESP32_WIFI_DISCONNECTED;
+				}
+				mutex_unlock(&data->state_mutex);
+
+				emu_timer_stop(data);
+
+				/* Start new connection */
+				mutex_lock(&data->state_mutex);
+				strncpy(data->current_ssid, ssid, sizeof(data->current_ssid) - 1);
+				strncpy(data->current_password, pwd,
+				    sizeof(data->current_password) - 1);
+				data->wifi_state = ESP32_WIFI_CONNECTING;
+				mutex_unlock(&data->state_mutex);
+
+				mutex_lock(&data->timer_mutex);
+				timer_init_start_msec(&data->conn_timer, TIMER_ONESHOT,
+				    WIFI_CONNECT_DELAY_MS, wifi_connect_timer_handler, data);
+				data->timer_active = true;
+				mutex_unlock(&data->timer_mutex);
+
+				return AT_OK;
+			}
+		}
+		return AT_ERROR;
+
+	case AT_CMD_READ:
+		mutex_lock(&data->state_mutex);
+		if (data->wifi_state >= ESP32_WIFI_CONNECTED
+		    && strlen(data->current_ssid) > 0) {
+			snprintf(response, resp_size,
+			    "+CWJAP:\"%s\",\"%02x:%02x:%02x:%02x:%02x:%02x\",%d,%d",
+			    data->current_ssid, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, /* Fake BSSID */
+			    6, -45); /* channel, rssi */
+		}
+		else {
+			response[0] = '\0';
+		}
+		mutex_unlock(&data->state_mutex);
+		return AT_OK;
+
+	case AT_CMD_TEST:
+		snprintf(response, resp_size, "+CWJAP:<ssid>,<pwd>[,<bssid>][,<pci_en>]");
+		return AT_OK;
+
+	default:
+		return AT_ERROR;
+	}
+}
+
+/* AT+CWQAP - Disconnect from AP */
+static at_result_t cmd_cwqap(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	(void)type;
+	(void)params;
+	(void)response;
+	(void)resp_size;
+
+	if (type != AT_CMD_EXEC) {
+		return AT_ERROR;
+	}
+
+	emu_timer_stop(data);
+
+	mutex_lock(&data->state_mutex);
+	if (data->wifi_state >= ESP32_WIFI_CONNECTED) {
+		data->wifi_state = ESP32_WIFI_DISCONNECTED;
+		memset(data->current_ssid, 0, sizeof(data->current_ssid));
+		memset(data->current_password, 0, sizeof(data->current_password));
+		memset(data->ip_addr, 0, sizeof(data->ip_addr));
+		memset(data->gateway, 0, sizeof(data->gateway));
+		memset(data->netmask, 0, sizeof(data->netmask));
+
+		at_emulator_push_urc(data->base_emu, "\r\nWIFI DISCONNECT\r\n");
+	}
+	mutex_unlock(&data->state_mutex);
+
+	return AT_OK;
+}
+
+/* AT+CWLAP - List available APs */
+static at_result_t cmd_cwlap(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	(void)params;
+
+	if (type != AT_CMD_EXEC && type != AT_CMD_SET) {
+		return AT_ERROR;
+	}
+
+	int len = 0;
+	mutex_lock(&data->state_mutex);
+	for (int i = 0; i < data->scan_count && len < (int)resp_size - 100; i++) {
+		len += snprintf(response + len, resp_size - len,
+		    "+CWLAP:(%d,\"%s\",%d,\"%02x:%02x:%02x:%02x:%02x:%02x\",%d)\r\n",
+		    data->scan_results[i].enc, data->scan_results[i].ssid,
+		    data->scan_results[i].rssi, 0x00, 0x11, 0x22, 0x33, 0x44,
+		    i, /* Fake BSSID */
+		    data->scan_results[i].channel);
+	}
+	mutex_unlock(&data->state_mutex);
+
+	/* Remove last \r\n */
+	if (len >= 2) {
+		response[len - 2] = '\0';
+	}
+
+	return AT_OK;
+}
+
+/* AT+CIPSTA? - Query station IP */
+static at_result_t cmd_cipsta(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	(void)params;
+
+	if (type == AT_CMD_READ) {
+		mutex_lock(&data->state_mutex);
+		if (data->wifi_state == ESP32_WIFI_GOT_IP) {
+			snprintf(response, resp_size,
+			    "+CIPSTA:ip:\"%s\"\r\n"
+			    "+CIPSTA:gateway:\"%s\"\r\n"
+			    "+CIPSTA:netmask:\"%s\"",
+			    data->ip_addr, data->gateway, data->netmask);
+		}
+		else {
+			snprintf(response, resp_size,
+			    "+CIPSTA:ip:\"0.0.0.0\"\r\n"
+			    "+CIPSTA:gateway:\"0.0.0.0\"\r\n"
+			    "+CIPSTA:netmask:\"0.0.0.0\"");
+		}
+		mutex_unlock(&data->state_mutex);
+		return AT_OK;
+	}
+
+	return AT_ERROR;
+}
+
+/* AT+CIPSTART - Establish TCP/UDP connection */
+static at_result_t cmd_cipstart(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	(void)response;
+	(void)resp_size;
+
+	if (type == AT_CMD_SET && params) {
+		mutex_lock(&data->state_mutex);
+		if (data->wifi_state != ESP32_WIFI_GOT_IP) {
+			mutex_unlock(&data->state_mutex);
+			return AT_ERROR;
+		}
+
+		/* Simplified parsing - simulate success */
+		data->tcp_state.connected = true;
+		strcpy(data->tcp_state.remote_ip, "192.168.1.10");
+		data->tcp_state.remote_port = 8080;
+
+		at_emulator_push_urc(data->base_emu, "\r\nCONNECT\r\n");
+		mutex_unlock(&data->state_mutex);
+
+		return AT_OK;
+	}
+
+	return AT_ERROR;
+}
+
+/* AT+CIPSEND - Send data */
+static at_result_t cmd_cipsend(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	(void)type;
+	(void)params;
+
+	mutex_lock(&data->state_mutex);
+	if (data->tcp_state.connected) {
+		strcpy(response, "> ");
+		mutex_unlock(&data->state_mutex);
+		return AT_OK;
+	}
+	mutex_unlock(&data->state_mutex);
+
+	(void)resp_size;
+	return AT_ERROR;
+}
+
+/* AT+SLEEP - Set sleep mode */
+static at_result_t cmd_sleep(at_emulator_t *emu, at_cmd_type_t type,
+    const char *params, char *response, size_t resp_size) {
+	esp32c3_emu_data_t *data = get_esp32_data(emu);
+
+	switch (type) {
+	case AT_CMD_SET:
+		if (params && *params) {
+			int mode = atoi(params);
+			if (mode >= 0 && mode <= 2) {
+				mutex_lock(&data->state_mutex);
+				data->sleep_mode = mode;
+				mutex_unlock(&data->state_mutex);
+				return AT_OK;
+			}
+		}
+		return AT_ERROR;
+
+	case AT_CMD_READ:
+		mutex_lock(&data->state_mutex);
+		snprintf(response, resp_size, "+SLEEP:%d", data->sleep_mode);
+		mutex_unlock(&data->state_mutex);
+		return AT_OK;
+
+	default:
+		return AT_ERROR;
+	}
+}
+
+/* Initialize ESP32-C3 emulator */
+at_emulator_t *esp32c3_emulator_create(void) {
+	at_emulator_t *emu = at_emulator_create();
+	if (!emu) {
+		return NULL;
+	}
+
+	esp32c3_emu_data_t *data = calloc(1, sizeof(esp32c3_emu_data_t));
+	if (!data) {
+		at_emulator_destroy(emu);
+		return NULL;
+	}
+
+	mutex_init(&data->timer_mutex);
+	mutex_init(&data->state_mutex);
+
+	data->wifi_mode = 1; /* STA mode */
+	data->wifi_state = ESP32_WIFI_IDLE;
+	data->base_emu = emu;
+	data->timer_active = false;
+	data->ip_timer_active = false;
+	data->rst_pending = false;
+
+	/* Initialize fake scan results */
+	data->scan_count = 3;
+	strcpy(data->scan_results[0].ssid, "TestAP_1");
+	data->scan_results[0].rssi = -45;
+	data->scan_results[0].channel = 1;
+	data->scan_results[0].enc = 3; /* WPA2 */
+
+	strcpy(data->scan_results[1].ssid, "TestAP_2");
+	data->scan_results[1].rssi = -60;
+	data->scan_results[1].channel = 6;
+	data->scan_results[1].enc = 0; /* Open */
+
+	strcpy(data->scan_results[2].ssid, "TestAP_3");
+	data->scan_results[2].rssi = -75;
+	data->scan_results[2].channel = 11;
+	data->scan_results[2].enc = 3; /* WPA2 */
+
+	at_emulator_set_device_info(emu, "ESP32-C3_Emulator", "Embox", "ESP32-C3",
+	    "AT 1.0");
+	at_emulator_set_user_data(emu, data);
+	emu->device_poll = esp32c3_device_poll;
+
+	/* Register ESP32-C3 specific commands */
+	at_emulator_register_command(emu, "AT+RST", cmd_rst);
+	at_emulator_register_command(emu, "AT+CWMODE", cmd_cwmode);
+	at_emulator_register_command(emu, "AT+CWJAP", cmd_cwjap);
+	at_emulator_register_command(emu, "AT+CWQAP", cmd_cwqap);
+	at_emulator_register_command(emu, "AT+CWLAP", cmd_cwlap);
+	at_emulator_register_command(emu, "AT+CIPSTA", cmd_cipsta);
+	at_emulator_register_command(emu, "AT+CIPSTART", cmd_cipstart);
+	at_emulator_register_command(emu, "AT+CIPSEND", cmd_cipsend);
+	at_emulator_register_command(emu, "AT+SLEEP", cmd_sleep);
+
+	return emu;
+}
+
+/* Destroy ESP32-C3 emulator */
+void esp32c3_emulator_destroy(at_emulator_t *emu) {
+	if (emu) {
+		esp32c3_emu_data_t *data = get_esp32_data(emu);
+		if (data) {
+			emu_timer_stop(data);
+			free(data);
+		}
+		at_emulator_destroy(emu);
+	}
+}

--- a/project/at/src/drivers/net/wifi/esp32c3/emulator/esp32c3_emulator.h
+++ b/project/at/src/drivers/net/wifi/esp32c3/emulator/esp32c3_emulator.h
@@ -1,0 +1,99 @@
+/**
+ * @file
+ * @brief ESP32-C3 AT Emulator Header
+ * 
+ * @date July 31, 2025
+ * @author Peize Li
+ */
+
+#ifndef ESP32C3_EMULATOR_H
+#define ESP32C3_EMULATOR_H
+
+#include <at/emulator/at_emulator.h>
+#include <kernel/thread/sync/mutex.h>
+#include <kernel/time/timer.h>
+
+/**
+ * @brief ESP32-C3 WiFi state
+ */
+typedef enum {
+	ESP32_WIFI_IDLE = 0,
+	ESP32_WIFI_CONNECTING,
+	ESP32_WIFI_CONNECTED,
+	ESP32_WIFI_GOT_IP,
+	ESP32_WIFI_DISCONNECTED
+} esp32_wifi_state_t;
+
+/**
+ * @brief ESP32-C3 emulator specific data
+ */
+typedef struct {
+	/* WiFi state machine */
+	esp32_wifi_state_t wifi_state;
+	char current_ssid[33];
+	char current_password[65];
+	char ip_addr[16];
+	char gateway[16];
+	char netmask[16];
+
+	/* WiFi mode: 1=STA, 2=AP, 3=STA+AP */
+	int wifi_mode;
+
+	/* Connection timers - separated for proper management */
+	struct sys_timer conn_timer; /* WiFi connection timer */
+	struct sys_timer ip_timer;   /* IP acquisition timer */
+	bool timer_active;           /* Connection timer active */
+	bool ip_timer_active;        /* IP timer active */
+
+	/* Timer synchronization mutex */
+	struct mutex timer_mutex; /* Protects timer operations */
+
+	/* State machine mutex */
+	struct mutex state_mutex; /* Protects wifi_state transitions */
+
+	/* TCP/IP state */
+	struct {
+		bool connected;
+		char remote_ip[16];
+		int remote_port;
+		int mux; /* Connection multiplexing ID */
+	} tcp_state;
+
+	/* WiFi scan results */
+	struct {
+		char ssid[33];
+		int rssi;
+		int channel;
+		int enc; /* Encryption type */
+	} scan_results[5];
+	int scan_count;
+
+	/* Parent emulator reference */
+	at_emulator_t *base_emu;
+
+	/* Special flags */
+	bool rst_pending; /* "READY" message pending after reset */
+	int sleep_mode;
+
+} esp32c3_emu_data_t;
+
+/**
+ * @brief Create ESP32-C3 emulator
+ * 
+ * Creates an AT emulator instance configured for ESP32-C3 WiFi module.
+ * The emulator simulates WiFi connection, IP acquisition, and basic TCP/IP.
+ * 
+ * @return Configured AT emulator instance, NULL on failure
+ */
+at_emulator_t *esp32c3_emulator_create(void);
+
+/**
+ * @brief Destroy ESP32-C3 emulator
+ * 
+ * Cleans up all resources including active timers and allocated memory.
+ * 
+ * @param emu Emulator instance to destroy
+ */
+void esp32c3_emulator_destroy(at_emulator_t *emu);
+
+#endif /* ESP32C3_EMULATOR_H */

--- a/project/at/src/drivers/net/wifi/esp32c3/esp32c3_wifi.c
+++ b/project/at/src/drivers/net/wifi/esp32c3/esp32c3_wifi.c
@@ -1,0 +1,702 @@
+/**
+ * @file
+ * @brief ESP32-C3 WiFi Driver Implementation
+ * 
+ * @date Aug 6, 2025
+ * @author Peize Li
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <at/at_client.h>
+#include <mem/sysmalloc.h>
+#include <net/wlan/wireless_ioctl.h>
+#include <wifi/esp32c3/esp32c3_wifi.h>
+#include <wifi/wifi_core.h>
+
+#define ESP32_CONNECT_TIMEOUT_MS 20000 /* connection timeout */
+#define ESP32_SCAN_TIMEOUT_MS    10000 /* scan timeout */
+#define ESP32_CMD_TIMEOUT_MS     5000  /* command timeout */
+#define ESP32_RESET_DELAY_MS     2000  /* reset delay */
+
+/* Forward declarations */
+static int esp32c3_hw_init(struct wifi_core *wifi);
+static void esp32c3_hw_cleanup(struct wifi_core *wifi);
+static int esp32c3_parse_scan_line(const char *line, struct wlan_scan_ap *ap);
+static const char *esp32c3_get_scan_cmd(void);
+static int esp32c3_build_connect_cmd(char *buf, size_t size, const char *ssid,
+    const char *pwd);
+static const char *esp32c3_get_disconnect_cmd(void);
+static int esp32c3_get_ip_config(struct wifi_core *wifi, char *ip, char *mask,
+    char *gw);
+static bool esp32c3_parse_urc(struct wifi_core *wifi, const char *line);
+static int esp32c3_get_rssi(struct wifi_core *wifi, int8_t *rssi);
+static int esp32c3_parse_mode_response(const char *resp, int *mode);
+int esp32c3_set_power_mode(struct wifi_core *wifi, int mode);
+int esp32c3_get_power_mode(struct wifi_core *wifi, int *mode);
+
+/* ===================================================================
+ * ESP32-C3 WiFi hardware operations
+ * =================================================================== */
+
+static const struct wifi_hw_ops esp32c3_ops = {
+	.hw_init = esp32c3_hw_init,
+	.hw_cleanup = esp32c3_hw_cleanup,
+	.parse_scan_line = esp32c3_parse_scan_line,
+	.get_scan_cmd = esp32c3_get_scan_cmd,
+	.build_connect_cmd = esp32c3_build_connect_cmd,
+	.get_disconnect_cmd = esp32c3_get_disconnect_cmd,
+	.get_ip_config = esp32c3_get_ip_config,
+	.parse_urc = esp32c3_parse_urc,
+	.get_rssi = esp32c3_get_rssi,
+	.parse_mode_response = esp32c3_parse_mode_response,
+	.set_power_mode = esp32c3_set_power_mode,
+	.get_power_mode = esp32c3_get_power_mode,
+	.timeouts = {
+		.scan_ms = ESP32_SCAN_TIMEOUT_MS,
+		.connect_ms = ESP32_CONNECT_TIMEOUT_MS,
+		.cmd_ms = ESP32_CMD_TIMEOUT_MS
+	},
+	
+	.urc_patterns = {
+		.connected = "WIFI CONNECTED",
+		.got_ip = "WIFI GOT IP", 
+		.disconnected = "WIFI DISCONNECT"
+	},
+
+	.basic_cmds = {
+		.scan = "AT+CWLAP",
+		.disconnect = "AT+CWQAP"
+	},
+
+	.mode_cmds = {
+		.get_mode = "AT+CWMODE?",
+		.set_mode_fmt = "AT+CWMODE=%d"
+	}
+};
+
+/* Helper functions */
+static int esp32_error_to_errno(int esp_error) {
+	switch (esp_error) {
+	case 1: /* timeout */
+		return -ETIMEDOUT;
+	case 2: /* wrong password */
+		return -EACCES;
+	case 3: /* AP not found */
+		return -ENOENT;
+	case 4: /* connection failed */
+		return -ECONNREFUSED;
+	default:
+		return -EIO;
+	}
+}
+
+/* Hardware initialization and cleanup */
+static int esp32c3_hw_init(struct wifi_core *wifi) {
+	struct esp32c3_wifi *esp32 = (struct esp32c3_wifi *)wifi->hw_priv;
+	char resp[256];
+	int ret;
+
+	printf("esp32c3: initializing WiFi module\n");
+
+	/* Test AT communication */
+	printf("esp32c3_hw_init: sending AT command\n");
+	ret = wifi_core_send_cmd(wifi, "AT", resp, sizeof(resp), 1000);
+	if (ret != 0) {
+		printf("esp32c3_hw_init: AT failed with ret=%d\n", ret);
+		return ret;
+	}
+	printf("esp32c3_hw_init: AT response: %s\n", resp);
+
+	/* Reset module */
+	wifi_core_send_cmd(wifi, "AT+RST", resp, sizeof(resp), 1000);
+	usleep(ESP32_RESET_DELAY_MS * 500);
+
+	/* Clear any boot messages */
+	at_client_process_rx(wifi->at_client);
+
+	/* Disable echo */
+	ret = wifi_core_send_cmd(wifi, "ATE0", resp, sizeof(resp), 1000);
+	if (ret != 0) {
+		printf("esp32c3: failed to disable echo\n");
+		return ret;
+	}
+
+	/* Query version */
+	ret = wifi_core_send_cmd(wifi, "AT+GMR", resp, sizeof(resp), 2000);
+	if (ret == 0) {
+		char *ver = strstr(resp, "AT version:");
+		if (ver) {
+			sscanf(ver, "AT version:%63s", esp32->fw_version);
+			printf("esp32c3: firmware %s\n", esp32->fw_version);
+		}
+	}
+
+	esp32->power_mode = WLAN_PWR_ACTIVE;
+	esp32->initialized = true;
+	printf("esp32c3: initialization complete\n");
+
+	return 0;
+}
+
+static void esp32c3_hw_cleanup(struct wifi_core *wifi) {
+	struct esp32c3_wifi *esp32 = (struct esp32c3_wifi *)wifi->hw_priv;
+
+	if (esp32->initialized) {
+		wifi_core_send_cmd(wifi, "AT+CWQAP", NULL, 0, 1000);
+		esp32->initialized = false;
+	}
+}
+
+/* Command builders and getters */
+static const char *esp32c3_get_scan_cmd(void) {
+	return "AT+CWLAP";
+}
+
+static int esp32c3_build_connect_cmd(char *buf, size_t size, const char *ssid,
+    const char *pwd) {
+	if (!ssid || !buf) {
+		return -EINVAL;
+	}
+
+	if (pwd && pwd[0]) {
+		snprintf(buf, size, "AT+CWJAP=\"%s\",\"%s\"", ssid, pwd);
+	}
+	else {
+		snprintf(buf, size, "AT+CWJAP=\"%s\",\"\"", ssid);
+	}
+
+	return 0;
+}
+
+static const char *esp32c3_get_disconnect_cmd(void) {
+	return "AT+CWQAP";
+}
+
+/* Response parsers */
+static int esp32c3_parse_scan_line(const char *line, struct wlan_scan_ap *ap) {
+	char work_buf[256];
+	char *ptr, *start;
+	int field = 0;
+
+	memset(ap, 0, sizeof(*ap));
+
+	if (strncmp(line, "+CWLAP:", 7) != 0) {
+		return -1;
+	}
+
+	/* Copy to work buffer, remove prefix */
+	strncpy(work_buf, line + 7, sizeof(work_buf) - 1);
+	work_buf[sizeof(work_buf) - 1] = '\0';
+
+	/* Remove leading '(' and trailing ')' */
+	ptr = work_buf;
+	while (*ptr == ' ' || *ptr == '(')
+		ptr++;
+	start = ptr;
+
+	ptr = strrchr(start, ')');
+	if (ptr)
+		*ptr = '\0';
+
+	/* Manual parsing to avoid strtok state issues */
+	ptr = start;
+
+	while (*ptr && field < 5) {
+		while (*ptr == ' ')
+			ptr++;
+
+		switch (field) {
+		case 0: /* Encryption type */
+		{
+			char *endptr;
+			long val = strtol(ptr, &endptr, 10);
+			ap->security = (val == 0) ? 0 : 3;
+			ptr = endptr;
+			if (*ptr == ',')
+				ptr++;
+		} break;
+
+		case 1: /* SSID */
+		{
+			if (*ptr == '"')
+				ptr++;
+			char *ssid_start = ptr;
+			char *ssid_end = strchr(ptr, '"');
+			if (!ssid_end) {
+				printf("esp32c3: SSID parse error\n");
+				return -1;
+			}
+			size_t len = ssid_end - ssid_start;
+			if (len > 32)
+				len = 32;
+			memcpy(ap->ssid, ssid_start, len);
+			ap->ssid[len] = '\0';
+			ptr = ssid_end + 1;
+			if (*ptr == ',')
+				ptr++;
+		} break;
+
+		case 2: /* RSSI */
+		{
+			char *endptr;
+			long val = strtol(ptr, &endptr, 10);
+			ap->rssi = (int8_t)val;
+			if (ap->rssi > 0)
+				ap->rssi = -ap->rssi;
+			if (ap->rssi < -100)
+				ap->rssi = -100;
+			ptr = endptr;
+			if (*ptr == ',')
+				ptr++;
+		} break;
+
+		case 3: /* MAC address */
+		{
+			if (*ptr == '"')
+				ptr++;
+			for (int i = 0; i < 6; i++) {
+				char *endptr;
+				unsigned long byte = strtoul(ptr, &endptr, 16);
+				if (byte > 255) {
+					printf("esp32c3: Invalid MAC byte\n");
+					return -1;
+				}
+				ap->bssid[i] = (uint8_t)byte;
+				ptr = endptr;
+				if (i < 5) {
+					if (*ptr == ':') {
+						ptr++;
+					}
+					else {
+						printf("esp32c3: MAC format error at byte %d\n", i);
+						return -1;
+					}
+				}
+			}
+			if (*ptr == '"')
+				ptr++;
+			if (*ptr == ',')
+				ptr++;
+		} break;
+
+		case 4: /* Channel */
+		{
+			char *endptr;
+			long val = strtol(ptr, &endptr, 10);
+			ap->channel = (uint8_t)val;
+			if (ap->channel < 1)
+				ap->channel = 1;
+			if (ap->channel > 14)
+				ap->channel = 14;
+			ptr = endptr;
+		} break;
+		}
+
+		field++;
+	}
+
+	if (field < 5) {
+		printf("esp32c3: incomplete parse, only %d fields\n", field);
+		return -1;
+	}
+
+	printf("esp32c3: parsed: ssid='%s', rssi=%d, ch=%d, sec=%d, "
+	       "mac=%02x:%02x:%02x:%02x:%02x:%02x\n",
+	    ap->ssid, ap->rssi, ap->channel, ap->security, ap->bssid[0],
+	    ap->bssid[1], ap->bssid[2], ap->bssid[3], ap->bssid[4], ap->bssid[5]);
+
+	return 0;
+}
+
+static int esp32c3_parse_mode_response(const char *resp, int *mode) {
+	char *p = strstr(resp, "+CWMODE:");
+	if (p) {
+		*mode = atoi(p + 8);
+		return 0;
+	}
+	return -EINVAL;
+}
+
+static bool esp32c3_parse_urc(struct wifi_core *wifi, const char *line) {
+	struct esp32c3_wifi *esp32 = (struct esp32c3_wifi *)wifi->hw_priv;
+
+	/* Connection error code */
+	if (strstr(line, "+CWJAP:")) {
+		int error_code;
+		if (sscanf(line, "+CWJAP:%d", &error_code) == 1) {
+			esp32->last_error_code = error_code;
+
+			int errno_val = esp32_error_to_errno(error_code);
+
+			wifi->connect_result = errno_val;
+			wifi->connect_done = true;
+
+			const char *error_msg = "";
+			switch (error_code) {
+			case 1:
+				error_msg = "connection timeout";
+				break;
+			case 2:
+				error_msg = "wrong password";
+				break;
+			case 3:
+				error_msg = "cannot find AP";
+				break;
+			case 4:
+				error_msg = "connection failed";
+				break;
+			default:
+				error_msg = "unknown error";
+				break;
+			}
+			printf("esp32c3: connection failed - %s (code=%d)\n", error_msg,
+			    error_code);
+		}
+		return true;
+	}
+
+	/* WiFi disconnect reason */
+	if (strstr(line, "WIFI DISCONNECT")) {
+		int reason = 0;
+		if (sscanf(line, "WIFI DISCONNECT,reason:%d", &reason) == 1) {
+			printf("esp32c3: disconnected with reason %d\n", reason);
+		}
+		return true;
+	}
+
+	/* Other ESP32-specific messages */
+	if (strstr(line, "+CWSTATE:") || strstr(line, "+DIST_STA_IP:")) {
+		return true;
+	}
+
+	return false;
+}
+
+/* Network configuration and status */
+static int esp32c3_get_ip_config(struct wifi_core *wifi, char *ip, char *mask,
+    char *gw) {
+	char resp[512];
+	char *line;
+	int ret;
+
+	ret = wifi_core_send_cmd(wifi, "AT+CIPSTA?", resp, sizeof(resp), 2000);
+	if (ret != 0) {
+		return ret;
+	}
+
+	line = strtok(resp, "\r\n");
+	while (line) {
+		char *colon = strstr(line, ":ip:");
+		if (colon) {
+			char *start = strchr(colon, '"');
+			if (start) {
+				start++;
+				char *end = strchr(start, '"');
+				if (end) {
+					size_t len = end - start;
+					if (len < 16) {
+						memcpy(ip, start, len);
+						ip[len] = '\0';
+					}
+				}
+			}
+		}
+
+		colon = strstr(line, ":gateway:");
+		if (colon) {
+			char *start = strchr(colon, '"');
+			if (start) {
+				start++;
+				char *end = strchr(start, '"');
+				if (end) {
+					size_t len = end - start;
+					if (len < 16) {
+						memcpy(gw, start, len);
+						gw[len] = '\0';
+					}
+				}
+			}
+		}
+
+		colon = strstr(line, ":netmask:");
+		if (colon) {
+			char *start = strchr(colon, '"');
+			if (start) {
+				start++;
+				char *end = strchr(start, '"');
+				if (end) {
+					size_t len = end - start;
+					if (len < 16) {
+						memcpy(mask, start, len);
+						mask[len] = '\0';
+					}
+				}
+			}
+		}
+
+		line = strtok(NULL, "\r\n");
+	}
+
+	return 0;
+}
+
+static int esp32c3_get_rssi(struct wifi_core *wifi, int8_t *rssi) {
+	char resp[256];
+	char *line;
+	int ret;
+
+	ret = wifi_core_send_cmd(wifi, "AT+CWJAP?", resp, sizeof(resp), 2000);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Parse format: +CWJAP:"ssid","bssid",channel,rssi */
+	line = strstr(resp, "+CWJAP:");
+	if (line) {
+		char *ptr = line;
+		int comma_count = 0;
+
+		/* Find the third comma */
+		while (*ptr != '\0' && comma_count < 3) {
+			if (*ptr == ',') {
+				comma_count++;
+			}
+			ptr++;
+		}
+
+		if (comma_count == 3) {
+			long val = strtol(ptr, NULL, 10);
+			*rssi = (int8_t)val;
+			return 0;
+		}
+	}
+
+	return -ENODATA;
+}
+
+/* Power management */
+int esp32c3_set_power_mode(struct wifi_core *wifi, int mode) {
+	char cmd[32];
+	char resp[256];
+	int sleep_mode;
+
+	/* Map to ESP32 sleep mode */
+	switch (mode) {
+	case WLAN_PWR_ACTIVE:
+		sleep_mode = 0; /* Disable sleep */
+		break;
+	case WLAN_PWR_SAVE:
+		sleep_mode = 1; /* Modem-sleep */
+		break;
+	case WLAN_PWR_DEEP_SAVE:
+		sleep_mode = 2; /* Light-sleep */
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	snprintf(cmd, sizeof(cmd), "AT+SLEEP=%d", sleep_mode);
+	int ret = wifi_core_send_cmd(wifi, cmd, resp, sizeof(resp), 2000);
+
+	if (ret == 0) {
+		struct esp32c3_wifi *esp32 = (struct esp32c3_wifi *)wifi->hw_priv;
+		esp32->power_mode = mode;
+
+		printf("esp32c3: power mode set to %s\n",
+		    mode == WLAN_PWR_ACTIVE ? "active"
+		    : mode == WLAN_PWR_SAVE ? "power save"
+		                            : "deep save");
+	}
+
+	return ret;
+}
+
+int esp32c3_get_power_mode(struct wifi_core *wifi, int *mode) {
+	struct esp32c3_wifi *esp32 = (struct esp32c3_wifi *)wifi->hw_priv;
+	char resp[256];
+	int ret;
+
+	ret = wifi_core_send_cmd(wifi, "AT+SLEEP?", resp, sizeof(resp), 1000);
+	if (ret == 0) {
+		char *p = strstr(resp, "+SLEEP:");
+		if (p) {
+			int sleep_mode = atoi(p + 7);
+			switch (sleep_mode) {
+			case 0:
+				*mode = WLAN_PWR_ACTIVE;
+				break;
+			case 1:
+				*mode = WLAN_PWR_SAVE;
+				break;
+			case 2:
+				*mode = WLAN_PWR_DEEP_SAVE;
+				break;
+			default:
+				return -EINVAL;
+			}
+			esp32->power_mode = *mode;
+			return 0;
+		}
+	}
+
+	return -EIO;
+}
+
+int esp32c3_wifi_init_fd(struct net_device *netdev, int fd) {
+	struct esp32c3_wifi *esp32;
+	struct wlan_device *wdev;
+	int ret;
+
+	printf("esp32c3_wifi_init_fd: entering with fd=%d\n", fd);
+
+	if (!netdev || fd < 0) {
+		printf("esp32c3_wifi_init_fd: invalid params\n");
+		return -EINVAL;
+	}
+
+	/* Set wireless_ops before wlan_device_init */
+	netdev->wireless_ops = &wifi_core_ops;
+
+	/* Initialize WLAN device if needed */
+	if (!(netdev->flags & IFF_WIRELESS)) {
+		ret = wlan_device_init(netdev);
+		if (ret != 0) {
+			printf("esp32c3_wifi_init_fd: wlan_device_init failed with %d\n", ret);
+			netdev->wireless_ops = NULL;
+			return ret;
+		}
+		printf("esp32c3_wifi_init_fd: wlan_device initialized\n");
+	}
+
+	wdev = netdev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	/* Allocate ESP32 driver structure */
+	esp32 = sysmalloc(sizeof(*esp32));
+	if (!esp32) {
+		return -ENOMEM;
+	}
+	memset(esp32, 0, sizeof(*esp32));
+
+	/* Create AT client */
+	esp32->at_client = sysmalloc(sizeof(at_client_t));
+	if (!esp32->at_client) {
+		sysfree(esp32);
+		return -ENOMEM;
+	}
+
+	/* Initialize AT client with FD */
+	ret = at_client_init_fd(esp32->at_client, fd);
+	if (ret != 0) {
+		printf("esp32c3: failed to init AT client with fd %d\n", fd);
+		sysfree(esp32->at_client);
+		sysfree(esp32);
+		return ret;
+	}
+
+	/* Mark that we don't own this fd */
+	esp32->owns_at_client_fd = false;
+
+	/* Configure AT client */
+	at_client_set_mode(esp32->at_client, AT_CLIENT_MODE_NORMAL);
+
+#ifdef CONFIG_ESP32C3_AT_DEBUG
+	at_client_enable_debug(esp32->at_client, true);
+	printf("esp32c3: AT debug enabled\n");
+#endif
+
+	/* Initialize WiFi Core */
+	ret = wifi_core_setup(&esp32->core, netdev, esp32->at_client, &esp32c3_ops,
+	    esp32);
+	if (ret != 0) {
+		printf("esp32c3: failed to init wifi core\n");
+		at_client_close(esp32->at_client);
+		sysfree(esp32->at_client);
+		sysfree(esp32);
+		return ret;
+	}
+
+	/* Register driver type */
+	ret = wlan_device_register_driver(netdev, WLAN_DRV_WIFI_CORE, &esp32->core);
+	if (ret != 0) {
+		printf("esp32c3: failed to register driver type\n");
+		wifi_core_cleanup(&esp32->core);
+		at_client_close(esp32->at_client);
+		sysfree(esp32->at_client);
+		sysfree(esp32);
+		return ret;
+	}
+
+	printf("esp32c3: driver initialized on fd %d\n", fd);
+	return 0;
+}
+
+int esp32c3_wifi_init(struct net_device *netdev, const char *uart_path) {
+	int fd;
+	int ret;
+
+	if (!netdev || !uart_path) {
+		return -EINVAL;
+	}
+
+	fd = open(uart_path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd < 0) {
+		printf("esp32c3: failed to open %s: %s\n", uart_path, strerror(errno));
+		return -EIO;
+	}
+
+	ret = esp32c3_wifi_init_fd(netdev, fd);
+	if (ret != 0) {
+		close(fd);
+		return ret;
+	}
+
+	/* Mark that we own this fd */
+	struct wlan_device *wdev = netdev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+	struct esp32c3_wifi *esp32 = wifi->hw_priv;
+	esp32->owns_at_client_fd = true;
+
+	printf("esp32c3: driver initialized on %s\n", uart_path);
+	return 0;
+}
+
+void esp32c3_wifi_cleanup(struct net_device *netdev) {
+	struct wlan_device *wdev;
+	struct wifi_core *wifi;
+	struct esp32c3_wifi *esp32;
+
+	if (!netdev || !(netdev->flags & IFF_WIRELESS)) {
+		return;
+	}
+
+	wdev = netdev->wireless_priv;
+	if (!wdev || !wdev->priv) {
+		return;
+	}
+
+	wifi = (struct wifi_core *)wdev->priv;
+	esp32 = (struct esp32c3_wifi *)wifi->hw_priv;
+
+	wifi_core_cleanup(wifi);
+
+	if (esp32->at_client) {
+		at_client_close(esp32->at_client);
+		sysfree(esp32->at_client);
+		esp32->at_client = NULL;
+	}
+
+	sysfree(esp32);
+
+	wlan_device_cleanup(netdev);
+
+	printf("esp32c3: driver cleaned up\n");
+}

--- a/project/at/src/drivers/net/wifi/esp32c3/esp32c3_wifi.h
+++ b/project/at/src/drivers/net/wifi/esp32c3/esp32c3_wifi.h
@@ -1,0 +1,79 @@
+/**
+ * @file
+ * @brief ESP32-C3 WiFi Driver Header
+ *
+ * @date Aug 6, 2025
+ * @author Peize Li
+ */
+
+#ifndef DRIVERS_NET_ESP32C3_WIFI_H_
+#define DRIVERS_NET_ESP32C3_WIFI_H_
+
+#include <at/at_client.h>
+#include <net/netdevice.h>
+#include <wifi/wifi_core.h>
+
+/**
+ * @brief ESP32-C3 WiFi driver structure
+ */
+struct esp32c3_wifi {
+	struct wifi_core core;  /* WiFi Core instance */
+	at_client_t *at_client; /* AT client */
+
+	bool owns_at_client_fd; /* Ownership flag for AT client file descriptor */
+
+	/* ESP32 specific data */
+	int wifi_mode; /* 1=STA, 2=AP, 3=STA+AP */
+	bool initialized;
+	char fw_version[64];
+
+	/* Connection error code mapping */
+	int last_error_code;
+
+	int power_mode; /* Current power mode */
+};
+
+/**
+ * @brief Initialize ESP32-C3 WiFi driver with file descriptor
+ *
+ * @param netdev Network device
+ * @param fd Open file descriptor (e.g., PTY, socket)
+ * @return 0 on success, negative on error
+ */
+extern int esp32c3_wifi_init_fd(struct net_device *netdev, int fd);
+
+/**
+ * @brief Initialize ESP32-C3 WiFi driver
+ *
+ * @param netdev Network device
+ * @param uart_path UART device path (e.g. "/dev/ttyS1")
+ * @return 0 on success, negative on error
+ */
+extern int esp32c3_wifi_init(struct net_device *netdev, const char *uart_path);
+
+/**
+ * @brief Cleanup ESP32-C3 WiFi driver
+ *
+ * @param netdev Network device
+ */
+extern void esp32c3_wifi_cleanup(struct net_device *netdev);
+
+/**
+ * @brief Set power mode
+ *
+ * @param wifi WiFi core instance
+ * @param mode Power mode (WLAN_PWR_ACTIVE, WLAN_PWR_SAVE, WLAN_PWR_DEEP_SAVE)
+ * @return 0 on success, negative on error
+ */
+extern int esp32c3_set_power_mode(struct wifi_core *wifi, int mode);
+
+/**
+ * @brief Get current power mode
+ *
+ * @param wifi WiFi core instance
+ * @param mode Pointer to store current power mode
+ * @return 0 on success, negative on error
+ */
+extern int esp32c3_get_power_mode(struct wifi_core *wifi, int *mode);
+
+#endif /* DRIVERS_NET_ESP32C3_WIFI_H_ */

--- a/project/at/src/drivers/net/wifi/wifi_core.c
+++ b/project/at/src/drivers/net/wifi/wifi_core.c
@@ -1,0 +1,747 @@
+/**
+ * @file
+ * @brief WiFi Core Framework Implementation
+ * 
+ * @date July 31, 2025
+ * @author Peize Li
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <mem/sysmalloc.h>
+#include <net/wlan/wireless_ioctl.h>
+#include <wifi/wifi_core.h>
+
+#define WIFI_SCAN_CACHE_DEFAULT 20
+#define WIFI_RESP_BUFFER_SIZE   4096
+
+/* Forward declarations */
+static void wifi_core_urc_handler(const char *line, void *arg);
+static void wifi_connect_timeout(struct sys_timer *timer, void *arg);
+static int wifi_core_scan(struct net_device *dev);
+static int wifi_core_connect(struct net_device *dev, const char *ssid,
+    const char *pwd);
+static int wifi_core_disconnect(struct net_device *dev);
+static int wifi_core_set_mode(struct net_device *dev, int mode);
+static int wifi_core_get_mode(struct net_device *dev, int *mode);
+static int wifi_core_dev_init(struct net_device *dev);
+static void wifi_core_dev_deinit(struct net_device *dev);
+static int wifi_core_get_rssi(struct net_device *dev, int8_t *rssi);
+static int wifi_core_set_power_mode(struct net_device *dev, int mode);
+
+/* ===================================================================
+ * Static Helper Functions
+ * =================================================================== */
+
+/**
+ * @brief Set WiFi state with thread safety
+ */
+static void wifi_set_state(struct wifi_core *wifi, enum wifi_core_state state) {
+	mutex_lock(&wifi->state_lock);
+	wifi_core_debug(wifi, "state: %d -> %d", wifi->state, state);
+	wifi->state = state;
+	mutex_unlock(&wifi->state_lock);
+}
+
+/**
+ * @brief Connection timeout handler
+ */
+static void wifi_connect_timeout(struct sys_timer *timer, void *arg) {
+	struct wifi_core *wifi = (struct wifi_core *)arg;
+
+	if (!wifi->timer_active) {
+		return;
+	}
+
+	wifi->timer_active = false;
+
+	if (!wifi->connect_done) {
+		wifi_core_error(wifi, "connect timeout in state %d", wifi->state);
+		wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+		wlan_device_set_state(wifi->netdev, WLAN_STATE_UP);
+
+		mutex_lock(&wifi->conn_lock);
+		wifi->conn_info.connected = false;
+		memset(&wifi->conn_info, 0, sizeof(wifi->conn_info));
+		mutex_unlock(&wifi->conn_lock);
+
+		wifi->connect_result = -ETIMEDOUT;
+		wifi->connect_done = true;
+
+		wifi->stats.connect_failures++;
+	}
+}
+
+/**
+ * @brief URC (Unsolicited Result Code) handler
+ */
+static void wifi_core_urc_handler(const char *line, void *arg) {
+	struct wifi_core *wifi = (struct wifi_core *)arg;
+	const struct wifi_hw_ops *ops = wifi->hw_ops;
+
+	if (wifi->config.debug_urc) {
+		printf("wifi_core URC: %s\n", line);
+	}
+
+	/* Handle connect command response */
+	if (wifi->state == WIFI_CORE_STATE_CONNECTING) {
+		if (strstr(line, "OK") && !strstr(line, "+")) {
+			wifi_set_state(wifi, WIFI_CORE_STATE_WAIT_CONNECTED);
+			return;
+		}
+		if (strstr(line, "FAIL") || strstr(line, "ERROR")) {
+			if (wifi->timer_active) {
+				wifi->timer_active = false;
+				timer_stop(&wifi->connect_timer);
+			}
+			wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+			wlan_device_set_state(wifi->netdev, WLAN_STATE_UP);
+			wifi->stats.connect_failures++;
+
+			wifi->connect_result = -ECONNREFUSED;
+			wifi->connect_done = true;
+			return;
+		}
+	}
+
+	/* Handle connected URC */
+	if (ops->urc_patterns.connected && strstr(line, ops->urc_patterns.connected)) {
+		if (wifi->state == WIFI_CORE_STATE_WAIT_CONNECTED
+		    || wifi->state == WIFI_CORE_STATE_CONNECTING) {
+			wifi_set_state(wifi, WIFI_CORE_STATE_WAIT_IP);
+
+			mutex_lock(&wifi->conn_lock);
+			wifi->conn_info.connected = true;
+			strcpy(wifi->conn_info.ssid, wifi->connect_req.ssid);
+			mutex_unlock(&wifi->conn_lock);
+		}
+		return;
+	}
+
+	/* Handle got IP URC */
+	if (ops->urc_patterns.got_ip && strstr(line, ops->urc_patterns.got_ip)) {
+		if (wifi->state == WIFI_CORE_STATE_WAIT_IP) {
+			if (wifi->timer_active) {
+				wifi->timer_active = false;
+				timer_stop(&wifi->connect_timer);
+			}
+
+			wifi_set_state(wifi, WIFI_CORE_STATE_CONNECTED);
+			wlan_device_set_state(wifi->netdev, WLAN_STATE_CONNECTED);
+
+			if (wifi->hw_ops->get_ip_config) {
+				mutex_lock(&wifi->conn_lock);
+				wifi->hw_ops->get_ip_config(wifi, wifi->conn_info.ip_addr,
+				    wifi->conn_info.netmask, wifi->conn_info.gateway);
+				wifi->conn_info.has_ip = true;
+				mutex_unlock(&wifi->conn_lock);
+
+				printf("wifi_core: connected to %s with IP %s\n",
+				    wifi->conn_info.ssid, wifi->conn_info.ip_addr);
+			}
+
+			wifi->connect_result = 0;
+			wifi->connect_done = true;
+
+			wifi->stats.connect_attempts++;
+		}
+		return;
+	}
+
+	/* Handle disconnect URC */
+	if (ops->urc_patterns.disconnected
+	    && strstr(line, ops->urc_patterns.disconnected)) {
+		if (wifi->timer_active) {
+			wifi->timer_active = false;
+			timer_stop(&wifi->connect_timer);
+		}
+
+		mutex_lock(&wifi->conn_lock);
+		bool was_connected = wifi->conn_info.connected;
+		wifi->conn_info.connected = false;
+		wifi->conn_info.has_ip = false;
+		mutex_unlock(&wifi->conn_lock);
+
+		wifi->disconnect_done = true;
+
+		if (!wifi->connect_done
+		    && (wifi->state == WIFI_CORE_STATE_CONNECTING
+		        || wifi->state == WIFI_CORE_STATE_WAIT_CONNECTED
+		        || wifi->state == WIFI_CORE_STATE_WAIT_IP)) {
+			wifi->connect_result = -ECONNABORTED;
+			wifi->connect_done = true;
+		}
+
+		if (was_connected) {
+			wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+			wlan_device_set_state(wifi->netdev, WLAN_STATE_UP);
+			printf("wifi_core: disconnected\n");
+		}
+		return;
+	}
+
+	/* Let hardware specific handler process other URCs */
+	if (wifi->hw_ops->parse_urc) {
+		bool handled = wifi->hw_ops->parse_urc(wifi, line);
+		if (handled) {
+			wifi->stats.rx_packets++;
+			return;
+		}
+	}
+
+	if (wifi->config.debug_urc) {
+		printf("wifi_core: unhandled URC: %s\n", line);
+	}
+
+	wifi->stats.rx_packets++;
+}
+
+/* ===================================================================
+ * WiFi Operations Implementation
+ * =================================================================== */
+
+static int wifi_core_dev_init(struct net_device *dev) {
+	/* Called by wlan_device_init after wifi_core instance is created */
+	return 0;
+}
+
+static void wifi_core_dev_deinit(struct net_device *dev) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	if (wdev && wdev->priv) {
+		struct wifi_core *wifi = wdev->priv;
+		wifi_core_cleanup(wifi);
+	}
+}
+
+static int wifi_core_scan(struct net_device *dev) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+	char *resp;
+	const char *scan_cmd = NULL;
+	int ret = -EINVAL;
+
+	resp = sysmalloc(WIFI_RESP_BUFFER_SIZE);
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	wlan_device_set_state(dev, WLAN_STATE_SCANNING);
+	wifi_set_state(wifi, WIFI_CORE_STATE_SCANNING);
+
+	mutex_lock(&wifi->scan_lock);
+	wifi->scan.count = 0;
+	mutex_unlock(&wifi->scan_lock);
+
+	if (wifi->hw_ops->get_scan_cmd) {
+		scan_cmd = wifi->hw_ops->get_scan_cmd();
+	}
+	else if (wifi->hw_ops->basic_cmds.scan) {
+		scan_cmd = wifi->hw_ops->basic_cmds.scan;
+	}
+
+	if (!scan_cmd) {
+		wifi_core_error(wifi, "no scan command defined");
+		ret = -EOPNOTSUPP;
+	}
+	else {
+		ret = wifi_core_send_cmd(wifi, scan_cmd, resp, WIFI_RESP_BUFFER_SIZE,
+		    wifi->hw_ops->timeouts.scan_ms);
+
+		if (ret == 0) {
+			char *line = strtok(resp, "\r\n");
+			int line_count = 0;
+
+			while (line && wifi->scan.count < wifi->scan.capacity) {
+				printf("wifi_core_scan: line %d: '%s'\n", line_count++, line);
+
+				struct wlan_scan_ap ap;
+				if (wifi->hw_ops->parse_scan_line(line, &ap) == 0) {
+					mutex_lock(&wifi->scan_lock);
+					memcpy(&wifi->scan.aps[wifi->scan.count], &ap, sizeof(ap));
+					wifi->scan.count++;
+					mutex_unlock(&wifi->scan_lock);
+
+					wifi_core_debug(wifi, "found AP: %s, rssi=%d", ap.ssid,
+					    ap.rssi);
+				}
+
+				line = strtok(NULL, "\r\n");
+			}
+
+			mutex_lock(&wdev->lock);
+			wdev->scan_result.aps = wifi->scan.aps;
+			wdev->scan_result.count = wifi->scan.count;
+			mutex_unlock(&wdev->lock);
+
+			printf("wifi_core: scan complete, found %d APs\n", wifi->scan.count);
+		}
+	}
+
+	if (wifi->state == WIFI_CORE_STATE_CONNECTED) {
+		wlan_device_set_state(dev, WLAN_STATE_CONNECTED);
+	}
+	else {
+		wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+		wlan_device_set_state(dev, WLAN_STATE_UP);
+	}
+
+	sysfree(resp);
+	return ret;
+}
+
+static int wifi_core_connect(struct net_device *dev, const char *ssid,
+    const char *pwd) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+	char cmd[256];
+	int ret;
+	int retry_count = 0;
+
+	if (!ssid || strlen(ssid) > 32) {
+		return -EINVAL;
+	}
+
+	/* Disconnect if already connected */
+	if (wifi->conn_info.connected) {
+		wifi->disconnect_done = false;
+		wifi_core_disconnect(dev);
+
+		/* Wait for disconnect completion (max 3 seconds) */
+		for (retry_count = 0; retry_count < 30 && !wifi->disconnect_done;
+		     retry_count++) {
+			at_client_process_rx(wifi->at_client);
+			usleep(100000); /* 100ms */
+		}
+
+		if (!wifi->disconnect_done) {
+			printf("wifi_core: disconnect timeout\n");
+		}
+	}
+
+	/* Save connection parameters */
+	mutex_lock(&wifi->conn_lock);
+	strncpy(wifi->connect_req.ssid, ssid, 32);
+	wifi->connect_req.ssid[32] = '\0';
+	if (pwd) {
+		strncpy(wifi->connect_req.password, pwd, 64);
+		wifi->connect_req.password[64] = '\0';
+		wifi->connect_req.has_password = true;
+	}
+	else {
+		wifi->connect_req.has_password = false;
+	}
+	mutex_unlock(&wifi->conn_lock);
+
+	/* Build connect command */
+	ret = wifi->hw_ops->build_connect_cmd(cmd, sizeof(cmd), ssid, pwd);
+	if (ret != 0) {
+		return -EINVAL;
+	}
+
+	wifi->connect_done = false;
+	wifi->connect_result = -EINPROGRESS;
+
+	wifi_set_state(wifi, WIFI_CORE_STATE_CONNECTING);
+
+	/* Start timeout timer */
+	wifi->timer_active = true;
+	timer_init_start_msec(&wifi->connect_timer, TIMER_ONESHOT,
+	    wifi->hw_ops->timeouts.connect_ms, wifi_connect_timeout, wifi);
+
+	/* Send connect command */
+	at_result_t result = at_client_send(wifi->at_client, cmd, NULL, 0, 1000);
+
+	if (result != AT_OK) {
+		wifi->timer_active = false;
+		timer_stop(&wifi->connect_timer);
+		wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+		wlan_device_set_state(dev, WLAN_STATE_UP);
+
+		printf("wifi_core: failed to send connect command\n");
+		return -EIO;
+	}
+
+	/* Wait for connection completion */
+	uint32_t wait_ms = 0;
+	while (!wifi->connect_done && wait_ms < wifi->hw_ops->timeouts.connect_ms) {
+		at_client_process_rx(wifi->at_client);
+		usleep(50000); /* 50ms */
+		wait_ms += 50;
+	}
+
+	if (wifi->timer_active) {
+		wifi->timer_active = false;
+		timer_stop(&wifi->connect_timer);
+	}
+
+	if (wifi->connect_done) {
+		return wifi->connect_result;
+	}
+	else {
+		wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+		wlan_device_set_state(dev, WLAN_STATE_UP);
+		return -ETIMEDOUT;
+	}
+}
+
+static int wifi_core_disconnect(struct net_device *dev) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+	const char *disconnect_cmd;
+	char resp[256];
+	int ret;
+
+	timer_stop(&wifi->connect_timer);
+
+	if (wifi->hw_ops->get_disconnect_cmd) {
+		disconnect_cmd = wifi->hw_ops->get_disconnect_cmd();
+	}
+	else if (wifi->hw_ops->basic_cmds.disconnect) {
+		disconnect_cmd = wifi->hw_ops->basic_cmds.disconnect;
+	}
+	else {
+		wifi_core_error(wifi, "no disconnect command defined");
+		return -EOPNOTSUPP;
+	}
+
+	ret = wifi_core_send_cmd(wifi, disconnect_cmd, resp, sizeof(resp),
+	    wifi->hw_ops->timeouts.cmd_ms);
+
+	mutex_lock(&wifi->conn_lock);
+	wifi->conn_info.connected = false;
+	wifi->conn_info.has_ip = false;
+	memset(&wifi->conn_info, 0, sizeof(wifi->conn_info));
+	mutex_unlock(&wifi->conn_lock);
+
+	wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+	wlan_device_set_state(dev, WLAN_STATE_UP);
+
+	mutex_lock(&wdev->lock);
+	memset(&wdev->connected, 0, sizeof(wdev->connected));
+	mutex_unlock(&wdev->lock);
+
+	if (ret == 0) {
+		printf("wifi_core: disconnected\n");
+	}
+
+	return ret;
+}
+
+static int wifi_core_get_rssi(struct net_device *dev, int8_t *rssi) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+
+	if (!wifi->conn_info.connected) {
+		return -ENOTCONN;
+	}
+
+	if (wifi->hw_ops->get_rssi) {
+		return wifi->hw_ops->get_rssi(wifi, rssi);
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static int wifi_core_set_power_mode(struct net_device *dev, int mode) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+
+	if (wifi->hw_ops->set_power_mode) {
+		return wifi->hw_ops->set_power_mode(wifi, mode);
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static int wifi_core_get_power_mode(struct net_device *dev, int *mode) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+
+	if (wifi->hw_ops->get_power_mode) {
+		return wifi->hw_ops->get_power_mode(wifi, mode);
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static int wifi_core_set_mode(struct net_device *dev, int mode) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+	char cmd[64];
+	char resp[256];
+
+	if (!wifi->hw_ops->mode_cmds.set_mode_fmt) {
+		return -EOPNOTSUPP;
+	}
+
+	snprintf(cmd, sizeof(cmd), wifi->hw_ops->mode_cmds.set_mode_fmt, mode);
+	return wifi_core_send_cmd(wifi, cmd, resp, sizeof(resp), 1000);
+}
+
+static int wifi_core_get_mode(struct net_device *dev, int *mode) {
+	struct wlan_device *wdev = dev->wireless_priv;
+	struct wifi_core *wifi = wdev->priv;
+	char resp[256];
+
+	if (!wifi->hw_ops->mode_cmds.get_mode) {
+		return -EOPNOTSUPP;
+	}
+
+	int ret = wifi_core_send_cmd(wifi, wifi->hw_ops->mode_cmds.get_mode, resp,
+	    sizeof(resp), 1000);
+	if (ret == 0) {
+		if (wifi->hw_ops->parse_mode_response) {
+			return wifi->hw_ops->parse_mode_response(resp, mode);
+		}
+	}
+	return -EIO;
+}
+
+/* ===================================================================
+ * Public API Functions
+ * =================================================================== */
+
+int wifi_core_setup(struct wifi_core *wifi, struct net_device *netdev,
+    at_client_t *at_client, const struct wifi_hw_ops *hw_ops, void *hw_priv) {
+	int ret;
+
+	if (!wifi || !netdev || !at_client || !hw_ops) {
+		return -EINVAL;
+	}
+
+	if (!hw_ops->hw_init || !hw_ops->parse_scan_line || !hw_ops->build_connect_cmd) {
+		printf("wifi_core: missing required operations\n");
+		return -EINVAL;
+	}
+
+	memset(wifi, 0, sizeof(*wifi));
+
+	wifi->netdev = netdev;
+	wifi->at_client = at_client;
+	wifi->hw_ops = hw_ops;
+	wifi->hw_priv = hw_priv;
+	wifi->connect_done = true;
+	wifi->disconnect_done = true;
+	wifi->timer_active = false;
+	wifi->connect_result = 0;
+
+	mutex_init(&wifi->state_lock);
+	mutex_init(&wifi->conn_lock);
+	mutex_init(&wifi->scan_lock);
+
+	wifi->state = WIFI_CORE_STATE_UNINIT;
+
+	wifi->config.auto_reconnect = false;
+	wifi->config.retry_count = 3;
+	wifi->config.retry_delay_ms = 1000;
+
+	wifi->scan.capacity = WIFI_SCAN_CACHE_DEFAULT;
+	wifi->scan.aps = sysmalloc(wifi->scan.capacity * sizeof(struct wlan_scan_ap));
+	if (!wifi->scan.aps) {
+		return -ENOMEM;
+	}
+
+	at_client_set_urc_handler(at_client, wifi_core_urc_handler, wifi);
+
+	if (netdev->wireless_priv) {
+		struct wlan_device *wdev = netdev->wireless_priv;
+		wdev->priv = wifi;
+	}
+
+	ret = hw_ops->hw_init(wifi);
+	if (ret != 0) {
+		printf("wifi_core: hardware init failed: %d\n", ret);
+		sysfree(wifi->scan.aps);
+		return ret;
+	}
+
+	wifi_set_state(wifi, WIFI_CORE_STATE_IDLE);
+	wlan_device_set_state(netdev, WLAN_STATE_UP);
+
+	printf("wifi_core: initialized for %s\n", netdev->name);
+	return 0;
+}
+
+void wifi_core_cleanup(struct wifi_core *wifi) {
+	if (!wifi) {
+		return;
+	}
+
+	if (wifi->timer_active) {
+		wifi->timer_active = false;
+		timer_stop(&wifi->connect_timer);
+	}
+
+	/* Only disconnect if connected */
+	if (wifi->state == WIFI_CORE_STATE_CONNECTED && wifi->conn_info.connected) {
+		const char *disconnect_cmd = NULL;
+
+		if (wifi->hw_ops->get_disconnect_cmd) {
+			disconnect_cmd = wifi->hw_ops->get_disconnect_cmd();
+		}
+		else if (wifi->hw_ops->basic_cmds.disconnect) {
+			disconnect_cmd = wifi->hw_ops->basic_cmds.disconnect;
+		}
+
+		if (disconnect_cmd) {
+			char resp[64];
+			wifi_core_send_cmd(wifi, disconnect_cmd, resp, sizeof(resp), 500);
+		}
+		else {
+			wifi_core_error(wifi, "no disconnect command defined, skipping "
+			                      "disconnect");
+		}
+	}
+
+	if (wifi->hw_ops->hw_cleanup) {
+		wifi->hw_ops->hw_cleanup(wifi);
+	}
+
+	at_client_set_urc_handler(wifi->at_client, NULL, NULL);
+
+	mutex_lock(&wifi->scan_lock);
+	if (wifi->scan.aps) {
+		sysfree(wifi->scan.aps);
+		wifi->scan.aps = NULL;
+	}
+	mutex_unlock(&wifi->scan_lock);
+
+	wifi_set_state(wifi, WIFI_CORE_STATE_UNINIT);
+	wlan_device_set_state(wifi->netdev, WLAN_STATE_DOWN);
+
+	printf("wifi_core: cleaned up\n");
+}
+
+int wifi_core_send_cmd(struct wifi_core *wifi, const char *cmd, char *resp,
+    size_t resp_size, uint32_t timeout_ms) {
+	at_result_t result;
+
+	if (timeout_ms == 0) {
+		timeout_ms = wifi->hw_ops->timeouts.cmd_ms;
+	}
+
+	wifi_core_debug(wifi, "sending: %s", cmd);
+
+	result = at_client_send(wifi->at_client, cmd, resp, resp_size, timeout_ms);
+
+	if (result != AT_OK) {
+		wifi_core_debug(wifi, "command failed: %d", result);
+		wifi->stats.tx_errors++;
+		return -EIO;
+	}
+
+	if (resp && resp_size > 0) {
+		int resp_len = strlen(resp);
+		printf("wifi_core: received %d bytes response\n", resp_len);
+		if (resp_len > 0) {
+			char debug_buf[101];
+			strncpy(debug_buf, resp, 100);
+			debug_buf[100] = '\0';
+			printf("wifi_core: response preview: %s%s\n", debug_buf,
+			    resp_len > 100 ? "..." : "");
+		}
+	}
+
+	wifi->stats.tx_packets++;
+	return 0;
+}
+
+void wifi_core_set_auto_reconnect(struct wifi_core *wifi, bool enable) {
+	if (wifi) {
+		wifi->config.auto_reconnect = enable;
+	}
+}
+
+void wifi_core_set_retry_params(struct wifi_core *wifi, int count,
+    uint32_t delay_ms) {
+	if (wifi) {
+		wifi->config.retry_count = count;
+		wifi->config.retry_delay_ms = delay_ms;
+	}
+}
+
+void wifi_core_set_debug_urc(struct wifi_core *wifi, bool enable) {
+	if (wifi) {
+		wifi->config.debug_urc = enable;
+	}
+}
+
+bool wifi_core_is_connected(struct wifi_core *wifi) {
+	bool connected;
+
+	if (!wifi) {
+		return false;
+	}
+
+	mutex_lock(&wifi->conn_lock);
+	connected = wifi->conn_info.connected;
+	mutex_unlock(&wifi->conn_lock);
+
+	return connected;
+}
+
+bool wifi_core_has_ip(struct wifi_core *wifi) {
+	bool has_ip;
+
+	if (!wifi) {
+		return false;
+	}
+
+	mutex_lock(&wifi->conn_lock);
+	has_ip = wifi->conn_info.has_ip;
+	mutex_unlock(&wifi->conn_lock);
+
+	return has_ip;
+}
+
+int wifi_core_get_connection_info(struct wifi_core *wifi, char *ssid, char *ip,
+    int8_t *rssi) {
+	if (!wifi || !wifi->conn_info.connected) {
+		return -ENOTCONN;
+	}
+
+	mutex_lock(&wifi->conn_lock);
+
+	if (ssid) {
+		strcpy(ssid, wifi->conn_info.ssid);
+	}
+	if (ip) {
+		strcpy(ip, wifi->conn_info.ip_addr);
+	}
+	if (rssi) {
+		/* Try to get real-time RSSI value */
+		if (wifi->hw_ops->get_rssi) {
+			if (wifi->hw_ops->get_rssi(wifi, rssi) != 0) {
+				*rssi = wifi->conn_info.rssi;
+			}
+		}
+		else {
+			*rssi = wifi->conn_info.rssi;
+		}
+	}
+
+	mutex_unlock(&wifi->conn_lock);
+
+	return 0;
+}
+
+/* ===================================================================
+ * WiFi Core Operations Structure
+ * =================================================================== */
+
+const struct wireless_ops wifi_core_ops = {
+    .init = wifi_core_dev_init,
+    .deinit = wifi_core_dev_deinit,
+    .scan = wifi_core_scan,
+    .connect = wifi_core_connect,
+    .disconnect = wifi_core_disconnect,
+    .get_rssi = wifi_core_get_rssi,
+    .set_power_mode = wifi_core_set_power_mode,
+    .get_power_mode = wifi_core_get_power_mode,
+    .set_mode = wifi_core_set_mode,
+    .get_mode = wifi_core_get_mode,
+};

--- a/project/at/src/drivers/net/wifi/wifi_core.h
+++ b/project/at/src/drivers/net/wifi/wifi_core.h
@@ -1,0 +1,270 @@
+/**
+ * @file
+ * @brief WiFi Core Framework Header
+ * 
+ * @date July 31, 2025
+ * @author Peize Li
+ */
+
+#ifndef DRIVERS_NET_WIFI_CORE_H_
+#define DRIVERS_NET_WIFI_CORE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <at/at_client.h>
+#include <kernel/printk.h>
+#include <kernel/thread/sync/mutex.h>
+#include <kernel/time/timer.h>
+#include <net/netdevice.h>
+#include <net/wlan/wlan_core.h>
+
+/* WiFi Core states */
+enum wifi_core_state {
+	WIFI_CORE_STATE_UNINIT = 0,
+	WIFI_CORE_STATE_IDLE,
+	WIFI_CORE_STATE_SCANNING,
+	WIFI_CORE_STATE_CONNECTING,
+	WIFI_CORE_STATE_WAIT_CONNECTED, /* Waiting for CONNECTED URC */
+	WIFI_CORE_STATE_WAIT_IP,        /* Waiting for GOT IP URC */
+	WIFI_CORE_STATE_CONNECTED,
+	WIFI_CORE_STATE_ERROR
+};
+
+/* Forward declarations */
+struct wifi_core;
+
+/**
+ * @brief WiFi hardware operations interface
+ */
+struct wifi_hw_ops {
+	/* Hardware init/cleanup */
+	int (*hw_init)(struct wifi_core *wifi);
+	void (*hw_cleanup)(struct wifi_core *wifi);
+
+	/* Scan operations */
+	int (*parse_scan_line)(const char *line, struct wlan_scan_ap *ap);
+	const char *(*get_scan_cmd)(void);
+
+	/* Connection operations */
+	int (*build_connect_cmd)(char *buf, size_t size, const char *ssid,
+	    const char *pwd);
+	const char *(*get_disconnect_cmd)(void);
+
+	/* IP configuration */
+	int (*get_ip_config)(struct wifi_core *wifi, char *ip, char *mask, char *gw);
+
+	/* URC handler - returns true if handled */
+	bool (*parse_urc)(struct wifi_core *wifi, const char *line);
+
+	/* Signal strength */
+	int (*get_rssi)(struct wifi_core *wifi, int8_t *rssi);
+
+	/* Timeout configuration */
+	struct {
+		uint32_t scan_ms;
+		uint32_t connect_ms;
+		uint32_t cmd_ms;
+	} timeouts;
+
+	struct {
+		const char *connected;    /* e.g. "WIFI CONNECTED" */
+		const char *got_ip;       /* e.g. "WIFI GOT IP" */
+		const char *disconnected; /* e.g. "WIFI DISCONNECT" */
+	} urc_patterns;
+
+	struct {
+		const char *scan;       /* e.g. "AT+CWLAP" */
+		const char *disconnect; /* e.g. "AT+CWQAP" */
+	} basic_cmds;
+
+	struct {
+		const char *get_mode;     /* e.g. "AT+CWMODE?" */
+		const char *set_mode_fmt; /* e.g. "AT+CWMODE=%d" */
+	} mode_cmds;
+
+	int (*parse_mode_response)(const char *resp, int *mode);
+	int (*set_power_mode)(struct wifi_core *wifi, int mode);
+	int (*get_power_mode)(struct wifi_core *wifi, int *mode);
+};
+
+/**
+ * @brief WiFi Core Driver structure
+ */
+struct wifi_core {
+	/* Associated network device */
+	struct net_device *netdev;
+
+	/* AT communication client */
+	at_client_t *at_client;
+
+	/* Hardware operations */
+	const struct wifi_hw_ops *hw_ops;
+
+	/* State machine */
+	enum wifi_core_state state;
+	struct mutex state_lock;
+
+	/* Current connection info */
+	struct {
+		char ssid[33];
+		char ip_addr[16];
+		char netmask[16];
+		char gateway[16];
+		int8_t rssi;
+		bool connected;
+		bool has_ip;
+	} conn_info;
+	struct mutex conn_lock;
+
+	/* Connection request */
+	struct {
+		char ssid[33];
+		char password[65];
+		bool has_password;
+	} connect_req;
+
+	/* Scan results */
+	struct {
+		struct wlan_scan_ap *aps;
+		int count;
+		int capacity;
+	} scan;
+	struct mutex scan_lock;
+
+	/* Timers */
+	struct sys_timer connect_timer;
+
+	/* Statistics */
+	struct {
+		uint32_t tx_packets;
+		uint32_t rx_packets;
+		uint32_t tx_errors;
+		uint32_t rx_errors;
+		uint32_t connect_attempts;
+		uint32_t connect_failures;
+	} stats;
+
+	/* Configuration options */
+	struct {
+		bool auto_reconnect;
+		int retry_count;
+		uint32_t retry_delay_ms;
+		bool debug_urc;
+	} config;
+
+	/* Hardware specific private data */
+	void *hw_priv;
+
+	volatile bool connect_done;
+	volatile int connect_result;
+	volatile bool disconnect_done;
+	volatile bool timer_active;
+};
+
+/**
+ * @brief Initialize WiFi core
+ * 
+ * @param wifi WiFi core instance
+ * @param netdev Network device
+ * @param at_client AT client instance
+ * @param hw_ops Hardware operations
+ * @param hw_priv Hardware private data
+ * @return 0 on success, negative on error
+ */
+extern int wifi_core_setup(struct wifi_core *wifi, struct net_device *netdev,
+    at_client_t *at_client, const struct wifi_hw_ops *hw_ops, void *hw_priv);
+
+/**
+ * @brief Cleanup WiFi core
+ * 
+ * @param wifi WiFi core instance
+ */
+extern void wifi_core_cleanup(struct wifi_core *wifi);
+
+/**
+ * @brief Check if WiFi is connected
+ * 
+ * @param wifi WiFi core instance
+ * @return true if connected, false otherwise
+ */
+extern bool wifi_core_is_connected(struct wifi_core *wifi);
+
+/**
+ * @brief Check if WiFi has IP address
+ * 
+ * @param wifi WiFi core instance
+ * @return true if has IP, false otherwise
+ */
+extern bool wifi_core_has_ip(struct wifi_core *wifi);
+
+/**
+ * @brief Get connection information
+ * 
+ * @param wifi WiFi core instance
+ * @param ssid SSID buffer (optional)
+ * @param ip IP address buffer (optional)
+ * @param rssi RSSI value pointer (optional)
+ * @return 0 on success, negative on error
+ */
+extern int wifi_core_get_connection_info(struct wifi_core *wifi, char *ssid,
+    char *ip, int8_t *rssi);
+
+/**
+ * @brief Send AT command
+ * 
+ * @param wifi WiFi core instance
+ * @param cmd AT command
+ * @param resp Response buffer (optional)
+ * @param resp_size Response buffer size
+ * @param timeout_ms Timeout in milliseconds
+ * @return 0 on success, negative on error
+ */
+extern int wifi_core_send_cmd(struct wifi_core *wifi, const char *cmd,
+    char *resp, size_t resp_size, uint32_t timeout_ms);
+
+/**
+ * @brief Set auto reconnect mode
+ * 
+ * @param wifi WiFi core instance
+ * @param enable true to enable, false to disable
+ */
+extern void wifi_core_set_auto_reconnect(struct wifi_core *wifi, bool enable);
+
+/**
+ * @brief Set retry parameters
+ * 
+ * @param wifi WiFi core instance
+ * @param count Retry count
+ * @param delay_ms Delay between retries in milliseconds
+ */
+extern void wifi_core_set_retry_params(struct wifi_core *wifi, int count,
+    uint32_t delay_ms);
+
+/**
+ * @brief Enable or disable URC debug
+ * 
+ * @param wifi WiFi core instance
+ * @param enable true to enable, false to disable
+ */
+extern void wifi_core_set_debug_urc(struct wifi_core *wifi, bool enable);
+
+/* WiFi Core wireless operations */
+extern const struct wireless_ops wifi_core_ops;
+
+/* Debug macros */
+#ifdef CONFIG_WIFI_CORE_DEBUG
+#define wifi_core_debug(wifi, fmt, ...)                                  \
+	do {                                                                 \
+		printk("wifi_core[%s]: " fmt "\n",                               \
+		    (wifi)->netdev ? (wifi)->netdev->name : "?", ##__VA_ARGS__); \
+	} while (0)
+#else
+#define wifi_core_debug(wifi, fmt, ...)
+#endif
+
+#define wifi_core_error(wifi, fmt, ...)      \
+	printk("wifi_core[%s] ERROR: " fmt "\n", \
+	    (wifi)->netdev ? (wifi)->netdev->name : "?", ##__VA_ARGS__)
+
+#endif /* DRIVERS_NET_WIFI_CORE_H_ */

--- a/project/at/src/net/wlan/Mybuild
+++ b/project/at/src/net/wlan/Mybuild
@@ -1,0 +1,11 @@
+package project.at.net.wlan
+
+module wlan_core {
+	source "wireless_ioctl.c"
+	source "wlan_core.c"
+
+	@IncludeExport(path="net/wlan/")
+  source "wireless_ioctl.h"
+	@IncludeExport(path="net/wlan/")
+	source "wlan_core.h"
+}

--- a/project/at/src/net/wlan/wireless_ioctl.c
+++ b/project/at/src/net/wlan/wireless_ioctl.c
@@ -1,0 +1,104 @@
+/**
+ * @file
+ * @brief Wireless Device IOCTL Operations Implementation
+ * 
+ * @date Jul 27, 2025
+ * @author Peize Li
+ */
+#include <errno.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include <net/wlan/wireless_ioctl.h>
+#include <net/wlan/wlan_core.h>
+
+int wireless_sock_ioctl(int cmd, void *arg) {
+	struct iwreq *iwr = (struct iwreq *)arg;
+	struct net_device *dev;
+	struct wlan_device *wdev;
+
+	/* Find network device by interface name */
+	dev = wlan_device_get_by_name(iwr->ifr_name);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	/* Get wlan_device from net_device */
+	wdev = (struct wlan_device *)dev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	switch (cmd) {
+	case SIOCSIWESSID: {
+		char ssid[33];
+		if (iwr->u.essid.length > 32)
+			return -EINVAL;
+
+		memcpy(ssid, iwr->u.essid.pointer, iwr->u.essid.length);
+		ssid[iwr->u.essid.length] = '\0';
+
+		return wlan_connect(dev->name, ssid, NULL);
+	}
+
+	case SIOCGIWESSID: {
+		mutex_lock(&wdev->lock);
+		if (wdev->state == WLAN_STATE_CONNECTED) {
+			size_t len = strlen(wdev->connected.ssid);
+			if (len > iwr->u.essid.length)
+				len = iwr->u.essid.length;
+
+			memcpy(iwr->u.essid.pointer, wdev->connected.ssid, len);
+			iwr->u.essid.length = len;
+			iwr->u.essid.flags = 1;
+		}
+		else {
+			iwr->u.essid.length = 0;
+			iwr->u.essid.flags = 0;
+		}
+		mutex_unlock(&wdev->lock);
+		return 0;
+	}
+
+	case SIOCSIWSCAN:
+		return wlan_scan(dev->name);
+
+	case SIOCGIWSCAN: {
+		/* Return scan results */
+		char *buf = iwr->u.data.pointer;
+		int maxlen = iwr->u.data.length;
+		int len = 0;
+
+		mutex_lock(&wdev->lock);
+		for (int i = 0; i < wdev->scan_result.count && len < maxlen - 100; i++) {
+			struct wlan_scan_ap *ap = &wdev->scan_result.aps[i];
+			int n = snprintf(buf + len, maxlen - len,
+			    "ESSID:\"%s\" Signal:%d Channel:%d%s\n", ap->ssid, ap->rssi,
+			    ap->channel, ap->security ? " Encryption:on" : "");
+			if (n > 0)
+				len += n;
+		}
+		mutex_unlock(&wdev->lock);
+
+		iwr->u.data.length = len;
+		return 0;
+	}
+
+	case SIOCSIWMODE: {
+		if (!dev->wireless_ops->set_mode) {
+			return -EOPNOTSUPP;
+		}
+		return dev->wireless_ops->set_mode(dev, iwr->u.mode);
+	}
+
+	case SIOCGIWMODE: {
+		if (!dev->wireless_ops->get_mode) {
+			return -EOPNOTSUPP;
+		}
+		return dev->wireless_ops->get_mode(dev, &iwr->u.mode);
+	}
+
+	default:
+		return -EOPNOTSUPP;
+	}
+}

--- a/project/at/src/net/wlan/wireless_ioctl.h
+++ b/project/at/src/net/wlan/wireless_ioctl.h
@@ -1,0 +1,53 @@
+/**
+ * @file
+ * @brief Wireless Device IOCTL Operations Header
+ * 
+ * @date Jul 27, 2025
+ * @author Peize Li
+ */
+
+#ifndef NET_WIRELESS_IOCTL_H_
+#define NET_WIRELESS_IOCTL_H_
+
+#include <stdint.h>
+
+#include <net/netdevice.h>
+
+/* Wireless device operations - structure declared in netdevice.h */
+struct wireless_ops {
+	int (*scan)(struct net_device *dev);
+	int (*connect)(struct net_device *dev, const char *ssid, const char *pwd);
+	int (*disconnect)(struct net_device *dev);
+	int (*get_rssi)(struct net_device *dev, int8_t *rssi);
+
+	int (*init)(struct net_device *dev);
+	void (*deinit)(struct net_device *dev);
+	int (*set_power_mode)(struct net_device *dev, int mode);
+	int (*get_power_mode)(struct net_device *dev, int *mode);
+	int (*set_mode)(struct net_device *dev, int mode); /* STA/AP/Monitor */
+	int (*get_mode)(struct net_device *dev, int *mode);
+};
+
+/* Power modes */
+#define WLAN_PWR_ACTIVE    0
+#define WLAN_PWR_SAVE      1
+#define WLAN_PWR_DEEP_SAVE 2
+
+/* Operation modes */
+#define WLAN_MODE_STA     1
+#define WLAN_MODE_AP      2
+#define WLAN_MODE_MONITOR 3
+
+/**
+ * @brief Perform wireless socket IOCTL operation
+ *
+ * Legacy interface for performing various wireless control operations
+ * through socket IOCTL interface.
+ *
+ * @param cmd IOCTL command code
+ * @param arg Pointer to command-specific argument structure
+ * @return 0 on success, negative error code on failure
+ */
+extern int wireless_sock_ioctl(int cmd, void *arg);
+
+#endif /* NET_WIRELESS_IOCTL_H_ */

--- a/project/at/src/net/wlan/wlan_core.c
+++ b/project/at/src/net/wlan/wlan_core.c
@@ -1,0 +1,371 @@
+/**
+ * @file
+ * @brief Wlan Core Framework Implementation
+ *
+ * @date July 27, 2025
+ * @author Peize Li
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mem/sysmalloc.h>
+#include <net/wlan/wireless_ioctl.h>
+#include <net/wlan/wlan_core.h>
+
+/* Default WLAN device */
+static struct net_device *default_wlan_device = NULL;
+static struct mutex wlan_global_lock = MUTEX_INIT_STATIC;
+
+int wlan_device_init(struct net_device *dev) {
+	struct wlan_device *wdev;
+	int ret;
+
+	if (!dev || !dev->wireless_ops) {
+		return -EINVAL;
+	}
+
+	/* Allocate WLAN management structure */
+	wdev = sysmalloc(sizeof(*wdev));
+	if (!wdev) {
+		return -ENOMEM;
+	}
+
+	memset(wdev, 0, sizeof(*wdev));
+	mutex_init(&wdev->lock);
+	wdev->state = WLAN_STATE_DOWN;
+	wdev->driver_type = WLAN_DRV_GENERIC;
+
+	/* Associate to net_device */
+	dev->wireless_priv = wdev;
+	dev->flags |= IFF_WIRELESS;
+
+	/* Call driver's init function */
+	if (dev->wireless_ops->init) {
+		ret = dev->wireless_ops->init(dev);
+		if (ret < 0) {
+			printf("wlan: driver init failed for '%s': %d\n", dev->name, ret);
+			sysfree(wdev);
+			dev->wireless_priv = NULL;
+			dev->flags &= ~IFF_WIRELESS;
+			return ret;
+		}
+	}
+
+	/* Device enters UP state after successful initialization */
+	wdev->state = WLAN_STATE_UP;
+
+	/* Set as default device */
+	mutex_lock(&wlan_global_lock);
+	if (!default_wlan_device) {
+		default_wlan_device = dev;
+	}
+	mutex_unlock(&wlan_global_lock);
+
+	printf("wlan: device '%s' initialized successfully\n", dev->name);
+	return 0;
+}
+
+void wlan_device_cleanup(struct net_device *dev) {
+	struct wlan_device *wdev;
+
+	if (!dev || !(dev->flags & IFF_WIRELESS)) {
+		return;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return;
+	}
+
+	/* Call driver's deinit function */
+	if (dev->wireless_ops && dev->wireless_ops->deinit) {
+		dev->wireless_ops->deinit(dev);
+	}
+
+	/* Clean up default device */
+	mutex_lock(&wlan_global_lock);
+	if (default_wlan_device == dev) {
+		default_wlan_device = NULL;
+	}
+	mutex_unlock(&wlan_global_lock);
+
+	sysfree(wdev);
+	dev->wireless_priv = NULL;
+	dev->flags &= ~IFF_WIRELESS;
+
+	printf("wlan: device '%s' cleaned up\n", dev->name);
+}
+
+/* Register driver type and private data */
+int wlan_device_register_driver(struct net_device *dev, int driver_type,
+    void *driver_priv) {
+	struct wlan_device *wdev;
+
+	if (!dev || !(dev->flags & IFF_WIRELESS)) {
+		return -EINVAL;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	mutex_lock(&wdev->lock);
+	wdev->driver_type = driver_type;
+	wdev->priv = driver_priv;
+	mutex_unlock(&wdev->lock);
+
+	return 0;
+}
+
+struct net_device *wlan_device_get_by_name(const char *name) {
+	struct net_device *dev = netdev_get_by_name(name);
+
+	if (dev && (dev->flags & IFF_WIRELESS)) {
+		return dev;
+	}
+
+	return NULL;
+}
+
+struct net_device *wlan_device_get_default(void) {
+	return default_wlan_device;
+}
+
+/* State management helpers */
+void wlan_device_set_state(struct net_device *dev, enum wlan_state state) {
+	struct wlan_device *wdev;
+
+	if (!dev || !(dev->flags & IFF_WIRELESS)) {
+		return;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return;
+	}
+
+	mutex_lock(&wdev->lock);
+	wdev->state = state;
+	mutex_unlock(&wdev->lock);
+
+	printf("wlan: %s state changed to %d\n", dev->name, state);
+}
+
+enum wlan_state wlan_device_get_state(struct net_device *dev) {
+	struct wlan_device *wdev;
+	enum wlan_state state;
+
+	if (!dev || !(dev->flags & IFF_WIRELESS)) {
+		return WLAN_STATE_DOWN;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return WLAN_STATE_DOWN;
+	}
+
+	mutex_lock(&wdev->lock);
+	state = wdev->state;
+	mutex_unlock(&wdev->lock);
+
+	return state;
+}
+
+/* Convenience function implementation */
+int wlan_scan(const char *dev_name) {
+	struct net_device *dev;
+	struct wlan_device *wdev;
+
+	if (dev_name) {
+		dev = wlan_device_get_by_name(dev_name);
+	}
+	else {
+		dev = wlan_device_get_default();
+	}
+
+	if (!dev || !dev->wireless_ops || !dev->wireless_ops->scan) {
+		return -ENODEV;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	mutex_lock(&wdev->lock);
+
+	if (wdev->state != WLAN_STATE_UP && wdev->state != WLAN_STATE_CONNECTED) {
+		mutex_unlock(&wdev->lock);
+		return -EINVAL;
+	}
+
+	/* For wifi_core drivers, state syncs automatically */
+	if (wdev->driver_type != WLAN_DRV_WIFI_CORE) {
+		wdev->state = WLAN_STATE_SCANNING;
+	}
+	mutex_unlock(&wdev->lock);
+
+	int ret = dev->wireless_ops->scan(dev);
+
+	/* For non-wifi_core drivers, state must be restored manually */
+	if (wdev->driver_type != WLAN_DRV_WIFI_CORE) {
+		mutex_lock(&wdev->lock);
+		if (wdev->state == WLAN_STATE_SCANNING) {
+			wdev->state = WLAN_STATE_UP;
+		}
+		mutex_unlock(&wdev->lock);
+	}
+
+	return ret;
+}
+
+int wlan_connect(const char *dev_name, const char *ssid, const char *pwd) {
+	struct net_device *dev;
+	struct wlan_device *wdev;
+
+	if (!ssid)
+		return -EINVAL;
+
+	if (dev_name) {
+		dev = wlan_device_get_by_name(dev_name);
+	}
+	else {
+		dev = wlan_device_get_default();
+	}
+
+	if (!dev || !dev->wireless_ops || !dev->wireless_ops->connect) {
+		return -ENODEV;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	mutex_lock(&wdev->lock);
+
+	if (wdev->state != WLAN_STATE_UP) {
+		mutex_unlock(&wdev->lock);
+		return -EINVAL;
+	}
+
+	/* For wifi_core drivers, state syncs automatically */
+	if (wdev->driver_type != WLAN_DRV_WIFI_CORE) {
+		wdev->state = WLAN_STATE_CONNECTING;
+	}
+	mutex_unlock(&wdev->lock);
+
+	int ret = dev->wireless_ops->connect(dev, ssid, pwd);
+
+	/* For non-wifi_core drivers, state must be updated manually */
+	if (wdev->driver_type != WLAN_DRV_WIFI_CORE) {
+		mutex_lock(&wdev->lock);
+		if (ret == 0) {
+			wdev->state = WLAN_STATE_CONNECTED;
+			strncpy(wdev->connected.ssid, ssid, 32);
+			wdev->connected.ssid[32] = '\0';
+		}
+		else {
+			wdev->state = WLAN_STATE_UP;
+		}
+		mutex_unlock(&wdev->lock);
+	}
+
+	return ret;
+}
+
+int wlan_disconnect(const char *dev_name) {
+	struct net_device *dev;
+	struct wlan_device *wdev;
+
+	if (dev_name) {
+		dev = wlan_device_get_by_name(dev_name);
+	}
+	else {
+		dev = wlan_device_get_default();
+	}
+
+	if (!dev || !dev->wireless_ops || !dev->wireless_ops->disconnect) {
+		return -ENODEV;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	int ret = dev->wireless_ops->disconnect(dev);
+
+	/* For non-wifi_core drivers, state must be updated manually */
+	if (wdev->driver_type != WLAN_DRV_WIFI_CORE) {
+		mutex_lock(&wdev->lock);
+		wdev->state = WLAN_STATE_UP;
+		memset(&wdev->connected, 0, sizeof(wdev->connected));
+		mutex_unlock(&wdev->lock);
+	}
+
+	return ret;
+}
+
+int wlan_get_scan_result(const char *dev_name, struct wlan_scan_ap *buf,
+    int buf_count) {
+	struct net_device *dev;
+	struct wlan_device *wdev;
+	int count;
+
+	if (!buf || buf_count <= 0) {
+		return -EINVAL;
+	}
+
+	if (dev_name) {
+		dev = wlan_device_get_by_name(dev_name);
+	}
+	else {
+		dev = wlan_device_get_default();
+	}
+
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	wdev = dev->wireless_priv;
+	if (!wdev) {
+		return -EINVAL;
+	}
+
+	mutex_lock(&wdev->lock);
+
+	count = wdev->scan_result.count;
+	if (count > buf_count) {
+		count = buf_count;
+	}
+
+	if (count > 0 && wdev->scan_result.aps) {
+		memcpy(buf, wdev->scan_result.aps, count * sizeof(struct wlan_scan_ap));
+	}
+
+	mutex_unlock(&wdev->lock);
+
+	return count;
+}
+
+int wlan_set_power_mode(const char *dev_name, int mode) {
+	struct net_device *dev;
+
+	if (dev_name) {
+		dev = wlan_device_get_by_name(dev_name);
+	}
+	else {
+		dev = wlan_device_get_default();
+	}
+
+	if (!dev || !dev->wireless_ops || !dev->wireless_ops->set_power_mode) {
+		return -ENODEV;
+	}
+
+	return dev->wireless_ops->set_power_mode(dev, mode);
+}

--- a/project/at/src/net/wlan/wlan_core.h
+++ b/project/at/src/net/wlan/wlan_core.h
@@ -1,0 +1,176 @@
+/**
+ * @file
+ * @brief Wlan Core Framework Header
+ *
+ * @date July 27, 2025
+ * @author Peize Li
+ */
+
+#ifndef NET_WLAN_CORE_H_
+#define NET_WLAN_CORE_H_
+
+#include <stdint.h>
+
+#include <kernel/thread/sync/mutex.h>
+#include <lib/libds/dlist.h>
+#include <net/netdevice.h>
+
+/* WLAN device states */
+enum wlan_state {
+	WLAN_STATE_DOWN = 0,
+	WLAN_STATE_UP,
+	WLAN_STATE_SCANNING,
+	WLAN_STATE_CONNECTING,
+	WLAN_STATE_CONNECTED
+};
+
+/* Scan results */
+struct wlan_scan_ap {
+	char ssid[33];
+	uint8_t bssid[6];
+	int8_t rssi;
+	uint8_t channel;
+	uint8_t security; /* 0:open, 1:wep, 2:wpa, 3:wpa2 */
+};
+
+/* WLAN device management structure - used as net_device->wireless_priv */
+struct wlan_device {
+	/* State management */
+	enum wlan_state state;
+	struct mutex lock;
+
+	/* Current connection */
+	struct {
+		char ssid[33];
+		uint8_t bssid[6];
+		int8_t rssi;
+	} connected;
+
+	/* Scan result cache */
+	struct {
+		struct wlan_scan_ap *aps;
+		int count;
+		int capacity;
+	} scan_result;
+
+	/* Driver private data */
+	void *priv;
+
+	/* Driver type identifier */
+	enum {
+		WLAN_DRV_GENERIC = 0,
+		WLAN_DRV_WIFI_CORE, /* Driver using wifi_core framework */
+		WLAN_DRV_CUSTOM     /* Fully custom driver */
+	} driver_type;
+};
+
+/* Basic operations */
+
+/**
+ * @brief Initialize WLAN device
+ *
+ * @param dev Network device to initialize for WLAN operations
+ * @return 0 on success, negative error code on failure
+ */
+extern int wlan_device_init(struct net_device *dev);
+
+/**
+ * @brief Clean up WLAN device resources
+ *
+ * @param dev Network device to clean up
+ */
+extern void wlan_device_cleanup(struct net_device *dev);
+
+/**
+ * @brief Get WLAN device by name
+ *
+ * @param name Name of the network device to find
+ * @return Pointer to the network device on success, NULL if not found
+ */
+extern struct net_device *wlan_device_get_by_name(const char *name);
+
+/**
+ * @brief Get default WLAN device
+ *
+ * @return Pointer to the default network device, NULL if no WLAN device exists
+ */
+extern struct net_device *wlan_device_get_default(void);
+
+/**
+ * @brief Scan for available wireless networks
+ *
+ * @param dev_name Name of the network device to perform scan
+ * @return 0 on success, negative error code on failure
+ */
+extern int wlan_scan(const char *dev_name);
+
+/**
+ * @brief Connect to a wireless network
+ *
+ * @param dev_name Name of the network device to use for connection
+ * @param ssid Service Set Identifier of the target network
+ * @param pwd Password for network authentication (NULL for open networks)
+ * @return 0 on success, negative error code on failure
+ */
+extern int wlan_connect(const char *dev_name, const char *ssid, const char *pwd);
+
+/**
+ * @brief Disconnect from current wireless network
+ *
+ * @param dev_name Name of the network device to disconnect
+ * @return 0 on success, negative error code on failure
+ */
+extern int wlan_disconnect(const char *dev_name);
+
+/**
+ * @brief Get wireless network scan results
+ *
+ * @param dev_name Name of the network device to query
+ * @param buf Buffer to store scan results
+ * @param buf_count Maximum number of results to retrieve
+ * @return Number of scan results copied to buffer, negative error code on failure
+ */
+extern int wlan_get_scan_result(const char *dev_name, struct wlan_scan_ap *buf,
+    int buf_count);
+
+/**
+ * @brief Set WLAN device power mode
+ *
+ * @param dev_name Name of the network device to configure
+ * @param mode Power mode (WLAN_PWR_ACTIVE, WLAN_PWR_SAVE, or WLAN_PWR_DEEP_SAVE)
+ * @return 0 on success, negative error code on failure
+ */
+extern int wlan_set_power_mode(const char *dev_name, int mode);
+
+/* Driver registration helper */
+
+/**
+ * @brief Register WLAN driver with device
+ *
+ * @param dev Network device to register driver with
+ * @param driver_type Type of driver (WLAN_DRV_GENERIC, WLAN_DRV_WIFI_CORE, or WLAN_DRV_CUSTOM)
+ * @param driver_priv Driver-specific private data pointer
+ * @return 0 on success, negative error code on failure
+ */
+extern int wlan_device_register_driver(struct net_device *dev, int driver_type,
+    void *driver_priv);
+
+/* State synchronization helpers */
+
+/**
+ * @brief Set WLAN device state
+ *
+ * @param dev Network device to update
+ * @param state New state to set (WLAN_STATE_DOWN, UP, SCANNING, CONNECTING, or CONNECTED)
+ */
+extern void wlan_device_set_state(struct net_device *dev, enum wlan_state state);
+
+/**
+ * @brief Get current WLAN device state
+ *
+ * @param dev Network device to query
+ * @return Current device state
+ */
+extern enum wlan_state wlan_device_get_state(struct net_device *dev);
+
+#endif /* NET_WLAN_CORE_H_ */

--- a/project/at/src/tests/esp32c3/Mybuild
+++ b/project/at/src/tests/esp32c3/Mybuild
@@ -1,0 +1,7 @@
+package project.at.test.esp32c3
+
+module esp32c3_emulator_test {
+  source "esp32c3_emulator_test.c"
+
+  depends project.at.driver.net.wifi.esp32c3_emulator
+}

--- a/project/at/src/tests/esp32c3/Mybuild
+++ b/project/at/src/tests/esp32c3/Mybuild
@@ -5,3 +5,9 @@ module esp32c3_emulator_test {
 
   depends project.at.driver.net.wifi.esp32c3_emulator
 }
+
+module esp32c3_wifi_test {
+  source "esp32c3_wifi_test.c"
+
+  depends project.at.driver.net.wifi.esp32c3_wifi
+}

--- a/project/at/src/tests/esp32c3/esp32c3_emulator_test.c
+++ b/project/at/src/tests/esp32c3/esp32c3_emulator_test.c
@@ -1,0 +1,282 @@
+/**
+ * @file
+ * @brief ESP32-C3 Emulator Unit Tests 
+ *
+ * @date July 31, 2025
+ * @author Peize Li
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <wifi/esp32c3/emulator/esp32c3_emulator.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("ESP32-C3 Emulator Tests");
+
+/* Helper to wait for URC with timeout */
+static const char *wait_for_urc(at_emulator_t *emu, int timeout_ms) {
+	int elapsed = 0;
+	const char *urc;
+
+	while (elapsed < timeout_ms) {
+		urc = at_emulator_poll(emu);
+		if (urc) {
+			return urc;
+		}
+		usleep(10000); /* 10ms */
+		elapsed += 10;
+	}
+	return NULL;
+}
+
+TEST_CASE("Basic ESP32-C3 commands") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+
+	test_assert_not_null(emu);
+
+	/* Test basic AT command */
+	resp = at_emulator_send_cmd(emu, "AT");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Test device info */
+	resp = at_emulator_send_cmd(emu, "ATI");
+	test_assert(strstr(resp, "ESP32-C3_Emulator") != NULL);
+	test_assert(strstr(resp, "Embox") != NULL);
+
+	/* Test WiFi mode query */
+	resp = at_emulator_send_cmd(emu, "AT+CWMODE?");
+	test_assert(strstr(resp, "+CWMODE:1") != NULL); /* Default STA mode */
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("WiFi mode configuration") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+
+	/* Set AP mode */
+	resp = at_emulator_send_cmd(emu, "AT+CWMODE=2");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Verify mode changed */
+	resp = at_emulator_send_cmd(emu, "AT+CWMODE?");
+	test_assert(strstr(resp, "+CWMODE:2") != NULL);
+
+	/* Test invalid mode */
+	resp = at_emulator_send_cmd(emu, "AT+CWMODE=4");
+	test_assert(strstr(resp, "ERROR") != NULL);
+
+	/* Test mode range */
+	resp = at_emulator_send_cmd(emu, "AT+CWMODE=?");
+	test_assert(strstr(resp, "+CWMODE:(1-3)") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("Reset command and ready URC") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+	const char *urc;
+
+	/* Send reset command */
+	resp = at_emulator_send_cmd(emu, "AT+RST");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Wait for "READY" URC */
+	urc = wait_for_urc(emu, 100);
+	test_assert_not_null(urc);
+	test_assert(strstr(urc, "READY") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("WiFi connection simulation") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+	const char *urc;
+
+	/* Connect to existing AP from scan list */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP=\"TestAP_1\",\"password123\"");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Wait for WIFI CONNECTED URC */
+	urc = wait_for_urc(emu, 3000);
+	test_assert_not_null(urc);
+	test_assert(strstr(urc, "WIFI CONNECTED") != NULL);
+
+	/* Wait for WIFI GOT IP URC */
+	urc = wait_for_urc(emu, 1000);
+	test_assert_not_null(urc);
+	test_assert(strstr(urc, "WIFI GOT IP") != NULL);
+
+	/* Query connection status */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP?");
+	test_assert(strstr(resp, "+CWJAP:\"TestAP_1\"") != NULL);
+
+	/* Query IP address */
+	resp = at_emulator_send_cmd(emu, "AT+CIPSTA?");
+	test_assert(strstr(resp, "192.168.1.100") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("WiFi disconnection") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+	const char *urc;
+
+	/* First connect to existing AP */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP=\"TestAP_2\",\"password\"");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Wait for connection */
+	wait_for_urc(emu, 3000); /* WIFI CONNECTED */
+	wait_for_urc(emu, 1000); /* WIFI GOT IP */
+
+	/* Disconnect */
+	resp = at_emulator_send_cmd(emu, "AT+CWQAP");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Wait for disconnect URC */
+	urc = wait_for_urc(emu, 100);
+	test_assert_not_null(urc);
+	test_assert(strstr(urc, "WIFI DISCONNECT") != NULL);
+
+	/* Verify disconnected state */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP?");
+	test_assert(resp != NULL); /* Should return empty response or just OK */
+
+	/* IP should be 0.0.0.0 */
+	resp = at_emulator_send_cmd(emu, "AT+CIPSTA?");
+	test_assert(strstr(resp, "0.0.0.0") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("AP scan functionality") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+
+	/* Scan for APs */
+	resp = at_emulator_send_cmd(emu, "AT+CWLAP");
+	test_assert_not_null(resp);
+
+	/* Check for test APs */
+	test_assert(strstr(resp, "TestAP_1") != NULL);
+	test_assert(strstr(resp, "TestAP_2") != NULL);
+	test_assert(strstr(resp, "TestAP_3") != NULL);
+
+	/* Verify format includes RSSI and channel */
+	test_assert(strstr(resp, "-45") != NULL); /* RSSI */
+	test_assert(strstr(resp, ",6") != NULL);  /* Channel */
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("TCP connection") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+	const char *urc;
+
+	/* First need to be connected to WiFi */
+	at_emulator_send_cmd(emu, "AT+CWJAP=\"TestAP_1\",\"password\"");
+	wait_for_urc(emu, 3000); /* WIFI CONNECTED */
+	wait_for_urc(emu, 1000); /* WIFI GOT IP */
+
+	/* Start TCP connection */
+	resp = at_emulator_send_cmd(emu, "AT+CIPSTART=\"TCP\",\"192.168.1.10\","
+	                                 "8080");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Wait for CONNECT URC */
+	urc = wait_for_urc(emu, 100);
+	test_assert_not_null(urc);
+	test_assert(strstr(urc, "CONNECT") != NULL);
+
+	/* Test CIPSEND */
+	resp = at_emulator_send_cmd(emu, "AT+CIPSEND");
+	test_assert(strstr(resp, ">") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("Error handling") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+
+	/* TCP connection without WiFi should fail */
+	resp = at_emulator_send_cmd(emu, "AT+CIPSTART=\"TCP\",\"192.168.1.10\","
+	                                 "8080");
+	test_assert(strstr(resp, "ERROR") != NULL);
+
+	/* Connect to non-existent AP should fail */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP=\"NonExistentAP\",\"password\"");
+	test_assert(strstr(resp, "ERROR") != NULL);
+
+	/* Invalid CWJAP parameters */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP=");
+	test_assert(strstr(resp, "ERROR") != NULL);
+
+	/* CIPSEND without connection */
+	resp = at_emulator_send_cmd(emu, "AT+CIPSEND");
+	test_assert(strstr(resp, "ERROR") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("Multiple connect/disconnect cycles") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+
+	/* Test with different APs from scan list */
+	const char *test_aps[] = {"TestAP_1", "TestAP_2", "TestAP_3"};
+
+	for (int i = 0; i < 3; i++) {
+		char cmd[128];
+		snprintf(cmd, sizeof(cmd), "AT+CWJAP=\"%s\",\"pass\"", test_aps[i]);
+
+		/* Connect */
+		resp = at_emulator_send_cmd(emu, cmd);
+		test_assert(strstr(resp, "OK") != NULL);
+
+		/* Wait for connection */
+		wait_for_urc(emu, 3000);
+		wait_for_urc(emu, 1000);
+
+		/* Disconnect */
+		resp = at_emulator_send_cmd(emu, "AT+CWQAP");
+		test_assert(strstr(resp, "OK") != NULL);
+
+		/* Wait for disconnect */
+		wait_for_urc(emu, 100);
+	}
+
+	esp32c3_emulator_destroy(emu);
+}
+
+TEST_CASE("Test prefix flexibility") {
+	at_emulator_t *emu = esp32c3_emulator_create();
+	const char *resp;
+	const char *urc;
+
+	/* Any SSID starting with "Test" should work for simulation flexibility */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP=\"TestNetwork\",\"pass123\"");
+	test_assert(strstr(resp, "OK") != NULL);
+
+	/* Wait for connection */
+	urc = wait_for_urc(emu, 3000);
+	test_assert_not_null(urc);
+	test_assert(strstr(urc, "WIFI CONNECTED") != NULL);
+
+	wait_for_urc(emu, 1000); /* WIFI GOT IP */
+
+	/* Query should show the connected SSID */
+	resp = at_emulator_send_cmd(emu, "AT+CWJAP?");
+	test_assert(strstr(resp, "TestNetwork") != NULL);
+
+	esp32c3_emulator_destroy(emu);
+}

--- a/project/at/src/tests/esp32c3/esp32c3_wifi_test.c
+++ b/project/at/src/tests/esp32c3/esp32c3_wifi_test.c
@@ -1,0 +1,208 @@
+/**
+ * @file
+ * @brief ESP32-C3 WiFi Driver Unit Tests
+ *
+ * @date Aug 9, 2025
+ * @author Peize Li
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <wifi/esp32c3/emulator/esp32c3_emulator.h>
+#include <embox/test.h>
+#include <net/netdevice.h>
+#include <net/wlan/wireless_ioctl.h>
+#include <net/wlan/wlan_core.h>
+#include <wifi/esp32c3/esp32c3_wifi.h>
+
+EMBOX_TEST_SUITE("ESP32-C3 WiFi Driver Tests");
+
+#define TEST_EMULATOR_STARTUP_DELAY_US   10000  /* 10ms */
+#define TEST_EMULATOR_THREAD_DELAY_US    500    /* 0.5ms */
+#define TEST_EMULATOR_POLL_DELAY_US      5000   /* 5ms */
+#define TEST_POST_INIT_DELAY_US          10000  /* 10ms */
+#define TEST_POST_SCAN_DELAY_US          5000   /* 5ms */
+#define TEST_POST_CONNECT_DELAY_US       5000   /* 5ms */
+#define TEST_POST_DISCONNECT_DELAY_US    10000  /* 10ms */
+
+extern int ppty(int ptyfds[2]);
+
+struct emulator_thread_data {
+	int fd;
+	at_emulator_t *emulator;
+	volatile int running;
+	pthread_t thread;
+	pthread_t poll_thread;
+};
+
+/* Helper Thread Functions */
+
+static void *emulator_thread_func(void *arg) {
+	struct emulator_thread_data *data = (struct emulator_thread_data *)arg;
+	char buffer[256];
+
+	while (data->running) {
+		int n = read(data->fd, buffer, sizeof(buffer));
+		if (n > 0) {
+			for (int i = 0; i < n; i++) {
+				const char *response = at_emulator_process(data->emulator,
+				    &buffer[i], 1);
+				if (response && *response) {
+					write(data->fd, response, strlen(response));
+				}
+			}
+		}
+		else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			break;
+		}
+		usleep(1000);
+	}
+	return NULL;
+}
+
+static void *emulator_poll_thread(void *arg) {
+	struct emulator_thread_data *data = (struct emulator_thread_data *)arg;
+
+	while (data->running) {
+		const char *urc = at_emulator_poll(data->emulator);
+		if (urc && *urc) {
+			write(data->fd, urc, strlen(urc));
+		}
+		usleep(TEST_EMULATOR_POLL_DELAY_US); /* 5ms */
+	}
+
+	return NULL;
+}
+
+/* Test Environment Setup */
+static int setup_test_env(int ptyfds[2], struct emulator_thread_data *emu_data) {
+	if (ppty(ptyfds) != 0) {
+		return -1;
+	}
+
+	fcntl(ptyfds[1], F_SETFL, O_NONBLOCK);
+
+	emu_data->emulator = esp32c3_emulator_create();
+	if (!emu_data->emulator) {
+		close(ptyfds[0]);
+		close(ptyfds[1]);
+		return -1;
+	}
+
+	emu_data->fd = ptyfds[1];
+	emu_data->running = 1;
+
+	pthread_create(&emu_data->thread, NULL, emulator_thread_func, emu_data);
+	pthread_create(&emu_data->poll_thread, NULL, emulator_poll_thread, emu_data);
+
+	usleep(TEST_EMULATOR_STARTUP_DELAY_US); /* Let emulator start */
+	return 0;
+}
+
+/* Test Environment Cleanup */
+static void cleanup_test_env(int ptyfds[2], struct emulator_thread_data *emu_data) {
+	emu_data->running = 0;
+	pthread_join(emu_data->thread, NULL);
+	pthread_join(emu_data->poll_thread, NULL);
+	esp32c3_emulator_destroy(emu_data->emulator);
+	close(ptyfds[0]);
+	close(ptyfds[1]);
+}
+
+TEST_CASE("Driver initialization") {
+	int ptyfds[2];
+	struct emulator_thread_data emu_data;
+	struct net_device netdev = {0};
+
+	test_assert_zero(setup_test_env(ptyfds, &emu_data));
+
+	strcpy(netdev.name, "wlan0");
+	test_assert_zero(esp32c3_wifi_init_fd(&netdev, ptyfds[0]));
+	test_assert_equal(netdev.flags & IFF_WIRELESS, IFF_WIRELESS);
+	test_assert_not_null(netdev.wireless_ops);
+	test_assert_not_null(netdev.wireless_priv);
+
+	esp32c3_wifi_cleanup(&netdev);
+	cleanup_test_env(ptyfds, &emu_data);
+}
+
+TEST_CASE("Parameter validation") {
+	struct net_device netdev = {0};
+
+	test_assert_equal(esp32c3_wifi_init_fd(NULL, 0), -EINVAL);
+	test_assert_equal(esp32c3_wifi_init_fd(&netdev, -1), -EINVAL);
+	test_assert_equal(esp32c3_wifi_init(&netdev, NULL), -EINVAL);
+}
+
+TEST_CASE("Connect to non-existent AP") {
+	int ptyfds[2];
+	struct emulator_thread_data emu_data;
+	struct net_device netdev = {0};
+
+	test_assert_zero(setup_test_env(ptyfds, &emu_data));
+
+	strcpy(netdev.name, "wlan0");
+	test_assert_zero(esp32c3_wifi_init_fd(&netdev, ptyfds[0]));
+
+	usleep(TEST_POST_CONNECT_DELAY_US);
+
+	int ret = netdev.wireless_ops->connect(&netdev, "NonExistentAP", "password");
+	test_assert_not_equal(ret, 0);
+
+	esp32c3_wifi_cleanup(&netdev);
+	cleanup_test_env(ptyfds, &emu_data);
+}
+
+TEST_CASE("Sequential operations") {
+	int ptyfds[2];
+	struct emulator_thread_data emu_data;
+	struct net_device netdev = {0};
+
+	test_assert_zero(setup_test_env(ptyfds, &emu_data));
+
+	strcpy(netdev.name, "wlan0");
+	test_assert_zero(esp32c3_wifi_init_fd(&netdev, ptyfds[0]));
+
+	usleep(TEST_POST_INIT_DELAY_US);
+
+	int scan_result = netdev.wireless_ops->scan(&netdev);
+	if (scan_result == 0) {
+		usleep(TEST_POST_SCAN_DELAY_US);
+
+		int conn_result = netdev.wireless_ops->connect(&netdev, "TestAP_1", "pass");
+		if (conn_result == 0) {
+			usleep(TEST_POST_CONNECT_DELAY_US);
+			netdev.wireless_ops->disconnect(&netdev);
+			usleep(TEST_POST_DISCONNECT_DELAY_US);
+		}
+	}
+
+	esp32c3_wifi_cleanup(&netdev);
+	cleanup_test_env(ptyfds, &emu_data);
+}
+
+TEST_CASE("Cleanup resilience") {
+	int ptyfds[2];
+	struct emulator_thread_data emu_data;
+	struct net_device netdev = {0};
+
+	test_assert_zero(setup_test_env(ptyfds, &emu_data));
+
+	strcpy(netdev.name, "wlan0");
+	test_assert_zero(esp32c3_wifi_init_fd(&netdev, ptyfds[0]));
+
+	/* Double cleanup should not crash */
+	esp32c3_wifi_cleanup(&netdev);
+	esp32c3_wifi_cleanup(&netdev);
+
+	/* Cleanup on uninitialized device should not crash */
+	struct net_device empty_dev = {0};
+	esp32c3_wifi_cleanup(&empty_dev);
+
+	cleanup_test_env(ptyfds, &emu_data);
+}

--- a/project/at/templates/x86_qemu/mods.conf
+++ b/project/at/templates/x86_qemu/mods.conf
@@ -123,6 +123,11 @@ configuration conf {
 	@Runlevel(2) include project.at.driver.net.wifi.esp32c3_emulator
 	@Runlevel(2) include project.at.test.esp32c3.esp32c3_emulator_test
 
+	@Runlevel(2) include project.at.net.wlan.wlan_core
+	@Runlevel(2) include project.at.driver.net.wifi.wifi_core
+	@Runlevel(2) include project.at.driver.net.wifi.esp32c3_wifi
+	@Runlevel(2) include project.at.test.esp32c3.esp32c3_wifi_test
+
 	include embox.init.system_start_service(log_level="LOG_INFO", tty_dev="ttyS0")
 	include embox.cmd.sh.tish(
 				prompt="%u@%h:%w%$", rich_prompt_support=1,

--- a/project/at/templates/x86_qemu/mods.conf
+++ b/project/at/templates/x86_qemu/mods.conf
@@ -120,6 +120,9 @@ configuration conf {
 	@Runlevel(2) include project.at.test.at.at_emulator_test
 	@Runlevel(2) include project.at.test.at.at_client_test
 
+	@Runlevel(2) include project.at.driver.net.wifi.esp32c3_emulator
+	@Runlevel(2) include project.at.test.esp32c3.esp32c3_emulator_test
+
 	include embox.init.system_start_service(log_level="LOG_INFO", tty_dev="ttyS0")
 	include embox.cmd.sh.tish(
 				prompt="%u@%h:%w%$", rich_prompt_support=1,
@@ -215,4 +218,5 @@ configuration conf {
 	include embox.cmd.testing.preemption
 	
 	include project.at.cmd.at_test
+	include project.at.cmd.wifi_test
 }

--- a/src/compat/linux/include/sys/ioctl.h
+++ b/src/compat/linux/include/sys/ioctl.h
@@ -87,6 +87,13 @@
 #define SIOCSARP           _IOW('s', 20, struct arpreq)     /* Set arp entry */
 #define SIOCGARP           _IOR('s', 21, struct arpreq)     /* Get arp entry */
 #define SIOCDARP           _IOW('s', 22, struct arpreq)     /* Delete arp entry */
+#define SIOCGIWNAME				 _IOR('s', 23, char[IFNAMSIZ])    /* get name == wireless protocol */
+#define SIOCSIWESSID   		 _IOW('s', 24, struct ifreq)      /* set ESSID */
+#define SIOCGIWESSID   		 _IOR('s', 25, struct ifreq)      /* get ESSID */
+#define SIOCSIWMODE    		 _IOW('s', 26, int)               /* set operation mode */
+#define SIOCGIWMODE    		 _IOR('s', 27, int)               /* get operation mode */
+#define SIOCSIWSCAN    		 _IOW('s', 28, struct ifreq)      /* trigger scanning */
+#define SIOCGIWSCAN    		 _IOR('s', 29, struct ifreq)      /* get scanning results */
 
 /**
  * TTY Control Operations

--- a/src/compat/posix/net/socket_index_operation.c
+++ b/src/compat/posix/net/socket_index_operation.c
@@ -14,6 +14,7 @@
 #include <poll.h>
 
 #include <net/socket/ksocket.h>
+#include <net/wlan/wireless_ioctl.h>
 
 #include <linux/net_tstamp.h>
 
@@ -91,6 +92,13 @@ static int socket_ioctl(struct idesc *idesc, int request, void *data) {
 	case SIOCGSTAMP:
 		memcpy(data, &sk->last_packet_tstamp, sizeof(struct timeval));
 		return 0;
+	case SIOCSIWESSID:
+	case SIOCGIWESSID:
+	case SIOCSIWMODE:
+	case SIOCGIWMODE:
+	case SIOCSIWSCAN:
+	case SIOCGIWSCAN:
+    return wireless_sock_ioctl(request, data);
 	default:
 		break;
 	}

--- a/src/include/net/if.h
+++ b/src/include/net/if.h
@@ -30,6 +30,7 @@
 #define IFF_PROMISC     0x0100 /* receive all packets */
 #define IFF_ALLMULTI    0x0200 /* receive all multicast packets */
 #define IFF_MULTICAST   0x1000 /* supports multicast */
+#define IFF_WIRELESS    0x8000 /* wireless interface */
 
 extern unsigned int if_nametoindex(const char *);
 
@@ -70,5 +71,20 @@ struct ifconf {
 
 #define ifc_buf ifc_ifcu.ifcu_buf /* buffer address	*/
 #define ifc_req ifc_ifcu.ifcu_req /* array of structures	*/
+
+struct iw_point {
+	void *pointer; /* Pointer to user space data */
+	int length;    /* Data length in bytes */
+	int flags;     /* Operation flags */
+};
+
+struct iwreq {
+	char ifr_name[IFNAMSIZ]; /* Interface name */
+	union {
+		struct iw_point essid; /* ESSID */
+		struct iw_point data;  /* Generic data */
+		int mode;              /* Operation mode */
+	} u;
+};
 
 #endif /* NET_IF_H_ */

--- a/src/include/net/netdevice.h
+++ b/src/include/net/netdevice.h
@@ -138,7 +138,8 @@ typedef struct net_device {
 #if defined(NET_NAMESPACE_ENABLED) && (NET_NAMESPACE_ENABLED == 1)
 	net_namespace_p net_ns;
 #endif
-
+	const struct wireless_ops *wireless_ops;  /* wireless operations */
+	void *wireless_priv;                      /* wireless driver private data */
 //#if IS_ENABLED(CONFIG_CFG80211)
 	struct wireless_dev	*nd_ieee80211_ptr;
 //#endif


### PR DESCRIPTION
New module:

`wlan_core`: Provides methods for controlling wireless modules via ioctl.

`wifi_core`: Base module for WiFi driver development

`esp32c3_emulator`: Simulate the response of ESP32-C3 to implemented AT commands

`esp32c3_wifi`: ESP32-C3 WiFi driver

Notes:
 
`esp32c3_emulator_test` and `esp32c3_wifi_test` take a while to run. You can delete them for faster startup in normal use.

Call chain:

application->`ioctl`->`wlan_core`->`wifi_core`->`at_client`

Related command：

`wifi_test`

`-t`: For testing the implements of `esp32c3_wifi`

Example:
```
2. Scan for access points
wlan: wlan0 state changed to 2
[EMU] Received 10 bytes: AT+CWLAP\r\n
[EMU] Sending response (154 bytes)
wifi_core: received 146 bytes response
wifi_core: response preview: +CWLAP:(3,"TestAP_1",-45,"00:11:22:33:44:00",1)
+CWLAP:(0,"TestAP_2",-60,"00:11:22:33:44:01",6)
+C...
wifi_core_scan: line 0: '+CWLAP:(3,"TestAP_1",-45,"00:11:22:33:44:00",1)'
esp32c3: parsed: ssid='TestAP_1', rssi=-45, ch=1, sec=3, mac=00:11:22:33:44:00
wifi_core_scan: line 1: '+CWLAP:(0,"TestAP_2",-60,"00:11:22:33:44:01",6)'
esp32c3: parsed: ssid='TestAP_2', rssi=-60, ch=6, sec=0, mac=00:11:22:33:44:01
wifi_core_scan: line 2: '+CWLAP:(3,"TestAP_3",-75,"00:11:22:33:44:02",11)'
esp32c3: parsed: ssid='TestAP_3', rssi=-75, ch=11, sec=3, mac=00:11:22:33:44:02
wifi_core: scan complete, found 3 APs
wlan: wlan0 state changed to 1
Scan operation returned: 0
Found 3 access points

Available networks:
  [0] SSID: TestAP_1             RSSI: -45 dBm  CH:  1  Security: WPA2
  [1] SSID: TestAP_2             RSSI: -60 dBm  CH:  6  Security: Open
  [2] SSID: TestAP_3             RSSI: -75 dBm  CH: 11  Security: WPA2
```