### PR TITLE
Improve stm32f7: usb_dev: CDC-ECM gadget

### DIFF
--- a/project/usb_dev/templates/stm32f769i-discovery-usb-gadget/mods.conf
+++ b/project/usb_dev/templates/stm32f769i-discovery-usb-gadget/mods.conf
@@ -33,7 +33,6 @@ configuration conf {
 	@Runlevel(1) include embox.driver.input.button.stm32cube_button
 	@Runlevel(2) include embox.driver.input.input_dev_devfs
 
-	@Runlevel(2) include embox.driver.net.stm32f7cube_eth
 	@Runlevel(2) include embox.driver.net.loopback
 
 	include embox.driver.periph_memory_stub
@@ -145,8 +144,8 @@ configuration conf {
 
 	/* USB Gadget (CDC-ACM / CDC-ECM) */
 	include embox.driver.usb.gadget.gadget
-	include embox.driver.usb.gadget.acm_gadget(max_packet_size=64, log_level="LOG_DEBUG")
-	//include embox.driver.usb.gadget.ecm_gadget(max_packet_size=64)
+	//include embox.driver.usb.gadget.acm_gadget(max_packet_size=64, log_level="LOG_DEBUG")
+	include embox.driver.usb.gadget.ecm_gadget(max_packet_size=64)
 
-	include embox.driver.usb.gadget.udc.stm32f7_udc(log_level="LOG_DEBUG")
+	include embox.driver.usb.gadget.udc.stm32f7_udc(log_level="LOG_ERR")
 }

--- a/src/drivers/usb/gadget/ecm/ecm_gadget.c
+++ b/src/drivers/usb/gadget/ecm/ecm_gadget.c
@@ -67,7 +67,7 @@ static struct usb_gadget_composite ecm_gadget = {
 		[ECM_STR_CONFIGURATION]     = "ECM",
 		[ECM_STR_CONTROL_INTERFACE] = "ECM Control Interface",
 		[ECM_STR_DATA_INTERFACE]    = "ECM Data Interface",
-		[ECM_STR_ETHADDR]           = "aabbccddee00",
+		[ECM_STR_ETHADDR]           = "000202030000",
 	},
 	.configs = {
 		&ecm_config,

--- a/src/drivers/usb/gadget/ecm/ecm_net_card.c
+++ b/src/drivers/usb/gadget/ecm/ecm_net_card.c
@@ -25,23 +25,51 @@
 #define ECM_RX_BUF_SZ    1024
 
 static struct net_device *ecm_card_nic;
+static const uint8_t ecm_card_mac[ETH_ALEN] = {
+	0x00, 0x02, 0x02, 0x03, 0x00, 0x00
+};
+
+static const uint32_t ecm_tx_max_wait_trials = 1000000U;
 
 static struct usb_gadget_ep *bulk_tx;
 static struct usb_gadget_ep *bulk_rx;
 
 static struct usb_gadget_request req_rx;
 static struct usb_gadget_request req_tx;
+static volatile int ecm_tx_busy;
 
 static uint8_t ecm_rx_buf[ECM_RX_BUF_SZ];
 static size_t ecm_rx_len;
 
 static int ecm_card_xmit(struct net_device *dev, struct sk_buff *skb) {
+	uint32_t trials = ecm_tx_max_wait_trials;
+	int ret;
+
+	while (ecm_tx_busy && trials > 0) {
+		trials--;
+	}
+
+	if (trials == 0) {
+		return -EBUSY;
+	}
+
 	memcpy(req_tx.buf, skb->mac.raw, skb->len);
 	req_tx.len = skb->len;
 
-	usb_gadget_ep_queue(bulk_tx, &req_tx);
+	ecm_tx_busy = 1;
+	ret = usb_gadget_ep_queue(bulk_tx, &req_tx);
+	if (ret != 0) {
+		ecm_tx_busy = 0;
+		return ret;
+	}
 
 	skb_free(skb);
+
+	return 0;
+}
+
+static int ecm_tx_complete(struct usb_gadget_ep *ep, struct usb_gadget_request *req) {
+	ecm_tx_busy = 0;
 
 	return 0;
 }
@@ -50,6 +78,13 @@ static int ecm_card_xmit(struct net_device *dev, struct sk_buff *skb) {
 static int ecm_rx_complete(struct usb_gadget_ep *ep,
 	                    struct usb_gadget_request *req) {
 	struct sk_buff *skb;
+
+	if (req->actual_len > sizeof(ecm_rx_buf) - ecm_rx_len) {
+		log_error("ECM RX packet is too large");
+		ecm_rx_len = 0;
+		usb_gadget_ep_queue(ep, req);
+		return 0;
+	}
 
 	memcpy(ecm_rx_buf + ecm_rx_len, req->buf, req->actual_len);
 	ecm_rx_len += req->actual_len;
@@ -97,6 +132,8 @@ static const struct net_driver ecm_card_drv_ops = {
 };
 
 int ecm_card_init(struct usb_gadget_ep *tx, struct usb_gadget_ep *rx) {
+	int ret;
+
 	bulk_tx = tx;
 	bulk_rx = rx;
 
@@ -104,6 +141,8 @@ int ecm_card_init(struct usb_gadget_ep *tx, struct usb_gadget_ep *rx) {
 	req_rx.len = sizeof req_rx.buf;
 	usb_gadget_ep_queue(bulk_rx, &req_rx);
 
+	ecm_tx_busy = 0;
+	req_tx.complete = ecm_tx_complete;
 	req_tx.len = sizeof req_tx.buf;
 
 	if (NULL == (ecm_card_nic = etherdev_alloc(0))) {
@@ -111,6 +150,11 @@ int ecm_card_init(struct usb_gadget_ep *tx, struct usb_gadget_ep *rx) {
 	}
 
 	ecm_card_nic->drv_ops = &ecm_card_drv_ops;
+
+	ret = netdev_set_macaddr(ecm_card_nic, ecm_card_mac);
+	if (ret != 0) {
+		return ret;
+	}
 
 	return inetdev_register_dev(ecm_card_nic);
 }

--- a/src/drivers/usb/gadget/ecm/ecm_net_card.c
+++ b/src/drivers/usb/gadget/ecm/ecm_net_card.c
@@ -22,7 +22,7 @@
 #include <drivers/usb/gadget/udc.h>
 #include <drivers/usb/gadget/gadget.h>
 
-#define ECM_RX_BUF_SZ    1024
+#define ECM_RX_BUF_SZ    USB_GADGET_REQ_BUFSIZE
 
 static struct net_device *ecm_card_nic;
 static const uint8_t ecm_card_mac[ETH_ALEN] = {

--- a/src/drivers/usb/gadget/ecm/f_ecm.c
+++ b/src/drivers/usb/gadget/ecm/f_ecm.c
@@ -61,7 +61,7 @@ static struct usb_desc_endpoint bulk_ep_tx_desc = {
     .b_length = sizeof(struct usb_desc_endpoint),
     .b_desc_type = USB_DESC_TYPE_ENDPOINT,
     .bm_attributes = USB_DESC_ENDP_TYPE_BULK,
-    .w_max_packet_size = 64,
+    .w_max_packet_size = 512,
     .b_interval = 0,
 };
 
@@ -69,7 +69,7 @@ static struct usb_desc_endpoint bulk_ep_rx_desc = {
     .b_length = sizeof(struct usb_desc_endpoint),
     .b_desc_type = USB_DESC_TYPE_ENDPOINT,
     .bm_attributes = USB_DESC_ENDP_TYPE_BULK,
-    .w_max_packet_size = 64,
+    .w_max_packet_size = 512,
     .b_interval = 0,
 };
 

--- a/src/drivers/usb/gadget/ecm/f_ecm.c
+++ b/src/drivers/usb/gadget/ecm/f_ecm.c
@@ -239,11 +239,17 @@ static int ecm_setup(struct usb_gadget_function *f,
 extern int ecm_card_init(struct usb_gadget_ep *tx, struct usb_gadget_ep *rx);
 
 static int ecm_enumerate(struct usb_gadget_function *f) {
-	ecm_card_init(&bulk_tx, &bulk_rx);
+	int ret;
 
 	usb_gadget_ep_enable(&bulk_tx);
 	usb_gadget_ep_enable(&bulk_rx);
 	usb_gadget_ep_enable(&intr);
+
+	ret = ecm_card_init(&bulk_tx, &bulk_rx);
+	if (ret != 0) {
+		log_error("ECM net card init failed: %d", ret);
+		return ret;
+	}
 
 	return 0;
 }

--- a/src/drivers/usb/gadget/udc/stm32/usb_stm32f7.c
+++ b/src/drivers/usb/gadget/udc/stm32/usb_stm32f7.c
@@ -132,7 +132,7 @@ void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd) {
 PCD_HandleTypeDef hpcd;
 extern void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd);
 static irq_return_t usb_stm32f7_usb_irq_handler(unsigned int irq_nr, void *data) {
-	printk("usb: irq entry\n");
+	log_debug("usb: irq entry");
 	HAL_PCD_IRQHandler(&hpcd);
 	return IRQ_HANDLED;
 }


### PR DESCRIPTION
Fixed cdc_ECM functionality. Packets are now sent successfully.
* Initialization order corrected
* wMaxPacketSize 64 -> 512 for bulk-endpoint
* Fixed TX synchronization. Added completion-callback + busy-flag
* Synchronized MAC addresses
* Fixed a bug with ECM_RX_BUF_SZ = 1024; the Ethernet frame reassembly buffer from 512-byte USB bulk chunks was too small for a full-size frame with an MTU of 1500.
* Removed annoying printk for each USB IRQ

Reproduced and tested on the stm32f769i-discovery