### PR TITLE
Add a bmp280 sensor

### DIFF
--- a/src/cmds/hardware/sensors/bmp280/Mybuild
+++ b/src/cmds/hardware/sensors/bmp280/Mybuild
@@ -1,0 +1,7 @@
+package embox.cmd.hardware.sensors
+
+@AutoCmd
+@Cmd(name="bmp280", help="bmp280 sensor demo")
+module bmp280 {
+	source "bmp280.c"
+}

--- a/src/cmds/hardware/sensors/bmp280/bmp280.c
+++ b/src/cmds/hardware/sensors/bmp280/bmp280.c
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    09.04.2026
+ * @author  Efim Perevalov
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <drivers/sensors/bmp280.h>
+
+int main(int argc, char **argv) {
+	printf("Testing bmp280\n");
+
+	if (0 != bmp280_init()) {
+		printf("Failed to init bmp280!\n");
+		return -1;
+	}
+
+	int temp = bmp280_get_temperature();
+
+	printf("TEMP: %4d\n", temp);
+}

--- a/src/drivers/sensors/bmp280/Mybuild
+++ b/src/drivers/sensors/bmp280/Mybuild
@@ -9,6 +9,6 @@ abstract module bmp280 {
 
 static module bmp280_i2c extends bmp280 {
 	option string log_level="LOG_ERR"
-	option number i2c_bus = 0
+	option number i2c_bus = 1
 	source "bmp280_i2c.c"
 }

--- a/src/drivers/sensors/bmp280/Mybuild
+++ b/src/drivers/sensors/bmp280/Mybuild
@@ -6,3 +6,9 @@ abstract module bmp280 {
 
 	source "bmp280.c"
 }
+
+static module bmp280_i2c extends bmp280 {
+	option string log_level="LOG_ERR"
+	option number i2c_bus = 0
+	source "bmp280_i2c.c"
+}

--- a/src/drivers/sensors/bmp280/Mybuild
+++ b/src/drivers/sensors/bmp280/Mybuild
@@ -1,0 +1,8 @@
+package embox.driver.sensors
+
+abstract module bmp280 {
+	@IncludeExport(path="drivers/sensors", target_name="bmp280.h")
+	source "bmp280.h"
+
+	source "bmp280.c"
+}

--- a/src/drivers/sensors/bmp280/bmp280.c
+++ b/src/drivers/sensors/bmp280/bmp280.c
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    09.04.2026
+ * @author  Efim Perevalov
+ */
+#include <unistd.h>
+#include <util/log.h>
+#include <drivers/i2c/i2c.h>
+
+#include "bmp280.h"
+
+/* https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf*/
+
+#define BMP280_ID            0xD0
+#define BMP280_RESET         0xE0
+#define BMP280_STATUS        0xF3
+#define BMP280_CTRL_MEAS     0xF4
+#define BMP280_CONFIG        0xF5
+#define BMP280_PRESS_MSB     0xF7
+#define BMP280_PRESS_LSB     0xF8
+#define BMP280_PRESS_XLSB    0xF9
+#define BMP280_TEMP_MSB      0xFA
+#define BMP280_TEMP_LSB      0xFB
+#define BMP280_TEMP_XLSB     0xFC
+#define BMP280_CALIB_START   0x88
+#define BMP280_CHIP_ID_VAL   0x58
+#define BMP280_RESET_VAL     0xB6
+
+extern struct bmp280_dev bmp280_dev0;
+
+int16_t bmp280_get_temperature(void) {
+
+    return 0;
+}
+
+int16_t bmp280_get_humidity(void) {
+
+	return 0;
+}
+
+int16_t bmp280_get_pressure(void) {
+
+	return 0;
+}
+
+int bmp280_init(void) {
+
+	return 0;
+}

--- a/src/drivers/sensors/bmp280/bmp280.c
+++ b/src/drivers/sensors/bmp280/bmp280.c
@@ -24,6 +24,7 @@
 #define BMP280_TEMP_MSB      0xFA
 #define BMP280_TEMP_LSB      0xFB
 #define BMP280_TEMP_XLSB     0xFC
+
 #define BMP280_CALIB_START   0x88
 #define BMP280_CHIP_ID_VAL   0x58
 #define BMP280_RESET_VAL     0xB6
@@ -52,6 +53,13 @@ int16_t bmp280_get_pressure(void) {
 }
 
 int bmp280_init(void) {
+    uint8_t chip_id;
 
-	return 0;
+    bmp280_readb(&bmp280_dev0, BMP280_ID, &chip_id);
+    if (chip_id != BMP280_CHIP_ID_VAL) {
+        log_error("BMP280: wrong chip id 0x%02x\n", chip_id);
+        return -1;
+    }
+
+    return 0;
 }

--- a/src/drivers/sensors/bmp280/bmp280.c
+++ b/src/drivers/sensors/bmp280/bmp280.c
@@ -7,9 +7,9 @@
  */
 #include <unistd.h>
 #include <util/log.h>
-#include <drivers/i2c/i2c.h>
 
 #include "bmp280.h"
+#include "bmp280_transfer.h"
 
 /* https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf*/
 
@@ -31,8 +31,14 @@
 extern struct bmp280_dev bmp280_dev0;
 
 int16_t bmp280_get_temperature(void) {
+	// recommended to use a burst read and not address every register individually
+	uint8_t msb, lsb, xlsb;
+	
+    bmp280_readb(&bmp280_dev0, BMP280_TEMP_MSB,  &msb);
+    bmp280_readb(&bmp280_dev0, BMP280_TEMP_LSB,  &lsb);
+    bmp280_readb(&bmp280_dev0, BMP280_TEMP_XLSB, &xlsb);
 
-    return 0;
+    return ((int32_t)msb << 12) | ((int32_t)lsb << 4) | (xlsb >> 4);
 }
 
 int16_t bmp280_get_humidity(void) {

--- a/src/drivers/sensors/bmp280/bmp280.h
+++ b/src/drivers/sensors/bmp280/bmp280.h
@@ -1,5 +1,13 @@
-#ifndef BMP280_TRANSFER_H_
-#define BMP280_TRANSFER_H_
+/**
+ * @file
+ * @brief
+ *
+ * @date    09.04.2026
+ * @author  Efim Perevalov
+ */
+
+#ifndef BMP280_H_
+#define BMP280_H_
 
 #include <stdint.h>
 
@@ -8,4 +16,4 @@ extern int16_t bmp280_get_temperature(void);
 extern int16_t bmp280_get_humidity(void);
 extern int16_t bmp280_get_pressure(void);
 
-#endif /* BMP280_TRANSFER_H_ */
+#endif /* BMP280_H_ */

--- a/src/drivers/sensors/bmp280/bmp280.h
+++ b/src/drivers/sensors/bmp280/bmp280.h
@@ -1,0 +1,11 @@
+#ifndef BMP280_TRANSFER_H_
+#define BMP280_TRANSFER_H_
+
+#include <stdint.h>
+
+extern int bmp280_init(void);
+extern int16_t bmp280_get_temperature(void);
+extern int16_t bmp280_get_humidity(void);
+extern int16_t bmp280_get_pressure(void);
+
+#endif /* BMP280_TRANSFER_H_ */

--- a/src/drivers/sensors/bmp280/bmp280_i2c.c
+++ b/src/drivers/sensors/bmp280/bmp280_i2c.c
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    09.04.2026
+ * @author  Efim Perevalov
+ */
+#include <stdint.h>
+#include <framework/mod/options.h>
+#include <drivers/i2c/i2c.h>
+
+#include "bmp280.h"
+#include "bmp280_transfer.h"
+
+#define BMP280_I2C_ADDR  0x76
+#define BMP280_I2C_BUS   OPTION_GET(NUMBER, i2c_bus)
+
+struct bmp280_dev {
+	int i2c_bus;
+	int i2c_addr;
+};
+
+struct bmp280_dev bmp280_dev0 = {
+	.i2c_bus  = BMP280_I2C_BUS,
+	.i2c_addr = BMP280_I2C_ADDR
+};
+
+int bmp280_hw_init(struct bmp280_dev *dev) {
+
+	return 0;
+}
+
+int bmp280_readb(struct bmp280_dev *dev, int offset, uint8_t *ret) {
+	if (i2c_bus_write(dev->i2c_bus, dev->i2c_addr,
+	        (uint8_t *) &offset, 1) < 0) {
+		return -1;
+	}
+	if (i2c_bus_read(dev->i2c_bus, dev->i2c_addr, ret, 1) < 0) {
+		return -1;
+	}
+	return 0;
+}
+
+int bmp280_writeb(struct bmp280_dev *dev,
+	    int offset, uint8_t val) {
+	uint16_t tmp = (offset & 0xFF) | (val << 8);
+	if (i2c_bus_write(dev->i2c_bus, dev->i2c_addr, (void *) &tmp, 2)) {
+		return -1;
+	}
+	return 0;
+}

--- a/src/drivers/sensors/bmp280/bmp280_transfer.h
+++ b/src/drivers/sensors/bmp280/bmp280_transfer.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * @brief
+ *
+ * @date    09.04.2026
+ * @author  Efim Perevalov
+ */
+#ifndef BMP280_TRANSFER_H_
+#define BMP280_TRANSFER_H_
+
+struct bmp280_dev;
+
+extern int bmp280_hw_init(struct bmp280_dev *dev);
+extern int bmp280_readb(struct bmp280_dev *dev, int offset, uint8_t *ret);
+extern int bmp280_writeb(struct bmp280_dev *dev, int offset, uint8_t val);
+
+#endif /* BMP280_TRANSFER_H_ */


### PR DESCRIPTION
1) Reading raw data from registers responsible for temperature has been implemented.
2) The bmp280 command outputs the raw temperature value.