### PR TITLE
src/drivers/video: QEMU ramfb, bcm2711_fb; RPi4 template

### DIFF
--- a/src/drivers/video/bcm2711_fb/Mybuild
+++ b/src/drivers/video/bcm2711_fb/Mybuild
@@ -1,0 +1,24 @@
+package embox.driver.video
+
+module bcm2711_fb {
+	/* VideoCore mailbox. BCM2711 (Pi 4) is at 0xFE00B880, BCM2837 (Pi 3)
+	 * at 0x3F00B880, BCM2835 (Pi 1) at 0x2000B880. */
+	option number base_addr = 0xFE00B880
+
+	/* Used when the firmware reports no display size (HDMI unplugged,
+	 * no EDID) - the mailbox is still able to allocate a buffer. */
+	option number fb_xres = 1920
+	option number fb_yres = 1080
+
+	option number fb_bpp = 32
+
+	source "bcm2711_fb.c"
+
+	depends embox.driver.periph_memory
+	@NoRuntime depends fb
+	depends fb_devfs
+	@NoRuntime depends embox.compat.libc.all
+	depends embox.mem.mmap
+	depends embox.kernel.task.idesc.idesc_mmap
+	depends embox.compat.posix.sys.mman.mmap_api
+}

--- a/src/drivers/video/bcm2711_fb/bcm2711_fb.c
+++ b/src/drivers/video/bcm2711_fb/bcm2711_fb.c
@@ -1,0 +1,324 @@
+/**
+ * @file
+ * @brief VideoCore mailbox framebuffer for BCM2711 (Raspberry Pi 4)
+ *
+ * The Pi 4 has no register-level display controller the kernel could
+ * program: the framebuffer is set up by asking the VideoCore firmware
+ * over the property mailbox (channel 8) to allocate one and report its
+ * bus address, which is then mapped as uncached device memory and
+ * published as /dev/fb0. The serial console is unaffected - HDMI is
+ * scanout only.
+ *
+ * Unlike embox.driver.video.raspi_video this does one bulk SET +
+ * ALLOCATE request, which is what the Pi 4 firmware expects, and takes
+ * the mailbox base as an option instead of going through the
+ * bcm2835_mailbox driver.
+ *
+ * @date 15.08.2026
+ * @author Vitaliy Rybnikov
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include <drivers/common/memory.h>
+#include <drivers/video/fb.h>
+#include <embox/unit.h>
+#include <framework/mod/options.h>
+#include <hal/cache.h>
+#include <hal/mem_barriers.h>
+#include <hal/reg.h>
+#include <kernel/printk.h>
+#include <kernel/task/kernel_task.h>
+#include <kernel/task/resource/mmap.h>
+#include <mem/mmap.h>
+#include <mem/page.h>
+#include <mem/vmem.h>
+#include <util/binalign.h>
+
+#define MBOX_BASE ((uintptr_t)OPTION_GET(NUMBER, base_addr))
+#define MBOX_READ (MBOX_BASE + 0x00)
+#define MBOX_STATUS (MBOX_BASE + 0x18)
+#define MBOX_WRITE (MBOX_BASE + 0x20)
+
+#define MBOX_FULL 0x80000000u
+#define MBOX_EMPTY 0x40000000u
+#define MBOX_CHAN_TAGS 8u
+
+#define MBOX_REQUEST 0u
+#define MBOX_RESP_OK 0x80000000u
+#define MBOX_TAG_END 0u
+
+#define TAG_GETDISP 0x40003u
+#define TAG_SETDISP 0x48003u
+#define TAG_SETVBUF 0x48004u
+#define TAG_SETDEPTH 0x48005u
+#define TAG_SETPIXORD 0x48006u
+#define TAG_FALLOC 0x40001u
+#define TAG_SETVIRTOFF 0x48009u
+#define TAG_GETPITCH 0x40008u
+
+#define FB_BPP        ((uint32_t)OPTION_GET(NUMBER, fb_bpp))
+#define FB_FALLBACK_W ((uint32_t)OPTION_GET(NUMBER, fb_xres))
+#define FB_FALLBACK_H ((uint32_t)OPTION_GET(NUMBER, fb_yres))
+
+/* The firmware answers with a VideoCore bus address: bits 30-31 select the
+ * cache alias. Strip the alias and keep the L2-coherent window, which is the
+ * one that works on a physical board. */
+#define VCADDR_TO_ARM(addr) (((addr) | 0x40000000u) & ~0xc0000000u)
+
+static uint32_t s_xres;
+static uint32_t s_yres;
+static uint32_t s_bpp = FB_BPP;
+
+static uint32_t mbox_load(uintptr_t addr) {
+	uint32_t v;
+
+	v = MMAP_REG_LOAD(uint32_t, addr);
+	dmb(sy);
+	return v;
+}
+
+static void mbox_store(uintptr_t addr, uint32_t val) {
+	dmb(sy);
+	MMAP_REG_STORE(uint32_t, addr, val);
+}
+
+static int mbox_send(uint32_t *buf, size_t bytes) {
+	uint32_t msg;
+	uint32_t got;
+	uint32_t spins;
+
+	msg = (uint32_t)(uintptr_t)buf;
+	if (msg & 0xfu) {
+		printk("bcm2711_fb: mailbox buffer not 16-aligned\n");
+		return -EINVAL;
+	}
+
+	dcache_flush(buf, bytes);
+	dsb(sy);
+
+	spins = 0;
+	while (mbox_load(MBOX_STATUS) & MBOX_FULL) {
+		if (++spins > 10000000u) {
+			printk("bcm2711_fb: mailbox write timeout\n");
+			return -ETIMEDOUT;
+		}
+	}
+	mbox_store(MBOX_WRITE, msg | MBOX_CHAN_TAGS);
+
+	spins = 0;
+	for (;;) {
+		while (mbox_load(MBOX_STATUS) & MBOX_EMPTY) {
+			if (++spins > 10000000u) {
+				printk("bcm2711_fb: mailbox read timeout\n");
+				return -ETIMEDOUT;
+			}
+		}
+		got = mbox_load(MBOX_READ);
+		if ((got & 0xfu) == MBOX_CHAN_TAGS) {
+			break;
+		}
+	}
+
+	dcache_inval(buf, bytes);
+	dsb(sy);
+
+	if ((got & ~0xfu) != msg) {
+		printk("bcm2711_fb: mailbox reply %08x want %08x\n", got, msg);
+		return -EIO;
+	}
+	if (buf[1] != MBOX_RESP_OK) {
+		printk("bcm2711_fb: mailbox code %08x\n", buf[1]);
+		return -EIO;
+	}
+	return 0;
+}
+
+static int mbox_get_disp(uint32_t *x, uint32_t *y) {
+	uint32_t buf[8] __attribute__((aligned(16)));
+
+	memset(buf, 0, sizeof(buf));
+	buf[0] = sizeof(buf);
+	buf[1] = MBOX_REQUEST;
+	buf[2] = TAG_GETDISP;
+	buf[3] = 8;
+	buf[4] = 0;
+	buf[7] = MBOX_TAG_END;
+	if (mbox_send(buf, sizeof(buf)) < 0) {
+		return -EIO;
+	}
+	*x = buf[5];
+	*y = buf[6];
+	return 0;
+}
+
+static int mbox_fbinit(uint32_t *x, uint32_t *y, uint32_t *bpp, void **fb,
+		uint32_t *fblen, uint32_t *pitch) {
+	uint32_t buf[35] __attribute__((aligned(16)));
+
+	memset(buf, 0, sizeof(buf));
+	buf[0] = sizeof(buf);
+	buf[1] = MBOX_REQUEST;
+
+	buf[2] = TAG_SETDISP;
+	buf[3] = 8;
+	buf[4] = 0;
+	buf[5] = *x;
+	buf[6] = *y;
+
+	buf[7] = TAG_SETVBUF;
+	buf[8] = 8;
+	buf[9] = 8;
+	buf[10] = *x;
+	buf[11] = *y;
+
+	buf[12] = TAG_SETVIRTOFF;
+	buf[13] = 8;
+	buf[14] = 8;
+	buf[15] = 0;
+	buf[16] = 0;
+
+	buf[17] = TAG_SETDEPTH;
+	buf[18] = 4;
+	buf[19] = 4;
+	buf[20] = *bpp;
+
+	/* 0 = "BGR" in the firmware docs, i.e. BGRA8888 in memory */
+	buf[21] = TAG_SETPIXORD;
+	buf[22] = 4;
+	buf[23] = 4;
+	buf[24] = 0;
+
+	buf[25] = TAG_FALLOC;
+	buf[26] = 8;
+	buf[27] = 8;
+	buf[28] = *bpp;
+	buf[29] = 0;
+
+	buf[30] = TAG_GETPITCH;
+	buf[31] = 4;
+	buf[32] = 4;
+	buf[33] = 0;
+
+	buf[34] = MBOX_TAG_END;
+
+	if (mbox_send(buf, sizeof(buf)) < 0) {
+		return -EIO;
+	}
+
+	*x = buf[10];
+	*y = buf[11];
+	*bpp = buf[20];
+	*fb = (void *)(uintptr_t)VCADDR_TO_ARM(buf[28]);
+	*fblen = buf[29];
+	*pitch = buf[33];
+	return 0;
+}
+
+static int bcm2711_fb_set_var(struct fb_info *info,
+		struct fb_var_screeninfo const *var) {
+	(void)info;
+	(void)var;
+	return 0;
+}
+
+static int bcm2711_fb_get_var(struct fb_info *info, struct fb_var_screeninfo *var) {
+	(void)info;
+	memset(var, 0, sizeof(*var));
+	var->xres = var->xres_virtual = s_xres;
+	var->yres = var->yres_virtual = s_yres;
+	var->bits_per_pixel = s_bpp;
+	var->fmt = BGRA8888;
+	return 0;
+}
+
+static struct fb_ops bcm2711_fb_ops = {
+	.fb_set_var = bcm2711_fb_set_var,
+	.fb_get_var = bcm2711_fb_get_var,
+};
+
+static int bcm2711_fb_init(void) {
+	uint32_t x = 0;
+	uint32_t y = 0;
+	uint32_t bpp = FB_BPP;
+	uint32_t fblen = 0;
+	uint32_t pitch = 0;
+	void *fb = NULL;
+	struct fb_info *info;
+	uint32_t *px;
+	unsigned n;
+	int tries;
+
+	if (mbox_get_disp(&x, &y) < 0 || x == 0 || y == 0) {
+		x = FB_FALLBACK_W;
+		y = FB_FALLBACK_H;
+		printk("bcm2711_fb: no EDID size, using %ux%u\n", x, y);
+	}
+
+	tries = 0;
+	do {
+		fb = NULL;
+		fblen = 0;
+		pitch = 0;
+		bpp = FB_BPP;
+		if (mbox_fbinit(&x, &y, &bpp, &fb, &fblen, &pitch) == 0 && fb && fblen) {
+			break;
+		}
+		tries++;
+	} while (tries < 3);
+
+	if (!fb || !fblen) {
+		printk("bcm2711_fb: allocate failed (HDMI unplugged?)\n");
+		return 0;
+	}
+	if (bpp != FB_BPP) {
+		printk("bcm2711_fb: got %u bpp, want %u\n", bpp, FB_BPP);
+		return 0;
+	}
+
+	s_xres = x;
+	s_yres = y;
+	s_bpp = bpp;
+
+	{
+		uintptr_t start = (uintptr_t)fb & ~(uintptr_t)MMU_PAGE_MASK;
+		uintptr_t map_len = binalign_bound((uintptr_t)fb + fblen, MMU_PAGE_SIZE)
+				- start;
+		int prot = PROT_READ | PROT_WRITE | PROT_NOCACHE;
+
+		/* GPU DRAM sits above ARM RAM in lds.conf. Do not switch the
+		 * image to vmem_device_memory_full: that would change phymem_init. */
+		(void)mmap_place(task_resource_mmap(task_kernel_task()), start, map_len,
+				prot);
+		if (vmem_map_region(vmem_current_context(), start, start, map_len, prot)) {
+			printk("bcm2711_fb: vmem_map_region %p failed\n", fb);
+			return 0;
+		}
+	}
+
+	px = fb;
+	n = fblen / 4u;
+	while (n--) {
+		*px++ = 0xff202020u;
+	}
+
+	info = fb_create(&bcm2711_fb_ops, (char *)fb, binalign_bound(fblen, PAGE_SIZE()));
+	if (!info) {
+		printk("bcm2711_fb: fb_create failed\n");
+		return 0;
+	}
+
+	printk("bcm2711_fb: /dev/fb0 %ux%u pitch=%u @ %p (%u bytes)\n", x, y, pitch, fb,
+			fblen);
+	if (pitch && pitch != x * (bpp / 8u)) {
+		printk("bcm2711_fb: pitch %u != xres*bpp/8 %u\n", pitch,
+				x * (bpp / 8u));
+	}
+	return 0;
+}
+
+EMBOX_UNIT_INIT(bcm2711_fb_init);
+PERIPH_MEMORY_DEFINE(bcm2711_mbox, MBOX_BASE, 0x40);

