### PR TITLE
usb: stm32f4_udc: fix bulk OUT handling for CDC-ACM

### DIFF
--- a/src/drivers/usb/gadget/udc/stm32/stm32f4_udc.c
+++ b/src/drivers/usb/gadget/udc/stm32/stm32f4_udc.c
@@ -226,6 +226,7 @@ static void stm32f4_ll_handle_standard_request(struct usb_control_header *req) {
         /* status stage for control-OUT request */
         HAL_PCD_EP_Transmit(&hpcd, 0x00U, NULL, 0U);
         // HAL_PCD_EP_Receive(&hpcd, 0x00U, NULL, 0U);
+		break;
     }
 	case USB_REQ_GET_CONFIG:
 		//stm32f4_ll_get_configuration(req);


### PR DESCRIPTION
Fixed STM32F4 USB gadget UDC bulk OUT path, released endpoint busy state after transfers, and added a missing break to avoid incorrect control flow.