### PR TITLE
lvgl: update to v9.2.2, keep backward compatibility with v7

### DIFF
--- a/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
+++ b/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
@@ -14,11 +14,18 @@
 #include "lvgl.h"
 #if LVGL_VERSION_MAJOR == 7
 #include "lv_examples.h"
-#else
+#elif LVGL_VERSION_MAJOR == 8
 #include "lv_demo.h"
+#else
+#include "demos/lv_demos.h"
+#include "demos/widgets/lv_demo_widgets.h"
 #endif
 
+#if LVGL_VERSION_MAJOR >= 9
+#include "lvgl_port_v9.h"
+#else
 #include "lvgl_port.h"
+#endif
 
 static char *fb_path;
 static char *input_dev_path;
@@ -29,6 +36,7 @@ static lv_color_t *buf1_1;
 static lv_disp_buf_t disp_buf1;
 #elif LVGL_VERSION_MAJOR == 8
 static lv_disp_draw_buf_t disp_buf1;
+#elif LVGL_VERSION_MAJOR == 9
 #else
 #error "wrong LVGL version"
 #endif
@@ -52,6 +60,56 @@ static void input_dev_touchscreen_handler(lv_timer_t *t) {
 #endif
 
 static int hal_init(void) {
+#if LVGL_VERSION_MAJOR >= 9
+	lv_display_t *disp;
+	lv_indev_t *indev;
+
+	if (lvgl_port_fbdev_init(fb_path) < 0) {
+		fprintf(stderr, "Failed to init framebuffer %s\n", fb_path);
+		return -1;
+	}
+	disp = lv_display_create(640, 480);
+
+	int32_t hor = lv_display_get_horizontal_resolution(disp);
+	int32_t ver = lv_display_get_vertical_resolution(disp);
+	buf1_1 = malloc(hor * ver * 4);
+
+	if (!buf1_1) {
+		fprintf(stderr, "Error allocation buffer for LVGL display\n");
+		return -1;
+	}
+
+	lv_display_set_flush_cb(disp, lvgl_port_fbdev_flush);
+	lv_display_set_buffers(disp, buf1_1, NULL, hor * ver * 4,
+	    LV_DISPLAY_RENDER_MODE_PARTIAL);
+
+	if (lvgl_port_input_dev_init(input_dev_path) < 0) {
+		fprintf(stderr, "Error open input device %s\n", input_dev_path);
+		free(buf1_1);
+		return -1;
+	}
+
+	indev = lv_indev_create();
+	lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
+	lv_indev_set_read_cb(indev, lvgl_port_input_dev_read);
+	lv_indev_set_display(indev, disp);
+
+	if (input_is_mouse) {
+		LV_IMG_DECLARE(mouse_cursor_icon);
+		lv_obj_t *cursor_obj = lv_image_create(lv_screen_active());
+		lv_image_set_src(cursor_obj, &mouse_cursor_icon);
+		lv_indev_set_cursor(indev, cursor_obj);
+	}
+
+	if (input_is_mouse) {
+		lv_timer_create(input_dev_mouse_handler, 10, NULL);
+	}
+	else {
+		lv_timer_create(input_dev_touchscreen_handler, 10, NULL);
+	}
+	return 0;
+
+#else
 	static lv_disp_drv_t disp_drv;
 	static lv_indev_drv_t indev_drv;
 	lv_indev_t *mouse_indev;
@@ -77,9 +135,9 @@ static int hal_init(void) {
 #if LVGL_VERSION_MAJOR == 7
 	disp_drv.buffer = &disp_buf1;
 #else
-    /*Set the resolution of the display*/
-    disp_drv.hor_res = LV_HOR_RES_MAX;
-    disp_drv.ver_res = LV_VER_RES_MAX;
+	/*Set the resolution of the display*/
+	disp_drv.hor_res = LV_HOR_RES_MAX;
+	disp_drv.ver_res = LV_VER_RES_MAX;
 	disp_drv.draw_buf = &disp_buf1;
 #endif
 	disp_drv.flush_cb = lvgl_port_fbdev_flush;
@@ -110,14 +168,12 @@ static int hal_init(void) {
 #if LVGL_VERSION_MAJOR == 7
 	if (input_is_mouse) {
 		lv_task_create(input_dev_mouse_handler, 10, LV_TASK_PRIO_HIGH, NULL);
-
 	} else {
 		lv_task_create(input_dev_touchscreen_handler, 10, LV_TASK_PRIO_HIGH, NULL);
 	}
 #else
 	if (input_is_mouse) {
 		lv_timer_create(input_dev_mouse_handler, 10, NULL);
-
 	} else {
 		lv_timer_create(input_dev_touchscreen_handler, 10, NULL);
 	}
@@ -127,11 +183,12 @@ static int hal_init(void) {
 err_free:
 	free(buf1_1);
 	return -1;
+#endif
 }
 
 static inline void lvgl_timer_handler(struct sys_timer *timer, void *param) {
-	(void) timer;
-	(void) param;
+	(void)timer;
+	(void)param;
 
 	lv_tick_inc(50);
 }
@@ -139,8 +196,7 @@ static inline void lvgl_timer_handler(struct sys_timer *timer, void *param) {
 static void print_usage(void) {
 	printf("Usage: lvgl_demo [-t] fb input_dev\n"
 	       "\t -t: Ifspecified, this means input device is touchscreen.\n"
-	       "\t     Othervice, it's mouse.\n"
-	);
+	       "\t     Othervice, it's mouse.\n");
 }
 
 int main(int argc, char **argv) {

--- a/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
+++ b/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
@@ -32,6 +32,7 @@ static char *input_dev_path;
 static int input_is_mouse = 0;
 
 static lv_color_t *buf1_1;
+static lv_indev_t *mouse_indev;
 #if LVGL_VERSION_MAJOR == 7
 static lv_disp_buf_t disp_buf1;
 #elif LVGL_VERSION_MAJOR == 8
@@ -62,7 +63,6 @@ static void input_dev_touchscreen_handler(lv_timer_t *t) {
 static int hal_init(void) {
 #if LVGL_VERSION_MAJOR >= 9
 	lv_display_t *disp;
-	lv_indev_t *indev;
 
 	if (lvgl_port_fbdev_init(fb_path) < 0) {
 		fprintf(stderr, "Failed to init framebuffer %s\n", fb_path);
@@ -81,7 +81,7 @@ static int hal_init(void) {
 
 	lv_display_set_flush_cb(disp, lvgl_port_fbdev_flush);
 	lv_display_set_buffers(disp, buf1_1, NULL, hor * ver * 4,
-	    LV_DISPLAY_RENDER_MODE_PARTIAL);
+	    LV_DISPLAY_RENDER_MODE_FULL);
 
 	if (lvgl_port_input_dev_init(input_dev_path) < 0) {
 		fprintf(stderr, "Error open input device %s\n", input_dev_path);
@@ -89,17 +89,10 @@ static int hal_init(void) {
 		return -1;
 	}
 
-	indev = lv_indev_create();
-	lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
-	lv_indev_set_read_cb(indev, lvgl_port_input_dev_read);
-	lv_indev_set_display(indev, disp);
-
-	if (input_is_mouse) {
-		LV_IMG_DECLARE(mouse_cursor_icon);
-		lv_obj_t *cursor_obj = lv_image_create(lv_screen_active());
-		lv_image_set_src(cursor_obj, &mouse_cursor_icon);
-		lv_indev_set_cursor(indev, cursor_obj);
-	}
+	mouse_indev = lv_indev_create();
+	lv_indev_set_type(mouse_indev, LV_INDEV_TYPE_POINTER);
+	lv_indev_set_read_cb(mouse_indev, lvgl_port_input_dev_read);
+	lv_indev_set_display(mouse_indev, disp);
 
 	if (input_is_mouse) {
 		lv_timer_create(input_dev_mouse_handler, 10, NULL);
@@ -236,6 +229,15 @@ int main(int argc, char **argv) {
 	}
 
 	lv_demo_widgets();
+
+#if LVGL_VERSION_MAJOR >= 9
+	if (input_is_mouse) {
+		LV_IMG_DECLARE(mouse_cursor_icon);
+		lv_obj_t *cursor_obj = lv_image_create(lv_layer_sys());
+		lv_image_set_src(cursor_obj, &mouse_cursor_icon);
+		lv_indev_set_cursor(mouse_indev, cursor_obj);
+	}
+#endif
 
 	sys_timer_set(&timer, SYS_TIMER_PERIODIC, 50, lvgl_timer_handler, NULL);
 

--- a/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
+++ b/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
@@ -32,7 +32,9 @@ static char *input_dev_path;
 static int input_is_mouse = 0;
 
 static lv_color_t *buf1_1;
+#if LVGL_VERSION_MAJOR >= 9
 static lv_indev_t *mouse_indev;
+#endif
 #if LVGL_VERSION_MAJOR == 7
 static lv_disp_buf_t disp_buf1;
 #elif LVGL_VERSION_MAJOR == 8

--- a/project/lvgl/cmds/lvgl_demo/mouse_cursor_icon.c
+++ b/project/lvgl/cmds/lvgl_demo/mouse_cursor_icon.c
@@ -95,10 +95,18 @@ const uint8_t mouse_cursor_icon_map[] = {
 };
 
 lv_img_dsc_t mouse_cursor_icon = {
+#if LVGL_VERSION_MAJOR < 9
     .header.always_zero = 0,
     .header.w = 14,
     .header.h = 20,
     .data_size = 280 * LV_IMG_PX_SIZE_ALPHA_BYTE,
     .header.cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
+#else
+    .header.magic = LV_IMAGE_HEADER_MAGIC,
+    .header.w = 14,
+    .header.h = 20,
+    .data_size = 280 * 4,
+    .header.cf = LV_COLOR_FORMAT_ARGB8888,
+#endif
     .data = mouse_cursor_icon_map,
 };

--- a/project/lvgl/templates/arm_qemu/lvgl/lv_conf.h
+++ b/project/lvgl/templates/arm_qemu/lvgl/lv_conf.h
@@ -67,7 +67,7 @@
 #define LV_DISP_LARGE_LIMIT  70
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
-typedef int16_t lv_coord_t;
+typedef int32_t lv_coord_t;
 
 /*=========================
    Memory manager settings
@@ -760,7 +760,10 @@ typedef void * lv_obj_user_data_t;
 #endif
 
 /*--END OF LV_CONF_H--*/
-
+/* v9 demo options */
+#if LVGL_VERSION_MAJOR >= 9
+#define LV_USE_DEMO_WIDGETS 1
+#endif
 #endif /*LV_CONF_H*/
 
 #endif /*End of "Content enable"*/

--- a/project/lvgl/templates/arm_qemu/mods.conf
+++ b/project/lvgl/templates/arm_qemu/mods.conf
@@ -214,8 +214,8 @@ configuration conf {
 	include embox.compat.posix.sys.mman.mmap_stub
 	include embox.kernel.task.idesc.idesc_mmap
 
-	include third_party.lib.lvgl(lvgl_version="v7.11.0")
-	include third_party.lib.lvgl_display_port_memcpy(log_level="LOG_DEBUG")
-	include third_party.lib.lvgl_input_dev_port(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl(lvgl_version="v9.2.2", log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_display_port_memcpy_v9(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_input_dev_port_v9(log_level="LOG_DEBUG")
 	include project.lvgl.cmd.lvgl_demo
 }

--- a/third-party/lib/lvgl/Makefile
+++ b/third-party/lib/lvgl/Makefile
@@ -15,6 +15,10 @@ PKG_PATCHES_v7.11.0 :=
 PKG_MD5_v8.1.0     := 2e2ce43854ab77ade4f6af0d4b175b0b
 PKG_PATCHES_v8.1.0 := patch-8.1.0.txt
 
+#PKG_VER := v9.2.2
+PKG_MD5_v9.2.2     := ccbb8f8fb5a320c0bc4ab9ccfaecfe5c
+PKG_PATCHES_v9.2.2 := #patch-9.2.2.txt
+
 PKG_PATCHES := $(PKG_PATCHES_$(PKG_VER))
 PKG_MD5     := $(PKG_MD5_$(PKG_VER))
 
@@ -39,5 +43,5 @@ $(INSTALL) :
 	mkdir -p $(PKG_INSTALL_DIR)/include
 	cp $(PKG_SOURCE_DIR)/*.h $(PKG_INSTALL_DIR)/include
 	cp -r $(PKG_SOURCE_DIR)/src $(PKG_INSTALL_DIR)/include
-	cp $(PKG_SOURCE_DIR)/build/liblvgl.a $(PKG_INSTALL_DIR)/bin
+	cp $(PKG_SOURCE_DIR)/build/lib/liblvgl.a $(PKG_INSTALL_DIR)/bin
 	touch $@

--- a/third-party/lib/lvgl/Makefile
+++ b/third-party/lib/lvgl/Makefile
@@ -43,5 +43,9 @@ $(INSTALL) :
 	mkdir -p $(PKG_INSTALL_DIR)/include
 	cp $(PKG_SOURCE_DIR)/*.h $(PKG_INSTALL_DIR)/include
 	cp -r $(PKG_SOURCE_DIR)/src $(PKG_INSTALL_DIR)/include
+ifeq ($(filter v9.%,$(PKG_VER)),$(PKG_VER))
 	cp $(PKG_SOURCE_DIR)/build/lib/liblvgl.a $(PKG_INSTALL_DIR)/bin
+else
+	cp $(PKG_SOURCE_DIR)/build/liblvgl.a $(PKG_INSTALL_DIR)/bin
+endif
 	touch $@

--- a/third-party/lib/lvgl/Makefile
+++ b/third-party/lib/lvgl/Makefile
@@ -17,7 +17,7 @@ PKG_PATCHES_v8.1.0 := patch-8.1.0.txt
 
 #PKG_VER := v9.2.2
 PKG_MD5_v9.2.2     := ccbb8f8fb5a320c0bc4ab9ccfaecfe5c
-PKG_PATCHES_v9.2.2 := #patch-9.2.2.txt
+PKG_PATCHES_v9.2.2 := patch-9.2.2.txt
 
 PKG_PATCHES := $(PKG_PATCHES_$(PKG_VER))
 PKG_MD5     := $(PKG_MD5_$(PKG_VER))

--- a/third-party/lib/lvgl/Mybuild
+++ b/third-party/lib/lvgl/Mybuild
@@ -37,3 +37,25 @@ static module lvgl_input_dev_port {
 
 	source "input_dev_port.c"
 }
+
+@BuildDepends(lvgl)
+static module lvgl_display_port_memcpy_v9 extends lvgl_display_port_api {
+    option string log_level="LOG_ERR"
+    source "display_port.c",
+           "display_port_memcpy_v9.c"
+}
+
+@BuildDepends(lvgl)
+@BuildDepends(third_party.bsp.st_bsp_api)
+static module lvgl_display_port_stm32_v9 extends lvgl_display_port_api {
+    option string log_level="LOG_ERR"
+    source "display_port.c",
+           "display_port_stm32_v9.c"
+    @NoRuntime depends third_party.bsp.st_bsp_api
+}
+
+@BuildDepends(lvgl)
+static module lvgl_input_dev_port_v9 {
+    option string log_level="LOG_ERR"
+    source "input_dev_port_v9.c"
+}

--- a/third-party/lib/lvgl/display_port_memcpy_v9.c
+++ b/third-party/lib/lvgl/display_port_memcpy_v9.c
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * @brief LVGL display interface port (LVGL v9)
+ * @details Based on lv_drivers/display/fbdev.c
+ *
+ * @date 27.04.2026
+ * @author Ruslan Nafikov
+ */
+#include <unistd.h>
+#include <util/log.h>
+#include <drivers/video/fb.h>
+#include "lvgl.h"
+
+extern uint8_t *lv_fbp;
+extern struct fb_var_screeninfo lv_vinfo;
+extern struct fb_fix_screeninfo lv_finfo;
+
+void lvgl_port_fbdev_flush(lv_display_t *disp, const lv_area_t *area,
+        uint8_t *px_map) {
+    int32_t act_x1, act_y1, act_x2, act_y2;
+    long int location = 0;
+    int32_t w;
+
+    if (lv_fbp == NULL ||
+            area->x2 < 0 ||
+            area->y2 < 0 ||
+            area->x1 > (int32_t)lv_vinfo.xres - 1 ||
+            area->y1 > (int32_t)lv_vinfo.yres - 1) {
+        lv_display_flush_ready(disp);
+        return;
+    }
+
+    act_x1 = area->x1 < 0 ? 0 : area->x1;
+    act_y1 = area->y1 < 0 ? 0 : area->y1;
+    act_x2 = area->x2 > (int32_t)lv_vinfo.xres - 1 ? (int32_t)lv_vinfo.xres - 1 : area->x2;
+    act_y2 = area->y2 > (int32_t)lv_vinfo.yres - 1 ? (int32_t)lv_vinfo.yres - 1 : area->y2;
+    w = (act_x2 - act_x1 + 1);
+
+    if (lv_vinfo.bits_per_pixel == 32 || lv_vinfo.bits_per_pixel == 24) {
+        uint32_t *lv_fbp32 = (uint32_t *)lv_fbp;
+        int32_t y;
+        for (y = act_y1; y <= act_y2; y++) {
+            location = (act_x1 + lv_vinfo.xoffset) +
+                       (y + lv_vinfo.yoffset) * lv_finfo.line_length / 4;
+            memcpy(&lv_fbp32[location], px_map, w * 4);
+            px_map += w * 4;
+        }
+    } else if (lv_vinfo.bits_per_pixel == 16) {
+        uint16_t *lv_fbp16 = (uint16_t *)lv_fbp;
+        int32_t y;
+        for (y = act_y1; y <= act_y2; y++) {
+            location = (act_x1 + lv_vinfo.xoffset) +
+                       (y + lv_vinfo.yoffset) * lv_finfo.line_length / 2;
+            memcpy(&lv_fbp16[location], px_map, w * 2);
+            px_map += w * 2;
+        }
+    } else {
+        log_error("Unsupported bits_per_pixel=%d", lv_vinfo.bits_per_pixel);
+    }
+
+    lv_display_flush_ready(disp);
+}

--- a/third-party/lib/lvgl/display_port_stm32_v9.c
+++ b/third-party/lib/lvgl/display_port_stm32_v9.c
@@ -1,0 +1,73 @@
+/**
+ * @file
+ * @brief LVGL display interface port for STM32 (LVGL v9)
+ * @details Based on lv_drivers/display/fbdev.c
+ *
+ * @date 27.04.2026
+ * @author Ruslan Nafikov
+ */
+#include <unistd.h>
+#include <util/log.h>
+#include <drivers/video/fb.h>
+#if defined STM32F746xx || defined STM32F769xx
+#include <stm32f7xx_hal.h>
+#elif defined STM32H745xx
+#include <stm32h7xx_hal.h>
+#elif defined (STM32F429xx)
+#include <stm32f4xx_hal.h>
+#endif
+#include "lvgl.h"
+
+extern uint8_t *lv_fbp;
+extern struct fb_var_screeninfo lv_vinfo;
+extern struct fb_fix_screeninfo lv_finfo;
+
+void lvgl_port_fbdev_flush(lv_display_t *disp, const lv_area_t *area,
+        uint8_t *px_map) {
+    int32_t act_x1, act_y1, act_x2, act_y2;
+    long int location = 0;
+    int32_t w;
+
+    if (lv_fbp == NULL ||
+            area->x2 < 0 ||
+            area->y2 < 0 ||
+            area->x1 > (int32_t)lv_vinfo.xres - 1 ||
+            area->y1 > (int32_t)lv_vinfo.yres - 1) {
+        lv_display_flush_ready(disp);
+        return;
+    }
+
+    act_x1 = area->x1 < 0 ? 0 : area->x1;
+    act_y1 = area->y1 < 0 ? 0 : area->y1;
+    act_x2 = area->x2 > (int32_t)lv_vinfo.xres - 1 ? (int32_t)lv_vinfo.xres - 1 : area->x2;
+    act_y2 = area->y2 > (int32_t)lv_vinfo.yres - 1 ? (int32_t)lv_vinfo.yres - 1 : area->y2;
+    w = (act_x2 - act_x1 + 1);
+
+    if (lv_vinfo.bits_per_pixel == 32 || lv_vinfo.bits_per_pixel == 24) {
+        uint32_t *lv_fbp32 = (uint32_t *)lv_fbp;
+        int32_t y;
+        for (y = act_y1; y <= act_y2; y++) {
+            location = (act_x1 + lv_vinfo.xoffset) +
+                       (y + lv_vinfo.yoffset) * lv_finfo.line_length / 4;
+            memcpy(&lv_fbp32[location], px_map, w * 4);
+            px_map += w * 4;
+        }
+    } else if (lv_vinfo.bits_per_pixel == 16) {
+        uint16_t *lv_fbp16 = (uint16_t *)lv_fbp;
+        int32_t y;
+        for (y = act_y1; y <= act_y2; y++) {
+            location = (act_x1 + lv_vinfo.xoffset) +
+                       (y + lv_vinfo.yoffset) * lv_finfo.line_length / 2;
+            memcpy(&lv_fbp16[location], px_map, w * 2);
+            px_map += w * 2;
+        }
+    } else {
+        log_error("Unsupported bits_per_pixel=%d", lv_vinfo.bits_per_pixel);
+    }
+
+#if defined STM32F746xx || defined STM32F769xx || defined STM32H745xx
+    SCB_CleanDCache();
+#endif
+
+    lv_display_flush_ready(disp);
+}

--- a/third-party/lib/lvgl/input_dev_port_v9.c
+++ b/third-party/lib/lvgl/input_dev_port_v9.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * @brief LVGL input devices interface port (LVGL v9)
+ *
+ * @date 27.04.2026
+ * @author Ruslan Nafikov
+ */
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <util/log.h>
+#include <drivers/input/input_dev.h>
+#include "lvgl.h"
+#include <stdio.h>
+
+static bool left_button_down = false;
+static int32_t last_x = 0, last_y = 0;
+static int inp_fd;
+
+void lvgl_port_input_dev_read(lv_indev_t *indev, lv_indev_data_t *data) {
+    (void) indev;
+    data->point.x = last_x;
+    data->point.y = last_y;
+    data->state = left_button_down ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+}
+
+int lvgl_port_input_dev_init(const char *path) {
+    inp_fd = open(path, O_RDONLY | O_NONBLOCK);
+    if (inp_fd == -1) {
+        log_error("Cannot find mouse \"%s\"", path);
+        return -1;
+    }
+    return 0;
+}
+
+static int normalize_coord(int x, int a, int b) {
+    if (x < a) {
+        return a;
+    } else if (x > b - 1) {
+        return b - 1;
+    } else {
+        return x;
+    }
+}
+
+void lvgl_port_mouse_handle(void) {
+    struct input_event ev;
+    while (1) {
+        if (read(inp_fd, &ev, sizeof ev) <= 0) {
+            break;
+        }
+        last_x += (int16_t)((ev.value >> 16) & 0xffff);
+        last_y -= (int16_t)(ev.value & 0xffff);
+        last_x = normalize_coord(last_x, 0, lv_display_get_horizontal_resolution(lv_display_get_default()));
+        last_y = normalize_coord(last_y, 0, lv_display_get_vertical_resolution(lv_display_get_default()));
+        left_button_down = !!(ev.type & MOUSE_BUTTON_LEFT);
+    }
+
+}
+
+void lvgl_port_touchscreen_handle(void) {
+    struct input_event ev;
+    while (1) {
+        if (read(inp_fd, &ev, sizeof ev) <= 0) {
+            break;
+        }
+        switch (ev.type & ~TS_EVENT_NEXT) {
+        case TS_TOUCH_1:
+            last_x = (int32_t) ((ev.value >> 16) & 0xffff);
+            last_y = (int32_t) ev.value & 0xffff;
+            last_x = normalize_coord(last_x, 0, LV_HOR_RES_MAX);
+            last_y = normalize_coord(last_y, 0, LV_VER_RES_MAX);
+            left_button_down = true;
+            break;
+        case TS_TOUCH_1_RELEASED:
+            left_button_down = false;
+            break;
+        default:
+            continue;
+        }
+    }
+}

--- a/third-party/lib/lvgl/lv_demos/Makefile
+++ b/third-party/lib/lvgl/lv_demos/Makefile
@@ -1,4 +1,3 @@
-
 define option_get_string
 $(shell echo OPTION_STRING_third_party__lib__lvgl__$(1) | \
 gcc -P -E -include $(SRCGEN_DIR)/include/config/third_party/lib/lvgl.h -)
@@ -9,22 +8,40 @@ PKG_VER  := $(call option_get_string,lvgl_version)
 
 #PKG_VER := v7.10.0
 PKG_MD5_v7.10.0 := 6d7ac30af3fb82c57008f6a49ea2497d
-
 #PKG_VER := v7.11.0
 PKG_MD5_v7.11.0 := 598e406a7fb295cbf93e887b373fa003
-
 #PKG_VER := v8.1.0
 PKG_MD5_v8.1.0 := 4c4d7dc1e18feddfac77193006764bda
-
-PKG_MD5 := $(PKG_MD5_$(PKG_VER))
-
-PKG_SOURCES := https://github.com/lvgl/lv_demos/archive/$(PKG_VER).tar.gz
 
 LVGL_CPP_FLAGS:=-DLV_CONF_PATH=$(CONF_DIR)/lvgl/lv_conf.h \
                 -DLV_EX_CONF_PATH=$(CONF_DIR)/lvgl/lv_ex_conf.h \
                 -DLV_DEMO_CONF_PATH=$(CONF_DIR)/lvgl/lv_demo_conf.h \
                 -DLV_LVGL_H_INCLUDE_SIMPLE \
                 -DLV_DEMO_CONF_INCLUDE_SIMPLE
+
+ifeq ($(filter v9.%,$(PKG_VER)),$(PKG_VER))
+
+PKG_SOURCES :=
+PKG_MD5 :=
+
+$(BUILD) :
+	touch $@
+
+$(INSTALL) :
+	mkdir -p $(PKG_INSTALL_DIR)/bin
+	mkdir -p $(PKG_INSTALL_DIR)/include
+	cp $(dir $(MOD_BUILD_DIR))lvgl/lvgl-$(PKG_VER:v%=%)/build/lib/liblvgl_demos.a \
+	   $(PKG_INSTALL_DIR)/bin/liblvglexamples.a
+	cp -r $(dir $(MOD_BUILD_DIR))lvgl/lvgl-$(PKG_VER:v%=%)/demos \
+	   $(PKG_INSTALL_DIR)/include/
+	cp $(dir $(MOD_BUILD_DIR))lvgl/lvgl-$(PKG_VER:v%=%)/lvgl.h \
+	   $(PKG_INSTALL_DIR)/include/
+	touch $@
+
+else
+
+PKG_MD5 := $(PKG_MD5_$(PKG_VER))
+PKG_SOURCES := https://github.com/lvgl/lv_demos/archive/$(PKG_VER).tar.gz
 
 $(BUILD) :
 	cp $(ROOT_DIR)/third-party/lib/lvgl/lv_demos/CMakeLists.txt $(PKG_SOURCE_DIR) \
@@ -47,3 +64,5 @@ $(INSTALL) :
 	cp -r $(PKG_SOURCE_DIR)/src $(PKG_INSTALL_DIR)/include
 	cp $(PKG_SOURCE_DIR)/build/liblvglexamples.a $(PKG_INSTALL_DIR)/bin
 	touch $@
+
+endif

--- a/third-party/lib/lvgl/lvgl_port_v9.h
+++ b/third-party/lib/lvgl/lvgl_port_v9.h
@@ -1,0 +1,24 @@
+/**
+ * @file
+ * @brief LVGL porting layer (LVGL v9)
+ *
+ * @date 27.04.2026
+ * @author Ruslan Nafikov
+ */
+#ifndef THIRD_PARTY_LIB_LVGL_LVGL_PORT_V9_H_
+#define THIRD_PARTY_LIB_LVGL_LVGL_PORT_V9_H_
+
+#include "lvgl.h"
+
+/* Display */
+extern int lvgl_port_fbdev_init(const char *fb_path);
+extern void lvgl_port_fbdev_flush(lv_display_t *disp, const lv_area_t *area,
+        uint8_t *px_map);
+
+/* Input device */
+extern int lvgl_port_input_dev_init(const char *path);
+extern void lvgl_port_input_dev_read(lv_indev_t *indev, lv_indev_data_t *data);
+extern void lvgl_port_mouse_handle(void);
+extern void lvgl_port_touchscreen_handle(void);
+
+#endif /* THIRD_PARTY_LIB_LVGL_LVGL_PORT_V9_H_ */

--- a/third-party/lib/lvgl/patch-9.2.2.txt
+++ b/third-party/lib/lvgl/patch-9.2.2.txt
@@ -1,0 +1,11 @@
+diff -aur ./lvgl-9.2.2/CMakeLists.txt ../lvgl-9.2.2/CMakeLists.txt
+--- ./lvgl-9.2.2/CMakeLists.txt	2024-10-30 10:14:36.000000000 +0300
++++ ../lvgl-9.2.2/CMakeLists.txt	2026-04-27 17:44:06.170303200 +0300
+@@ -1,7 +1,6 @@
+ cmake_minimum_required(VERSION 3.12.4)
+ 
+ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+-
+ if(NOT ESP_PLATFORM)
+   if(NOT (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
+     project(lvgl LANGUAGES C CXX ASM HOMEPAGE_URL https://github.com/lvgl/lvgl)


### PR DESCRIPTION
Update LVGL support to v9.2.2 for arm_qemu template.

Changes:
- Add v9 display and input port modules (display_port_memcpy_v9, input_dev_port_v9)
- Update lvgl_demo to support v7/v8/v9 via LVGL_VERSION_MAJOR guards
- Update mouse_cursor_icon struct for v9 image header format
- Fix library install path selection in Makefile for different versions

Tested on arm_qemu with v9.2.2 and v7.10.0.