### PR TITLE
lvgl: update remaining templates to v9.2.2 and fix port API

### DIFF
--- a/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
+++ b/project/lvgl/cmds/lvgl_demo/lvgl_demo.c
@@ -70,7 +70,7 @@ static int hal_init(void) {
 		fprintf(stderr, "Failed to init framebuffer %s\n", fb_path);
 		return -1;
 	}
-	disp = lv_display_create(640, 480);
+	disp = lv_display_create(lvgl_port_fbdev_width(), lvgl_port_fbdev_height());
 
 	int32_t hor = lv_display_get_horizontal_resolution(disp);
 	int32_t ver = lv_display_get_vertical_resolution(disp);

--- a/project/lvgl/cmds/lvgl_gpio_test/Mybuild
+++ b/project/lvgl/cmds/lvgl_gpio_test/Mybuild
@@ -12,3 +12,14 @@ module lvgl_gpio_test {
 	@NoRuntime depends third_party.lib.lvgl_display_port_api
 }
 
+@AutoCmd
+@Cmd(name="lvgl_gpio_test", help="LVGL GPIO test stm32f429i (v9)", man="")
+@BuildDepends(third_party.lib.lvgl)
+@BuildDepends(third_party.lib.lvgl_display_port_api)
+module lvgl_gpio_test_v9 {
+	@IncludePath("$(CONF_DIR)")
+	source "lvgl_gpio_test_v9.c"
+
+	@NoRuntime depends third_party.lib.lvgl
+	@NoRuntime depends third_party.lib.lvgl_display_port_api
+}

--- a/project/lvgl/cmds/lvgl_gpio_test/lvgl_gpio_test_v9.c
+++ b/project/lvgl/cmds/lvgl_gpio_test/lvgl_gpio_test_v9.c
@@ -1,0 +1,136 @@
+/**
+ * @file
+ * @brief LVGL GPIO test (LVGL v9)
+ *
+ * @date 14.06.2026
+ * @author Ruslan Nafikov
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <kernel/time/sys_timer.h>
+#include <lib/leddrv.h>
+#include <lib/libds/array.h>
+
+#include "lvgl.h"
+#include "lvgl_port_v9.h"
+
+static char *fb_path = "/dev/fb0";
+static char *input_dev_path = "/dev/stm32-ts";
+
+static lv_color_t *buf1_1 = (lv_color_t *)(0xD0000000 + (320 * 240 * 2));
+
+#define PIN_PG13_NAME "LED PG13"
+#define PIN_PG14_NAME "LED PG14"
+
+static void input_dev_touchscreen_handler(lv_timer_t *t) {
+	lvgl_port_touchscreen_handle();
+}
+
+static int hal_init(void) {
+	lv_display_t *disp;
+	lv_indev_t *indev;
+
+	if (lvgl_port_fbdev_init(fb_path) < 0) {
+		fprintf(stderr, "Failed to init framebuffer %s\n", fb_path);
+		return -1;
+	}
+
+	disp = lv_display_create(lvgl_port_fbdev_width(), lvgl_port_fbdev_height());
+
+	int32_t hor = lv_display_get_horizontal_resolution(disp);
+	int32_t ver = lv_display_get_vertical_resolution(disp);
+
+	lv_display_set_flush_cb(disp, lvgl_port_fbdev_flush);
+	lv_display_set_buffers(disp, buf1_1, NULL, hor * ver * sizeof(lv_color_t),
+	    LV_DISPLAY_RENDER_MODE_FULL);
+
+	if (lvgl_port_input_dev_init(input_dev_path) < 0) {
+		fprintf(stderr, "Error open input device %s\n", input_dev_path);
+		return -1;
+	}
+
+	indev = lv_indev_create();
+	lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
+	lv_indev_set_read_cb(indev, lvgl_port_input_dev_read);
+	lv_indev_set_display(indev, disp);
+
+	lv_timer_create(input_dev_touchscreen_handler, 10, NULL);
+
+	return 0;
+}
+
+static inline void lvgl_timer_handler(struct sys_timer *timer, void *param) {
+	(void)timer;
+	(void)param;
+
+	lv_tick_inc(50);
+}
+
+static void event_handler(lv_event_t *e) {
+	lv_event_code_t code = lv_event_get_code(e);
+	lv_obj_t *obj = lv_event_get_target(e);
+
+	if (code == LV_EVENT_VALUE_CHANGED) {
+		const char *txt = lv_checkbox_get_text(obj);
+		uint8_t state = lv_obj_get_state(obj) & LV_STATE_CHECKED ? 1 : 0;
+
+		int8_t pin = -1;
+
+		if (strcmp(txt, PIN_PG13_NAME) == 0) {
+			pin = 0;
+		}
+		if (strcmp(txt, PIN_PG14_NAME) == 0) {
+			pin = 1;
+		}
+
+		if (state) {
+			leddrv_led_on(pin);
+		}
+		else {
+			leddrv_led_off(pin);
+		}
+	}
+}
+
+void lv_checkbox_demo(void) {
+	lv_obj_set_flex_flow(lv_scr_act(), LV_FLEX_FLOW_COLUMN);
+	lv_obj_set_flex_align(lv_scr_act(), LV_FLEX_ALIGN_CENTER,
+	    LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER);
+
+	lv_obj_t *cb;
+	cb = lv_checkbox_create(lv_scr_act());
+	lv_checkbox_set_text(cb, PIN_PG13_NAME);
+	lv_obj_add_event_cb(cb, event_handler, LV_EVENT_ALL, NULL);
+
+	cb = lv_checkbox_create(lv_scr_act());
+	lv_checkbox_set_text(cb, PIN_PG14_NAME);
+	lv_obj_add_event_cb(cb, event_handler, LV_EVENT_ALL, NULL);
+
+	lv_obj_update_layout(cb);
+}
+
+int main(int argc, char **argv) {
+	struct sys_timer *timer;
+
+	lv_init();
+
+	if (0 != hal_init()) {
+		fprintf(stderr, "lvgl hal_init failed\n");
+		return -1;
+	}
+
+	lv_checkbox_demo();
+
+	sys_timer_set(&timer, SYS_TIMER_PERIODIC, 50, lvgl_timer_handler, NULL);
+
+	while (1) {
+		lv_timer_handler();
+		usleep(5 * 1000);
+	}
+
+	return 0;
+}

--- a/project/lvgl/templates/stm32f429i_discovery/lvgl/lv_conf.h
+++ b/project/lvgl/templates/stm32f429i_discovery/lvgl/lv_conf.h
@@ -67,7 +67,7 @@
 #define LV_DISP_LARGE_LIMIT  70
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
-typedef int16_t lv_coord_t;
+typedef int32_t lv_coord_t;
 
 /*=========================
    Memory manager settings
@@ -745,7 +745,10 @@ typedef void * lv_obj_user_data_t;
 #endif
 
 /*--END OF LV_CONF_H--*/
