### PR TITLE
math/tests :add yn_test()

### DIFF
--- a/src/compat/libc/math/tests/Mybuild
+++ b/src/compat/libc/math/tests/Mybuild
@@ -239,3 +239,7 @@ module rint_test {
 	@Cflags("-fno-builtin")
 	source "rint_test.c"
 }
+module yn_test {
+	@Cflags("-fno-builtin")
+	source "yn_test.c"
+}

--- a/src/compat/libc/math/tests/yn_test.c
+++ b/src/compat/libc/math/tests/yn_test.c
@@ -1,0 +1,36 @@
+#include <math.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("yn() tests");
+
+TEST_CASE("Test for yn() with negative x argument") {
+    test_assert(isnan(yn(0,-1.0)));
+}
+
+TEST_CASE("Test for yn() with negative x argument") {
+    test_assert(isnan(yn(1,-1.0)));
+}
+
+TEST_CASE("Test for yn(0,0.0)") {
+    test_assert(yn(0, 0.0) == -INFINITY);
+}
+
+TEST_CASE("Test for yn(1,0.0)") {
+    test_assert(yn(1, 0.0) == -INFINITY);
+}
+
+TEST_CASE("Test for yn(0,INFINITY)") {
+    test_assert(yn(0,INFINITY)==0.0);
+}
+
+TEST_CASE("Test for yn(1,INFINITY)") {
+    test_assert(yn(1,INFINITY)==0.0);
+}
+
+TEST_CASE("Test for yn(0,NaN)") {
+    test_assert(isnan(yn(0,NAN)));
+}
+
+TEST_CASE("Test for yn(1,NaN)") {
+    test_assert(isnan(yn(1,NAN)));
+}

--- a/templates/aarch64/test/units/mods.conf
+++ b/templates/aarch64/test/units/mods.conf
@@ -274,6 +274,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.tgamma_test
 	@Runlevel(1) include embox.compat.libc.test.trunc_test
 	@Runlevel(1) include embox.compat.libc.test.erf_test
+	@Runlevel(1) include embox.compat.libc.test.yn_test
 
 	@Runlevel(1) include embox.test.mem.slab_test
 	@Runlevel(1) include embox.test.mem.pool_test

--- a/templates/riscv64/test/units/mods.conf
+++ b/templates/riscv64/test/units/mods.conf
@@ -232,6 +232,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.tanh_test
 	@Runlevel(1) include embox.compat.libc.test.tgamma_test
 	@Runlevel(1) include embox.compat.libc.test.trunc_test
+	@Runlevel(1) include embox.compat.libc.test.yn_test
 
 	@Runlevel(1) include embox.test.mem.slab_test
 	@Runlevel(1) include embox.test.mem.pool_test

--- a/templates/x86/test/units/mods.conf
+++ b/templates/x86/test/units/mods.conf
@@ -272,6 +272,7 @@ configuration conf {
 	@Runlevel(1) include embox.compat.libc.test.tan_test
 	@Runlevel(1) include embox.compat.libc.test.rint_test
 	@Runlevel(1) include embox.compat.libc.test.hypot_test
+	@Runlevel(1) include embox.compat.libc.test.yn_test
 
 	@Runlevel(1) include embox.test.mem.pool_test
 	@Runlevel(1) include embox.test.mem.heap_test


### PR DESCRIPTION
Fixes #3905 
Adding test for bessel yn function

Changes:

- Added tests covering common and corner cases with input x being negative , 0.0 , infinity and NaN , all with n = 0 and n =1
- Added test module in src/compat/libc/math/tests/Mybuild.
- Updated configure in mods.conf file of x86, aarch64, riscv64 