### PR TITLE
Etl lib support for embox .

### DIFF
--- a/third-party/lib/etl/Makefile
+++ b/third-party/lib/etl/Makefile
@@ -1,0 +1,35 @@
+PKG_NAME := etl
+PKG_VER  := 20.38.1
+
+PKG_SOURCES := https://github.com/ETLCPP/etl/archive/refs/tags/$(PKG_VER).tar.gz
+PKG_MD5 := skip  # ETL tarballs don’t usually provide md5sums; you can omit or compute one
+
+ETL_BUILD_DIR := $(MOD_BUILD_DIR)/build
+
+ETL_CMAKE_FLAGS = \
+	-DCMAKE_INSTALL_PREFIX=$(PKG_INSTALL_DIR) \
+	-DBUILD_SHARED_LIBS=OFF \
+	-DCMAKE_C_COMPILER_FORCED=on \
+	-DCMAKE_CXX_COMPILER_FORCED=on \
+	-DCMAKE_C_COMPILER_WORKS=true \
+	-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+	-DCMAKE_SYSTEM_PROCESSOR:STRING=$(AUTOCONF_TARGET_TRIPLET) \
+	-DCMAKE_C_COMPILER:PATH=$(EMBOX_GCC) \
+	-DCMAKE_CXX_COMPILER:PATH=$(EMBOX_GXX) \
+	-DCMAKE_AR:STRING=$(EMBOX_CROSS_COMPILE)ar \
+	-DCMAKE_SYSTEM_NAME:STRING=Generic \
+	-DCMAKE_BUILD_TYPE:STRING=None \
+	-DCMAKE_VERBOSE_MAKEFILE:BOOL=on
+
+# ETL is header-only, so build & install just copy headers
+$(CONFIGURE):
+	$(MKDIR) $(ETL_BUILD_DIR)
+	touch $@
+
+$(BUILD):
+	touch $@
+
+$(INSTALL):
+	$(MKDIR) $(PKG_INSTALL_DIR)/include
+	cp -r $(PKG_SOURCE_DIR)/include/etl $(PKG_INSTALL_DIR)/include/
+	touch $@

--- a/third-party/lib/etl/Mybuild
+++ b/third-party/lib/etl/Mybuild
@@ -1,0 +1,6 @@
+package third_party.lib.etl
+
+@Build(script="$(EXTERNAL_MAKE)")
+@BuildArtifactPath(cppflags="-I$(EXTERNAL_BUILD_DIR)/third_party/lib/etl/include/etl")
+static module etl {
+}

--- a/third-party/lib/etl/tests/Makefile
+++ b/third-party/lib/etl/tests/Makefile
@@ -1,0 +1,29 @@
+# Compiler and flags
+CC = gcc
+CXX = g++
+CFLAGS = -I$(PKG_INSTALL_DIR)/include -I$(EMBOX_INCLUDE) -Wall -Wextra -g
+LDFLAGS =
+
+# Source files
+SRCS = etl_test.c
+OBJS = $(SRCS:.c=.o)
+
+# Target executable
+TARGET = etl_tests
+
+# Default target
+all: $(TARGET)
+
+# Link step
+$(TARGET): $(OBJS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+# Compile step
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Clean objects and binary
+clean:
+	rm -f $(OBJS) $(TARGET)
+
+.PHONY: all clean

--- a/third-party/lib/etl/tests/Mybuild
+++ b/third-party/lib/etl/tests/Mybuild
@@ -1,0 +1,5 @@
+package third_party.lib.etl.tests
+
+static module etl_tests {
+    source "etl_test.c"
+}

--- a/third-party/lib/etl/tests/etl_test.c
+++ b/third-party/lib/etl/tests/etl_test.c
@@ -1,0 +1,10 @@
+#include <embox/test.h>
+#include <etl/vector.h>
+
+EMBOX_TEST_SUITE("ETL basic test");
+
+TEST_CASE("Simple vector push and read") {
+    etl::vector<int, 5> v;
+    v.push_back(42);
+    test_assert(v[0] == 42);
+}

--- a/third-party/lib/etl/tests/test_1.c
+++ b/third-party/lib/etl/tests/test_1.c
@@ -1,0 +1,31 @@
+// #include <embox/unit.h>
+// #include <shell/shell.h>
+// #include <stdio.h>
+
+// static int etl_test_cmd(int argc, char **argv) {
+//     printf("ETL Test command executed\n");
+
+//     // Sample C code printing values
+//     int vec[10];
+//     for (int i = 0; i < 5; i++) {
+//         vec[i] = i * 10;
+//     }
+//     printf("ETL vector contents:\n");
+//     for (int i = 0; i < 5; i++) {
+//         printf("  %d\n", vec[i]);
+//     }
+//     return 0;
+// }
+
+// static const shell_cmd_t shell_etl_test_cmd = {
+//     .cmd = "etl_test",
+//     .help = "Run ETL test",
+//     .handler = etl_test_cmd,
+// };
+
+// EMBOX_UNIT_INIT(etl_test_shell_init);
+
+// static int etl_test_shell_init(void) {
+//     shell_cmd_register(&shell_etl_test_cmd);
+//     return 0;
+// }


### PR DESCRIPTION
I integrated the ETL library as a third-party dependency in the Embox project by placing it in the third_party directory and adding its include paths in mk/flags.mk. Since ETL is header-only, no separate compilation was necessary, and the build for QEMU x86 target completed successfully.

Additionally, I created a test application in src/etl_test/test_1.c with an accompanying Makefile specifying obj-y := test_1.o. The application registers a shell command to verify ETL library functionality.

To include the test app in the build, I added include etl_test in mods.conf. However, despite a successful build and boot in QEMU, the registered shell command isn't recognized in the Embox shell.

Issue : https://github.com/embox/embox/issues/3736