--- a/src/drivers/video/ramfb/Mybuild
+++ b/src/drivers/video/ramfb/Mybuild
@@ -1,0 +1,18 @@
+package embox.driver.video
+
+module ramfb {
+	/* QEMU fw_cfg MMIO window ("virt" machine) */
+	option number base_addr = 0x09020000
+
+	option number fb_xres = 640
+	option number fb_yres = 480
+
+	source "ramfb.c"
+
+	depends embox.driver.periph_memory
+	@NoRuntime depends fb
+	depends fb_devfs
+	@NoRuntime depends embox.compat.libc.all
+	depends embox.kernel.task.idesc.idesc_mmap
+	depends embox.compat.posix.sys.mman.mmap_api
+}

--- a/src/drivers/video/ramfb/ramfb.c
+++ b/src/drivers/video/ramfb/ramfb.c
@@ -1,0 +1,192 @@
+/**
+ * @file
+ * @brief QEMU ramfb framebuffer (fw_cfg "etc/ramfb")
+ *
+ * QEMU's -device ramfb turns a guest-owned buffer into the scanout:
+ * the guest writes address, format and geometry into the fw_cfg file
+ * etc/ramfb, and from then on the display simply shows that memory.
+ *
+ * @date 14.08.2026
+ * @author Vitaliy Rybnikov
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include <drivers/common/memory.h>
+#include <drivers/video/fb.h>
+#include <embox/unit.h>
+#include <framework/mod/options.h>
+#include <hal/reg.h>
+#include <kernel/printk.h>
+
+#define FW_CFG_BASE     OPTION_GET(NUMBER, base_addr)
+#define RAMFB_WIDTH     OPTION_GET(NUMBER, fb_xres)
+#define RAMFB_HEIGHT    OPTION_GET(NUMBER, fb_yres)
+
+#define RAMFB_BPP       32
+#define RAMFB_STRIDE    (RAMFB_WIDTH * 4)
+#define RAMFB_SIZE      (RAMFB_STRIDE * RAMFB_HEIGHT)
+
+#define FW_CFG_DATA     (FW_CFG_BASE + 0x00)
+#define FW_CFG_SELECTOR (FW_CFG_BASE + 0x08)
+#define FW_CFG_DMA      (FW_CFG_BASE + 0x10)
+
+#define FW_CFG_FILE_DIR 0x19
+
+#define FW_CFG_DMA_CTL_ERROR  0x01u
+#define FW_CFG_DMA_CTL_READ   0x02u
+#define FW_CFG_DMA_CTL_SELECT 0x08u
+#define FW_CFG_DMA_CTL_WRITE  0x10u
+
+#define DRM_FORMAT_XRGB8888   0x34325258u
+
+#define FW_CFG_FILES_MAX      64
+#define FW_CFG_DMA_SPINS      100000
+
+/* fw_cfg is big endian, the CPU is not */
+struct fw_cfg_dma {
+	uint32_t control;
+	uint32_t length;
+	uint64_t address;
+} __attribute__((packed, aligned(8)));
+
+struct ramfb_cfg {
+	uint64_t addr;
+	uint32_t fourcc;
+	uint32_t flags;
+	uint32_t width;
+	uint32_t height;
+	uint32_t stride;
+} __attribute__((packed, aligned(8)));
+
+struct fw_cfg_file {
+	uint32_t size;
+	uint16_t select;
+	uint16_t reserved;
+	char name[56];
+} __attribute__((packed));
+
+static uint32_t ramfb_mem[RAMFB_WIDTH * RAMFB_HEIGHT]
+    __attribute__((aligned(64)));
+
+static int ramfb_set_var(struct fb_info *info,
+    struct fb_var_screeninfo const *var) {
+	(void)info;
+	(void)var;
+	return 0;
+}
+
+static int ramfb_get_var(struct fb_info *info, struct fb_var_screeninfo *var) {
+	(void)info;
+	memset(var, 0, sizeof(*var));
+	var->xres = var->xres_virtual = RAMFB_WIDTH;
+	var->yres = var->yres_virtual = RAMFB_HEIGHT;
+	var->bits_per_pixel = RAMFB_BPP;
+	var->fmt = BGRA8888;
+	return 0;
+}
+
+static struct fb_ops ramfb_ops = {
+    .fb_set_var = ramfb_set_var,
+    .fb_get_var = ramfb_get_var,
+};
+
+static void ramfb_dsb(void) {
+	__asm__ volatile("dsb sy" ::: "memory");
+}
+
+static int ramfb_dma(uint16_t select, uint32_t ctl, void *buf, uint32_t len) {
+	struct fw_cfg_dma dma;
+	int i;
+
+	dma.control = __builtin_bswap32(ctl | FW_CFG_DMA_CTL_SELECT
+	                                | ((uint32_t)select << 16));
+	dma.length = __builtin_bswap32(len);
+	dma.address = __builtin_bswap64((uint64_t)(uintptr_t)buf);
+	ramfb_dsb();
+	MMAP_REG_STORE(uint64_t, FW_CFG_DMA,
+	    __builtin_bswap64((uint64_t)(uintptr_t)&dma));
+	ramfb_dsb();
+
+	for (i = 0; i < FW_CFG_DMA_SPINS; i++) {
+		uint32_t c = __builtin_bswap32(dma.control);
+
+		if (c == 0) {
+			return 0;
+		}
+		if (c & FW_CFG_DMA_CTL_ERROR) {
+			return -1;
+		}
+	}
+	return -1;
+}
+
+static int ramfb_find_file(const char *name, uint16_t *select_out,
+    uint32_t *size_out) {
+	uint8_t dir[4 + FW_CFG_FILES_MAX * sizeof(struct fw_cfg_file)];
+	uint32_t count;
+	uint32_t i;
+
+	if (ramfb_dma(FW_CFG_FILE_DIR, FW_CFG_DMA_CTL_READ, dir, sizeof(dir)) < 0) {
+		return -1;
+	}
+	memcpy(&count, dir, 4);
+	count = __builtin_bswap32(count);
+	if (count > FW_CFG_FILES_MAX) {
+		count = FW_CFG_FILES_MAX;
+	}
+	for (i = 0; i < count; i++) {
+		struct fw_cfg_file f;
+
+		memcpy(&f, dir + 4 + i * sizeof(f), sizeof(f));
+		if (strncmp(f.name, name, sizeof(f.name)) == 0) {
+			*select_out = __builtin_bswap16(f.select);
+			*size_out = __builtin_bswap32(f.size);
+			return 0;
+		}
+	}
+	return -1;
+}
+
+static int ramfb_init(void) {
+	uint16_t sel;
+	uint32_t sz;
+	struct ramfb_cfg cfg;
+	struct fb_info *info;
+
+	if (ramfb_find_file("etc/ramfb", &sel, &sz) < 0) {
+		printk("ramfb: etc/ramfb missing (start QEMU with -device ramfb)\n");
+	}
+	else {
+		memset(&cfg, 0, sizeof(cfg));
+		cfg.addr = __builtin_bswap64((uint64_t)(uintptr_t)ramfb_mem);
+		cfg.fourcc = __builtin_bswap32(DRM_FORMAT_XRGB8888);
+		cfg.flags = 0;
+		cfg.width = __builtin_bswap32(RAMFB_WIDTH);
+		cfg.height = __builtin_bswap32(RAMFB_HEIGHT);
+		cfg.stride = __builtin_bswap32(RAMFB_STRIDE);
+		if (sz > sizeof(cfg)) {
+			sz = sizeof(cfg);
+		}
+		if (ramfb_dma(sel, FW_CFG_DMA_CTL_WRITE, &cfg, sz) < 0) {
+			printk("ramfb: fw_cfg write failed\n");
+		}
+		else {
+			printk("ramfb: scanout %ux%u @ %p\n", RAMFB_WIDTH, RAMFB_HEIGHT,
+			    (void *)ramfb_mem);
+		}
+	}
+
+	memset(ramfb_mem, 0, sizeof(ramfb_mem));
+
+	info = fb_create(&ramfb_ops, (char *)ramfb_mem, RAMFB_SIZE);
+	if (!info) {
+		printk("ramfb: fb_create failed\n");
+		return -1;
+	}
+	return 0;
+}
+
+EMBOX_UNIT_INIT(ramfb_init);
+PERIPH_MEMORY_DEFINE(ramfb_fwcfg, FW_CFG_BASE, 0x18);

