### PR TITLE
tests/libc: add tests for bzero()

### DIFF
--- a/src/compat/libc/strings/tests/Mybuild
+++ b/src/compat/libc/strings/tests/Mybuild
@@ -16,3 +16,8 @@ module ffs_test {
 	@Cflags("-fno-builtin")
 	source "ffs_test.c"
 }
+
+module bzero_test {
+        @Cflags("-fno-builtin")
+        source "bzero_test.c"
+}

--- a/src/compat/libc/strings/tests/bzero_test.c
+++ b/src/compat/libc/strings/tests/bzero_test.c
@@ -1,0 +1,79 @@
+/**
+ * @file
+ * @brief Test of bzero() function.
+ *
+ * @date Mar 2026
+ */
+
+#include <string.h>
+#include <strings.h>
+#include <embox/test.h>
+
+#define BZERO_LARGE_BUF_LEN 1024
+
+EMBOX_TEST_SUITE("bzero test");
+
+TEST_CASE("bzero basic") {
+	char buf[] = {'a', 'b', 'c', 'd'};
+
+	bzero(buf, sizeof(buf));
+
+	for (size_t i = 0; i < sizeof(buf); i++) {
+		test_assert_equal(buf[i], 0);
+	}
+}
+
+TEST_CASE("bzero partial") {
+	char buf[] = {'a', 'b', 'c', 'd', 'e'};
+	const size_t n = 3;
+
+	bzero(buf, n);
+
+	for (size_t i = 0; i < n; i++) {
+		test_assert_equal(buf[i], 0);
+	}
+
+	test_assert_equal(buf[3], 'd');
+	test_assert_equal(buf[4], 'e');
+}
+
+TEST_CASE("bzero zero length") {
+	char buf[] = {'a', 'b', 'c'};
+
+	bzero(buf, 0);
+
+	test_assert_equal(buf[0], 'a');
+	test_assert_equal(buf[1], 'b');
+	test_assert_equal(buf[2], 'c');
+}
+
+TEST_CASE("bzero single byte") {
+	char buf[] = {'x'};
+
+	bzero(buf, 1);
+
+	test_assert_equal(buf[0], 0);
+}
+
+TEST_CASE("bzero full buffer") {
+	char buf[] = {'a', 'b', 'c', 'd', 'e'};
+
+	bzero(buf, sizeof(buf));
+
+	for (size_t i = 0; i < sizeof(buf); i++) {
+		test_assert_equal(buf[i], 0);
+	}
+}
+
+
+TEST_CASE("bzero large buffer") {
+	static char buf[BZERO_LARGE_BUF_LEN];
+
+	memset(buf, 'A', sizeof(buf));
+
+	bzero(buf, sizeof(buf));
+
+	for (size_t i = 0; i < sizeof(buf); i++) {
+		test_assert_equal(buf[i], 0);
+	}
+}

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -190,7 +190,7 @@ configuration conf {
 
 	@Runlevel(1) include embox.compat.libc.strings.test.ffs_test
 	@Runlevel(1) include embox.compat.libc.strings.test.strcasecmp_test
-
+	@Runlevel(1) include embox.compat.libc.strings.test.bzero_test
 	@Runlevel(1) include embox.compat.libc.str.test.strcoll_test
 	@Runlevel(1) include embox.compat.libc.str.test.strxfrm_test
 	@Runlevel(1) include embox.compat.libc.str.test.memccpy_test


### PR DESCRIPTION
Fix #3899 
In this PR tests for `bzero()`  were added.

Changes:
1. Added tests covering common and corner cases, including basic zeroing, partial zeroing, zero-length operations, single byte zeroing, full buffer zeroing, and large buffer zeroing. All tests are implemented in new file `src/compat/libc/strings/tests/bzero_test.c`.
2. Added test module in `src/compat/libc/strings/tests/Mybuild`.
3. Updated configure in file `templates/x86/test/units/mods.conf`.