### PR TITLE
Added test cases for rint () function in math.h

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -226,8 +226,11 @@ module erf_test {
 	@Cflags("-fno-builtin")
 	source "erf_test.c"
 }
-
 module tan_test {
 	@Cflags("-fno-builtin")
 	source "tan_test.c"
+}
+module rint_test {
+	@Cflags("-fno-builtin")
+	source "rint_test.c"
 }

--- a/src/compat/libc/math/tests/rint_test.c
+++ b/src/compat/libc/math/tests/rint_test.c
@@ -1,0 +1,60 @@
+//rint_test.c
+/**
+ * @file
+ *
+ * @date Oct 13 2025
+ * @author Biancaa.R
+ */
+
+#include <math.h>
+
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("rint() tests");
+
+TEST_CASE("Test for rint() with positive fractional part < 0.5") {
+	test_assert(rint(2.3) == 2.0);
+}
+
+TEST_CASE("Test for rint() with positive fractional part >= 0.5") {
+	test_assert(rint(2.7) == 3.0);
+}
+
+TEST_CASE("Test for rint() with negative fractional part > -0.5") {
+	test_assert(rint(-2.3) == -2.0);
+}
+
+TEST_CASE("Test for rint() with negative fractional part <= -0.5") {
+	test_assert(rint(-2.7) == -3.0);
+}
+
+TEST_CASE("Test for rint() with exact integer") {
+	test_assert(rint(5.0) == 5.0);
+}
+
+TEST_CASE("Test for rint() with +INFINITY") {
+	test_assert(isinf(rint(INFINITY)));
+}
+
+TEST_CASE("Test for rint() with -INFINITY") {
+	test_assert(isinf(rint(-INFINITY)));
+}
+
+TEST_CASE("Test for rint() with NaN") {
+	test_assert(isnan(rint(NAN)));
+}
+
+TEST_CASE("Test for rint() with 0.0 and -0.0") {
+	test_assert(rint(0.0) == 0.0);
+	test_assert(rint(-0.0) == -0.0);
+}
+
+ TEST_CASE("Test for rint() with positive fractional part exactly 0.5") {
+    test_assert(rint(2.5) == 2.0); // nearest even
+    test_assert(rint(3.5) == 4.0); // nearest even
+}
+
+TEST_CASE("Test for rint() with negative fractional part exactly -0.5") {
+    test_assert(rint(-2.5) == -2.0); // nearest even
+    test_assert(rint(-3.5) == -4.0); // nearest even
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -255,6 +255,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.trunc_test
 	@Runlevel(1) include embox.compat.libc.test.erfc_test
 	@Runlevel(1) include embox.compat.libc.test.tan_test
+	@Runlevel(1) include embox.compat.libc.test.rint_test
 
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap_test


### PR DESCRIPTION
Fixes #3593

Added test cases for rint () function in math.h
Tested cases :

rint(): rounds positive numbers with fractional part < 0.5 down to nearest integer
rint(): rounds positive numbers with fractional part ≥ 0.5 up to nearest integer
rint(): rounds negative numbers with fractional part > -0.5 toward zero
rint(): rounds negative numbers with fractional part ≤ -0.5 away from zero
rint(): returns the same value for exact integers
rint(): returns +INFINITY when input is +INFINITY
rint(): returns -INFINITY when input is -INFINITY
rint(): returns NaN when input is NaN
rint(): preserves the sign of zero for +0.0 and -0.0


    Created a new test file: rint_test.c and added it in Mybuild.
    Registered the test in mods.conf under the x86 architecture.


Issue addressed : https://github.com/embox/embox/issues/3593