### PR TITLE
tests/libc: add tests for gcvt()

### DIFF
--- a/src/compat/libc/stdlib/tests/Mybuild
+++ b/src/compat/libc/stdlib/tests/Mybuild
@@ -12,6 +12,10 @@ module bsearch_test {
 	source "bsearch_test.c"
 }
 
+module gcvt_test {
+       source "gcvt_test.c"
+}
+
 module mbstowcs_test {
 	source "mbstowcs_test.c"
 }

--- a/src/compat/libc/stdlib/tests/gcvt_test.c
+++ b/src/compat/libc/stdlib/tests/gcvt_test.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+#include <string.h>
+#include <embox/test.h>
+
+EMBOX_TEST_SUITE("gcvt() tests");
+
+TEST_CASE("gcvt with positive float") {
+	char buf[32];
+	gcvt(3.14, 3, buf);
+	test_assert(strcmp(buf, "3.14") == 0);
+}
+
+TEST_CASE("gcvt with negative float") {
+	char buf[32];
+	gcvt(-3.14, 3, buf);
+	test_assert(strcmp(buf, "-3.14") == 0);
+}
+
+TEST_CASE("gcvt with zero") {
+	char buf[32];
+	gcvt(0.0, 3, buf);
+	test_assert(strcmp(buf, "0.000") == 0);
+}
+
+TEST_CASE("gcvt with integer-like value") {
+	char buf[32];
+	gcvt(100.0, 3, buf);
+	test_assert(strcmp(buf, "100") == 0);
+}
+
+TEST_CASE("gcvt with trailing zero") {
+	char buf[32];
+	gcvt(1.5, 3, buf);
+	test_assert(strcmp(buf, "1.50") == 0);
+}
+
+TEST_CASE("gcvt with NULL buf returns NULL") {
+	test_assert(gcvt(1.5, 3, NULL) == NULL);
+}

--- a/templates/aarch64/test/units/mods.conf
+++ b/templates/aarch64/test/units/mods.conf
@@ -194,7 +194,15 @@ configuration conf {
 	
 	@Runlevel(1) include embox.compat.libc.stdlib.tests.wcstombs_test
 	@Runlevel(1) include embox.compat.libc.stdlib.tests.itoa_test
-
+	
+	@Runlevel(1) include embox.compat.libc.stdlib.tests.atof_test
+    	@Runlevel(1) include embox.compat.libc.stdlib.tests.bsearch_test
+    	@Runlevel(1) include embox.compat.libc.stdlib.tests.mblen_test
+    	@Runlevel(1) include embox.compat.libc.stdlib.tests.mbstowcs_test
+   	@Runlevel(1) include embox.compat.libc.stdlib.tests.qsort_test
+   	@Runlevel(1) include embox.compat.libc.stdlib.tests.wcstombs_test
+    	@Runlevel(1) include embox.compat.libc.stdlib.tests.itoa_test
+    	@Runlevel(1) include embox.compat.libc.stdlib.tests.gcvt_test 
 	@Runlevel(1) include embox.compat.libc.setjmp.tests.setjmp_test
 
 	@Runlevel(1) include embox.compat.libc.strings.test.ffs_test


### PR DESCRIPTION
Added test suite for `gcvt()` in `src/compat/libc/stdlib/tests/gcvt_test.c`.

Tests cover:
- Positive float
- Negative float
- Zero
- Integer-like value
- Trailing zero padding
- NULL buffer returns NULL