### PR TITLE
tests/libc: add tests for bcopy()

### DIFF
--- a/src/compat/libc/strings/tests/Mybuild
+++ b/src/compat/libc/strings/tests/Mybuild
@@ -16,3 +16,8 @@ module ffs_test {
 	@Cflags("-fno-builtin")
 	source "ffs_test.c"
 }
+
+module bcopy_test {
+	@Cflags("-fno-builtin")
+	source "bcopy_test.c"
+}

--- a/src/compat/libc/strings/tests/bcopy_test.c
+++ b/src/compat/libc/strings/tests/bcopy_test.c
@@ -1,0 +1,131 @@
+/**
+ * @file
+ * @brief Test of bcopy() function.
+ *
+ * @date Mar 11, 2026
+ * @author: Piyush Patle
+ */
+
+#include <string.h>
+#include <strings.h>
+#include <embox/test.h>
+
+#define BCOPY_LARGE_BUF_LEN 1024
+
+EMBOX_TEST_SUITE("bcopy test");
+
+TEST_CASE("bcopy basic copy") {
+	const char src[] = {'a', 'b', 'c', 'd'};
+	char dest[sizeof(src)];
+
+	bcopy(src, dest, sizeof(src));
+
+	test_assert_zero(memcmp(dest, src, sizeof(src)));
+}
+
+TEST_CASE("bcopy partial copy") {
+	const char src[] = {'a', 'b', 'c', 'd', 'e'};
+	char dest[sizeof(src)];
+	const size_t copy_len = 3;
+
+	memset(dest, 0, sizeof(dest));
+	bcopy(src, dest, copy_len);
+
+	test_assert_zero(memcmp(dest, src, copy_len));
+    test_assert_zero(memcmp(dest + copy_len,
+                        "\0\0",
+                        sizeof(src) - copy_len));
+}
+
+TEST_CASE("bcopy forward overlap") {
+	char buf[] = {'a', 'b', 'c', 'd', 'e', 'f'};
+	const char expected[] = {'a', 'b', 'a', 'b', 'c', 'd'};
+	const size_t offset = 2;
+
+	bcopy(buf, buf + offset, sizeof(buf) - offset);
+
+	test_assert_zero(memcmp(buf, expected, sizeof(buf)));
+}
+
+TEST_CASE("bcopy backward overlap") {
+	char buf[] = {'a', 'b', 'c', 'd', 'e', 'f'};
+	const char expected[] = {'c', 'd', 'e', 'f', 'e', 'f'};
+	const size_t offset = 2;
+
+	bcopy(buf + offset, buf, sizeof(buf) - offset);
+
+	test_assert_zero(memcmp(buf, expected, sizeof(buf)));
+}
+
+TEST_CASE("bcopy zero length") {
+	const char src[] = {'a', 'b', 'c'};
+	char dest[] = {'x', 'y', 'z'};
+
+	bcopy(src, dest, 0);
+
+	test_assert_equal(dest[0], 'x');
+	test_assert_equal(dest[1], 'y');
+	test_assert_equal(dest[2], 'z');
+}
+
+TEST_CASE("bcopy self copy") {
+	char buf[] = {'a', 'b', 'c', 'd'};
+	const char expected[] = {'a', 'b', 'c', 'd'};
+
+	bcopy(buf, buf, sizeof(buf));
+
+	test_assert_zero(memcmp(buf, expected, sizeof(buf)));
+}
+
+TEST_CASE("bcopy single byte") {
+	char src[] = {'a'};
+	char dest[] = {'x'};
+
+	bcopy(src, dest, 1);
+
+	test_assert_equal(dest[0], 'a');
+}
+
+TEST_CASE("bcopy full buffer boundary") {
+	const char src[] = {'a', 'b', 'c', 'd', 'e'};
+	char dest[sizeof(src)];
+	const size_t n = sizeof(src);
+
+	bcopy(src, dest, n);
+
+	test_assert_zero(memcmp(dest, src, n));
+}
+
+TEST_CASE("bcopy minimum forward overlap") {
+	char buf[] = {'a', 'b', 'c', 'd', 'e', 'f'};
+	const char expected[] = {'a', 'a', 'b', 'c', 'd', 'e'};
+	const size_t offset = 1;
+
+	bcopy(buf, buf + offset, sizeof(buf) - offset);
+
+	test_assert_zero(memcmp(buf, expected, sizeof(buf)));
+}
+
+TEST_CASE("bcopy minimum backward overlap") {
+	char buf[] = {'a', 'b', 'c', 'd', 'e', 'f'};
+	const char expected[] = {'b', 'c', 'd', 'e', 'f', 'f'};
+	const size_t offset = 1;
+
+	bcopy(buf + offset, buf, sizeof(buf) - offset);
+
+	test_assert_zero(memcmp(buf, expected, sizeof(buf)));
+}
+
+TEST_CASE("bcopy large buffer") {
+	static char src[BCOPY_LARGE_BUF_LEN];
+	static char dest[BCOPY_LARGE_BUF_LEN];
+
+	for (size_t i = 0; i < sizeof(src); i++) {
+		src[i] = (char)(i & 0xff);
+	}
+
+	memset(dest, 0, sizeof(dest));
+	bcopy(src, dest, sizeof(src));
+
+	test_assert_zero(memcmp(dest, src, sizeof(src)));
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -190,6 +190,7 @@ configuration conf {
 
 	@Runlevel(1) include embox.compat.libc.strings.test.ffs_test
 	@Runlevel(1) include embox.compat.libc.strings.test.strcasecmp_test
+	@Runlevel(1) include embox.compat.libc.strings.test.bcopy_test
 
 	@Runlevel(1) include embox.compat.libc.str.test.strcoll_test
 	@Runlevel(1) include embox.compat.libc.str.test.strxfrm_test


### PR DESCRIPTION
Fix #3900.
In this PR some tests for `bcopy()` were added.

Changes:

1. Added tests covering common and corner cases, including basic copying, partial copying, forward and backward overlapping buffers, zero-length copies, self-copy behavior, and large buffer copying. All tests are implemented within new `file src/compat/libc/strings/tests/bcopy_test.c`.
2. Added test module in `src/compat/libc/strings/tests/Mybuild`.
3. Updated configure in file `templates/x86/test/units/mods.conf`.