### PR TITLE
Fix riscv/sifive_e

### DIFF
--- a/templates/riscv/sifive_e/mods.conf
+++ b/templates/riscv/sifive_e/mods.conf
@@ -13,7 +13,7 @@ configuration conf {
 	include embox.driver.tty.serial_stub
 
 	include embox.driver.interrupt.riscv_plic
-	include embox.driver.clock.riscv_mtimer(rtc_freq=10000000)
+	include embox.driver.clock.riscv_mtimer(rtc_freq=32768)
 	include embox.kernel.time.jiffies(cs_name="riscv_mtimer")
 
 	include embox.driver.periph_memory_stub


### PR DESCRIPTION
Specified the correct value for rtc_freq

https://github.com/sifive/freedom-e-sdk/blob/4518a22c213d7fec6e23e20d24a2ba646014f6dd/software/sifive-welcome/sifive-welcome.c#L10