### PR TITLE
Fix I2C driver for K1921VG015

### DIFF
--- a/src/drivers/clk/niiet/k1921vg015/k1921vg015_rcu.c
+++ b/src/drivers/clk/niiet/k1921vg015/k1921vg015_rcu.c
@@ -1,7 +1,9 @@
 /**
  * @file
- * 
+ * @brief RCU (Reset and Clock Unit) driver for NIIET K1921VG015
+ *
  * @author Anton Bondarev
+ * @author kimstik
  * @date 04.04.2024
  */
 
@@ -214,8 +216,17 @@ void niiet_spi_set_rcu(int num) {
 }
 
 void niiet_i2c_set_rcu(int num) {
+	volatile uint32_t dummy;
 
+	/* Put I2C in reset state first */
+	RCU->RCU_RSTDISAPB_reg &= ~RCU_RSTDISAPB_I2C_EN(num);
+	dummy = RCU->RCU_RSTDISAPB_reg; /* dummy read */
+	(void)dummy;
+
+	/* Enable clock */
 	RCU->RCU_CGCFGAPB_reg |= RCU_CGCFGAPB_I2C_EN(num);
+
+	/* Release reset */
 	RCU->RCU_RSTDISAPB_reg |= RCU_RSTDISAPB_I2C_EN(num);
 }
 

--- a/src/drivers/i2c/niiet/vg015_i2c/vg015_i2c0.c
+++ b/src/drivers/i2c/niiet/vg015_i2c/vg015_i2c0.c
@@ -1,55 +1,50 @@
 /**
  * @file
+ * @brief I2C0 bus instance for NIIET K1921VG015
  *
  * @date Oct 23, 2025
  * @author Anton Bondarev
+ * @author kimstik
  */
 
- #include <util/log.h>
-
-#include <errno.h>
 #include <stddef.h>
-#include <stdint.h>
 
-#include <drivers/i2c/i2c.h>
 #include <drivers/gpio.h>
-
-#include <framework/mod/options.h>
-#include <config/board_config.h>
-
-#define I2C_BUS_ID  0
-
-#define BASE_ADDR   OPTION_GET(NUMBER, base_addr)
-
-extern const struct i2c_ops vg015_i2c_ops;
-
+#include <drivers/i2c/i2c.h>
 #include <drivers/pin_description.h>
 
