### PR TITLE
aarch64: FPSIMD, exceptions, debug, clang/lld support

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -177,7 +177,10 @@ ifeq ($(COMPILER),clang)
 common_ccflags += -Wno-gnu
 common_ccflags += -fshort-enums
 common_ccflags += -Wno-address-of-packed-member
+# -meabi gnu is ARM32. Clang aarch64 rejects it.
+ifneq ($(ARCH),aarch64)
 common_ccflags += -meabi gnu
+endif
 ifeq ($(shell expr $(CLANG_VERSION_MAJOR) \>= 16), 1)
 common_ccflags += -Wno-missing-multilib
 endif

--- a/mk/image.lds.S
+++ b/mk/image.lds.S
@@ -31,6 +31,8 @@ SECTION_SYMBOLS(bss)
 SECTIONS {
 	.text : ALIGN(TEXT_ALIGNMENT) {
 
+		KEEP(*(.bootcode));
+		KEEP(*(.text.kernel_vectors*));
 		LDS_MODULES_TEXT
 		*(.text)
 		*(.text.*)

--- a/mk/image.lds.S
+++ b/mk/image.lds.S
@@ -67,9 +67,11 @@ SECTIONS {
 
 		ALIGNMENT();
 		_eh_frame_begin = .;
+		__eh_frame_start = .;
 		KEEP(*(.eh_frame))
 		KEEP(*(.eh_frame.*))
 		KEEP(*(.eh_frame_end))
+		__eh_frame_end = .;
 		KEEP(*(.gcc_except_table*))
 
 		ALIGNMENT();

--- a/src/arch/aarch64/embox.lds.S
+++ b/src/arch/aarch64/embox.lds.S
@@ -14,6 +14,7 @@ _ram_size = LENGTH(RAM);
 SECTIONS {
 	.text : {
 		KEEP(*(.bootcode));
+		KEEP(*(.text.kernel_vectors*));
 
 		*(.text)
 		*(.text.*)

--- a/src/arch/aarch64/kernel/boot/reset_handler.S
+++ b/src/arch/aarch64/kernel/boot/reset_handler.S
@@ -9,7 +9,7 @@
 
 .weak gicv3_init_el3
 
-.section .bootcode
+.section .bootcode, "ax", %progbits
 .global aarch64_reset_handler
 
 aarch64_reset_handler:

--- a/src/arch/aarch64/kernel/context/context.c
+++ b/src/arch/aarch64/kernel/context/context.c
@@ -11,12 +11,29 @@
 #include <hal/context.h>
 #include <hal/reg.h>
 
+/* Space context_switch uses to spill q0-q31 below the saved SP. */
+#define FPSIMD_FRAME 512
+
 void context_init(struct context *ctx, unsigned int flags,
     void (*routine_fn)(void), void *sp) {
+	uintptr_t top;
+
 	memset(ctx, 0, sizeof(*ctx));
 
 	ctx->lr = (uint64_t)routine_fn;
-	ctx->sp = (uint64_t)sp;
+
+	/* Reserve the FPSIMD frame the first context_switch to this context
+	 * will restore from. Its contents do not matter - a thread that has
+	 * never run has no live FPSIMD state - but the area has to exist and
+	 * to be 16-byte aligned, since `stp q` faults otherwise, and thread
+	 * stacks are only guaranteed 8-byte alignment.
+	 *
+	 * The frame is deliberately not zeroed: context_init() is also used
+	 * for the bootstrap context, whose stack pointer is the one currently
+	 * in use, and memset()ing memory below it would clobber the live
+	 * frame of the caller. */
+	top = (uintptr_t)sp & ~(uintptr_t)(16 - 1);
+	ctx->sp = (uint64_t)(top - FPSIMD_FRAME);
 
 	if (!(flags & CONTEXT_IRQDISABLE)) {
 		ctx->daif |= DAIF_I | DAIF_F;

--- a/src/arch/aarch64/kernel/context/context_switch.S
+++ b/src/arch/aarch64/kernel/context/context_switch.S
@@ -6,33 +6,76 @@
  * @date 19.07.2019
  */
 
+/* Callee-saved GPRs go to struct context, q0-q31 go onto the thread stack
+ * right below the saved SP. The order matters: SP has to be lowered before
+ * the registers are stored, because AAPCS64 has no red zone - anything
+ * written below SP is fair game for the next exception frame. */
+#define FPSIMD_FRAME 512
+
 .text
 .global context_switch
 context_switch:
 	/* Save current context (struct context) */
+	sub     sp, sp, #FPSIMD_FRAME
+	stp     q0, q1, [sp, #0]
+	stp     q2, q3, [sp, #32]
+	stp     q4, q5, [sp, #64]
+	stp     q6, q7, [sp, #96]
+	stp     q8, q9, [sp, #128]
+	stp     q10, q11, [sp, #160]
+	stp     q12, q13, [sp, #192]
+	stp     q14, q15, [sp, #224]
+	stp     q16, q17, [sp, #256]
+	stp     q18, q19, [sp, #288]
+	stp     q20, q21, [sp, #320]
+	stp     q22, q23, [sp, #352]
+	stp     q24, q25, [sp, #384]
+	stp     q26, q27, [sp, #416]
+	stp     q28, q29, [sp, #448]
+	stp     q30, q31, [sp, #480]
+
 	mov     x2, sp
 	mrs     x3, spsr_el1
 	mrs     x4, daif
-	stp     x19, x20, [x0]
-	stp     x21, x22, [x0, #16]!
-	stp     x23, x24, [x0, #16]!
-	stp     x25, x26, [x0, #16]!
-	stp     x27, x28, [x0, #16]!
-	stp     x29, x30, [x0, #16]!
-	stp     x2, x3, [x0, #16]!
-	str     x4, [x0, #16]
+	stp     x19, x20, [x0, #0]
+	stp     x21, x22, [x0, #16]
+	stp     x23, x24, [x0, #32]
+	stp     x25, x26, [x0, #48]
+	stp     x27, x28, [x0, #64]
+	stp     x29, x30, [x0, #80]
+	stp     x2, x3, [x0, #96]
+	str     x4, [x0, #112]
 
 	/* Load previous context (struct context) */
-	ldp     x19, x20, [x1]
-	ldp     x21, x22, [x1, #16]!
-	ldp     x23, x24, [x1, #16]!
-	ldp     x25, x26, [x1, #16]!
-	ldp     x27, x28, [x1, #16]!
-	ldp     x29, x30, [x1, #16]!
-	ldp     x2, x3, [x1, #16]!
-	ldr     x4, [x1, #16]
+	ldp     x19, x20, [x1, #0]
+	ldp     x21, x22, [x1, #16]
+	ldp     x23, x24, [x1, #32]
+	ldp     x25, x26, [x1, #48]
+	ldp     x27, x28, [x1, #64]
+	ldp     x29, x30, [x1, #80]
+	ldp     x2, x3, [x1, #96]
+	ldr     x4, [x1, #112]
 	mov     sp, x2
 	// msr spsr_el1, x3
+
+	ldp     q0, q1, [sp, #0]
+	ldp     q2, q3, [sp, #32]
+	ldp     q4, q5, [sp, #64]
+	ldp     q6, q7, [sp, #96]
+	ldp     q8, q9, [sp, #128]
+	ldp     q10, q11, [sp, #160]
+	ldp     q12, q13, [sp, #192]
+	ldp     q14, q15, [sp, #224]
+	ldp     q16, q17, [sp, #256]
+	ldp     q18, q19, [sp, #288]
+	ldp     q20, q21, [sp, #320]
+	ldp     q22, q23, [sp, #352]
+	ldp     q24, q25, [sp, #384]
+	ldp     q26, q27, [sp, #416]
+	ldp     q28, q29, [sp, #448]
+	ldp     q30, q31, [sp, #480]
+	add     sp, sp, #FPSIMD_FRAME
+
 	msr     daif, x4
 
 	ret     /* Jump to x30 */

--- a/src/arch/aarch64/kernel/exceptions/entry.S
+++ b/src/arch/aarch64/kernel/exceptions/entry.S
@@ -6,40 +6,30 @@
  * @author Denis Deryugin <deryugin.denis@gmail.com>
  */
 
+/* Exception frame:
+ *
+ *   [sp                              ] x0-x29, lr, sp, elr_el1, spsr_el1
+ *   [sp + EXCPT_GPRS                 ] q0-q31
+ *   [sp + EXCPT_GPRS + EXCPT_Q       ] fpsr, fpcr
+ *
+ * The GPR part is struct excpt_context and keeps its layout. */
+#define EXCPT_GPRS  (8 * 34)
+#define EXCPT_Q     (16 * 32)
+#define EXCPT_SYS   16
+#define EXCPT_FRAME (EXCPT_GPRS + EXCPT_Q + EXCPT_SYS)
+
+/* All vectors are 128 byte aligned and limited to 32 instructions, which
+ * is not enough for the FPSIMD part, so a vector only stores what it needs
+ * to pass on (the EL it was taken from and the handler) and branches to the
+ * common entry code. */
 .macro excpt_vector el:req fn:req
-/* All vectors are 128 byte aligned and limited to 32 instructions */
 .align 7
-	sub     sp, sp, #(8 * 34)
-	/* Store x0-x29 regs */
+	sub     sp, sp, #EXCPT_FRAME
 	stp     x0, x1, [sp, #(8 * 0)]
 	stp     x2, x3, [sp, #(8 * 2)]
-	stp     x4, x5, [sp, #(8 * 4)]
-	stp     x6, x7, [sp, #(8 * 6)]
-	stp     x8, x9, [sp, #(8 * 8)]
-	stp     x10, x11, [sp, #(8 * 10)]
-	stp     x12, x13, [sp, #(8 * 12)]
-	stp     x14, x15, [sp, #(8 * 14)]
-	stp     x16, x17, [sp, #(8 * 16)]
-	stp     x18, x19, [sp, #(8 * 18)]
-	stp     x20, x21, [sp, #(8 * 20)]
-	stp     x22, x23, [sp, #(8 * 22)]
-	stp     x24, x25, [sp, #(8 * 24)]
-	stp     x26, x27, [sp, #(8 * 26)]
-	stp     x28, x29, [sp, #(8 * 28)]
-	/* Store lr, sp, pc, psr */
-.if \el == 0
-	mrs     x10, sp_el0
-.else
-	add     x10, sp, #(8 * 34)
-.endif
-	mrs     x11, elr_el1
-	mrs     x12, spsr_el1
-	stp     x30, x10, [sp, #(8 * 30)]
-	stp     x11, x12, [sp, #(8 * 32)]
-	/* Call the handler */
-	mov     x0, sp
-	ldr     x30, =excpt_exit
-	b       \fn
+	mov     x0, #\el
+	ldr     x1, =\fn
+	b       excpt_entry_common
 .endm
 
 .section .text.kernel_vectors
@@ -69,7 +59,86 @@ aarch64_kernel_vectors:
 	excpt_vector 0, aarch64_fiq_handler
 	excpt_vector 0, aarch64_serror_handler
 
+/* x0 = source EL, x1 = handler, x0-x3 already stored */
+excpt_entry_common:
+	/* Store x4-x29 regs */
+	stp     x4, x5, [sp, #(8 * 4)]
+	stp     x6, x7, [sp, #(8 * 6)]
+	stp     x8, x9, [sp, #(8 * 8)]
+	stp     x10, x11, [sp, #(8 * 10)]
+	stp     x12, x13, [sp, #(8 * 12)]
+	stp     x14, x15, [sp, #(8 * 14)]
+	stp     x16, x17, [sp, #(8 * 16)]
+	stp     x18, x19, [sp, #(8 * 18)]
+	stp     x20, x21, [sp, #(8 * 20)]
+	stp     x22, x23, [sp, #(8 * 22)]
+	stp     x24, x25, [sp, #(8 * 24)]
+	stp     x26, x27, [sp, #(8 * 26)]
+	stp     x28, x29, [sp, #(8 * 28)]
+	/* Store q0-q31 */
+	add     x2, sp, #EXCPT_GPRS
+	stp     q0, q1, [x2, #0]
+	stp     q2, q3, [x2, #32]
+	stp     q4, q5, [x2, #64]
+	stp     q6, q7, [x2, #96]
+	stp     q8, q9, [x2, #128]
+	stp     q10, q11, [x2, #160]
+	stp     q12, q13, [x2, #192]
+	stp     q14, q15, [x2, #224]
+	stp     q16, q17, [x2, #256]
+	stp     q18, q19, [x2, #288]
+	stp     q20, q21, [x2, #320]
+	stp     q22, q23, [x2, #352]
+	stp     q24, q25, [x2, #384]
+	stp     q26, q27, [x2, #416]
+	stp     q28, q29, [x2, #448]
+	stp     q30, q31, [x2, #480]
+	/* Store fpsr, fpcr */
+	mrs     x3, fpsr
+	mrs     x4, fpcr
+	add     x5, sp, #(EXCPT_GPRS + EXCPT_Q)
+	stp     x3, x4, [x5]
+	/* Store lr, sp, pc, psr */
+	cbz     x0, 1f
+	add     x10, sp, #EXCPT_FRAME
+	b       2f
+1:
+	mrs     x10, sp_el0
+2:
+	mrs     x11, elr_el1
+	mrs     x12, spsr_el1
+	stp     x30, x10, [sp, #(8 * 30)]
+	stp     x11, x12, [sp, #(8 * 32)]
+	/* Call the handler */
+	mov     x2, x1
+	mov     x0, sp
+	ldr     x30, =excpt_exit
+	br      x2
+
 excpt_exit:
+	/* Load q0-q31 */
+	add     x2, sp, #EXCPT_GPRS
+	ldp     q0, q1, [x2, #0]
+	ldp     q2, q3, [x2, #32]
+	ldp     q4, q5, [x2, #64]
+	ldp     q6, q7, [x2, #96]
+	ldp     q8, q9, [x2, #128]
+	ldp     q10, q11, [x2, #160]
+	ldp     q12, q13, [x2, #192]
+	ldp     q14, q15, [x2, #224]
+	ldp     q16, q17, [x2, #256]
+	ldp     q18, q19, [x2, #288]
+	ldp     q20, q21, [x2, #320]
+	ldp     q22, q23, [x2, #352]
+	ldp     q24, q25, [x2, #384]
+	ldp     q26, q27, [x2, #416]
+	ldp     q28, q29, [x2, #448]
+	ldp     q30, q31, [x2, #480]
+	/* Load fpsr, fpcr */
+	add     x5, sp, #(EXCPT_GPRS + EXCPT_Q)
+	ldp     x3, x4, [x5]
+	msr     fpsr, x3
+	msr     fpcr, x4
 	/* Load lr, pc, psr */
 	ldp     x30, x10, [sp, #(8 * 30)]
 	ldp     x11, x12, [sp, #(8 * 32)]
@@ -92,5 +161,5 @@ excpt_exit:
 	ldp     x26, x27, [sp, #(8 * 26)]
 	ldp     x28, x29, [sp, #(8 * 28)]
 	/* Return from exception */
-	add     sp, sp, #(8 * 34)
+	add     sp, sp, #EXCPT_FRAME
 	eret

--- a/src/arch/aarch64/kernel/exceptions/sync_handler.c
+++ b/src/arch/aarch64/kernel/exceptions/sync_handler.c
@@ -16,11 +16,12 @@
 
 static void print_abort_syndrome(uint32_t syndrome) {
 	int el;
+	unsigned dfsc;
 
 	el = 1;
-	syndrome &= 0b111111;
+	dfsc = syndrome & 0b111111;
 
-	switch (syndrome) {
+	switch (dfsc) {
 	case 0b000000:
 		el = 0;
 	case 0b000001:
@@ -28,9 +29,10 @@ static void print_abort_syndrome(uint32_t syndrome) {
 		break;
 
 	case 0b000100:
-		el = 0;
 	case 0b000101:
-		log_raw(LOG_EMERG, "Translation fault (EL%i)\n", el);
+	case 0b000110:
+	case 0b000111:
+		log_raw(LOG_EMERG, "Translation fault (level %u)\n", dfsc & 0b11);
 		break;
 
 	case 0b001000:
@@ -76,6 +78,10 @@ static void print_abort_syndrome(uint32_t syndrome) {
 	case 0b110000:
 		log_raw(LOG_EMERG, "TLB Conflict fault\n");
 		break;
+
+	default:
+		log_raw(LOG_EMERG, "Unknown fault (DFSC = %#x)\n", dfsc);
+		break;
 	}
 }
 
@@ -92,16 +98,20 @@ void _NORETURN aarch64_sync_handler(struct excpt_context *ctx) {
 	case ESR_ELn_EC_INST_ABT:
 		log_raw(LOG_EMERG, "\nInstruction abort exception!\n");
 		print_abort_syndrome(syndrome);
+		log_raw(LOG_EMERG, "FAR_EL1 = %#" PRIx64 "\n",
+		    (uint64_t)ARCH_REG_LOAD(FAR_EL1));
 		break;
 
 	case ESR_ELn_EC_DATA_ABT:
 		log_raw(LOG_EMERG, "\nData abort exception!\n");
 		print_abort_syndrome(syndrome);
+		log_raw(LOG_EMERG, "FAR_EL1 = %#" PRIx64 "\n",
+		    (uint64_t)ARCH_REG_LOAD(FAR_EL1));
 		break;
 
 	default:
 		log_raw(LOG_EMERG, "\nSynchronous exception!\n");
-		log_raw(LOG_EMERG, "ESR_EL1 = " PRIx32 "\n", esr);
+		log_raw(LOG_EMERG, "ESR_EL1 = %" PRIx32 "\n", esr);
 		break;
 	}
 

--- a/src/arch/aarch64/kernel/reg/sysreg.h
+++ b/src/arch/aarch64/kernel/reg/sysreg.h
@@ -468,6 +468,52 @@
 #define TCR_ELn_TG0_16KB                       0b10
 #define TCR_ELn_TG0_64KB                       0b01
 
+#define TCR_ELn_IRGN0                          /* Inner cacheability of the TTBR0 table walk */
+#define TCR_ELn_IRGN0_MASK                     0b11UL
+#define TCR_ELn_IRGN0_SHIFT                    8
+#define TCR_ELn_IRGN0_NC                       0b00UL /* Non-cacheable */
+#define TCR_ELn_IRGN0_WBWA                     0b01UL /* Write-Back Write-Allocate */
+#define TCR_ELn_IRGN0_WT                       0b10UL /* Write-Through */
+#define TCR_ELn_IRGN0_WB                       0b11UL /* Write-Back no Write-Allocate */
+
+#define TCR_ELn_ORGN0                          /* Outer cacheability of the TTBR0 table walk */
+#define TCR_ELn_ORGN0_MASK                     0b11UL
+#define TCR_ELn_ORGN0_SHIFT                    10
+#define TCR_ELn_ORGN0_NC                       0b00UL /* Non-cacheable */
+#define TCR_ELn_ORGN0_WBWA                     0b01UL /* Write-Back Write-Allocate */
+#define TCR_ELn_ORGN0_WT                       0b10UL /* Write-Through */
+#define TCR_ELn_ORGN0_WB                       0b11UL /* Write-Back no Write-Allocate */
+
+#define TCR_ELn_IRGN1                          /* Inner cacheability of the TTBR1 table walk */
+#define TCR_ELn_IRGN1_MASK                     0b11UL
+#define TCR_ELn_IRGN1_SHIFT                    24
+#define TCR_ELn_IRGN1_NC                       0b00UL /* Non-cacheable */
+#define TCR_ELn_IRGN1_WBWA                     0b01UL /* Write-Back Write-Allocate */
+#define TCR_ELn_IRGN1_WT                       0b10UL /* Write-Through */
+#define TCR_ELn_IRGN1_WB                       0b11UL /* Write-Back no Write-Allocate */
+
+#define TCR_ELn_ORGN1                          /* Outer cacheability of the TTBR1 table walk */
+#define TCR_ELn_ORGN1_MASK                     0b11UL
+#define TCR_ELn_ORGN1_SHIFT                    26
+#define TCR_ELn_ORGN1_NC                       0b00UL /* Non-cacheable */
+#define TCR_ELn_ORGN1_WBWA                     0b01UL /* Write-Back Write-Allocate */
+#define TCR_ELn_ORGN1_WT                       0b10UL /* Write-Through */
+#define TCR_ELn_ORGN1_WB                       0b11UL /* Write-Back no Write-Allocate */
+
+#define TCR_ELn_SH0                            /* Shareability of the TTBR0 table walk */
+#define TCR_ELn_SH0_MASK                       0b11UL
+#define TCR_ELn_SH0_SHIFT                      12
+#define TCR_ELn_SH0_NS                         0b00UL /* Non-shareable */
+#define TCR_ELn_SH0_OS                         0b10UL /* Outer Shareable */
+#define TCR_ELn_SH0_IS                         0b11UL /* Inner Shareable */
+
+#define TCR_ELn_SH1                            /* Shareability of the TTBR1 table walk */
+#define TCR_ELn_SH1_MASK                       0b11UL
+#define TCR_ELn_SH1_SHIFT                      28
+#define TCR_ELn_SH1_NS                         0b00UL /* Non-shareable */
+#define TCR_ELn_SH1_OS                         0b10UL /* Outer Shareable */
+#define TCR_ELn_SH1_IS                         0b11UL /* Inner Shareable */
+
 /** Thread Pointer / ID Register (EL0) */
 #define TPIDR_EL0                              TPIDR_EL0
 #define __ARCH_REG_LOAD__TPIDR_EL0()           __MRS_SYS(TPIDR_EL0)

--- a/src/arch/aarch64/mmu/mmu.c
+++ b/src/arch/aarch64/mmu/mmu.c
@@ -64,6 +64,15 @@ static int mmu_init(void) {
 	/* TTBR0_EL1.ASID defines the ASID */
 	tcr &= ~TCR_EL1_A1;
 
+	/* Table walks are cacheable and Inner Shareable, matching the
+	 * attributes the page tables themselves are mapped with */
+	tcr = FIELD_SET(tcr, TCR_ELn_IRGN0, TCR_ELn_IRGN0_WBWA);
+	tcr = FIELD_SET(tcr, TCR_ELn_ORGN0, TCR_ELn_ORGN0_WBWA);
+	tcr = FIELD_SET(tcr, TCR_ELn_SH0, TCR_ELn_SH0_IS);
+	tcr = FIELD_SET(tcr, TCR_ELn_IRGN1, TCR_ELn_IRGN1_WBWA);
+	tcr = FIELD_SET(tcr, TCR_ELn_ORGN1, TCR_ELn_ORGN1_WBWA);
+	tcr = FIELD_SET(tcr, TCR_ELn_SH1, TCR_ELn_SH1_IS);
+
 	/* Store Translation Control Register */
 	ARCH_REG_STORE(TCR_EL1, tcr);
 
@@ -86,16 +95,28 @@ void mmu_on(void) {
 
 	dmb(sy);
 
-	/* Enable MMU (stage 1 address translation) */
-	ARCH_REG_ORIN(SCTLR_EL1, SCTLR_ELn_M);
+	/* Enable MMU (stage 1 address translation) together with the caches.
+	 * With SCTLR.M set but SCTLR.C clear, all data accesses are treated as
+	 * Non-cacheable regardless of what the page tables say, and exclusive
+	 * accesses to Non-cacheable memory are not architecturally guaranteed
+	 * to work: on a Cortex-A72 an ldaxr/stxr pair to such memory raises an
+	 * SError. */
+	__asm__ __volatile__("ic iallu" : : : "memory");
+	dsb(sy);
+	isb();
+	ARCH_REG_ORIN(SCTLR_EL1, SCTLR_ELn_M | SCTLR_ELn_C | SCTLR_ELn_I);
+	isb();
 }
 
 void mmu_off(void) {
 	/* Flush TLB */
 	ARCH_REG_STORE(TLBI_VMALLE1, 0);
 
-	/* Disable MMU (stage 1 address translation) */
-	ARCH_REG_CLEAR(SCTLR_EL1, SCTLR_ELn_M);
+	/* Disable MMU (stage 1 address translation). The caches have to go
+	 * down with it: leaving SCTLR.C set with translation off would make
+	 * every access Cacheable, which is not what the caller asked for. */
+	ARCH_REG_CLEAR(SCTLR_EL1, SCTLR_ELn_C | SCTLR_ELn_I | SCTLR_ELn_M);
+	isb();
 }
 
 mmu_ctx_t mmu_create_context(uintptr_t *pgd) {
@@ -196,10 +217,12 @@ uintptr_t mmu_pte_pack(uintptr_t addr, int prot) {
 	if (prot & PROT_NOCACHE) {
 		/* Use memory attribute 0 (device) */
 		pte = FIELD_SET(pte, MMU_DESC_ATTRINDX, MEM_DEVICE_ATTRINDX);
+		pte = FIELD_SET(pte, MMU_DESC_SH, MMU_DESC_SH_OS);
 	}
 	else {
 		/* Use memory attribute 1 (normal) */
 		pte = FIELD_SET(pte, MMU_DESC_ATTRINDX, MEM_NORMAL_ATTRINDX);
+		pte = FIELD_SET(pte, MMU_DESC_SH, MMU_DESC_SH_IS);
 	}
 
 	if (!(prot & PROT_EXEC)) {

--- a/src/arch/aarch64/mmu/mmu.h
+++ b/src/arch/aarch64/mmu/mmu.h
@@ -47,6 +47,12 @@
 #define MMU_DESC_TP             (1UL << 1)  /* Block or Table/Page */
 #define MMU_DESC_NS             (1UL << 5)  /* Non-secure bit */
 #define MMU_DESC_AF             (1UL << 10) /* The Access flag */
+#define MMU_DESC_SH             /* Shareability field */
+#define MMU_DESC_SH_MASK        0b11UL
+#define MMU_DESC_SH_SHIFT       8
+#define MMU_DESC_SH_NS          0b00UL /* Non-shareable */
+#define MMU_DESC_SH_OS          0b10UL /* Outer Shareable */
+#define MMU_DESC_SH_IS          0b11UL /* Inner Shareable */
 #define MMU_DESC_PXN            (1UL << 53) /* The Execute-never bit EL1 */
 #define MMU_DESC_UXN            (1UL << 54) /* The Execute-never bit EL0 */
 

--- a/src/compat/libc/math/libm_simple/sqrt.c
+++ b/src/compat/libc/math/libm_simple/sqrt.c
@@ -1,43 +1,62 @@
 #include <math.h>
 
-static long double sqrt_common(long double x) {
-	long double l = 0.;
-	long double r = MAXFLOAT;
-	long double m = (r + l) / 2.;
-	long double eps = 1e-6;
-	int steps = 100;
+/* Newton-Raphson: r_{n+1} = (r_n + x / r_n) / 2.
+ *
+ * x is first scaled into [1, 4) by even powers of two, so that the
+ * linear seed below is accurate to a few percent and the (quadratically
+ * convergent) iteration reaches the last bit in about five steps
+ * regardless of the exponent of x.
+ *
+ * On [1, 4) the seed lies above sqrt(x) - the chord of a concave curve -
+ * and the iteration approaches the root from above, so "the estimate
+ * stopped decreasing" is a safe termination condition. */
+static double sqrt_positive(double x) {
+	double scale;
+	double r;
+	double next;
+	int i;
 
-	/* sqrt returns NaN is x < 0 or x is NaN */
-	if ((x < 0.) || isnan(x))
-		return NAN;
-	/* sqrt returns Inf if x is Inf */
-	if (isinf(x))
-		return INFINITY;
-	/* sqrt of 0 = 0 */
-	if (x == 0.)
-		return 0.;
-	
-	do {
-		if (x > m*m) {
-			l = m;
-		} else {
-			r = m;
+	scale = 1.;
+
+	while (x >= 4.) {
+		x *= .25;
+		scale *= 2.;
+	}
+	while (x < 1.) {
+		x *= 4.;
+		scale *= .5;
+	}
+
+	r = .5 * x + .5;
+
+	for (i = 0; i < 16; i++) {
+		next = .5 * (r + x / r);
+		if (next >= r) {
+			break;
 		}
-		m = r - (r - l) / 2;
-	} while (steps-- > 0 && fabsl(x - m*m) < eps);
+		r = next;
+	}
 
-	return m;
-}
-
-long double sqrtl(long double x) {
-	return sqrt_common(x);
-}
-
-float sqrtf(float x) {
-	return sqrt_common(x);
+	return r * scale;
 }
 
 double sqrt(double x) {
-	return sqrt_common(x);
+	/* sqrt returns NaN if x < 0 or x is NaN */
+	if ((x < 0.) || isnan(x)) {
+		return NAN;
+	}
+	/* sqrt returns Inf if x is Inf, and +-0 if x is +-0 */
+	if (isinf(x) || (x == 0.)) {
+		return x;
+	}
+
+	return sqrt_positive(x);
 }
 
+float sqrtf(float x) {
+	return (float)sqrt((double)x);
+}
+
+long double sqrtl(long double x) {
+	return (long double)sqrt((double)x);
+}

--- a/src/include/framework/mod/self.h
+++ b/src/include/framework/mod/self.h
@@ -28,8 +28,9 @@
 #define MOD_SELF_INIT(mod_ops) _MOD_INIT(__EMBUILD_MOD__, mod_ops)
 
 /* Make current module a runtime module */
-#define MOD_SELF_RUNTIME()                       \
-	struct mod_data __MOD_DATA(__EMBUILD_MOD__); \
+#define MOD_SELF_RUNTIME()                                    \
+	struct mod_data __MOD_DATA(__EMBUILD_MOD__)                \
+	    __attribute__((section(".bss.embox.mod_data")));       \
 	RUNLEVEL_MOD_REGISTER(__EMBUILD_MOD__)
 
 __BEGIN_DECLS

--- a/src/mem/heap/heap_bm.c
+++ b/src/mem/heap/heap_bm.c
@@ -8,6 +8,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
@@ -251,7 +252,9 @@ void *bm_memalign(void *heap, size_t boundary, size_t size) {
 		size = sizeof(struct free_block);
 	}
 
-	size = (size + (3)) & ~(3); /* align by word*/
+	/* Keep every block a whole number of max_align_t units, so that a
+	 * split never leaves the next block header misaligned. */
+	size = binalign_bound(size, __alignof__(max_align_t));
 
 	for (link = free_blocks_list->next; link != free_blocks_list; link = link->next) {
 		block = (struct free_block *) ((uintptr_t *) link - 1);

--- a/src/mem/heap/mspace_malloc.c
+++ b/src/mem/heap/mspace_malloc.c
@@ -15,6 +15,7 @@
 
 #include <util/err.h>
 #include <errno.h>
+#include <stddef.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -239,7 +240,7 @@ out_unlock:
 
 void *mspace_malloc(size_t size, struct dlist_head *mspace) {
 	assert(mspace);
-	return mspace_memalign(8, size, mspace);
+	return mspace_memalign(__alignof__(max_align_t), size, mspace);
 }
 
 int mspace_free(void *ptr, struct dlist_head *mspace) {
@@ -284,7 +285,7 @@ void *mspace_realloc(void *ptr, size_t size, struct dlist_head *mspace) {
 	assert(mspace);
 	assert(size != 0 || ptr == NULL);
 
-	ret = mspace_memalign(8, size, mspace);
+	ret = mspace_memalign(__alignof__(max_align_t), size, mspace);
 
 	if (ret == NULL) {
 		return NULL; /* error: errno set in malloc */


### PR DESCRIPTION
Embox has been launched and tested as a host OS for Xenolith Engine on aarch64 (QEMU, RPi4). This batch contains key patches that enabled us to run all the required functions. Particularly noteworthy are the malloc() patch and register preservation during thread switches and exceptions.

## The patches

| Patch | Subject | Fixes |
|---|---|---|
| 4bc0c47 | `.bootcode` allocatable/executable | lld rejects PC-relative relocs out of a non-alloc section |
| 36b9c41 | no `-meabi gnu` on aarch64 | clang errors on the first TU of an aarch64 clang build |
| c558293 | keep `.bootcode`/vectors at the start of `.text` | `ADR` to `aarch64_kernel_vectors` overflows ±1 MiB on large images |
| 15d5309 | `__eh_frame_start`/`__eh_frame_end` | baremetal LLVM libunwind finds no unwind tables |
| 5f4eb7f | heap alignment via `__alignof__(max_align_t)` | 16-byte NEON stores smash the next block header |
| 17aaede | `sqrt` rewritten (Newton, scaled argument) | `sqrtf(1.f)` returns ~8.5e37 |
| 7f8bc6f | FPSIMD saved across `context_switch` | q0–q31 leak between threads |
| ab771a4 | FPSIMD saved on exception entry | IRQ handlers destroy the interrupted thread's q registers |
| 64f33b0 | FAR_EL1 + all DFSC levels + `%` in `PRIx32` | a level-2/3 data abort prints nothing useful |
| de2a342 | MMU: SCTLR.C/I, cacheable IS table walks, PTE SH | Cortex-A72 SErrors on `ldaxr` to Non-cacheable memory |
| f91cab8 | `mod_data` into `.bss.embox.mod_data` | an `@App` command works once, then `-ENOENT` forever |