### PR TITLE
 setup tty diag respect dev name

### DIFF
--- a/src/init/setup_tty_diag.c
+++ b/src/init/setup_tty_diag.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief
+ * @brief Setup TTY with fallback to diag device
  *
  * @date 06.03.14
  * @author Ilia Vaprol
@@ -11,21 +11,31 @@
 #include <unistd.h>
 #include <stddef.h>
 #include <string.h>
-#include <errno.h>
 #include <stdarg.h>
+#include <stdio.h>
 
 #define DIAG_NAME "diag"
+#define DEV_PREFIX "/dev/"
 
 extern int diag_fd(void);
 
-const char *setup_tty(const char *dev_name) {
+static int try_open_dev(const char *dev_name) {
+	char path[64];
 	int fd;
 
-	fd = diag_fd();
-	if (fd < 0) {
-		return NULL;
+	/* Try /dev/<dev_name> first */
+	snprintf(path, sizeof(path), DEV_PREFIX "%s", dev_name);
+	fd = open(path, O_RDWR);
+	if (fd >= 0) {
+		return fd;
 	}
 
+	/* Try the name as-is (might be a full path) */
+	fd = open(dev_name, O_RDWR);
+	return fd;
+}
+
+static void redirect_stdio(int fd) {
 	dup2(fd, STDIN_FILENO);
 	dup2(fd, STDOUT_FILENO);
 	dup2(fd, STDERR_FILENO);
@@ -33,6 +43,28 @@ const char *setup_tty(const char *dev_name) {
 	if (fd > STDERR_FILENO) {
 		close(fd);
 	}
+}
+
+const char *setup_tty(const char *dev_name) {
+	int fd;
+
+	/* If a device name is specified and it's not "diag", try to open it */
+	if (dev_name != NULL && dev_name[0] != '\0'
+			&& strcmp(dev_name, DIAG_NAME) != 0) {
+		fd = try_open_dev(dev_name);
+		if (fd >= 0) {
+			redirect_stdio(fd);
+			return dev_name;
+		}
+	}
+
+	/* Fallback to diag device */
+	fd = diag_fd();
+	if (fd < 0) {
+		return NULL;
+	}
+
+	redirect_stdio(fd);
 
 	return DIAG_NAME;
 }

--- a/src/init/start_script.c
+++ b/src/init/start_script.c
@@ -39,6 +39,9 @@ static int run_script(void) {
 	}
 
 	tty_dev_name = setup_tty(OPTION_STRING_GET(tty_dev));
+	if (NULL == tty_dev_name) {
+		tty_dev_name = "(none)";
+	}
 
 	printf("\nStarted shell [%s] on device [%s]\n",
 		shell->name, tty_dev_name);

--- a/src/init/system_start_service.c
+++ b/src/init/system_start_service.c
@@ -5,7 +5,6 @@
  * @date 04.10.11
  * @author Alexander Kalmuk
  */
-#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,7 +36,9 @@ int system_start(void) {
 	int ret;
 
 	tty_dev_name = setup_tty(OPTION_STRING_GET(tty_dev));
-	assert(tty_dev_name);
+	if (NULL == tty_dev_name) {
+		tty_dev_name = "(none)";
+	}
 
 	printf("Default IO device[%s]\n", tty_dev_name);
 


### PR DESCRIPTION
  `setup_tty_diag` always ignored the `dev_name` parameter and                                                                                                                                                     
  unconditionally used the diag device. This meant any `tty_dev`
  option set in `start_script` or `system_start_service` was silently                                                                                                                                              
  discarded.                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  Now `setup_tty_diag` attempts to open the requested device first                                                                                                                                                 
  (`/dev/<name>`) and only falls back to diag when:
  - No device name is specified                                                                                                                                                                                    
  - The device name is "diag"
  - The requested device fails to open                                                                                                                                                                             
                                                                                                                                                                                                                   
  Also replaces an `assert()` and unchecked NULL in `start_script.c`                                                                                                                                               
  and `system_start_service.c` with graceful error handling.                                  
                                                                                                                                                                                                                                                                                                                                        
  Closes #3530    
                                                                                                                                                                                                                   
  ## Tested       
  Built and booted on x86/qemu. Shell starts on the configured
  serial device instead of always falling back to diag:   
<img width="692" height="356" alt="Screenshot from 2026-04-04 00-36-45" src="https://github.com/user-attachments/assets/94985f17-6019-45b3-a7cc-5dca20b1f3b6" />