+#include <config/board_config.h>
+#include <framework/mod/options.h>
+
+#define I2C_BUS_ID   0
+#define BASE_ADDR    OPTION_GET(NUMBER, base_addr)
+
+extern const struct i2c_ops vg015_i2c_ops;
 extern int clk_enable(char *clk_name);
 
 static const struct pin_description vg015_i2c_pins[] = {
-	{CONF_I2C0_PIN_SCL_PORT, CONF_I2C0_PIN_SCL_NR, CONF_I2C0_PIN_SCL_NR},
+	{CONF_I2C0_PIN_SCL_PORT, CONF_I2C0_PIN_SCL_NR, CONF_I2C0_PIN_SCL_AF},
 	{CONF_I2C0_PIN_SDA_PORT, CONF_I2C0_PIN_SDA_NR, CONF_I2C0_PIN_SDA_AF},
 };
 
 int vg015_i2c_hw_init0(const struct i2c_bus *bus) {
-    if (bus->i2cb_pins) {
-        const struct pin_description *pin;
+	if (bus->i2cb_pins) {
+		const struct pin_description *pin;
 
-        pin = &bus->i2cb_pins[I2C_BUS_PIN_SCL];
-    	gpio_setup_mode(pin->pd_port, (1 << pin->pd_pin),
-            GPIO_MODE_ALT_SET(pin->pd_func)
-                            | GPIO_MODE_OUT_OPEN_DRAIN | GPIO_MODE_IN_PULL_UP);
+		pin = &bus->i2cb_pins[I2C_BUS_PIN_SCL];
+		gpio_setup_mode(pin->pd_port, (1 << pin->pd_pin),
+		    GPIO_MODE_ALT_SET(pin->pd_func)
+		        | GPIO_MODE_OUT_OPEN_DRAIN | GPIO_MODE_IN_PULL_UP);
 
-        pin = &bus->i2cb_pins[I2C_BUS_PIN_SDA];
-    	gpio_setup_mode(pin->pd_port, (1 << pin->pd_pin),
-            GPIO_MODE_ALT_SET(pin->pd_func)
-                            | GPIO_MODE_OUT_OPEN_DRAIN | GPIO_MODE_IN_PULL_UP);
-	
-    }
-    clk_enable(CONF_I2C0_CLK_DEF);
+		pin = &bus->i2cb_pins[I2C_BUS_PIN_SDA];
+		gpio_setup_mode(pin->pd_port, (1 << pin->pd_pin),
+		    GPIO_MODE_ALT_SET(pin->pd_func)
+		        | GPIO_MODE_OUT_OPEN_DRAIN | GPIO_MODE_IN_PULL_UP);
+	}
 
-    return 0;
+	clk_enable(CONF_I2C0_CLK_DEF);
+
+	return 0;
 }
 
 static const struct i2c_bus i2c_bus0 = {
@@ -61,4 +56,3 @@ static const struct i2c_bus i2c_bus0 = {
 };
 
 I2C_BUS_REGISTER(&i2c_bus0);
-

--- a/src/drivers/i2c/niiet/vg015_i2c/vg015_i2c_drv.c
+++ b/src/drivers/i2c/niiet/vg015_i2c/vg015_i2c_drv.c
@@ -1,8 +1,10 @@
 /**
  * @file
+ * @brief I2C driver for NIIET K1921VG015
  *
  * @date Oct 23, 2025
  * @author Anton Bondarev
+ * @author kimstik
  */
 
 #include <util/log.h>
@@ -10,231 +12,360 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <unistd.h>
 
 #include <drivers/i2c/i2c.h>
 
+#define I2C_SYSTEM_FREQ    50000000
+#define I2C_FS_FREQ        100000
 
-#define SMBUS_SYSTEM_FREQ 16000000
-#define SMBUS_BLOCK_BYTES_MAX 32
-
-#define FSFreq 100000
-#define HSFreq 3400000
-
-struct niiet_i2c_regs {                                                            
-	volatile uint32_t SDA;                                               /*!< Data register */
-	volatile uint32_t ST;                                                /*!< Status register */
-	volatile uint32_t CST;                                               /*!< Status and control register */
- 	volatile uint32_t CTL0;                                              /*!< Control register 0 */                                                   
-    volatile uint32_t ADDR;                                              /*!< Register own address */
-    volatile uint32_t CTL1;                                              /*!< Control register 1 */
-	volatile uint32_t TOPR;                                              /*!< Prescaler load register */
-	volatile uint32_t CTL2;                                              /*!< Control register 2 */
-	volatile uint32_t CTL3;                                              /*!< Control register 3 */
-	volatile uint32_t CTL4;                                              /*!< Control Register 4 */
+struct niiet_i2c_regs {
+	volatile uint32_t SDA;
+	volatile uint32_t ST;
+	volatile uint32_t CST;
+	volatile uint32_t CTL0;
+	volatile uint32_t ADDR;
+	volatile uint32_t CTL1;
+	volatile uint32_t TOPR;
+	volatile uint32_t CTL2;
+	volatile uint32_t CTL3;
+	volatile uint32_t CTL4;
 };
 
+/* CTL0 register bits */
+#define CTL0_START_BIT    (1 << 0)
+#define CTL0_STOP_BIT     (1 << 1)
+#define CTL0_INTEN_BIT    (1 << 2)
+#define CTL0_ACK_BIT      (1 << 4)
+#define CTL0_CLRST_BIT    (1 << 7)
 
-#define CTL0_START_OFFSET     0x0
-#define CTL0_STOP_OFFSET      0x1
-#define CTL0_INTEN_OFFSET     0x2
-#define CTL0_ACK_OFFSET       0x4
-#define CTL0_GCMEN_OFFSET     0x5
-#define CTL0_SMBARE_OFFSET    0x6
-#define CTL0_CLRST_OFFSET     0x7
+/* CTL1 register bits */
+#define CTL1_ENABLE_BIT   (1 << 0)
+#define CTL1_SCLFRQ(v)    (((v) & 0x7F) << 1)
 
-#define CTL0_START_BIT        (1 << CTL0_START_OFFSET)
-#define CTL0_STOP_BIT         (1 << CTL0_STOP_OFFSET)
-#define CTL0_INTEN_BIT        (1 << CTL0_INTEN_OFFSET)
-#define CTL0_ACK_BIT          (1 << CTL0_ACK_OFFSET)
-#define CTL0_GCMEN_BIT        (1 << CTL0_GCMEN_OFFSET)
-#define CTL0_SMBARE_BIT       (1 << CTL0_SMBARE_OFFSET)
-#define CTL0_CLRST_BIT        (1 << CTL0_CLRST_OFFSET)
+/* CTL3 register */
+#define CTL3_SCLFRQ(v)    ((v) & 0xFF)
 
-#define CTL1_ENABLE_OFFSET     0x0
-#define CTL1_SCLFRQ_OFFSET     0x1
+/* ST register */
+#define ST_INT_BIT        (1 << 7)
+#define ST_MODE(reg)      ((reg) & 0x3F)
 
-#define CTL1_ENABLE_BIT        (1 << CTL1_ENABLE_OFFSET)
-#define CTL1_SCLFRQ(freq)      ((freq & 0x7F) << CTL1_SCLFRQ_OFFSET)
+/* CST register bits */
+#define CST_BB_BIT        (1 << 0)
+#define CST_TOERR_BIT     (1 << 3)
 
-#define CTL3_SCLFRQ(freq)      (freq & 0xFF)
+/* Timeout for polling loops - prevents infinite hangs */
+#define I2C_TIMEOUT_LOOPS      100000
 
-#define CTL2_SHSDIV_OFFSET     0x4
+/* ST.MODE status codes (FS master mode only) */
+#define I2C_ST_MODE_STDONE     0x01  /* Start condition generated */
+#define I2C_ST_MODE_RSDONE     0x02  /* Repeated start generated */
+#define I2C_ST_MODE_MTADPA     0x04  /* TX: slave addr ACK */
+#define I2C_ST_MODE_MTADNA     0x05  /* TX: slave addr NAK */
+#define I2C_ST_MODE_MTDAPA     0x06  /* TX: data byte ACK */
+#define I2C_ST_MODE_MTDANA     0x07  /* TX: data byte NAK */
+#define I2C_ST_MODE_MRADPA     0x08  /* RX: slave addr ACK */
+#define I2C_ST_MODE_MRADNA     0x09  /* RX: slave addr NAK */
+#define I2C_ST_MODE_MRDAPA     0x0A  /* RX: data byte ACK */
+#define I2C_ST_MODE_MRDANA     0x0B  /* RX: data byte NAK */
+#define I2C_ST_MODE_BERROR     0x1F  /* Bus error */
+#define I2C_ST_MODE_HMTMCOK    0x21  /* HS mode entered (master code sent) */
 
-#define CTL2_SHSDIV(freq)      ((freq & 0x0F) << CTL2_SHSDIV_OFFSET)
+static void vg015_i2c_dump_regs(struct niiet_i2c_regs *regs) {
+	log_error("I2C: ST=0x%02x CST=0x%02x CTL0=0x%02x CTL1=0x%02x",
+	    regs->ST, regs->CST, regs->CTL0, regs->CTL1);
+}
 
-#define CTL4_SHSDIV(freq)      (freq & 0xFF)
+/* Wait for INT flag with timeout and hardware error check.
+ * Returns 0 on success, -ETIMEDOUT on timeout, -EIO on hardware error */
+static int vg015_i2c_wait_int(struct niiet_i2c_regs *regs) {
+	int timeout = I2C_TIMEOUT_LOOPS;
+	uint32_t mode;
 
-#define ST_MODE_OFFSET         0x0        
-#define ST_INT_OFFSET          0x7
+	while(!(regs->ST & ST_INT_BIT)) {
+		/* Check for bus error (invalid start/stop condition) */
+		mode = ST_MODE(regs->ST);
+		if (mode == I2C_ST_MODE_BERROR) {
+			log_error("I2C: bus error (BERROR)");
+			vg015_i2c_dump_regs(regs);
+			regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return -EIO;
+		}
+		/* Check for hardware timeout (slave clock stretch too long) */
+		if (regs->CST & CST_TOERR_BIT) {
+			log_error("I2C: hardware timeout (TOERR)");
+			vg015_i2c_dump_regs(regs);
+			/* Clear TOERR by writing CLRST */
+			regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return -ETIMEDOUT;
+		}
+		if (--timeout == 0) {
+			log_error("I2C: software timeout waiting for INT");
+			vg015_i2c_dump_regs(regs);
+			/* Controller may be stuck - will be reset by caller */
+			return -ETIMEDOUT;
+		}
+	}
+	return 0;
+}
 
-#define ST_INT_BIT             (1 << ST_INT_OFFSET)
-#define ST_MODE(reg)           ((reg & 0x3F) << ST_MODE_OFFSET)
+/* Wait for STOP condition to complete.
+ * Returns 0 on success, -ETIMEDOUT on timeout */
+static int vg015_i2c_wait_stop(struct niiet_i2c_regs *regs) {
+	int timeout = I2C_TIMEOUT_LOOPS;
 
-#define CST_BB_OFFSET          0x0
-
-#define CST_BB_BIT             (1 << CST_BB_OFFSET)
-
-#define I2C_ST_MODE_IDLE       0x0UL      /*!< General - Idle, no valid status information available */
-#define I2C_ST_MODE_STDONE     0x1UL      /*!< FS master - Start condition generated */
-#define I2C_ST_MODE_RSDONE     0x2UL      /*!< FS master - Repeated start condition generated */
-#define I2C_ST_MODE_IDLARL     0x3UL      /*!< FS master - Arbitration lost, unaddressed slave mode entered */
-#define I2C_ST_MODE_MTADPA     0x4UL      /*!< FS master transmit - Slave address sent, positive ACK */
-#define I2C_ST_MODE_MTADNA     0x5UL      /*!< FS master transmit - Slave address sent, negative ACK */
-#define I2C_ST_MODE_MTDAPA     0x6UL      /*!< FS master transmit - Data byte sent, positive ACK */
-#define I2C_ST_MODE_MTDANA     0x7UL      /*!< FS master transmit - Data byte sent, negative ACK */
-#define I2C_ST_MODE_MRADPA     0x8UL      /*!< FS master receive - Slave addres sent, positive ACK */
-#define I2C_ST_MODE_MRADNA     0x9UL      /*!< FS master receive - Slave addres sent, negative ACK */
-#define I2C_ST_MODE_MRDAPA     0xAUL      /*!< FS master receive - Data byte received, positive ACK */
-#define I2C_ST_MODE_MRDANA     0xBUL      /*!< FS master receive - Data byte received, negative ACK */
-#define I2C_ST_MODE_MTMCER     0xCUL      /*!< FS master - Mastercode transmitted, error detected (positive ACK) */
-#define I2C_ST_MODE_SRADPA     0x10UL     /*!< FS slave receive - Slave address received, positive ACK */
-#define I2C_ST_MODE_SRAAPA     0x11UL     /*!< FS slave receive - Slave address received after arbitration loss, positive ACK */
-#define I2C_ST_MODE_SRDAPA     0x12UL     /*!< FS slave receive - Data byte received, positive ACK */
-#define I2C_ST_MODE_SRDANA     0x13UL     /*!< FS slave receive - Data byte received, negative ACK */
-#define I2C_ST_MODE_STADPA     0x14UL     /*!< FS slave transmit - Slave address received, positive ACK */
-#define I2C_ST_MODE_STAAPA     0x15UL     /*!< FS slave transmit - Slave address received, negative ACK */
-#define I2C_ST_MODE_STDAPA     0x16UL     /*!< FS slave transmit - Data byte sent, positive ACK */
-#define I2C_ST_MODE_STDANA     0x17UL     /*!< FS slave transmit - Data byte sent, negative ACK */
-#define I2C_ST_MODE_SATADP     0x18UL     /*!< FS slave transmit alert response - Alert response address received, positive ACK */
-#define I2C_ST_MODE_SATAAP     0x19UL     /*!< FS slave transmit alert response - Alert response address received after arbitration loss, positive ACK */
-#define I2C_ST_MODE_SATDAP     0x1AUL     /*!< FS slave transmit alert response - Alert response data byte sent, positive ACK */
-#define I2C_ST_MODE_SATDAN     0x1BUL     /*!< FS slave transmit alert response - Alert response data byte sent, negative ACK */
-#define I2C_ST_MODE_SSTOP      0x1CUL     /*!< FS slave - Slave mode stop condition detected */
-#define I2C_ST_MODE_SGADPA     0x1DUL     /*!< FS slave - Global call address received, positive ACK */
-#define I2C_ST_MODE_SDAAPA     0x1EUL     /*!< FS slave - Global call address received after arbitration loss, positive ACK */
-#define I2C_ST_MODE_BERROR     0x1FUL     /*!< General - Bus error detected (invalid start or stop condition */
-#define I2C_ST_MODE_HMTMCOK    0x21UL     /*!< HS master - Master code transmitted OK - switched to HS mode */
-#define I2C_ST_MODE_HRSDONE    0x22UL     /*!< HS master - Repeated start condition generated */
-#define I2C_ST_MODE_HIDLARL    0x23UL     /*!< HS master - Arbitration lost, HS unaddressed slave mode entered */
-#define I2C_ST_MODE_HMTADPA    0x24UL     /*!< HS master transmit - Slave address sent, positive ACK */
-#define I2C_ST_MODE_HMTADNA    0x25UL     /*!< HS master transmit - Slave address sent, negative ACK */
-#define I2C_ST_MODE_HMTDAPA    0x26UL     /*!< HS master transmit - Data byte sent, positive ACK */
-#define I2C_ST_MODE_HMTDANA    0x27UL     /*!< HS master transmit - Data byte sent, negative ACK */
-#define I2C_ST_MODE_HMRADPA    0x28UL     /*!< HS master receive - Slave address sent, positive ACK */
-#define I2C_ST_MODE_HMRADNA    0x29UL     /*!< HS master receive - Slave address sent, negative ACK */
-#define I2C_ST_MODE_HMRDAPA    0x2AUL     /*!< HS master receive - Data byte received, positive ACK */
-#define I2C_ST_MODE_HMRDANA    0x2BUL     /*!< HS master receive - Data byte received, negative ACK */
-#define I2C_ST_MODE_HSRADPA    0x30UL     /*!< HS slave receive - Slave address received, positive ACK */
-#define I2C_ST_MODE_HSRDAPA    0x32UL     /*!< HS slave receive - Data byte received, positive ACK */
-#define I2C_ST_MODE_HSRDANA    0x33UL     /*!< HS slave receive - Data byte received, negative ACK */
-#define I2C_ST_MODE_HSTADPA    0x34UL     /*!< HS slave transmit - Slave address received, positive ACK */
-#define I2C_ST_MODE_HSTDAPA    0x36UL     /*!< HS slave transmit - Data byte sent, positive ACK */
-#define I2C_ST_MODE_HSTDANA    0x37UL     /*!< HS slave transmit - Data byte sent, negative ACK */
-
-
+	/* Wait for STOP bit to clear (hardware finished sending STOP) */
+	while(regs->CTL0 & CTL0_STOP_BIT) {
+		if (regs->CST & CST_TOERR_BIT) {
+			log_error("I2C: hardware timeout during STOP");
+			regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return -ETIMEDOUT;
+		}
+		if (--timeout == 0) {
+			log_error("I2C: timeout waiting for STOP completion");
+			return -ETIMEDOUT;
+		}
+	}
+	return 0;
+}
 
 static int vg015_i2c_tx(const struct i2c_bus *bus, uint16_t addr,
 									uint8_t *buff, size_t sz) {
 	struct niiet_i2c_regs *regs;
-	int i;
+	uint32_t mode;
+	size_t i;
+	int ret;
 
 	regs = (void *)bus->i2cb_label;
 
-	while(!(regs->ST & ST_INT_BIT)) ;
-	if (ST_MODE(regs->ST) & I2C_ST_MODE_STDONE) {
-		regs->SDA = (addr << 1) | 1;
-	} else {
-		log_error("st mode not I2C_ST_MODE_STDONE");
+	/* Wait for start condition completion */
+	ret = vg015_i2c_wait_int(regs);
+	if (ret != 0) {
+		return ret;
+	}
+	mode = ST_MODE(regs->ST);
+	if (mode != I2C_ST_MODE_STDONE && mode != I2C_ST_MODE_RSDONE) {
+		log_error("TX: expected STDONE/RSDONE, got 0x%x", mode);
+		vg015_i2c_dump_regs(regs);
+		return -EIO;
 	}
 
-	for (i = 0; i < sz; i ++) {
-		if(regs->ST & ST_INT_BIT) {
-			uint32_t mode;
+	/* Send slave address with write bit (R/W = 0) */
+	regs->SDA = (addr << 1);
+	regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
 
-			mode = ST_MODE(regs->ST);
-			switch (mode) {
-				case I2C_ST_MODE_MTADPA:
-					regs->SDA = buff[i];
-					break;
-				case I2C_ST_MODE_MTDAPA:
-					regs->CTL0 |= CTL0_STOP_BIT;
+	/* Wait for address ACK */
+	ret = vg015_i2c_wait_int(regs);
+	if (ret != 0) {
+		return ret;
+	}
+	mode = ST_MODE(regs->ST);
+	if (mode == I2C_ST_MODE_MTADNA) {
+		/* NAK is normal for device scanning (i2cdetect), not an error */
+		log_debug("TX: slave 0x%02x not responding (NAK)", addr);
+		regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		return -ENXIO;
+	}
+	if (mode == I2C_ST_MODE_HMTMCOK) {
+		/* Addresses 0x04-0x07 when shifted become master codes (0x08-0x0E)
+		 * which trigger HS mode. These are reserved I2C addresses.
+		 * Send STOP to exit HS mode and return no-device. */
+		log_debug("TX: addr 0x%02x triggered HS mode (reserved)", addr);
+		regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		return -ENXIO;
+	}
+	if (mode != I2C_ST_MODE_MTADPA) {
+		log_error("TX: expected MTADPA, got 0x%x", mode);
+		vg015_i2c_dump_regs(regs);
+		regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		return -EIO;
+	}
 
-					break;
-				default  :	break;
-			}
+	/* Quick write (sz=0): address sent, no data - used by i2cdetect.
+	 * Must clear INT before returning, STOP is sent by master_xfer. */
+	if (sz == 0) {
+		regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		return 0;
+	}
 
-			regs->CTL0 = (CTL0_CLRST_BIT /*| CTL0_INTEN_BIT */);
+	/* Transmit data bytes */
+	for (i = 0; i < sz; i++) {
+		regs->SDA = buff[i];
+		regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+
+		ret = vg015_i2c_wait_int(regs);
+		if (ret != 0) {
+			regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return ret;
+		}
+		mode = ST_MODE(regs->ST);
+		if (mode == I2C_ST_MODE_MTDANA) {
+			log_error("TX: data NAK at byte %zu", i);
+			vg015_i2c_dump_regs(regs);
+			regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return -EIO;
+		}
+		if (mode != I2C_ST_MODE_MTDAPA) {
+			log_error("TX: expected MTDAPA, got 0x%x", mode);
+			vg015_i2c_dump_regs(regs);
+			regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return -EIO;
 		}
 	}
 
-	return 0;
+	return sz;
 }
 
 static int vg015_i2c_rx(const struct i2c_bus *bus, uint16_t addr,
 									uint8_t *buff, size_t sz) {
 	struct niiet_i2c_regs *regs;
-	int i;
+	uint32_t mode;
+	size_t i;
+	int ret;
 
 	regs = (void *)bus->i2cb_label;
 
-	while(!(regs->ST & ST_INT_BIT)) ;
-	if (ST_MODE(regs->ST) & I2C_ST_MODE_STDONE) {
-		regs->SDA = (addr << 1) | 1;
-	} else {
-		log_error("st mode not I2C_ST_MODE_STDONE");
+	/* Wait for start condition completion */
+	ret = vg015_i2c_wait_int(regs);
+	if (ret != 0) {
+		return ret;
+	}
+	mode = ST_MODE(regs->ST);
+	if (mode != I2C_ST_MODE_STDONE && mode != I2C_ST_MODE_RSDONE) {
+		log_error("RX: expected STDONE/RSDONE, got 0x%x", mode);
+		vg015_i2c_dump_regs(regs);
+		return -EIO;
 	}
 
-	for (i = 0; i < sz; i ++) {
-		if(regs->ST & ST_INT_BIT) {
-			uint32_t mode;
+	/* Send slave address with read bit (R/W = 1) */
+	regs->SDA = (addr << 1) | 1;
+	regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
 
-			mode = ST_MODE(regs->ST);
-			switch (mode) {
-				case I2C_ST_MODE_MRADPA:
-					break;
-				case I2C_ST_MODE_MRDAPA:
-					buff[i] = regs->SDA;
-					if (i != sz - 1) {
-						regs->CTL0 |= CTL0_ACK_BIT;
-					}/* else {
-						regs->CTL0 &= ~CTL0_ACK_BIT;
-					} */
+	/* Wait for address ACK */
+	ret = vg015_i2c_wait_int(regs);
+	if (ret != 0) {
+		return ret;
+	}
+	mode = ST_MODE(regs->ST);
+	if (mode == I2C_ST_MODE_MRADNA) {
+		/* NAK is normal for device scanning (i2cdetect), not an error */
+		log_debug("RX: slave 0x%02x not responding (NAK)", addr);
+		regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		return -ENXIO;
+	}
+	if (mode != I2C_ST_MODE_MRADPA) {
+		log_error("RX: expected MRADPA, got 0x%x", mode);
+		vg015_i2c_dump_regs(regs);
+		regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		return -EIO;
+	}
 
-					break;
-				case I2C_ST_MODE_MRDANA:
-					regs->CTL0 |= CTL0_STOP_BIT;
-					break;
-				default  :	break;
-			}
-
-			regs->CTL0 = (CTL0_CLRST_BIT /*| CTL0_INTEN_BIT */);
+	/* Receive data bytes */
+	for (i = 0; i < sz; i++) {
+		/* ACK bit: 0 = send ACK, 1 = send NACK
+		 * Send ACK for all bytes except the last one */
+		if (i < sz - 1) {
+			regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+		} else {
+			/* NACK for last byte to signal end of transfer */
+			regs->CTL0 = CTL0_ACK_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
 		}
+
+		ret = vg015_i2c_wait_int(regs);
+		if (ret != 0) {
+			regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return ret;
+		}
+		mode = ST_MODE(regs->ST);
+		if (mode != I2C_ST_MODE_MRDAPA && mode != I2C_ST_MODE_MRDANA) {
+			log_error("RX: expected MRDAPA/MRDANA, got 0x%x", mode);
+			vg015_i2c_dump_regs(regs);
+			regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+			return -EIO;
+		}
+
+		buff[i] = regs->SDA;
 	}
 
-	return 0;
+	return sz;
 }
 
 static inline int niiet_i2c_is_busy(struct niiet_i2c_regs *regs) {
 	return regs->CST & CST_BB_BIT;
+}
 
+/* Reset I2C controller to recover from stuck state */
+static void vg015_i2c_reset(struct niiet_i2c_regs *regs) {
+	uint32_t ctl1_save;
+
+	log_warning("I2C: resetting controller");
+
+	/* Save CTL1 (frequency settings) */
+	ctl1_save = regs->CTL1;
+
+	/* Disable I2C controller */
+	regs->CTL1 &= ~CTL1_ENABLE_BIT;
+
+	/* Small delay for disable to take effect */
+	for (volatile int i = 0; i < 100; i++);
+
+	/* Re-enable controller with saved settings */
+	regs->CTL1 = ctl1_save | CTL1_ENABLE_BIT;
+
+	/* Clear status and enable INT */
+	regs->CTL0 = CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+
+	/* Generate STOP to reset bus state */
+	regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+	vg015_i2c_wait_stop(regs);
 }
 
 static int vg015_i2c_master_xfer(const struct i2c_bus *bus,
 						struct i2c_msg *msgs, size_t num_msgs) {
 	struct niiet_i2c_regs *regs;
-	int res;
-	int i;
+	int res = 0;
+	size_t i;
+	int timeout;
 
 	regs = (void *)bus->i2cb_label;
 
-	i = 0;
+	timeout = 0;
 	while(niiet_i2c_is_busy(regs)) {
-		if (i++ > 1000) {
-			return -EBUSY;
+		if (timeout++ > 1000) {
+			/* Bus stuck - try to recover */
+			vg015_i2c_reset(regs);
+			if (niiet_i2c_is_busy(regs)) {
+				return -EBUSY;
+			}
+			break;
 		}
 	}
 
-	regs->CTL0 = CTL0_START_BIT;
-
-
 	for (i = 0; i < num_msgs; i++) {
+		/* Generate start or repeated start condition.
+		 * Use |= to preserve INTEN bit set during init */
+		regs->CTL0 |= CTL0_START_BIT;
+
 		if (msgs[i].flags & I2C_M_RD) {
-			res = vg015_i2c_rx(bus, msgs->addr, msgs[i].buf, msgs[i].len);
+			res = vg015_i2c_rx(bus, msgs[i].addr, msgs[i].buf, msgs[i].len);
+		} else {
+			res = vg015_i2c_tx(bus, msgs[i].addr, msgs[i].buf, msgs[i].len);
 		}
-		else {
-			res = vg015_i2c_tx(bus, msgs->addr, msgs[i].buf, msgs[i].len);
+
+		if (res < 0) {
+			break;
 		}
+	}
+
+	/* Generate stop condition and wait for completion */
+	regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+	if (vg015_i2c_wait_stop(regs) != 0) {
+		/* STOP failed - reset controller */
+		vg015_i2c_reset(regs);
+	}
+
+	/* Reset controller after serious errors to prevent stuck state */
+	if (res == -ETIMEDOUT || res == -EIO) {
+		vg015_i2c_reset(regs);
 	}
 
 	return res;
@@ -250,15 +381,28 @@ static int vg015_i2c_init(const struct i2c_bus *bus) {
 
 	vg015_i2c_hw_init0(bus);
 
-	freq_calc = SMBUS_SYSTEM_FREQ / (4 * FSFreq);
+	freq_calc = I2C_SYSTEM_FREQ / (4 * I2C_FS_FREQ);
 	regs->CTL1 = CTL1_SCLFRQ(freq_calc & 0x7F);
 	regs->CTL3 = CTL3_SCLFRQ(freq_calc >> 7);
 
-	freq_calc = SMBUS_SYSTEM_FREQ / ( 3 * HSFreq );
-	regs->CTL2 = CTL2_SHSDIV(freq_calc & 0x0F);
-	regs->CTL4 = CTL4_SHSDIV(freq_calc >> 4);
+	/* Set HS mode dividers so STOP works if HS mode entered accidentally
+	 * (reserved addresses 0x04-0x07 trigger HS mode) */
+	regs->CTL2 = 0x80;  /* HSDIV[3:0] = 8 */
+	regs->CTL4 = 0x00;  /* HSDIV[11:4] = 0 */
 
 	regs->CTL1 |= CTL1_ENABLE_BIT;
+
+	/* Enable INT flag generation (required for polling ST.INT) */
+	regs->CTL0 = CTL0_INTEN_BIT;
+
+	/* Generate dummy STOP to set BB=1 (bus busy) for clean state */
+	regs->CTL0 = CTL0_STOP_BIT | CTL0_CLRST_BIT | CTL0_INTEN_BIT;
+	vg015_i2c_wait_stop(regs);
+
+	/* Check bus state - warn if stuck (possible missing pull-ups) */
+	if (niiet_i2c_is_busy(regs)) {
+		log_warning("I2C: bus busy after init - check pull-up resistors");
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Fixes:
- Handle HMTMCOK status for reserved addresses 0x04-0x07 (HS mode)
- Set HS mode dividers so STOP works if HS mode entered accidentally
- Add GPIO OUTMODE open-drain support for I2C pins
- Preserve INTEN bit in all CTL0 writes
- Fix SCL pin GPIO alternate function
- Add dummy STOP in init to set BB=1 for clean state
- Add timeout protection in polling loops
- Support i2cdetect quick-write mode

Bus recovery:
- Add controller reset function for stuck bus recovery
- Reset on EBUSY, ETIMEDOUT, EIO errors
- Warn if bus stuck after init (missing pull-ups)

Code quality:
- Align with STM32 I2C driver code style
- Remove unused macros and status codes
- Fix indentation and formatting

Tested: M24C16 EEPROM detected at 0x50-0x57