### PR TITLE
math/tests: fix copysign_test

### DIFF
--- a/src/compat/libc/math/tests/copysign_test.c
+++ b/src/compat/libc/math/tests/copysign_test.c
@@ -34,11 +34,12 @@ TEST_CASE("Test for copysign(+8.0, -1.0)") {
 TEST_CASE("Test for copysign(+INFINITY, -2.0)") {
 	test_assert(copysign(INFINITY, -2.0) == -INFINITY);
 }
-#if 0
+
 TEST_CASE("Test for copysign(NAN, -2.0)") {
-	test_assert(copysign(NAN, -2.0) == -NAN);
+	test_assert(isnan(copysign(NAN, -2.0)));
+	test_assert(signbit(copysign(NAN, -2.0)));
 }
-#endif
+
 TEST_CASE("Test for copysign(2.0, -0.0)") {
 	test_assert(copysign(2.0, -0.0) == -2.0);
 }


### PR DESCRIPTION
Fixes #3458

Changes:

fixed the test copysign(NAN,-2.0) by using the isnan() function and signbit() function instead of equating directly with -NAN