### PR TITLE
Mem man

### DIFF
--- a/src/cmds/mem/Mybuild
+++ b/src/cmds/mem/Mybuild
@@ -1,6 +1,6 @@
 package embox.cmd
 @AutoCmd
-@Cmd(name = "mem", help="mem tool")
+@Cmd(name = "mem_man", help="mem tool")
 module mem {
     source "memory_man.c"
 }


### PR DESCRIPTION
fix: improve memory utility portability and eliminate magic numbers

- Change cmd to mem_man
- Replace magic number 8192 with PROGRESS_UPDATE_BYTES constant
- Use uintptr_t and PRIxPTR for architecture-independent address handling
- Add inttypes.h include for cross-platform support
- Make progress indicator adaptive based on test length
- Fix format specifiers in error messages