--- a/templates/aarch64/rpi4/build.conf
+++ b/templates/aarch64/rpi4/build.conf
@@ -1,0 +1,12 @@
+TARGET = embox
+
+ARCH = aarch64
+
+CROSS_COMPILE = aarch64-elf-
+// CROSS_COMPILE = aarch64-none-elf-
+// CROSS_COMPILE = aarch64-linux-gnu-
+
+CFLAGS += -O0 -g3
+CFLAGS += -march=armv8-a -mtune=cortex-a72
+CFLAGS += -mabi=lp64
+CFLAGS += -mstrict-align

--- a/templates/aarch64/rpi4/lds.conf
+++ b/templates/aarch64/rpi4/lds.conf
@@ -1,0 +1,20 @@
+/*
+ * Linkage configuration for Raspberry Pi 4B.
+ *
+ * The firmware loads kernel8.img at 0x80000, so that is the origin. The
+ * length below is for a 2 GiB board with the default 64 MiB GPU split:
+ * 2 GiB - 64 MiB - 0x80000 = 1983M, ending right below the GPU carveout.
+ *
+ * Adjust for other SKUs. Do not simply claim the full 4 GiB on a smaller
+ * board: the heap then grows into DRAM that is not there, and the failure
+ * shows up much later as a data abort in an unrelated allocation.
+ */
+
+/* region (origin, length) */
+RAM (0x80000, 1983M)
+
+/* section (region[, lma_region]) */
+text   (RAM)
+rodata (RAM)
+data   (RAM)
+bss    (RAM)

