### PR TITLE
Added tests for erfc() from math.h

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -87,6 +87,11 @@ module expm1_test {
 	source "expm1_test.c"
 }
 
+module erfc_test {
+	@Cflags("-fno-builtin")
+    source "erfc_test.c"
+}
+
 module exp_test {
 	@Cflags("-fno-builtin")
 	source "exp_test.c"

--- a/src/compat/libc/math/tests/erfc_test.c
+++ b/src/compat/libc/math/tests/erfc_test.c
@@ -1,0 +1,29 @@
+/**
+ * @file
+ *
+ * @date September 10, 2025
+ * @author Stanislav Kidun
+ */
+
+#include <math.h>
+#include <float.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("erfc() tests");
+
+TEST_CASE("Test for  erfc(0) == 1 - erf(0)") {
+    double arg = 0;
+    test_assert(erfc(arg) == 1 - erf(arg));
+}
+
+TEST_CASE("Test for erfc(+INFINITY)") {
+	test_assert(erfc(INFINITY) == 0.0);
+}
+
+TEST_CASE("Test for erfc(-INFINITY)") {
+	test_assert(erfc(-INFINITY) == 2.0);
+}
+
+TEST_CASE("Test for erfc(NaN)") {
+	test_assert(isnan(erfc(NAN)));
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -253,6 +253,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.tanh_test
 	@Runlevel(1) include embox.compat.libc.test.tgamma_test
 	@Runlevel(1) include embox.compat.libc.test.trunc_test
+	@Runlevel(1) include embox.compat.libc.test.erfc_test
 
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap_test


### PR DESCRIPTION
In this pull request, unit tests were added for the erfc() method from math.h

Changes:
1. Added test module in `src/compat/libc/math/Mybuild`
```
module erfc_test {
	@Cflags("-fno-builtin")
    source "erfc_test.c"
}
```

2. Added tests covering corner cases, including +Inf, -Inf, NaN and Zero. All tests are implemented within new file `src/compat/libc/math/tests/erfc_test.c`
3. Updated configure in file `templates/x86/test/units/mods.conf`
