### PR TITLE
removing reference to old module in stm32f4

### DIFF
--- a/project/pjsip/templates/stm32f4discovery/mods.conf
+++ b/project/pjsip/templates/stm32f4discovery/mods.conf
@@ -76,7 +76,7 @@ configuration conf {
 	include embox.fs.driver.initfs_dvfs(file_quantity=32)
 	//include embox.fs.driver.devfs_dvfs
 	include embox.fs.rootfs_dvfs(fstype="initfs")
-	include embox.fs.dvfs.super_block(super_block_pool_size=2)
+	//include embox.fs.dvfs.super_block(super_block_pool_size=2)
 	include embox.fs.dvfs.core(inode_pool_size=4, dentry_pool_size=4, file_pool_size=4)
 	include embox.compat.posix.file_system_dvfs
 	include embox.fs.syslib.perm_stub


### PR DESCRIPTION
Fixes the issue : https://github.com/embox/embox/issues/3820

<img width="1308" height="186" alt="image" src="https://github.com/user-attachments/assets/89ff8d82-b8d2-40de-8c60-d6486bf07def" />
make confload-project/pjsip/stm32f4discovery
<img width="1306" height="41" alt="image" src="https://github.com/user-attachments/assets/41a51063-eec3-4a81-a134-24fa65fe957f" />

 when trying to make for stm32f4 disc boards a warning arises in the build.

Its reference is only for discovery boards and removing it works fine.

<img width="1306" height="168" alt="image" src="https://github.com/user-attachments/assets/651a0b65-a98f-4037-b6d9-f08f65bea57a" />
