### PR TITLE
scripts/qemu: Fix RAM address parsing for auto_qemu

### DIFF
--- a/scripts/qemu/auto_qemu
+++ b/scripts/qemu/auto_qemu
@@ -80,7 +80,7 @@ guess_arch() {
 get_user_empty_guess AUTOQEMU_ARCH guess_arch
 
 guess_mem() {
-	ram=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/^RAM *([0-9x]*, *\([0-9]*[MK]\))/\1/p')
+	ram=$(cat $LDS_CONF | gcc -P -E - | sed -n 's/^RAM *([0-9a-fA-Fx]*, *\([0-9]*[MK]\))/\1/p')
 	if [ "$ram" ]; then
 		echo "$ram"
 	else


### PR DESCRIPTION
The RAM address was not parsed if it contained letters, as a result of which the size was set to the standard 128M, instead of the specified one.