-
+/* v9 demo options */
+#if LVGL_VERSION_MAJOR >= 9
+#define LV_USE_DEMO_WIDGETS 1
+#endif
 #endif /*LV_CONF_H*/
 
 #endif /*End of "Content enable"*/

--- a/project/lvgl/templates/stm32f429i_discovery/mods.conf
+++ b/project/lvgl/templates/stm32f429i_discovery/mods.conf
@@ -107,10 +107,10 @@ configuration conf {
 	include embox.cmd.fs.ls
 	include embox.cmd.hardware.pin
 
-	include third_party.lib.lvgl
-	include third_party.lib.lvgl_display_port_stm32(log_level="LOG_DEBUG")
-	include third_party.lib.lvgl_input_dev_port(log_level="LOG_DEBUG")
-	include project.lvgl.cmd.lvgl_gpio_test
+	include third_party.lib.lvgl(lvgl_version="v9.2.2", log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_display_port_stm32_v9(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_input_dev_port_v9(log_level="LOG_DEBUG")
+	include project.lvgl.cmd.lvgl_gpio_test_v9(log_level="LOG_DEBUG")
 
 	include embox.lib.leddrv_gpio
 }

--- a/project/lvgl/templates/stm32f746g-discovery/lvgl/lv_conf.h
+++ b/project/lvgl/templates/stm32f746g-discovery/lvgl/lv_conf.h
@@ -67,7 +67,7 @@
 #define LV_DISP_LARGE_LIMIT  70
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
-typedef int16_t lv_coord_t;
+typedef int32_t lv_coord_t;
 
 /*=========================
    Memory manager settings
@@ -745,7 +745,10 @@ typedef void * lv_obj_user_data_t;
 #endif
 
 /*--END OF LV_CONF_H--*/
-
+/* v9 demo options */
+#if LVGL_VERSION_MAJOR >= 9
+#define LV_USE_DEMO_WIDGETS 1
+#endif
 #endif /*LV_CONF_H*/
 
 #endif /*End of "Content enable"*/

--- a/project/lvgl/templates/stm32f746g-discovery/lvgl/lv_conf.h
+++ b/project/lvgl/templates/stm32f746g-discovery/lvgl/lv_conf.h
@@ -203,7 +203,9 @@ typedef void * lv_fs_drv_user_data_t;
 #define LV_USE_USER_DATA 1
 
 /*1: Show CPU usage and FPS count in the right bottom corner*/
-#define LV_USE_PERF_MONITOR     1
+#if LV_USE_SYSMON == 1
+#define LV_USE_PERF_MONITOR 1
+#endif
 
 /*1: Use the functions and types from the older API if possible */
 #define LV_USE_API_EXTENSION_V6  1

--- a/project/lvgl/templates/stm32f746g-discovery/mods.conf
+++ b/project/lvgl/templates/stm32f746g-discovery/mods.conf
@@ -100,8 +100,8 @@ configuration conf {
 	include embox.compat.posix.sys.mman.mmap_stub
 	include embox.kernel.task.idesc.idesc_mmap
 
-	include third_party.lib.lvgl
-	include third_party.lib.lvgl_display_port_stm32(log_level="LOG_DEBUG")
-	include third_party.lib.lvgl_input_dev_port(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl(lvgl_version="v9.2.2", log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_display_port_stm32_v9(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_input_dev_port_v9(log_level="LOG_DEBUG")
 	include project.lvgl.cmd.lvgl_demo
 }

--- a/project/lvgl/templates/stm32f769i-discovery/lvgl/lv_conf.h
+++ b/project/lvgl/templates/stm32f769i-discovery/lvgl/lv_conf.h
@@ -67,7 +67,7 @@
 #define LV_DISP_LARGE_LIMIT  70
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
-typedef int16_t lv_coord_t;
+typedef int32_t lv_coord_t;
 
 /*=========================
    Memory manager settings
@@ -745,7 +745,10 @@ typedef void * lv_obj_user_data_t;
 #endif
 
 /*--END OF LV_CONF_H--*/
-
+/* v9 demo options */
+#if LVGL_VERSION_MAJOR >= 9
+#define LV_USE_DEMO_WIDGETS 1
+#endif
 #endif /*LV_CONF_H*/
 
 #endif /*End of "Content enable"*/

--- a/project/lvgl/templates/stm32f769i-discovery/lvgl/lv_conf.h
+++ b/project/lvgl/templates/stm32f769i-discovery/lvgl/lv_conf.h
@@ -203,7 +203,9 @@ typedef void * lv_fs_drv_user_data_t;
 #define LV_USE_USER_DATA 1
 
 /*1: Show CPU usage and FPS count in the right bottom corner*/
-#define LV_USE_PERF_MONITOR     1
+#if LV_USE_SYSMON == 1
+#define LV_USE_PERF_MONITOR 1
+#endif
 
 /*1: Use the functions and types from the older API if possible */
 #define LV_USE_API_EXTENSION_V6  1

--- a/project/lvgl/templates/stm32f769i-discovery/mods.conf
+++ b/project/lvgl/templates/stm32f769i-discovery/mods.conf
@@ -97,8 +97,8 @@ configuration conf {
 	include embox.compat.posix.sys.mman.mmap_stub
 	include embox.kernel.task.idesc.idesc_mmap
 
-	include third_party.lib.lvgl
-	include third_party.lib.lvgl_display_port_stm32(log_level="LOG_DEBUG")
-	include third_party.lib.lvgl_input_dev_port(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl(lvgl_version="v9.2.2", log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_display_port_stm32_v9(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_input_dev_port_v9(log_level="LOG_DEBUG")
 	include project.lvgl.cmd.lvgl_demo
 }

--- a/project/lvgl/templates/stm32h745i-discovery/lvgl/lv_conf.h
+++ b/project/lvgl/templates/stm32h745i-discovery/lvgl/lv_conf.h
@@ -67,7 +67,7 @@
 #define LV_DISP_LARGE_LIMIT  70
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
-typedef int16_t lv_coord_t;
+typedef int32_t lv_coord_t;
 
 /*=========================
    Memory manager settings
@@ -745,7 +745,10 @@ typedef void * lv_obj_user_data_t;
 #endif
 
 /*--END OF LV_CONF_H--*/
-
+/* v9 demo options */
+#if LVGL_VERSION_MAJOR >= 9
+#define LV_USE_DEMO_WIDGETS 1
+#endif
 #endif /*LV_CONF_H*/
 
 #endif /*End of "Content enable"*/

--- a/project/lvgl/templates/stm32h745i-discovery/mods.conf
+++ b/project/lvgl/templates/stm32h745i-discovery/mods.conf
@@ -120,8 +120,8 @@ configuration conf {
 	include embox.compat.posix.sys.mman.mmap_stub
 	include embox.kernel.task.idesc.idesc_mmap
 
-	include third_party.lib.lvgl
-	include third_party.lib.lvgl_display_port_stm32(log_level="LOG_DEBUG")
-	include third_party.lib.lvgl_input_dev_port(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl(lvgl_version="v9.2.2", log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_display_port_stm32_v9(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_input_dev_port_v9(log_level="LOG_DEBUG")
 	include project.lvgl.cmd.lvgl_demo
 }

--- a/project/lvgl/templates/x86_qemu/lvgl/lv_conf.h
+++ b/project/lvgl/templates/x86_qemu/lvgl/lv_conf.h
@@ -67,7 +67,7 @@
 #define LV_DISP_LARGE_LIMIT  70
 
 /* Type of coordinates. Should be `int16_t` (or `int32_t` for extreme cases) */
-typedef int16_t lv_coord_t;
+typedef int32_t lv_coord_t;
 
 /*=========================
    Memory manager settings
@@ -760,7 +760,10 @@ typedef void * lv_obj_user_data_t;
 #endif
 
 /*--END OF LV_CONF_H--*/
-
+/* v9 demo options */
+#if LVGL_VERSION_MAJOR >= 9
+#define LV_USE_DEMO_WIDGETS 1
+#endif
 #endif /*LV_CONF_H*/
 
 #endif /*End of "Content enable"*/

--- a/project/lvgl/templates/x86_qemu/mods.conf
+++ b/project/lvgl/templates/x86_qemu/mods.conf
@@ -223,10 +223,8 @@ configuration conf {
 
 	include embox.kernel.task.idesc.idesc_mmap
 
-	//include third_party.lib.lvgl(lvgl_version="v7.10.0")
-	//include third_party.lib.lvgl(lvgl_version="v7.11.0")
-	include third_party.lib.lvgl(lvgl_version="v8.1.0")
-	include third_party.lib.lvgl_display_port_memcpy(log_level="LOG_DEBUG")
-	include third_party.lib.lvgl_input_dev_port(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl(lvgl_version="v9.2.2", log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_display_port_memcpy_v9(log_level="LOG_DEBUG")
+	include third_party.lib.lvgl_input_dev_port_v9(log_level="LOG_DEBUG")
 	include project.lvgl.cmd.lvgl_demo
 }

--- a/third-party/lib/lvgl/display_port.c
+++ b/third-party/lib/lvgl/display_port.c
@@ -21,6 +21,14 @@ uint8_t *lv_fbp = NULL;
 struct fb_var_screeninfo lv_vinfo;
 struct fb_fix_screeninfo lv_finfo;
 
+int lvgl_port_fbdev_width(void) {
+	return lv_vinfo.xres;
+}
+
+int lvgl_port_fbdev_height(void) {
+	return lv_vinfo.yres;
+}
+
 int lvgl_port_fbdev_init(const char *fb_path) {
 	int fbfd;
 	size_t fb_size;

--- a/third-party/lib/lvgl/lvgl_port_v9.h
+++ b/third-party/lib/lvgl/lvgl_port_v9.h
@@ -12,6 +12,8 @@
 
 /* Display */
 extern int lvgl_port_fbdev_init(const char *fb_path);
+extern int lvgl_port_fbdev_width(void);
+extern int lvgl_port_fbdev_height(void);
 extern void lvgl_port_fbdev_flush(lv_display_t *disp, const lv_area_t *area,
         uint8_t *px_map);
 


### PR DESCRIPTION
arm_qemu was already on v9.2.2, this brings the rest of the templates
(x86_qemu, stm32f429i, stm32f746g, stm32f769i, stm32h745i) up to date.

Also fixed a couple of issues found along the way:
- lvgl_demo was passing hardcoded 640x480 to lv_display_create regardless
  of the actual framebuffer resolution. Now reads it from the port after
  fbdev init.
- lvgl_port_v9.h was exposing fb_var_screeninfo directly, pulling linux/fb.h
  into user code. Replaced with lvgl_port_fbdev_width/height() accessors.
- lvgl_gpio_test had no v9 support at all. Added lvgl_gpio_test_v9.c
  with the updated HAL init API. Old file left intact for v7/v8 builds.
- lvgl_gpio_test.c was missing #include <string.h> for strcmp (latent bug,
  not caught because it wasn't compiled with v9 before).

lv_conf.h changes: lv_coord_t switched to int32_t (required by v9),
LV_USE_DEMO_WIDGETS enabled for v9 demo builds.
