### PR TITLE
Fix scr4_64 interrupt controller config

### DIFF
--- a/platform/syntacore/templates/scr4_64/mods.conf
+++ b/platform/syntacore/templates/scr4_64/mods.conf
@@ -8,8 +8,8 @@ configuration conf {
 	include embox.arch.riscv.libarch
 	include embox.arch.riscv.vfork
 
-	//include embox.driver.interrupt.syntacore_ipic(scr_ver=4)
-	include embox.driver.interrupt.riscv_plic(base_addr=0x00fffffffe000000)
+	include embox.driver.interrupt.syntacore_ipic(scr_ver=4)
+	//include embox.driver.interrupt.riscv_plic(base_addr=0x00fffffffe000000)
 
 	include embox.driver.clock.syntacore_mtimer(base_addr=0x00FFFFFFf0040000, rtc_freq=75000000)
 	include embox.kernel.time.jiffies(cs_name="syntacore_mtimer")


### PR DESCRIPTION
## What
Fix `scr4_64` to use the Syntacore IPIC interrupt controller instead of `riscv_plic`.

## Why
`platform/syntacore/templates/scr4_64/mods.conf` was configured with `riscv_plic`, but on `scr4_64` this caused a boot failure during `plic_init`. The `scr4_64` platform works correctly with `syntacore_ipic(scr_ver=4)`.

## Verification
I reproduced the issue on `scr4_64`, switched the interrupt controller to `syntacore_ipic(scr_ver=4)`, and verified that Embox boots successfully on `scr4` with:
- `tish` started on `ttyS0`
- `help` working
- `ticker -c 5` working

Fixes #3531