--- a/templates/aarch64/rpi4/mods.conf
+++ b/templates/aarch64/rpi4/mods.conf
@@ -1,0 +1,149 @@
+package genconfig
+
+configuration conf {
+	include embox.arch.system(core_freq=1500000000)
+	include embox.arch.aarch64.cpu_idle
+	include embox.arch.aarch64.locore
+	include embox.arch.aarch64.interrupt
+	include embox.arch.aarch64.context
+	include embox.arch.aarch64.mem_barriers
+	include embox.arch.aarch64.libarch
+	include embox.arch.aarch64.vfork
+
+	include embox.kernel.cpu.bkl
+	include embox.kernel.cpu.cpudata
+	include embox.kernel.irq
+
+	@Runlevel(0) include embox.arch.aarch64.mmu(granule=4)
+	@Runlevel(0) include embox.kernel.task.kernel_task
+	@Runlevel(0) include embox.kernel.stack(stack_size=0x200000)
+
+	/* GIC-400 (GICv2) in low peripheral mode, not the QEMU virt GICv3 */
+	include embox.driver.interrupt.gicv1(gicd_base=0xff841000, gicc_base=0xff842000)
+
+	/* PL011 UART0 at 0xFE201000, muxed onto GPIO 14/15 by
+	 * dtoverlay=disable-bt in config.txt. The core clock the firmware
+	 * gives UART0 is 48 MHz. SPI 121 is IRQ 153. */
+	include embox.driver.serial.pl011(uartclk=48000000)
+	include embox.driver.serial.pl011_diag(base_addr=0xFE201000)
+	include embox.driver.serial.pl011_ttyS0(base_addr=0xFE201000, irq_num=153)
+	include embox.driver.diag(impl="embox__driver__serial__pl011_diag")
+
+	@Runlevel(0) include embox.driver.clock.armv8_phy_timer(irq_num=30)
+	include embox.kernel.time.jiffies(cs_name="armv8_phy_timer")
+
+	include embox.driver.block_dev
+
+	/* HDMI framebuffer through the VideoCore property mailbox. The
+	 * console stays on the UART. */
+	include embox.driver.video.fb
+	include embox.driver.video.fb_devfs
+	@Runlevel(2) include embox.driver.video.bcm2711_fb
+
+	@Runlevel(0) include embox.mem.phymem
+	@Runlevel(1) include embox.kernel.timer.sys_timer
+	@Runlevel(1) include embox.kernel.time.kernel_time
+
+	@Runlevel(2) include embox.kernel.irq
+	@Runlevel(2) include embox.kernel.critical
+	@Runlevel(2) include embox.kernel.timer.sleep
+	@Runlevel(2) include embox.kernel.timer.strategy.head_timer
+	@Runlevel(2) include embox.kernel.time.kernel_time
+	@Runlevel(2) include embox.kernel.task.multi
+	@Runlevel(2) include embox.kernel.thread.core(thread_stack_size=0x20000, thread_stack_align=16)
+	include embox.kernel.sched.strategy.priority_based
+	include embox.kernel.thread.signal.sigstate
+	include embox.kernel.thread.signal.siginfoq
+	include embox.kernel.task.resource.env(env_str_len=64)
+
+	include embox.mem.pool_adapter
+	@Runlevel(2) include embox.mem.static_heap(heap_size=0x8000000)
+	include embox.mem.heap_bm(heap_size=0x4000000)
+	include embox.mem.bitmask(page_size=4096)
+
+	@Runlevel(2) include embox.fs.node(fnode_quantity=1024)
+	@Runlevel(2) include embox.fs.rootfs_oldfs
+	@Runlevel(2) include embox.fs.driver.initfs
+	@Runlevel(2) include embox.fs.driver.ramfs
+	include embox.fs.driver.devfs_old
+	include embox.compat.posix.file_system_oldfs
+
+	@Runlevel(2) include embox.cmd.sh.tish(
+				prompt="%u@%h:%w%$", rich_prompt_support=1,
+				builtin_commands="exit logout cd export mount umount")
+	include embox.init.system_start_service(log_level="LOG_INFO", tty_dev="ttyS0")
+	include embox.cmd.service
+
+	include embox.cmd.wc
+	include embox.cmd.fs.head
+	include embox.cmd.fs.cat
+	include embox.cmd.fs.cd
+	include embox.cmd.fs.pwd
+	include embox.cmd.fs.ls
+	include embox.cmd.fs.rm
+	include embox.cmd.fs.echo
+	include embox.cmd.fs.touch
+	include embox.cmd.fs.mkdir
+	include embox.cmd.help
+	include embox.cmd.man
+
+	include embox.cmd.sys.uname
+	include embox.cmd.sys.env
+	include embox.cmd.sys.export
+	include embox.cmd.sys.version
+	include embox.cmd.sys.date
+	include embox.cmd.sys.time
+	include embox.cmd.sys.shutdown
+
+	include embox.cmd.lsmod
+	include embox.cmd.test
+
+	include embox.cmd.proc.thread
+	include embox.cmd.proc.top
+
+	include embox.cmd.hw.mmutrans
+	include embox.cmd.hw.mem
+
+	include embox.cmd.testing.ticker
+
+	/* The on-board NIC (GENET) has no driver yet, so only loopback */
+	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=4000)
+	@Runlevel(2) include embox.net.skbuff_data(
+				amount_skb_data=4000, data_size=1514,
+				data_align=1, data_padto=1,ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(
+				amount_skb_extra=128,extra_size=10,extra_align=1,extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.tcp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.tcp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.net.net_entry
+	include embox.net.lib.dns_file
+
+	include embox.compat.libc.all
+	include embox.compat.libc.stdio.asprintf
+	include embox.compat.libc.math_simple
+	include embox.compat.posix.pthread_key
+	include embox.compat.posix.pthread_rwlock
+	include embox.compat.posix.sched.sched
+	include embox.compat.posix.proc.atexit_stub
+	include embox.compat.posix.unistd.pipe
+	include embox.compat.posix.time.time
+	include embox.compat.posix.time.nanosleep
+	include embox.kernel.task.idesc.idesc_mmap
+
+	include embox.compat.atomic.pseudo_atomic
+
+	include embox.lib.libds
+	include embox.framework.LibFramework
+}

--- a/templates/aarch64/rpi4/system_start.inc
+++ b/templates/aarch64/rpi4/system_start.inc
@@ -1,0 +1,3 @@
+"export PWD=/",
+"export HOME=/",
+"tish",


### PR DESCRIPTION
aarch64 display path for the QEMU virt machine and real Pi 4.

### drivers/video: ramfb driver for the QEMU virt machine

`-device ramfb` as a pseudo video device: the guest allocates a buffer and
writes its address, format and geometry into the fw_cfg file `etc/ramfb`,
and the host scans out of that memory from then on. The driver looks the
file up in the fw_cfg directory over the DMA interface, points it at a
static buffer and publishes it through `fb_create()` as `/dev/fb0`.

### drivers/video: VideoCore mailbox framebuffer for BCM2711 (Pi 4)

On the Pi the framebuffer is owned by the VideoCore firmware and is set up
over a property-channel mailbox request. `embox.driver.video.raspi_video`
already does this for the older SoCs, but it goes through the
`bcm2835_mailbox` driver, sends the tags one at a time and defaults to a
BCM2835 mailbox base — none of which works on a Pi 4. Rather than reworking
raspi_video and risking the boards it currently serves, this is a separate
driver.

It sends one bulk request (SET PHYS/VIRT SIZE, VIRT OFFSET, DEPTH, PIXEL
ORDER, ALLOCATE, GET PITCH) — the sequence the Pi 4 firmware expects —
converts the returned VideoCore bus address to an ARM physical address,
maps it uncached into the kernel context and publishes it as `/dev/fb0` in
BGRA8888. Display size comes from the firmware (EDID), with a configurable
fallback so a board booted with no monitor attached still gets a buffer.
The mailbox base is an option, so the same code covers the earlier SoCs'
base addresses.

The serial console is untouched: HDMI is scanout only.

### templates/aarch64: Raspberry Pi 4B template

There is currently no Pi 4 template in the tree. This one boots from the SD
card as `kernel8.img` with the console on the 40-pin header:

  * GIC-400 (GICv2) at `0xff841000` / `0xff842000` — low peripheral mode,;
  * PL011 UART0 at `0xFE201000`, 48 MHz core clock, IRQ 153 (SPI 121) —
    `dtoverlay=disable-bt` muxes it onto GPIO 14/15;
  * generic armv8 physical timer on IRQ 30, `core_freq` 1.5 GHz;
  * 4 KiB translation granule, matching the page size;
  * HDMI through `embox.driver.video.bcm2711_fb`, console stays on UART;
  * loopback only — the on-board GENET NIC has no driver yet.
