### PR TITLE
Add rk3568 gmac 0/1 support

### DIFF
--- a/mk/board_conf/gen_board_conf.h
+++ b/mk/board_conf/gen_board_conf.h
@@ -30,7 +30,7 @@ struct device_conf {
 	struct field_pin pins[64];
 	struct field_int clocks[16];
 	struct field_int dmas[16];
-	struct field_int misc[16];
+	struct field_int misc[64];
 };
 
 struct gpio_conf {

--- a/platform/rockchip/board_config/rockchip_rk3568_itx_dev.conf.h
+++ b/platform/rockchip/board_config/rockchip_rk3568_itx_dev.conf.h
@@ -1,0 +1,108 @@
+/**
+ * @file
+ * @brief Board configuration for the Rockchip RK3568 ITX board.
+ *
+ * Describes the two GMAC ports the way the board is wired: RGMII
+ * to an RTL8211F each, with the CRU clock gates / soft resets, the
+ * GRF interface mode and RGMII delay registers, the pin multiplexing
+ * and the PHY reset GPIOs.  Each pin batch is an initializer-list
+ * fragment of `struct rk3568_gmac_pin` (GRF pin number, function).
+ *
+ * All registers use the Rockchip hiword write-enable protocol.
+ */
+
+#include <gen_board_conf.h>
+
+#define GMAC0_MAC_ADDR  "02:e4:a5:35:68:00"
+#define GMAC1_MAC_ADDR  "02:e4:a5:35:68:01"
+
+/* gmac0_rgmii_bus, gmac0_rgmii_clk */
+#define GMAC0_PINS_A  {3, 2}, {4, 2}, {5, 2}, {6, 2}, {7, 2}, {8, 2},
+/* gmac0_tx_bus2, gmac0_rx_bus2 */
+#define GMAC0_PINS_B  {11, 1}, {12, 1}, {13, 1}, {14, 1}, {15, 2}, {16, 2},
+/* gmac0_miim */
+#define GMAC0_PINS_C  {19, 2}, {20, 2},
+
+/* gmac1m0 tx_bus2, rx_bus2 */
+#define GMAC1_PINS_A  {13, 3}, {14, 3}, {2, 3}, {3, 3}, {15, 3}, {9, 3},
+/* gmac1m0 rx_bus2 (cont), rgmii_clk */
+#define GMAC1_PINS_B  {10, 3}, {4, 3}, {5, 3}, {11, 3}, {6, 3}, {7, 3},
+/* gmac1m0 clkinout, miim */
+#define GMAC1_PINS_C  {16, 3}, {20, 3}, {21, 3},
+
+struct eth_conf eths[] = {
+	[0] = {
+		.status = ENABLED,
+		.name = "GMAC0",
+		.dev = {
+			.name = "GMAC0",
+			.regs = {
+				REGMAP("BASE", 0xFE2A0000, 0x2000),
+			},
+			.irqs = {
+				VAL("NUM", 59),
+			},
+			.clocks = { },
+			.misc = {
+				VAL("MAC_ADDR", GMAC0_MAC_ADDR),
+				VAL("CRU_GATE_REG", 0x33C),
+				VAL("CRU_GATE_MASK", 0x1F70),
+				VAL("CRU_RST_REG", 0x434),
+				VAL("CRU_RST_MASK", 0x0080),
+				VAL("CRU_SEL_REG", 0x17C),
+				VAL("GRF_MACCON0_REG", 0x380),
+				VAL("GRF_MACCON0_VAL", 0x264F),
+				VAL("GRF_MACCON0_MASK", 0x7F7F),
+				VAL("GRF_MACCON1_REG", 0x384),
+				VAL("GRF_MACCON1_VAL", 0x0013),
+				VAL("GRF_MACCON1_MASK", 0x0073),
+				VAL("GRF_IOMUX_OFF", 0x020),
+				VAL("GRF_ROUTE_REG", 0),
+				VAL("GRF_ROUTE_VAL", 0),
+				VAL("RST_GPIO_BASE", 0xFE750000),
+				VAL("RST_GPIO_PIN", 9),
+				VAL("PINS_A", GMAC0_PINS_A),
+				VAL("PINS_B", GMAC0_PINS_B),
+				VAL("PINS_C", GMAC0_PINS_C),
+			},
+		},
+	},
+	[1] = {
+		.status = ENABLED,
+		.name = "GMAC1",
+		.dev = {
+			.name = "GMAC1",
+			.regs = {
+				REGMAP("BASE", 0xFE010000, 0x2000),
+			},
+			.irqs = {
+				VAL("NUM", 64),
+			},
+			.clocks = { },
+			.misc = {
+				VAL("MAC_ADDR", GMAC1_MAC_ADDR),
+				VAL("CRU_GATE_REG", 0x344),
+				VAL("CRU_GATE_MASK", 0x07DC),
+				VAL("CRU_RST_REG", 0x438),
+				VAL("CRU_RST_MASK", 0x1000),
+				VAL("CRU_SEL_REG", 0x184),
+				VAL("GRF_MACCON0_REG", 0x388),
+				VAL("GRF_MACCON0_VAL", 0x033C),
+				VAL("GRF_MACCON0_MASK", 0x7F7F),
+				VAL("GRF_MACCON1_REG", 0x38C),
+				VAL("GRF_MACCON1_VAL", 0x0013),
+				VAL("GRF_MACCON1_MASK", 0x0073),
+				VAL("GRF_IOMUX_OFF", 0x040),
+				VAL("GRF_ROUTE_REG", 0x300),
+				VAL("GRF_ROUTE_VAL", 0x0100),
+				VAL("RST_GPIO_BASE", 0xFE760000),
+				VAL("RST_GPIO_PIN", 18),
+				VAL("PINS_A", GMAC1_PINS_A),
+				VAL("PINS_B", GMAC1_PINS_B),
+				VAL("PINS_C", GMAC1_PINS_C),
+			},
+		},
+	},
+};
+
+EXPORT_CONFIG(ETH(eths))

--- a/platform/rockchip/rk3568/board.conf.h
+++ b/platform/rockchip/rk3568/board.conf.h
@@ -1,0 +1,6 @@
+#include <rockchip_rk3568_itx_dev.conf.h>
+
+CONFIG {
+	eths[0].status = ENABLED;
+	eths[1].status = ENABLED;
+}

--- a/platform/rockchip/rk3568/build.conf
+++ b/platform/rockchip/rk3568/build.conf
@@ -9,3 +9,4 @@ CFLAGS += -O2 -g
 CFLAGS += -march=armv8-a -mtune=cortex-a55
 CFLAGS += -mabi=lp64
 CFLAGS += -mstrict-align
+CHIP_VENDOR = rockchip

--- a/platform/rockchip/rk3568/mods.conf
+++ b/platform/rockchip/rk3568/mods.conf
@@ -48,6 +48,39 @@ configuration conf {
 	include embox.driver.pci_msi
 	@Runlevel(3) include embox.driver.nvme(msi_mode=true)
 
+	/* Network: the stock Embox stack over both GMAC ports. gmac0
+	 * @0xFE2A0000 enumerates as eth0 (MAC 02:e4:a5:35:68:00, the
+	 * U-Boot ethaddr contract, IRQ 59 = SPI 27 + 32) and gmac1
+	 * @0xFE010000 as eth1 (02:e4:a5:35:68:01 = U-Boot eth1addr,
+	 * IRQ 64 = SPI 32 + 32); the ethN indexes thus match U-Boot's
+	 * device naming. */
+	@Runlevel(2) include embox.driver.net.loopback
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=128)
+	@Runlevel(2) include embox.net.skbuff_data(
+				amount_skb_data=128, data_size=1514,
+				data_align=1, data_padto=1, ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(
+				amount_skb_extra=128, extra_size=10,
+				extra_align=1, extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.net_entry
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	@Runlevel(2) include embox.driver.net.rk3568_gmac
+
+	include embox.cmd.net.ping
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.route
+	include embox.cmd.net.arp
+
 	/* UART2 (DW-APB 16550) at 0xFE660000, 24 MHz baud clock, IRQ 150 --
 	 * the console the vendor U-Boot already leaves running at 115200.
 	 * reg_width=4 + mem32_access matches the DW-APB layout the Linux DTS

--- a/src/drivers/net/dwc_eqos/Mybuild
+++ b/src/drivers/net/dwc_eqos/Mybuild
@@ -1,0 +1,46 @@
+package embox.driver.net
+
+module dwc_eqos {
+	option string log_level="LOG_INFO"
+
+	option number rx_desc_quantity = 64
+	option number tx_desc_quantity = 64
+	option number rx_buf_size = 1600
+	option number pclk_hz = 100000000
+	option number txpbl = 32
+	option number rxpbl = 8
+
+	source "dwc_eqos.c"
+
+	depends embox.net.skbuff
+	depends embox.compat.libc.all
+	depends embox.net.l2.ethernet
+	depends embox.kernel.irq
+	depends embox.net.dev
+	depends embox.driver.net.phy
+	depends embox.net.entry_api
+	@NoRuntime depends embox.driver.periph_memory
+	@NoRuntime depends embox.driver.periph_memory_alloc
+	@NoRuntime depends embox.arch.mem_barriers
+}
+
+/* Rockchip RK3568 glue for dwc_eqos: CRU clocks, GRF interface
+ * mode / RGMII delays, pin iomux and PHY reset GPIOs. */
+module dwc_eqos_rk3568 {
+	option number cru_base = 0xFDD20000
+	option number grf_base = 0xFDC60000
+
+	source "dwc_eqos_rk3568.c"
+
+	@NoRuntime depends embox.driver.periph_memory
+}
+
+module rk3568_gmac {
+	option string log_level="LOG_ERR"
+
+	source "rk3568_gmac.c"
+
+	@NoRuntime depends dwc_eqos
+	@NoRuntime depends dwc_eqos_rk3568
+	depends embox.net.dev
+}

--- a/src/drivers/net/dwc_eqos/dwc_eqos.c
+++ b/src/drivers/net/dwc_eqos/dwc_eqos.c
@@ -1,0 +1,838 @@
+/**
+ * @file
+ * @brief Synopsys DesignWare Ethernet QoS (dwmac-4.x) core driver.
+ *
+ * One combined mac/dma interrupt per port, a single RX/TX channel with
+ * tail-pointer ring arming, and MDIO through the dwmac4 register block.
+ * The generic Embox PHY layer (drivers/net/phy) drives autonegotiation
+ * through the mdio_read/mdio_write/set_speed hooks.  Everything
+ * SoC-specific (clock trees, pin iomux, PHY reset GPIOs) is behind the
+ * soc_init/soc_swr_quirk hooks of struct dwc_eqos_plat.
+ *
+ * Descriptor rings and frame buffers are static arrays shared with the
+ * DMA through explicit cache maintenance: every descriptor is flushed
+ * after the software writes it and invalidated before the software
+ * reads the hardware writeback.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <framework/mod/options.h>
+#include <hal/cache.h>
+#include <hal/ipl.h>
+#include <hal/mem_barriers.h>
+#include <hal/reg.h>
+#include <kernel/irq.h>
+#include <kernel/time/sys_timer.h>
+#include <kernel/time/time.h>
+#include <util/log.h>
+
+#include <net/l0/net_entry.h>
+#include <net/l2/ethernet.h>
+#include <net/inetdevice.h>
+#include <net/mii.h>
+#include <net/netdevice.h>
+#include <net/phy.h>
+#include <net/skbuff.h>
+
+#include "dwc_eqos.h"
+
+#define RX_DESC_QUANTITY  OPTION_GET(NUMBER, rx_desc_quantity)
+#define TX_DESC_QUANTITY  OPTION_GET(NUMBER, tx_desc_quantity)
+#define RX_BUF_SIZE       OPTION_GET(NUMBER, rx_buf_size)
+#define PCLK_HZ           OPTION_GET(NUMBER, pclk_hz)
+#define TXPBL             OPTION_GET(NUMBER, txpbl)
+#define RXPBL             OPTION_GET(NUMBER, rxpbl)
+
+#define PORT_NUM          2
+
+/* Per-frame DMA buffers: every buffer gets its own 2K slot so that
+ * cache maintenance on one buffer never touches a neighbour. */
+#define DMA_BUF_ALIGN     0x800
+#define DMA_BUF_STRIDE    0x800
+
+struct dwc_eqos_priv {
+	const struct dwc_eqos_plat *plat;
+	struct net_device    *dev;
+	unsigned long         base_addr;
+	uint8_t               macaddr[ETH_ALEN];
+	int                   phy_id;
+
+	struct dwc_eqos_desc  *rx_ring;
+	struct dwc_eqos_desc  *tx_ring;
+	int                   tx_head;
+	int                   tx_tail;
+	/* Software ownership handoff per rx slot: a slot is delivered
+	 * and refilled wherever its writeback shows up in the ring,
+	 * because the rx dma laps past the software instead of
+	 * stopping at a single head position (see eqos_rx_complete). */
+	uint8_t               rx_in_flight[RX_DESC_QUANTITY];
+
+	struct sys_timer      rx_poll;
+};
+
+static struct dwc_eqos_priv eqos_priv[PORT_NUM];
+
+static struct dwc_eqos_desc rx_rings[PORT_NUM][RX_DESC_QUANTITY]
+		__attribute__((aligned(DMA_BUF_ALIGN)));
+static struct dwc_eqos_desc tx_rings[PORT_NUM][TX_DESC_QUANTITY]
+		__attribute__((aligned(DMA_BUF_ALIGN)));
+
+static uint8_t rx_buffers[PORT_NUM][RX_DESC_QUANTITY][DMA_BUF_STRIDE]
+		__attribute__((aligned(DMA_BUF_ALIGN)));
+static uint8_t tx_buffers[PORT_NUM][TX_DESC_QUANTITY][DMA_BUF_STRIDE]
+		__attribute__((aligned(DMA_BUF_ALIGN)));
+
+static inline uint32_t eqos_read(const struct dwc_eqos_priv *priv,
+		unsigned int reg) {
+	return REG32_LOAD(priv->base_addr + reg);
+}
+
+static inline void eqos_write(const struct dwc_eqos_priv *priv,
+		unsigned int reg, uint32_t val) {
+	REG32_STORE(priv->base_addr + reg, val);
+}
+
+static void eqos_set_macaddr_regs(const struct dwc_eqos_priv *priv,
+		const uint8_t *addr) {
+	eqos_write(priv, DWC_EQOS_MAC_ADDRESS0_LOW,
+			addr[0] | (addr[1] << 8) | (addr[2] << 16) | (addr[3] << 24));
+	eqos_write(priv, DWC_EQOS_MAC_ADDRESS0_HIGH,
+			addr[4] | (addr[5] << 8));
+}
+
+static int eqos_mdio_read(struct net_device *dev, uint8_t reg_addr) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	uint32_t mii_addr;
+	int cnt;
+
+	mii_addr = ((uint32_t) priv->phy_id << DWC_EQOS_MDIO_PA_SHIFT)
+			| ((uint32_t) reg_addr << DWC_EQOS_MDIO_RDA_SHIFT)
+			| (DWC_EQOS_MDIO_CR_150_250M << DWC_EQOS_MDIO_CR_SHIFT)
+			| DWC_EQOS_MDIO_GOC_READ
+			| DWC_EQOS_MDIO_GB;
+
+	eqos_write(priv, DWC_EQOS_MAC_MDIO_ADDRESS, mii_addr);
+	for (cnt = 0; cnt < 100000; cnt++) {
+		if (!(eqos_read(priv, DWC_EQOS_MAC_MDIO_ADDRESS) & DWC_EQOS_MDIO_GB)) {
+			return eqos_read(priv, DWC_EQOS_MAC_MDIO_DATA) & 0xffff;
+		}
+	}
+
+	log_error("mdio read %#x timeout", reg_addr);
+	return -ETIMEDOUT;
+}
+
+static int eqos_mdio_write(struct net_device *dev, uint8_t reg_addr,
+		uint16_t data) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	uint32_t mii_addr;
+	int cnt;
+
+	eqos_write(priv, DWC_EQOS_MAC_MDIO_DATA, data);
+	mii_addr = ((uint32_t) priv->phy_id << DWC_EQOS_MDIO_PA_SHIFT)
+			| ((uint32_t) reg_addr << DWC_EQOS_MDIO_RDA_SHIFT)
+			| (DWC_EQOS_MDIO_CR_150_250M << DWC_EQOS_MDIO_CR_SHIFT)
+			| DWC_EQOS_MDIO_GOC_WRITE
+			| DWC_EQOS_MDIO_GB;
+
+	eqos_write(priv, DWC_EQOS_MAC_MDIO_ADDRESS, mii_addr);
+	for (cnt = 0; cnt < 100000; cnt++) {
+		if (!(eqos_read(priv, DWC_EQOS_MAC_MDIO_ADDRESS) & DWC_EQOS_MDIO_GB)) {
+			return 0;
+		}
+	}
+
+	log_error("mdio write %#x timeout", reg_addr);
+	return -ETIMEDOUT;
+}
+
+/* Raw MDIO helpers for the pre-mii PHY poke, phy id passed explicitly */
+static int eqos_mdio_raw_read(struct dwc_eqos_priv *priv, int phy,
+		uint8_t reg_addr, uint32_t *val) {
+	uint32_t mii_addr;
+	int cnt;
+
+	mii_addr = ((uint32_t) phy << DWC_EQOS_MDIO_PA_SHIFT)
+			| ((uint32_t) reg_addr << DWC_EQOS_MDIO_RDA_SHIFT)
+			| (DWC_EQOS_MDIO_CR_150_250M << DWC_EQOS_MDIO_CR_SHIFT)
+			| DWC_EQOS_MDIO_GOC_READ
+			| DWC_EQOS_MDIO_GB;
+
+	eqos_write(priv, DWC_EQOS_MAC_MDIO_ADDRESS, mii_addr);
+	for (cnt = 0; cnt < 100000; cnt++) {
+		if (!(eqos_read(priv, DWC_EQOS_MAC_MDIO_ADDRESS) & DWC_EQOS_MDIO_GB)) {
+			*val = eqos_read(priv, DWC_EQOS_MAC_MDIO_DATA) & 0xffff;
+			return 0;
+		}
+	}
+
+	return -ETIMEDOUT;
+}
+
+static int eqos_mdio_raw_write(struct dwc_eqos_priv *priv, int phy,
+		uint8_t reg_addr, uint16_t data) {
+	uint32_t mii_addr;
+	int cnt;
+
+	eqos_write(priv, DWC_EQOS_MAC_MDIO_DATA, data);
+	mii_addr = ((uint32_t) phy << DWC_EQOS_MDIO_PA_SHIFT)
+			| ((uint32_t) reg_addr << DWC_EQOS_MDIO_RDA_SHIFT)
+			| (DWC_EQOS_MDIO_CR_150_250M << DWC_EQOS_MDIO_CR_SHIFT)
+			| DWC_EQOS_MDIO_GOC_WRITE
+			| DWC_EQOS_MDIO_GB;
+
+	eqos_write(priv, DWC_EQOS_MAC_MDIO_ADDRESS, mii_addr);
+	for (cnt = 0; cnt < 100000; cnt++) {
+		if (!(eqos_read(priv, DWC_EQOS_MAC_MDIO_ADDRESS) & DWC_EQOS_MDIO_GB)) {
+			return 0;
+		}
+	}
+
+	return -ETIMEDOUT;
+}
+
+static void eqos_set_phyid(struct net_device *dev, uint8_t phyid) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+
+	priv->phy_id = phyid;
+}
+
+static int eqos_set_speed(struct net_device *dev, int speed) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	uint32_t reg;
+
+	reg = eqos_read(priv, DWC_EQOS_MAC_CONFIGURATION);
+
+	/* Frame burst enable, jabber disable, jumbo enable, disable CRC
+	 * status removal: the received frames keep their FCS, which the
+	 * rx path strips manually (same configuration as the proven
+	 * netbsd eqos setup on this board). */
+	reg |= DWC_EQOS_MAC_CONF_BE | DWC_EQOS_MAC_CONF_JD
+			| DWC_EQOS_MAC_CONF_JE | DWC_EQOS_MAC_CONF_DCRS;
+
+	speed = net_to_mbps(speed);
+	switch (speed) {
+	case 1000:
+		reg &= ~(DWC_EQOS_MAC_CONF_PS | DWC_EQOS_MAC_CONF_FES);
+		break;
+	case 100:
+		reg |= DWC_EQOS_MAC_CONF_PS | DWC_EQOS_MAC_CONF_FES;
+		break;
+	case 10:
+		reg |= DWC_EQOS_MAC_CONF_PS;
+		reg &= ~DWC_EQOS_MAC_CONF_FES;
+		break;
+	default:
+		log_error("unsupported speed %d", speed);
+		return -EINVAL;
+	}
+
+	reg |= DWC_EQOS_MAC_CONF_DM;
+	eqos_write(priv, DWC_EQOS_MAC_CONFIGURATION, reg);
+
+	log_info("link speed %d Mbps full duplex", speed);
+
+	return 0;
+}
+
+/* Clear the RTL8211F strapped RGMII TX-delay after the hard reset
+ * pulse re-latched it.  The board GRF delays are calibrated with the
+ * PHY-side delay off; leaving the strap set double-delays the TX path
+ * and long frames never reach the wire.  Raw MDIO, before the PHY
+ * layer attaches. */
+static void eqos_phy_tx_delay_clear(struct dwc_eqos_priv *priv) {
+	uint32_t id1, id2, val;
+	int phy, res;
+
+	for (phy = 0; phy < 32; phy++) {
+		res = eqos_mdio_raw_read(priv, phy, MII_PHYSID1, &id1);
+		if (res) {
+			continue;
+		}
+		res = eqos_mdio_raw_read(priv, phy, MII_PHYSID2, &id2);
+		if (res) {
+			continue;
+		}
+		if (id1 != RTL8211F_PHYSID1 || id2 != RTL8211F_PHYSID2) {
+			continue;
+		}
+
+		log_info("RTL8211F phy %d: id %#x:%#x", phy, id1, id2);
+
+		/* switch to page d08 */
+		eqos_mdio_raw_write(priv, phy, RTL8211F_PAGESEL, 0x0d08);
+		if (eqos_mdio_raw_read(priv, phy, 0x11, &val) == 0) {
+			if (val & RTL8211F_TXDELAY) {
+				eqos_mdio_raw_write(priv, phy, 0x11,
+						val & ~RTL8211F_TXDELAY);
+				log_info("RTL8211F phy %d: cleared strapped RGMII"
+						" TX-delay (d08.0x11 %#x -> %#x)",
+						phy, val, val & ~RTL8211F_TXDELAY);
+			}
+		}
+		/* back to page 0 */
+		eqos_mdio_raw_write(priv, phy, RTL8211F_PAGESEL, 0);
+	}
+}
+
+static int eqos_hw_stop(struct dwc_eqos_priv *priv) {
+	uint32_t reg;
+
+	eqos_write(priv, DWC_EQOS_DMA_CH0_INTR_ENABLE, 0);
+
+	reg = eqos_read(priv, DWC_EQOS_DMA_CH0_TX_CONTROL);
+	reg &= ~DWC_EQOS_TX_CTRL_ST;
+	eqos_write(priv, DWC_EQOS_DMA_CH0_TX_CONTROL, reg);
+
+	reg = eqos_read(priv, DWC_EQOS_DMA_CH0_RX_CONTROL);
+	reg &= ~DWC_EQOS_RX_CTRL_SR;
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_CONTROL, reg);
+
+	reg = eqos_read(priv, DWC_EQOS_MAC_CONFIGURATION);
+	reg &= ~(DWC_EQOS_MAC_CONF_TE | DWC_EQOS_MAC_CONF_RE);
+	eqos_write(priv, DWC_EQOS_MAC_CONFIGURATION, reg);
+
+	return 0;
+}
+
+static int eqos_hw_reset(struct dwc_eqos_priv *priv) {
+	const struct dwc_eqos_plat *plat = priv->plat;
+	uint32_t mode;
+	int cnt, cleared = 0;
+
+	log_debug("dma_mode before swr: %#x",
+			eqos_read(priv, DWC_EQOS_DMA_MODE));
+
+	if (plat->soc_swr_quirk != NULL) {
+		plat->soc_swr_quirk(plat, 1);
+	}
+
+	eqos_write(priv, DWC_EQOS_DMA_MODE, DWC_EQOS_DMA_MODE_SWR);
+	/* The reset normally clears within a few dma clock cycles: spin
+	 * on the register first, then fall back to sleeping. */
+	for (cnt = 0; (cnt < 1000000) && !cleared; cnt++) {
+		cleared = !(eqos_read(priv, DWC_EQOS_DMA_MODE)
+				& DWC_EQOS_DMA_MODE_SWR);
+	}
+	for (cnt = 0; (cnt < 500) && !cleared; cnt++) {
+		usleep(10 * USEC_PER_MSEC);
+		cleared = !(eqos_read(priv, DWC_EQOS_DMA_MODE)
+				& DWC_EQOS_DMA_MODE_SWR);
+	}
+
+	if (plat->soc_swr_quirk != NULL) {
+		plat->soc_swr_quirk(plat, 0);
+	}
+
+	if (!cleared) {
+		mode = eqos_read(priv, DWC_EQOS_DMA_MODE);
+		log_error("dma soft reset timeout, mode=%#x", mode);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static void eqos_setup_rx_desc(struct dwc_eqos_priv *priv, int idx) {
+	struct dwc_eqos_desc *desc = &priv->rx_ring[idx];
+	uint8_t *buf = rx_buffers[priv->plat->idx][idx];
+
+	/* The buffer was written by software (bss init) or by the previous
+	 * DMA transfer: make sure no stale dirty line survives before the
+	 * dma starts writing into it. */
+	dcache_flush(buf, RX_BUF_SIZE);
+	dcache_inval(buf, RX_BUF_SIZE);
+
+	desc->des0 = (uint32_t) ((uintptr_t) buf);
+	desc->des1 = 0;
+	desc->des2 = 0;
+	desc->des3 = DWC_EQOS_DESC_OWN | DWC_EQOS_DESC_RX_IOC | DWC_EQOS_DESC_RX_BUF1V;
+	dcache_flush(desc, sizeof(*desc));
+}
+
+static int eqos_hw_start(struct dwc_eqos_priv *priv) {
+	uint32_t reg;
+
+	/* Channel: PBLx8, contiguous 16-byte descriptors (no skip) */
+	reg = eqos_read(priv, DWC_EQOS_DMA_CH0_CONTROL);
+	reg |= DWC_EQOS_CH0_CTRL_PBLX8;
+	eqos_write(priv, DWC_EQOS_DMA_CH0_CONTROL, reg);
+
+	eqos_write(priv, DWC_EQOS_DMA_CH0_TX_CONTROL,
+			(TXPBL << DWC_EQOS_TX_CTRL_TXPBL_SHIFT) | DWC_EQOS_TX_CTRL_OSP);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_CONTROL,
+			(RXPBL << DWC_EQOS_RX_CTRL_RXPBL_SHIFT)
+			| (RX_BUF_SIZE << DWC_EQOS_RX_CTRL_RBSZ_SHIFT));
+
+	/* RX end-pointer arming: on this core the fetch window is
+	 * [ring base, end address) -- the dma wraps to the ring base
+	 * once it reaches the end and never fetches the end descriptor
+	 * itself. Point it at the last slot once and leave it alone:
+	 * moving the boundary with every refill is what wedges the
+	 * ring when the dma catches up with the software. */
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_END_ADDR,
+			(uint32_t) (uintptr_t) &priv->rx_ring[RX_DESC_QUANTITY - 1]);
+
+	/* Enable channel interrupts, then start both DMA engines. */
+	eqos_write(priv, DWC_EQOS_DMA_CH0_INTR_ENABLE, DWC_EQOS_CH0_INTR_DEFAULT);
+
+	eqos_write(priv, DWC_EQOS_DMA_CH0_TX_CONTROL,
+			eqos_read(priv, DWC_EQOS_DMA_CH0_TX_CONTROL)
+			| DWC_EQOS_TX_CTRL_ST);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_CONTROL,
+			eqos_read(priv, DWC_EQOS_DMA_CH0_RX_CONTROL)
+			| DWC_EQOS_RX_CTRL_SR);
+
+	/* MAC transmit/receive enable */
+	reg = eqos_read(priv, DWC_EQOS_MAC_CONFIGURATION);
+	reg |= DWC_EQOS_MAC_CONF_TE | DWC_EQOS_MAC_CONF_RE;
+	eqos_write(priv, DWC_EQOS_MAC_CONFIGURATION, reg);
+
+	return 0;
+}
+
+static int eqos_hw_init(struct dwc_eqos_priv *priv) {
+	uint32_t reg, hw_feat;
+	int res, i;
+
+	/* Stop the tx/rx engines and mask all channel interrupts before
+	 * the soft reset (the firmware may have left them running). */
+	eqos_hw_stop(priv);
+
+	res = eqos_hw_reset(priv);
+	if (res) {
+		return res;
+	}
+
+	/* AXI bus: outstanding request limits and 4/8/16-beat bursts. */
+	eqos_write(priv, DWC_EQOS_DMA_SYSBUS_MODE,
+			(4u << DWC_EQOS_SYSBUS_WR_OSR_SHIFT)
+			| (8u << DWC_EQOS_SYSBUS_RD_OSR_SHIFT)
+			| DWC_EQOS_SYSBUS_EAME
+			| DWC_EQOS_SYSBUS_BLEN16 | DWC_EQOS_SYSBUS_BLEN8
+			| DWC_EQOS_SYSBUS_BLEN4);
+
+	/* MTL queue sizes from the hardware feature registers: the fifo
+	 * size is encoded as log2(n/128) and the TQS/RQS fields hold
+	 * fifo/256 - 1. */
+	hw_feat = eqos_read(priv, DWC_EQOS_MAC_HW_FEATURE1);
+	reg = DWC_EQOS_MTL_TXQ0_OP_TXQEN_EN | DWC_EQOS_MTL_TXQ0_OP_TSF;
+	reg |= ((((128u << ((hw_feat & DWC_EQOS_HW_TXFIFOSZ_MASK)
+					>> DWC_EQOS_HW_TXFIFOSZ_SHIFT)) >> 8) - 1u)
+			<< DWC_EQOS_MTL_TXQ0_OP_TQS_SHIFT)
+			& DWC_EQOS_MTL_TXQ0_OP_TQS_MASK;
+	eqos_write(priv, DWC_EQOS_MTL_TXQ0_OPERATION_MODE, reg);
+
+	reg = DWC_EQOS_MTL_RXQ0_OP_RSF | DWC_EQOS_MTL_RXQ0_OP_FEP
+			| DWC_EQOS_MTL_RXQ0_OP_FUP;
+	reg |= ((((128u << (hw_feat & DWC_EQOS_HW_RXFIFOSZ_MASK)) >> 8) - 1u)
+			<< DWC_EQOS_MTL_RXQ0_OP_RQS_SHIFT)
+			& DWC_EQOS_MTL_RXQ0_OP_RQS_MASK;
+	eqos_write(priv, DWC_EQOS_MTL_RXQ0_OPERATION_MODE, reg);
+
+	/* Route all traffic to RX queue 0, MC/BC filter to queue 0. */
+	eqos_write(priv, DWC_EQOS_MAC_RXQ_CTRL0, DWC_EQOS_RXQ_CTRL0_RXQ0EN_DCB);
+	reg = eqos_read(priv, DWC_EQOS_MAC_RXQ_CTRL1);
+	reg |= DWC_EQOS_RXQ_CTRL1_MCBCQEN;
+	eqos_write(priv, DWC_EQOS_MAC_RXQ_CTRL1, reg);
+
+	/* Flow control off, promiscuous reception, ~1us tick for the
+	 * watchdog timers. */
+	eqos_write(priv, DWC_EQOS_MAC_Q0_TX_FLOW_CTRL, 0);
+	eqos_write(priv, DWC_EQOS_MAC_RX_FLOW_CTRL, 0);
+	eqos_write(priv, DWC_EQOS_MAC_PACKET_FILTER, DWC_EQOS_PKT_FLT_PR);
+	eqos_write(priv, DWC_EQOS_MAC_1US_TIC_COUNTER, PCLK_HZ / 1000000 - 1);
+
+	eqos_set_macaddr_regs(priv, priv->macaddr);
+	memcpy(priv->dev->dev_addr, priv->macaddr, ETH_ALEN);
+
+	/* Descriptor rings: static arrays, made visible to the dma with
+	 * explicit cache maintenance. */
+	memset(priv->rx_ring, 0,
+			RX_DESC_QUANTITY * sizeof(struct dwc_eqos_desc));
+	memset(priv->tx_ring, 0,
+			TX_DESC_QUANTITY * sizeof(struct dwc_eqos_desc));
+	dcache_flush(priv->rx_ring,
+			RX_DESC_QUANTITY * sizeof(struct dwc_eqos_desc));
+	dcache_flush(priv->tx_ring,
+			TX_DESC_QUANTITY * sizeof(struct dwc_eqos_desc));
+	memset(priv->rx_in_flight, 1, RX_DESC_QUANTITY);
+	priv->tx_head = 0;
+	priv->tx_tail = 0;
+
+	for (i = 0; i < RX_DESC_QUANTITY; i++) {
+		eqos_setup_rx_desc(priv, i);
+	}
+
+	eqos_write(priv, DWC_EQOS_DMA_CH0_TX_BASE_ADDR_HI, 0);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_TX_BASE_ADDR_LO,
+			(uint32_t) (uintptr_t) priv->tx_ring);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_BASE_ADDR_HI, 0);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_BASE_ADDR_LO,
+			(uint32_t) (uintptr_t) priv->rx_ring);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_TX_RING_LEN, TX_DESC_QUANTITY - 1);
+	eqos_write(priv, DWC_EQOS_DMA_CH0_RX_RING_LEN, RX_DESC_QUANTITY - 1);
+
+	return 0;
+}
+
+static int eqos_rx_complete(struct net_device *dev) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	struct sk_buff *skb;
+	struct dwc_eqos_desc *desc;
+	uint8_t *buf;
+	int len, i;
+
+	/* The rx dma laps the ring: once its fetch pointer reaches the
+	 * end address it wraps to the ring base, so writebacks land
+	 * wherever the next frame went, not at a moving head. Sweep
+	 * every slot with an outstanding handoff instead and deliver
+	 * each frame from the slot its writeback actually landed in. */
+	for (i = 0; i < RX_DESC_QUANTITY; i++) {
+		if (!priv->rx_in_flight[i]) {
+			continue;
+		}
+		desc = &priv->rx_ring[i];
+		dcache_inval(desc, sizeof(*desc));
+		if (desc->des3 & DWC_EQOS_DESC_OWN) {
+			continue;
+		}
+
+		priv->rx_in_flight[i] = 0;
+		buf = rx_buffers[priv->plat->idx][i];
+		len = desc->des3 & DWC_EQOS_DESC_RX_LEN_MASK;
+
+		if (len < 4) {
+			log_error("runt frame, len %d", len);
+		} else {
+			dcache_inval(buf, len);
+
+			/* The skb data pool holds ETH_FRAME_LEN bytes:
+			 * strip the frame check sequence before
+			 * copying. */
+			len -= 4;
+			skb = skb_alloc(len);
+			if (skb == NULL) {
+				log_error("no skb for rx frame");
+			} else {
+				memcpy(skb_data_cast_in(skb->data), buf, len);
+				skb->len = len;
+				skb->dev = dev;
+
+				netif_rx(skb);
+			}
+		}
+
+		eqos_setup_rx_desc(priv, i);
+		priv->rx_in_flight[i] = 1;
+	}
+
+	return 0;
+}
+
+static void eqos_tx_complete(struct dwc_eqos_priv *priv) {
+	struct dwc_eqos_desc *desc;
+	int cnt;
+
+	for (cnt = 0; cnt < TX_DESC_QUANTITY; cnt++) {
+		if (priv->tx_tail == priv->tx_head) {
+			break;
+		}
+		desc = &priv->tx_ring[priv->tx_tail];
+		dcache_inval(desc, sizeof(*desc));
+		if (desc->des3 & DWC_EQOS_DESC_OWN) {
+			break;
+		}
+		priv->tx_tail = (priv->tx_tail + 1) % TX_DESC_QUANTITY;
+	}
+
+	if (priv->tx_tail != priv->tx_head) {
+		/* resume the dma if it stopped on an unavailable buffer */
+		eqos_write(priv, DWC_EQOS_DMA_CH0_TX_END_ADDR,
+				(uint32_t) (uintptr_t) &priv->tx_ring[priv->tx_head]);
+	}
+}
+
+/* Belt and braces for the rx path: even a single lost rx interrupt
+ * would leave freshly received frames sitting in the ring until the
+ * next one arrives, and a dma suspended on a not-yet-refilled slot
+ * needs the end register rewritten to resume. Reclaim on a slow
+ * timer as well; ipl_save serializes this against the irq handler. */
+static void eqos_rx_poll(struct sys_timer *timer, void *param) {
+	struct dwc_eqos_priv *priv = param;
+	ipl_t ipl;
+
+	ipl = ipl_save();
+	{
+		eqos_rx_complete(priv->dev);
+		eqos_tx_complete(priv);
+		eqos_write(priv, DWC_EQOS_DMA_CH0_RX_END_ADDR,
+				(uint32_t) (uintptr_t)
+				&priv->rx_ring[RX_DESC_QUANTITY - 1]);
+	}
+	ipl_restore(ipl);
+}
+
+static irq_return_t eqos_irq_handler(unsigned int irq_num, void *dev_id) {
+	struct net_device *dev = dev_id;
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	uint32_t status;
+	int pass;
+
+	for (pass = 0; pass < 8; pass++) {
+		status = eqos_read(priv, DWC_EQOS_DMA_CH0_STATUS);
+		if (status == 0) {
+			break;
+		}
+		/* write-one-to-clear everything latched: leaving e.g. the
+		 * abnormal interrupt summary set would keep the line
+		 * asserted forever */
+		eqos_write(priv, DWC_EQOS_DMA_CH0_STATUS, status);
+
+		if (!(status & (DWC_EQOS_CH0_STATUS_RI | DWC_EQOS_CH0_STATUS_TI
+						| DWC_EQOS_CH0_STATUS_FB))) {
+			log_debug("%s: dma status %#x", dev->name, status);
+			break;
+		}
+
+		if (status & DWC_EQOS_CH0_STATUS_FB) {
+			/* Fatal bus error: shut the channel down (no sleeping
+			 * is allowed here, so no full re-init). */
+			log_error("dma fatal bus error, stopping %s", dev->name);
+			eqos_hw_stop(priv);
+			return IRQ_HANDLED;
+		}
+
+		if (status & DWC_EQOS_CH0_STATUS_RI) {
+			eqos_rx_complete(dev);
+		}
+
+		if (status & DWC_EQOS_CH0_STATUS_TI) {
+			eqos_tx_complete(priv);
+		}
+	}
+
+	return IRQ_HANDLED;
+}
+
+static int eqos_xmit(struct net_device *dev, struct sk_buff *skb) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	struct dwc_eqos_desc *desc;
+	uint8_t *buf;
+	ipl_t ipl;
+	unsigned int tx_len;
+	int cur, next;
+
+	if (skb->len > RX_BUF_SIZE) {
+		log_error("tx frame too long %d", skb->len);
+		skb_free(skb);
+		return -EINVAL;
+	}
+
+	ipl = ipl_save();
+	{
+		cur = priv->tx_head;
+		next = (cur + 1) % TX_DESC_QUANTITY;
+		if (next == priv->tx_tail) {
+			ipl_restore(ipl);
+			log_error("tx ring full, dropping frame");
+			skb_free(skb);
+			return -ENOMEM;
+		}
+
+		buf = tx_buffers[priv->plat->idx][cur];
+		memcpy(buf, skb_data_cast_in(skb->data), skb->len);
+
+		/* Ethernet requires a minimum frame of 60 bytes before the
+		 * FCS: shorter frames (e.g. 42-byte ARP) are discarded as
+		 * runts by every receiver, so zero-pad them here. */
+		tx_len = skb->len;
+		if (tx_len < ETH_ZLEN) {
+			memset(buf + skb->len, 0, ETH_ZLEN - skb->len);
+			tx_len = ETH_ZLEN;
+		}
+		dcache_flush(buf, tx_len);
+
+		desc = &priv->tx_ring[cur];
+		desc->des0 = (uint32_t) ((uintptr_t) buf);
+		desc->des1 = 0;
+		/* On this core the tx descriptor carries the frame length
+		 * in des3 (like the rx writeback) and the completion
+		 * interrupt enable in des2 bit31. */
+		desc->des2 = DWC_EQOS_DESC_TX_IOC | (tx_len & 0x3fffu);
+		desc->des3 = DWC_EQOS_DESC_OWN | DWC_EQOS_DESC_TX_FD | DWC_EQOS_DESC_TX_LD
+				| tx_len;
+		dcache_flush(desc, sizeof(*desc));
+
+		priv->tx_head = next;
+
+		/* Kick the dma: the fetch window is [ring base, end), so
+		 * the end must point past the descriptor just armed. */
+		eqos_write(priv, DWC_EQOS_DMA_CH0_TX_END_ADDR,
+				(uint32_t) (uintptr_t)
+				&priv->tx_ring[priv->tx_head]);
+	}
+	ipl_restore(ipl);
+
+	skb_free(skb);
+
+	return 0;
+}
+
+static int eqos_open(struct net_device *dev) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+	int id1, id2, bmsr;
+	int a;
+
+	log_info("%s: opening", dev->name);
+	for (a = 0; a < 8; a++) {
+		priv->phy_id = a;
+		id1 = eqos_mdio_read(dev, MII_PHYSID1);
+		id2 = eqos_mdio_read(dev, MII_PHYSID2);
+		bmsr = eqos_mdio_read(dev, MII_BMSR);
+		log_info("mdio phy %d: id1=%#x id2=%#x bmsr=%#x",
+				a, id1, id2, bmsr);
+	}
+
+	/* Detect the PHY and run autonegotiation; this also programs the
+	 * negotiated speed into the MAC configuration via set_speed. */
+	phy_detect(dev);
+	log_info("phy_detect done, phy_id=%d", priv->phy_id);
+	phy_autoneg(dev, 0);
+	log_info("phy_autoneg done");
+
+	eqos_set_macaddr_regs(priv, priv->macaddr);
+
+	return eqos_hw_start(priv);
+}
+
+static int eqos_stop(struct net_device *dev) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+
+	return eqos_hw_stop(priv);
+}
+
+static int eqos_set_macaddr(struct net_device *dev, const void *addr) {
+	struct dwc_eqos_priv *priv = (struct dwc_eqos_priv *) dev->priv;
+
+	memcpy(priv->macaddr, addr, ETH_ALEN);
+	memcpy(dev->dev_addr, addr, ETH_ALEN);
+	eqos_set_macaddr_regs(priv, priv->macaddr);
+
+	return 0;
+}
+
+static const struct net_driver eqos_drv_ops = {
+	.xmit        = eqos_xmit,
+	.start       = eqos_open,
+	.stop        = eqos_stop,
+	.set_macaddr = eqos_set_macaddr,
+	.mdio_read   = eqos_mdio_read,
+	.mdio_write  = eqos_mdio_write,
+	.set_phyid   = eqos_set_phyid,
+	.set_speed   = eqos_set_speed,
+};
+
+static int eqos_parse_macaddr(const char *str, uint8_t *out) {
+	int vals[ETH_ALEN];
+	int i;
+
+	if (sscanf(str, "%x:%x:%x:%x:%x:%x",
+				&vals[0], &vals[1], &vals[2],
+				&vals[3], &vals[4], &vals[5]) != ETH_ALEN) {
+		return -EINVAL;
+	}
+	for (i = 0; i < ETH_ALEN; i++) {
+		if ((vals[i] < 0) || (vals[i] > 0xff)) {
+			return -EINVAL;
+		}
+		out[i] = (uint8_t) vals[i];
+	}
+
+	return 0;
+}
+
+int dwc_eqos_dev_init(const struct dwc_eqos_plat *plat) {
+	struct dwc_eqos_priv *priv;
+	struct net_device *nic;
+	int res;
+
+	if ((plat->idx < 0) || (plat->idx >= PORT_NUM)) {
+		return -EINVAL;
+	}
+	priv = &eqos_priv[plat->idx];
+	memset(priv, 0, sizeof(*priv));
+	priv->plat = plat;
+	priv->base_addr = plat->base_addr;
+	priv->rx_ring = rx_rings[plat->idx];
+	priv->tx_ring = tx_rings[plat->idx];
+
+	if ((res = eqos_parse_macaddr(plat->mac_addr, priv->macaddr))) {
+		log_error("bad mac_addr '%s'", plat->mac_addr);
+		return res;
+	}
+
+	if (NULL == (nic = etherdev_alloc(0))) {
+		return -ENOMEM;
+	}
+	nic->drv_ops = &eqos_drv_ops;
+	nic->priv = priv;
+	priv->dev = nic;
+
+	log_info("%s: mac version %#x", plat->mac_addr,
+			eqos_read(priv, DWC_EQOS_MAC_VERSION));
+
+	/* SoC side: clocks, iomux, rgmii delays, then the PHY hard reset
+	 * (which re-latches the RTL8211F strap we clear right after). */
+	if (plat->soc_init == NULL) {
+		log_error("no SoC glue hooked up");
+		return -EINVAL;
+	}
+	res = plat->soc_init(plat);
+	if (res) {
+		return res;
+	}
+
+	log_info("%s: mac version after soc init %#x", plat->mac_addr,
+			eqos_read(priv, DWC_EQOS_MAC_VERSION));
+
+	if (plat->clear_rtl8211f_tx_delay) {
+		eqos_phy_tx_delay_clear(priv);
+	}
+
+	res = eqos_hw_init(priv);
+	if (res) {
+		return res;
+	}
+
+	res = irq_attach(plat->irq_num, eqos_irq_handler, 0, nic,
+			"dwc_eqos");
+	if (res) {
+		return res;
+	}
+
+	/* inetdev_register_dev (not bare netdev_register) creates the
+	 * IPv4 interface object the stock stack's ifconfig/route/ping
+	 * work through. */
+	res = inetdev_register_dev(nic);
+	if (res) {
+		return res;
+	}
+
+	res = sys_timer_init_start_msec(&priv->rx_poll, SYS_TIMER_PERIODIC,
+			100, eqos_rx_poll, priv);
+	if (res) {
+		return res;
+	}
+
+	log_info("%s at %#x irq %d mac %s", nic->name,
+			(unsigned int) plat->base_addr, plat->irq_num,
+			plat->mac_addr);
+
+	return 0;
+}

--- a/src/drivers/net/dwc_eqos/dwc_eqos.h
+++ b/src/drivers/net/dwc_eqos/dwc_eqos.h
@@ -1,0 +1,201 @@
+/**
+ * @file
+ * @brief Synopsys DesignWare Ethernet QoS (dwmac-4.x) MAC core
+ *
+ * Register interface of the DesignWare EQoS generation: MAC block at
+ * 0x000, MTL queues at 0xd00, per-channel DMA at 0x1000 and MDIO
+ * through the dwmac4 register layout.  Found in e.g. Rockchip
+ * RK3568 (dwmac-4.20a, two instances gmac0 @0xFE2A0000 and gmac1
+ * @0xFE010000, RTL8211F PHYs over RGMII).  This file covers only the
+ * IP itself; board/SoC integration (clock trees, GRF iomux, PHY
+ * reset GPIOs) goes through the soc_init/soc_swr_quirk hooks of
+ * struct dwc_eqos_plat, so other SoCs reuse the core unchanged.
+ *
+ * Register names and field positions follow the DesignWare Ethernet
+ * QoS user manual.  Note the older in-tree dwc_gmac driver targets
+ * the previous DWMAC 3.x generation (different register map) and is
+ * intentionally separate.
+ */
+
+#ifndef SRC_DRIVERS_NET_DWC_EQOS_DWC_EQOS_H_
+#define SRC_DRIVERS_NET_DWC_EQOS_DWC_EQOS_H_
+
+#include <stdint.h>
+
+#define DWC_EQOS_MAC_CONFIGURATION           0x000
+#define  DWC_EQOS_MAC_CONF_RE                (1u << 0)
+#define  DWC_EQOS_MAC_CONF_TE                (1u << 1)
+#define  DWC_EQOS_MAC_CONF_DCRS              (1u << 9)
+#define  DWC_EQOS_MAC_CONF_DM                (1u << 13)
+#define  DWC_EQOS_MAC_CONF_FES               (1u << 14)
+#define  DWC_EQOS_MAC_CONF_PS                (1u << 15)
+#define  DWC_EQOS_MAC_CONF_JE                (1u << 16)
+#define  DWC_EQOS_MAC_CONF_JD                (1u << 17)
+#define  DWC_EQOS_MAC_CONF_BE                (1u << 18)
+
+#define DWC_EQOS_MAC_PACKET_FILTER           0x008
+#define  DWC_EQOS_PKT_FLT_PR                 (1u << 0)
+
+#define DWC_EQOS_MAC_Q0_TX_FLOW_CTRL         0x070
+#define DWC_EQOS_MAC_RX_FLOW_CTRL            0x090
+#define  DWC_EQOS_RX_FLOW_CTRL_RFE           (1u << 0)
+
+#define DWC_EQOS_MAC_RXQ_CTRL0               0x0A0
+#define  DWC_EQOS_RXQ_CTRL0_RXQ0EN_MASK      (3u << 0)
+#define  DWC_EQOS_RXQ_CTRL0_RXQ0EN_DCB       (1u << 0)
+#define DWC_EQOS_MAC_RXQ_CTRL1               0x0A4
+#define  DWC_EQOS_RXQ_CTRL1_MCBCQEN          (1u << 20)
+
+#define DWC_EQOS_MAC_1US_TIC_COUNTER         0x0DC
+
+#define DWC_EQOS_MAC_VERSION                 0x110
+
+#define DWC_EQOS_MAC_MDIO_ADDRESS            0x200
+/* Field layout on this core: PA[24:21] RDA[20:16] CR[10:8] GOC[3:2] GB[0].
+ * This is NOT the older dwmac3 layout (PA[20:16] RDA[15:11]). */
+#define  DWC_EQOS_MDIO_PA_SHIFT              21
+#define  DWC_EQOS_MDIO_PA_MASK               (0x1fu << 21)
+#define  DWC_EQOS_MDIO_RDA_SHIFT             16
+#define  DWC_EQOS_MDIO_RDA_MASK              (0x1fu << 16)
+#define  DWC_EQOS_MDIO_CR_SHIFT              8
+#define  DWC_EQOS_MDIO_CR_MASK               (0x7u << 8)
+/* MDC divider: pclk_gmac runs at 100 MHz here, CR=4 selects the
+ * 150-250 MHz range (divide by 12) which keeps MDC at ~8.3 MHz,
+ * inside the 12.5 MHz limit of the RTL8211F. */
+#define  DWC_EQOS_MDIO_CR_150_250M           0x4
+#define  DWC_EQOS_MDIO_GOC_READ              (3u << 2)
+#define  DWC_EQOS_MDIO_GOC_WRITE             (1u << 2)
+#define  DWC_EQOS_MDIO_GB                    (1u << 0)
+#define DWC_EQOS_MAC_MDIO_DATA               0x204
+
+#define DWC_EQOS_MAC_ADDRESS0_HIGH           0x300
+#define DWC_EQOS_MAC_ADDRESS0_LOW            0x304
+
+#define DWC_EQOS_MAC_HW_FEATURE1             0x120
+#define  DWC_EQOS_HW_TXFIFOSZ_SHIFT          6
+#define  DWC_EQOS_HW_TXFIFOSZ_MASK           (0x1fu << 6)
+#define  DWC_EQOS_HW_RXFIFOSZ_MASK           0x1fu
+
+#define DWC_EQOS_MTL_TXQ0_OPERATION_MODE     0xD00
+#define  DWC_EQOS_MTL_TXQ0_OP_TQS_SHIFT      16
+#define  DWC_EQOS_MTL_TXQ0_OP_TQS_MASK       (0x1ffu << 16)
+#define  DWC_EQOS_MTL_TXQ0_OP_TXQEN_EN       (2u << 2)
+#define  DWC_EQOS_MTL_TXQ0_OP_TSF            (1u << 1)
+
+#define DWC_EQOS_MTL_RXQ0_OPERATION_MODE     0xD30
+#define  DWC_EQOS_MTL_RXQ0_OP_RQS_SHIFT      20
+#define  DWC_EQOS_MTL_RXQ0_OP_RQS_MASK       (0x3ffu << 20)
+#define  DWC_EQOS_MTL_RXQ0_OP_RSF            (1u << 5)
+#define  DWC_EQOS_MTL_RXQ0_OP_FEP            (1u << 4)
+#define  DWC_EQOS_MTL_RXQ0_OP_FUP            (1u << 3)
+
+#define DWC_EQOS_DMA_MODE                    0x1000
+#define  DWC_EQOS_DMA_MODE_SWR               (1u << 0)
+
+#define DWC_EQOS_DMA_SYSBUS_MODE             0x1004
+#define  DWC_EQOS_SYSBUS_WR_OSR_SHIFT        24
+#define  DWC_EQOS_SYSBUS_RD_OSR_SHIFT        16
+#define  DWC_EQOS_SYSBUS_EAME                (1u << 11)
+#define  DWC_EQOS_SYSBUS_BLEN16              (1u << 3)
+#define  DWC_EQOS_SYSBUS_BLEN8               (1u << 2)
+#define  DWC_EQOS_SYSBUS_BLEN4               (1u << 1)
+
+#define DWC_EQOS_DMA_CH0_CONTROL             0x1100
+#define  DWC_EQOS_CH0_CTRL_PBLX8             (1u << 16)
+
+#define DWC_EQOS_DMA_CH0_TX_CONTROL          0x1104
+#define  DWC_EQOS_TX_CTRL_TXPBL_SHIFT        16
+#define  DWC_EQOS_TX_CTRL_TXPBL_MASK         (0x3fu << 16)
+#define  DWC_EQOS_TX_CTRL_OSP                (1u << 4)
+#define  DWC_EQOS_TX_CTRL_ST                 (1u << 0)
+
+#define DWC_EQOS_DMA_CH0_RX_CONTROL          0x1108
+#define  DWC_EQOS_RX_CTRL_RXPBL_SHIFT        16
+#define  DWC_EQOS_RX_CTRL_RXPBL_MASK         (0x3fu << 16)
+#define  DWC_EQOS_RX_CTRL_RBSZ_SHIFT         1
+#define  DWC_EQOS_RX_CTRL_RBSZ_MASK          (0x3fffu << 1)
+#define  DWC_EQOS_RX_CTRL_SR                 (1u << 0)
+
+#define DWC_EQOS_DMA_CH0_TX_BASE_ADDR_HI     0x1110
+#define DWC_EQOS_DMA_CH0_TX_BASE_ADDR_LO     0x1114
+#define DWC_EQOS_DMA_CH0_RX_BASE_ADDR_HI     0x1118
+#define DWC_EQOS_DMA_CH0_RX_BASE_ADDR_LO     0x111C
+#define DWC_EQOS_DMA_CH0_TX_END_ADDR         0x1120
+#define DWC_EQOS_DMA_CH0_RX_END_ADDR         0x1128
+#define DWC_EQOS_DMA_CH0_TX_RING_LEN         0x112C
+#define DWC_EQOS_DMA_CH0_RX_RING_LEN         0x1130
+
+#define DWC_EQOS_DMA_CH0_INTR_ENABLE         0x1134
+/* Interrupt enable bits: on this silicon NIE/AIE are at 15/14
+ * (dwmac4.10a layout); bit 16 is not writable. */
+#define  DWC_EQOS_CH0_INTR_NIE               (1u << 15)
+#define  DWC_EQOS_CH0_INTR_AIE               (1u << 14)
+#define  DWC_EQOS_CH0_INTR_FBE               (1u << 12)
+#define  DWC_EQOS_CH0_INTR_RIE               (1u << 6)
+#define  DWC_EQOS_CH0_INTR_TIE               (1u << 0)
+#define  DWC_EQOS_CH0_INTR_DEFAULT           (DWC_EQOS_CH0_INTR_NIE \
+			| DWC_EQOS_CH0_INTR_AIE \
+			| DWC_EQOS_CH0_INTR_FBE \
+			| DWC_EQOS_CH0_INTR_RIE \
+			| DWC_EQOS_CH0_INTR_TIE)
+
+#define DWC_EQOS_DMA_CH0_STATUS              0x1160
+#define  DWC_EQOS_CH0_STATUS_NIS             (1u << 15)
+#define  DWC_EQOS_CH0_STATUS_AIS             (1u << 14)
+#define  DWC_EQOS_CH0_STATUS_FB              (1u << 12)
+#define  DWC_EQOS_CH0_STATUS_RI              (1u << 6)
+#define  DWC_EQOS_CH0_STATUS_TI              (1u << 0)
+
+/* 16-byte normal DMA descriptor ring (contiguous, no skip length).
+ * TX: des2 = frame length [13:0] | IOC [31], des3 = OWN [31] | FD [29]
+ * | LD [28] | frame length [14:0].  RX: des2 = 0, des3 = OWN [31] |
+ * IOC [30] | BUF1V [24], writeback length in des3 [14:0]. */
+struct dwc_eqos_desc {
+	uint32_t des0;   /* buffer address bits[31:0] */
+	uint32_t des1;   /* buffer address bits[47:32] (unused, 0) */
+	uint32_t des2;   /* TX: frame length | IOC */
+	uint32_t des3;   /* control / writeback status */
+};
+
+#define DWC_EQOS_DESC_TX_IOC                      (1u << 31)
+#define DWC_EQOS_DESC_OWN                         (1u << 31)
+#define DWC_EQOS_DESC_RX_IOC                      (1u << 30)
+#define DWC_EQOS_DESC_TX_FD                       (1u << 29)
+#define DWC_EQOS_DESC_TX_LD                       (1u << 28)
+#define DWC_EQOS_DESC_RX_BUF1V                    (1u << 24)
+#define DWC_EQOS_DESC_RX_LEN_MASK                 0x7fffu
+
+/* RTL8211F: the PHY straps its internal RGMII TX-delay and a hardware
+ * reset re-latches the strap.  Boards whose GRF delays are calibrated
+ * with the PHY-side delay off need the strap bit cleared after every
+ * reset pulse (page d08, register 0x11, bit 8); the core does it when
+ * plat->clear_rtl8211f_tx_delay is set. */
+#define RTL8211F_PHYSID1                 0x001c
+#define RTL8211F_PHYSID2                 0xc916
+#define RTL8211F_PAGESEL                 0x1f
+#define RTL8211F_TXDELAY                 (1u << 8)
+
+/* Per-instance configuration.  Everything IP-specific lives here;
+ * SoC integration data is opaque (soc_data) and only touched by the
+ * glue hooks, keeping the core reusable across SoCs. */
+struct dwc_eqos_plat {
+	int            idx;              /* per-driver instance slot */
+	unsigned long  base_addr;        /* MAC register base */
+	unsigned int   irq_num;          /* combined mac/dma IRQ (INTID) */
+	const char     *mac_addr;        /* fixed MAC, "xx:xx:xx:xx:xx:xx" */
+	/* Clear the strapped RTL8211F RGMII TX-delay after each hard
+	 * reset (see the RTL8211F defines above). */
+	int            clear_rtl8211f_tx_delay;
+
+	/* SoC glue.  soc_init brings up clocks, pin iomux, RGMII
+	 * delays and the PHY reset before the core touches the MAC;
+	 * soc_swr_quirk (optional) works around clock-path quirks
+	 * while DMA_MODE.SWR is asserted. */
+	int  (*soc_init)(const struct dwc_eqos_plat *plat);
+	void (*soc_swr_quirk)(const struct dwc_eqos_plat *plat, int enter);
+	const void *soc_data;
+};
+
+extern int dwc_eqos_dev_init(const struct dwc_eqos_plat *plat);
+
+#endif /* SRC_DRIVERS_NET_DWC_EQOS_DWC_EQOS_H_ */

--- a/src/drivers/net/dwc_eqos/dwc_eqos_rk3568.c
+++ b/src/drivers/net/dwc_eqos/dwc_eqos_rk3568.c
@@ -1,0 +1,133 @@
+/**
+ * @file
+ * @brief RK3568 SoC glue for the DesignWare EQoS MAC core: CRU
+ *        clocks, GRF interface/delay config, pin iomux and the PHY
+ *        reset GPIO.
+ *
+ * See dwc_eqos_rk3568.h.  The core driver reaches this glue only
+ * through the soc_init/soc_swr_quirk hooks of struct dwc_eqos_plat,
+ * so other SoCs plug in their own glue without touching the core.
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+
+#include <framework/mod/options.h>
+#include <hal/reg.h>
+#include <util/log.h>
+
+#include <drivers/common/memory.h>
+
+#include "dwc_eqos_rk3568.h"
+
+#define CRU_BASE  OPTION_GET(NUMBER, cru_base)
+#define GRF_BASE  OPTION_GET(NUMBER, grf_base)
+
+/* GRF iomux register for a pin of a bank: 8 pins per register pair,
+ * 4 pins per 32-bit word. */
+static unsigned long grf_iomux_reg(unsigned int bank_off, unsigned int pin,
+		unsigned int *shift) {
+	*shift = (pin % 4) * 4;
+
+	return GRF_BASE + bank_off + (pin / 8) * 8 + ((pin % 8) / 4) * 4;
+}
+
+static void grf_write(unsigned long off, uint32_t mask, uint32_t val) {
+	REG32_STORE(GRF_BASE + off, ((mask & 0xffffu) << 16) | (val & mask));
+}
+
+static void rk3568_gmac_clocks_enable(const struct rk3568_gmac_soc *soc) {
+	/* Gate bits are active-low: write 0 to the hiword-masked field to
+	 * enable the clock. */
+	log_debug("cru gate %#x: %#x -> ", soc->clkgate_con_off,
+			REG32_LOAD(CRU_BASE + soc->clkgate_con_off));
+	REG32_STORE(CRU_BASE + soc->clkgate_con_off,
+			(uint32_t)soc->clkgate_mask << 16);
+	log_debug("%#x", REG32_LOAD(CRU_BASE + soc->clkgate_con_off));
+	/* Soft reset bits are active-low too: write 0 to deassert. */
+	log_debug("cru rst %#x: %#x -> ", soc->softrst_con_off,
+			REG32_LOAD(CRU_BASE + soc->softrst_con_off));
+	REG32_STORE(CRU_BASE + soc->softrst_con_off,
+			(uint32_t)soc->softrst_mask << 16);
+	log_debug("%#x", REG32_LOAD(CRU_BASE + soc->softrst_con_off));
+	/* GMAC clock muxes: all-zero selector = 125 MHz RGMII output mode
+	 * (rx/tx from the 125M source, ptp ref 62.5M). */
+	log_debug("cru sel %#x: %#x -> ", soc->clksel_con_off,
+			REG32_LOAD(CRU_BASE + soc->clksel_con_off));
+	REG32_STORE(CRU_BASE + soc->clksel_con_off, 0xffffu << 16);
+	log_debug("%#x", REG32_LOAD(CRU_BASE + soc->clksel_con_off));
+}
+
+static void rk3568_gmac_iomux(const struct rk3568_gmac_soc *soc) {
+	int i;
+
+	if (soc->grf_route_off != 0) {
+		/* Full register word: write-enable mask in bits[31:16]. */
+		REG32_STORE(GRF_BASE + soc->grf_route_off, soc->grf_route_val);
+	}
+
+	for (i = 0; i < soc->pin_num; i++) {
+		const struct rk3568_gmac_pin *p = &soc->pins[i];
+		unsigned int shift;
+		unsigned long reg;
+
+		reg = grf_iomux_reg(soc->grf_iomux_off, p->pin, &shift);
+		REG32_STORE(reg, ((0xfu << shift) << 16) | (p->func << shift));
+	}
+}
+
+static void rk3568_gmac_rgmii_setup(const struct rk3568_gmac_soc *soc) {
+	grf_write(soc->grf_maccon1_off, soc->grf_maccon1_mask,
+			soc->grf_maccon1_val);
+	grf_write(soc->grf_maccon0_off, soc->grf_maccon0_mask,
+			soc->grf_maccon0_val);
+}
+
+/* GPIO bank, version 2 layout: data at 0x00/0x04, direction at 0x08/0x0c,
+ * value in bits[15:0], write-enable in bits[31:16]. */
+static void gpio_write(unsigned long bank, unsigned int pin, int output,
+		int value) {
+	unsigned long off = (pin < 16) ? 0x0 : 0x4;
+	uint32_t bit = 1u << (pin & 15);
+	uint32_t we = bit << 16;
+
+	/* set the data first, then switch the direction */
+	REG32_STORE(bank + off, we | (value ? bit : 0));
+	REG32_STORE(bank + off + 0x8, we | (output ? bit : 0));
+}
+
+static void rk3568_gmac_phy_reset_pulse(const struct rk3568_gmac_soc *soc) {
+	/* Active low: assert for 20 ms, release, then wait 100 ms for the
+	 * PHY to boot and re-latch its straps. */
+	gpio_write(soc->rst_gpio_base, soc->rst_gpio_pin, 1, 0);
+	usleep(20 * 1000);
+	gpio_write(soc->rst_gpio_base, soc->rst_gpio_pin, 1, 1);
+	usleep(100 * 1000);
+}
+
+int rk3568_gmac_soc_init(const struct dwc_eqos_plat *plat) {
+	const struct rk3568_gmac_soc *soc = plat->soc_data;
+
+	rk3568_gmac_clocks_enable(soc);
+	rk3568_gmac_iomux(soc);
+	rk3568_gmac_rgmii_setup(soc);
+	rk3568_gmac_phy_reset_pulse(soc);
+
+	return 0;
+}
+
+void rk3568_gmac_soc_swr_quirk(const struct dwc_eqos_plat *plat, int enter) {
+	const struct rk3568_gmac_soc *soc = plat->soc_data;
+	uint32_t val = (enter != 0) ? 0x1u : 0x0u;
+
+	/* During DMA_MODE.SWR the GMAC clock mux must take the RMII
+	 * (62.5M) path or the reset never clears: on gmac0 the 125M
+	 * direct path is not active at cold boot, and gmac1 needs the
+	 * same walk on some boots. */
+	REG32_STORE(CRU_BASE + soc->clksel_con_off, (0x3u << 16) | val);
+}
+
+PERIPH_MEMORY_DEFINE(dwc_eqos_rk3568_grf, GRF_BASE, 0x1000);
+PERIPH_MEMORY_DEFINE(dwc_eqos_rk3568_cru, CRU_BASE, 0x1000);
+PERIPH_MEMORY_DEFINE(dwc_eqos_rk3568_gpio2, 0xFE750000, 0x1000);
+PERIPH_MEMORY_DEFINE(dwc_eqos_rk3568_gpio3, 0xFE760000, 0x1000);

--- a/src/drivers/net/dwc_eqos/dwc_eqos_rk3568.h
+++ b/src/drivers/net/dwc_eqos/dwc_eqos_rk3568.h
@@ -1,0 +1,61 @@
+/**
+ * @file
+ * @brief RK3568 SoC glue for the DesignWare EQoS MAC core.
+ *
+ * The glue owns everything outside the IP: CRU clock gates/soft
+ * resets/clock mux, GRF interface mode and RGMII delay programming,
+ * pin iomux with io routing, and the PHY hard reset GPIO.  Instances
+ * (rk3568_gmac0/rk3568_gmac1) fill a struct rk3568_gmac_soc with
+ * their coordinates and hook rk3568_gmac_soc_init /
+ * rk3568_gmac_soc_swr_quirk into struct dwc_eqos_plat.
+ *
+ * Embox configures the board statically (no FDT/pinctrl layer), so
+ * all coordinates are per-instance data.  The CRU, GRF and GPIO v2
+ * registers all use the Rockchip hiword write-enable protocol: value
+ * in bits[15:0], write-enable mask in bits[31:16].
+ */
+
+#ifndef SRC_DRIVERS_NET_DWC_EQOS_DWC_EQOS_RK3568_H_
+#define SRC_DRIVERS_NET_DWC_EQOS_DWC_EQOS_RK3568_H_
+
+#include <stdint.h>
+
+#include "dwc_eqos.h"
+
+/* GRF iomux entry, one pin group per word: 4 bits per pin, 4 pins
+ * per GRF register. */
+struct rk3568_gmac_pin {
+	uint8_t pin;   /* pin number inside the GPIO bank */
+	uint8_t func;  /* iomux function selector */
+};
+
+struct rk3568_gmac_soc {
+	/* CRU: clock gates, soft reset and the GMAC clock mux */
+	unsigned int   clkgate_con_off;  /* CRU_CLKGATE_CON[n] offset */
+	uint32_t       clkgate_mask;     /* bits to ungate (write 0) */
+	unsigned int   softrst_con_off;  /* CRU_SOFTRST_CON[n] offset */
+	uint32_t       softrst_mask;     /* bits to deassert (write 0) */
+	unsigned int   clksel_con_off;   /* CRU_CLKSEL_CON[n] offset */
+
+	/* GRF: interface mode, RGMII delays, iomux and io route */
+	unsigned int   grf_maccon0_off;  /* tx/rx delay value register */
+	uint32_t       grf_maccon0_val;  /* (rx_delay << 8) | tx_delay */
+	uint32_t       grf_maccon0_mask;
+	unsigned int   grf_maccon1_off;  /* interface mode + delay enables */
+	uint32_t       grf_maccon1_val;
+	uint32_t       grf_maccon1_mask;
+	unsigned int   grf_iomux_off;    /* GRF iomux bank base offset */
+	const struct rk3568_gmac_pin *pins;
+	int            pin_num;
+	unsigned int   grf_route_off;    /* io route register, 0 if unused */
+	uint32_t       grf_route_val;
+
+	/* PHY hard reset GPIO (DW-APB GPIO bank, version 2 layout) */
+	unsigned long  rst_gpio_base;
+	unsigned int   rst_gpio_pin;     /* pin inside the bank */
+};
+
+int rk3568_gmac_soc_init(const struct dwc_eqos_plat *plat);
+void rk3568_gmac_soc_swr_quirk(const struct dwc_eqos_plat *plat, int enter);
+
+#endif /* SRC_DRIVERS_NET_DWC_EQOS_DWC_EQOS_RK3568_H_ */

--- a/src/drivers/net/dwc_eqos/rk3568_gmac.c
+++ b/src/drivers/net/dwc_eqos/rk3568_gmac.c
@@ -1,0 +1,131 @@
+/**
+ * @file
+ * @brief RK3568 GMAC instantiation module.
+ *
+ * The ports themselves are wired by the board configuration: every
+ * GMAC<n> enabled there gets a net device here, with its base
+ * address, irq, MAC address, CRU/GRF coordinates, pin multiplexing
+ * and PHY reset GPIO taken from the config.
+ */
+
+#include <config/board_config.h>
+
+#include <drivers/common/memory.h>
+#include <embox/unit.h>
+
+#include "dwc_eqos.h"
+#include "dwc_eqos_rk3568.h"
+
+#if defined(CONF_GMAC0_ENABLED)
+
+static const struct rk3568_gmac_pin gmac0_pins[] = {
+	CONF_GMAC0_MISC_PINS_A
+	CONF_GMAC0_MISC_PINS_B
+	CONF_GMAC0_MISC_PINS_C
+};
+
+static const struct rk3568_gmac_soc gmac0_soc = {
+	.clkgate_con_off  = CONF_GMAC0_MISC_CRU_GATE_REG,
+	.clkgate_mask     = CONF_GMAC0_MISC_CRU_GATE_MASK,
+	.softrst_con_off  = CONF_GMAC0_MISC_CRU_RST_REG,
+	.softrst_mask     = CONF_GMAC0_MISC_CRU_RST_MASK,
+	.clksel_con_off   = CONF_GMAC0_MISC_CRU_SEL_REG,
+
+	.grf_maccon0_off  = CONF_GMAC0_MISC_GRF_MACCON0_REG,
+	.grf_maccon0_val  = CONF_GMAC0_MISC_GRF_MACCON0_VAL,
+	.grf_maccon0_mask = CONF_GMAC0_MISC_GRF_MACCON0_MASK,
+	.grf_maccon1_off  = CONF_GMAC0_MISC_GRF_MACCON1_REG,
+	.grf_maccon1_val  = CONF_GMAC0_MISC_GRF_MACCON1_VAL,
+	.grf_maccon1_mask = CONF_GMAC0_MISC_GRF_MACCON1_MASK,
+
+	.grf_iomux_off    = CONF_GMAC0_MISC_GRF_IOMUX_OFF,
+	.pins             = gmac0_pins,
+	.pin_num          = sizeof(gmac0_pins) / sizeof(gmac0_pins[0]),
+	.grf_route_off    = CONF_GMAC0_MISC_GRF_ROUTE_REG,
+	.grf_route_val    = CONF_GMAC0_MISC_GRF_ROUTE_VAL,
+
+	.rst_gpio_base    = CONF_GMAC0_MISC_RST_GPIO_BASE,
+	.rst_gpio_pin     = CONF_GMAC0_MISC_RST_GPIO_PIN,
+};
+
+static const struct dwc_eqos_plat gmac0_plat = {
+	.idx             = 0,
+	.base_addr       = CONF_GMAC0_REGION_BASE,
+	.irq_num         = CONF_GMAC0_IRQ_NUM,
+	.mac_addr        = CONF_GMAC0_MISC_MAC_ADDR,
+	/* The RTL8211F is strapped to add its own RGMII TX delay; the
+	 * GRF delays are calibrated with the PHY-side delay off. */
+	.clear_rtl8211f_tx_delay = 1,
+
+	.soc_init        = rk3568_gmac_soc_init,
+	.soc_swr_quirk   = rk3568_gmac_soc_swr_quirk,
+	.soc_data        = &gmac0_soc,
+};
+
+PERIPH_MEMORY_DEFINE(rk3568_gmac0_regs, CONF_GMAC0_REGION_BASE,
+		CONF_GMAC0_REGION_BASE_LEN);
+
+#endif /* CONF_GMAC0_ENABLED */
+
+#if defined(CONF_GMAC1_ENABLED)
+
+static const struct rk3568_gmac_pin gmac1_pins[] = {
+	CONF_GMAC1_MISC_PINS_A
+	CONF_GMAC1_MISC_PINS_B
+	CONF_GMAC1_MISC_PINS_C
+};
+
+static const struct rk3568_gmac_soc gmac1_soc = {
+	.clkgate_con_off  = CONF_GMAC1_MISC_CRU_GATE_REG,
+	.clkgate_mask     = CONF_GMAC1_MISC_CRU_GATE_MASK,
+	.softrst_con_off  = CONF_GMAC1_MISC_CRU_RST_REG,
+	.softrst_mask     = CONF_GMAC1_MISC_CRU_RST_MASK,
+	.clksel_con_off   = CONF_GMAC1_MISC_CRU_SEL_REG,
+
+	.grf_maccon0_off  = CONF_GMAC1_MISC_GRF_MACCON0_REG,
+	.grf_maccon0_val  = CONF_GMAC1_MISC_GRF_MACCON0_VAL,
+	.grf_maccon0_mask = CONF_GMAC1_MISC_GRF_MACCON0_MASK,
+	.grf_maccon1_off  = CONF_GMAC1_MISC_GRF_MACCON1_REG,
+	.grf_maccon1_val  = CONF_GMAC1_MISC_GRF_MACCON1_VAL,
+	.grf_maccon1_mask = CONF_GMAC1_MISC_GRF_MACCON1_MASK,
+
+	.grf_iomux_off    = CONF_GMAC1_MISC_GRF_IOMUX_OFF,
+	.pins             = gmac1_pins,
+	.pin_num          = sizeof(gmac1_pins) / sizeof(gmac1_pins[0]),
+	.grf_route_off    = CONF_GMAC1_MISC_GRF_ROUTE_REG,
+	.grf_route_val    = CONF_GMAC1_MISC_GRF_ROUTE_VAL,
+
+	.rst_gpio_base    = CONF_GMAC1_MISC_RST_GPIO_BASE,
+	.rst_gpio_pin     = CONF_GMAC1_MISC_RST_GPIO_PIN,
+};
+
+static const struct dwc_eqos_plat gmac1_plat = {
+	.idx             = 1,
+	.base_addr       = CONF_GMAC1_REGION_BASE,
+	.irq_num         = CONF_GMAC1_IRQ_NUM,
+	.mac_addr        = CONF_GMAC1_MISC_MAC_ADDR,
+	.clear_rtl8211f_tx_delay = 1,
+
+	.soc_init        = rk3568_gmac_soc_init,
+	.soc_swr_quirk   = rk3568_gmac_soc_swr_quirk,
+	.soc_data        = &gmac1_soc,
+};
+
+PERIPH_MEMORY_DEFINE(rk3568_gmac1_regs, CONF_GMAC1_REGION_BASE,
+		CONF_GMAC1_REGION_BASE_LEN);
+
+#endif /* CONF_GMAC1_ENABLED */
+
+static int rk3568_gmac_init(void) {
+	int ret = 0;
+
+#if defined(CONF_GMAC0_ENABLED)
+	ret = dwc_eqos_dev_init(&gmac0_plat);
+#endif
+#if defined(CONF_GMAC1_ENABLED)
+	ret = ret ? ret : dwc_eqos_dev_init(&gmac1_plat);
+#endif
+	return ret;
+}
+
+EMBOX_UNIT_INIT(rk3568_gmac_init);

--- a/src/net/l4/udp.c
+++ b/src/net/l4/udp.c
@@ -91,6 +91,7 @@ static int udp_rcv(struct sk_buff *skb) {
 		old_check = skb->h.uh->check;
 		udp_set_check_field(skb->h.uh, skb->nh.raw);
 		if (old_check != skb->h.uh->check) {
+			skb_free(skb);
 			return 0; /* error: bad checksum */
 		}
 	}


### PR DESCRIPTION

hello, following i add dual gmac 0/1 support for rk3568, and small memory leak found when do continuous ping

<img width="655" height="568" alt="image" src="https://github.com/user-attachments/assets/2b586114-f432-4b99-b890-e2268c568e4e" />


```
 NAND:  0 MiB
MMC:   dwmmc@fe2b0000: 0, dwmmc@fe2c0000: 2, sdhci@fe310000: 1
Model: Indium Engine RK3568-E4AP5G1-ITX
switch to partitions #0, OK
mmc1(part 0) is current device
switch to partitions #0, OK
mmc0 is current device
Bootdev(scan): mmc 0
MMC0: Legacy, 52Mhz
PartType: EFI
rockchip_set_serialno: could not find efuse/otp device
boot mode: None
CLK: (sync kernel. arm: enter 816000 KHz, init 816000 KHz, kernel 0N/A)
  apll 816000 KHz
  dpll 390000 KHz
  gpll 1188000 KHz
  cpll 1000000 KHz
  npll 1200000 KHz
  vpll 24000 KHz
  hpll 24000 KHz
  ppll 200000 KHz
  armclk 816000 KHz
  aclk_bus 150000 KHz
  pclk_bus 100000 KHz
  aclk_top_high 300000 KHz
  aclk_top_low 200000 KHz
  hclk_top 150000 KHz
  pclk_top 100000 KHz
  aclk_perimid 300000 KHz
  hclk_perimid 150000 KHz
  pclk_pmu 100000 KHz
Net:   eth1: ethernet@fe010000, eth0: ethernet@fe2a0000
scanning bus for devices...
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq stag pm led clo only pmp fbss pio slum part ccc apst 
  Device 0: (0:0) Vendor: ATA Prod.: SanDisk SD8SBAT1 Rev: Z232
            Type: Hard Disk
            Capacity: 122104.3 MB = 119.2 GB (250069680 x 512)
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq stag pm led clo only pmp fbss pio slum part ccc apst 
  Device 0: (0:0) Vendor: ATA Prod.: SanDisk SD8SBAT1 Rev: Z233
            Type: Hard Disk
            Capacity: 122104.3 MB = 119.2 GB (250069680 x 512)
cfg rdback: CON0=00001000 CON1=00004000 CON2=00000101 CON3=00000200 clksel9=00008088 gate2=00000000 con10=00000000 con34=00000000
cfg rdback mmio@00000000fe840000: 7c=10 74=c0 80=08 6c=4c 28=90 64=20 98=00000028 9c=00000000 a0=00000000
pcie@fe260000: PCIe Link up, LTSSM is 0x130011
pcie@fe260000: PCIE-0: Link up (Gen2-x1, Bus0)
pcie@fe280000: PCIe Linking... LTSSM is 0x1
pcie@fe280000: PCIe Link up, LTSSM is 0x30011
pcie@fe280000: PCIE-2: Link up (Gen1-x1, Bus2)
=> setenv autoload no
=> dhcp
ethernet@fe010000 Waiting for PHY auto negotiation to complete. done
BOOTP broadcast 1
BOOTP broadcast 2
BOOTP broadcast 3
*** Unhandled DHCP Option in OFFER/ACK: 213
DHCP client bound to address 192.168.0.200 (812 ms)
=> setenv serverip 192.168.0.18
=> tftp 0xa000000 embox-rk3568.bin
Using ethernet@fe010000 device
TFTP from server 192.168.0.18; our IP address is 192.168.0.200
Filename 'embox-rk3568.bin'.
Load address: 0xa000000
Loading: #################################
         7.6 MiB/s
done
Bytes transferred = 470536 (72e08 hex)
=> go 0xa000000
## Starting application at 0x0A000000 ...

[info] (Kernel) Interrupt controller: gicv3
[info] (Kernel) Embox kernel start
[info] (unit) initializing embox.kernel.task.task_resource
[info] (unit) initializing embox.kernel.task.task_table
[info] (unit) initializing embox.kernel.task.kernel_task
[info] (unit) initializing embox.driver.periph_memory_mmap
[info] (unit) initializing embox.arch.aarch64.mmu
[info] (unit) initializing embox.mem.phymem
[info] (phymem) start=0x000000000ea80000 end=0x000000001a000000 size=190316544
[info] (unit) initializing embox.driver.clock.armv8_phy_timer
[info] (mod) runlevel is 0
[info] (unit) initializing embox.mem.static_heap
[info] (unit) initializing embox.kernel.sched.sched
[info] (mod) runlevel is 1
[info] (unit) initializing embox.device.char_dev
[info] (unit) initializing embox.fs.buffer_cache
[info] (unit) initializing embox.driver.pci_chip.pcie_dw
[info] (pcie_dw) pcie0: firmware link inherited (bus 0-1), link Gen2 x1 (max Gen2 x1)
[info] (pcie_dw) pcie1: firmware link inherited (bus 2-3), link Gen1 x1 (max Gen3 x2)
[info] (unit) initializing embox.driver.flash.flash_nofs
[info] (unit) initializing embox.driver.interrupt.gicv3_its
[info] (gicv3_its) its: base 0xfd440000 typer 000000130001ef31 pta 0 rd_target 0
[info] (gicv3_its) its: PROPBASER.IDbits 15
[info] (gicv3_its) its: BASER0 devices b9e000000a4a451f -> b9e700000a4a451f
[info] (gicv3_its) its: BASER1 collections bce000000a4a0400 -> bce100000a4a0400
[info] (gicv3_its) its: ready, irq window 208..255, doorbell 0xfd450040
[info] (unit) initializing embox.driver.net.loopback
[info] (unit) initializing embox.driver.tty.serial
[info] (unit) initializing embox.driver.pci
[info] (unit) initializing embox.fs.rootfs_oldfs
[info] (unit) initializing embox.driver.net.rk3568_gmac0
[info] (dwc_eqos) 02:e4:a5:35:68:00: mac version 0x3051
[info] (dwc_eqos) 02:e4:a5:35:68:00: mac version after soc init 0x3051
[info] (dwc_eqos) RTL8211F phy 0: id 0x1c:0xc916
[info] (dwc_eqos) RTL8211F phy 0: cleared strapped RGMII TX-delay (d08.0x11 0x109 -> 0x9)
[info] (dwc_eqos) RTL8211F phy 1: id 0x1c:0xc916
[info] (dwc_eqos) eth0 at 0xfe2a0000 irq 59 mac 02:e4:a5:35:68:00
[info] (unit) initializing embox.driver.net.rk3568_gmac1
[info] (dwc_eqos) 02:e4:a5:35:68:01: mac version 0x3051
[info] (dwc_eqos) 02:e4:a5:35:68:01: mac version after soc init 0x3051
[info] (dwc_eqos) RTL8211F phy 0: id 0x1c:0xc916
[info] (dwc_eqos) RTL8211F phy 0: cleared strapped RGMII TX-delay (d08.0x11 0x109 -> 0x9)
[info] (dwc_eqos) RTL8211F phy 1: id 0x1c:0xc916
[info] (dwc_eqos) eth1 at 0xfe010000 irq 64 mac 02:e4:a5:35:68:01
[info] (mod) runlevel is 2
[info] (unit) initializing embox.driver.nvme
[info] (gicv3_its) its: 01:00.0 got 2 message irq(s)
[info] (nvme) nvme: 2 message vector(s), completion irq 208
[info] (nvme) nvme0: 126f:2263 at 0x00000000f4300000, ns1: 500118192 blocks of 512 bytes (244198 MiB)
[info] (mod) runlevel is 3
Default IO device[ttyS0]
>tish
root@embox:(null)#ifconfig eth1 192.168.0.200 netmask 255.255.255.0 up
[info] (dwc_eqos) eth1: opening
[info] (dwc_eqos) mdio phy 0: id1=0x1c id2=0xc916 bmsr=0x79a9
[info] (dwc_eqos) mdio phy 1: id1=0x1c id2=0xc916 bmsr=0x79ad
[info] (dwc_eqos) mdio phy 2: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 3: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 4: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 5: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 6: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 7: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) phy_detect done, phy_id=0
[info] (dwc_eqos) link speed 1000 Mbps full duplex
[info] (dwc_eqos) phy_autoneg done
root@embox:(null)#ifconfig eth0 192.168.0.201 netmask 255.255.255.0 up
[info] (dwc_eqos) eth0: opening
[info] (dwc_eqos) mdio phy 0: id1=0x1c id2=0xc916 bmsr=0x79a9
[info] (dwc_eqos) mdio phy 1: id1=0x1c id2=0xc916 bmsr=0x79ad
[info] (dwc_eqos) mdio phy 2: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 3: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 4: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 5: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 6: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) mdio phy 7: id1=0xffff id2=0xffff bmsr=0xffff
[info] (dwc_eqos) phy_detect done, phy_id=0
[info] (dwc_eqos) link speed 1000 Mbps full duplex
[info] (dwc_eqos) phy_autoneg done
root@embox:(null)#route add 192.168.0.0 netmask 255.255.255.0 eth1
root@embox:(null)#route add 192.168.0.18/32 dev eth0
root@embox:(null)#ping -c 4 192.168.0.1
PING 192.168.0.1 (192.168.0.1) 64 bytes of data
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=1 ttl=64 time=11 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=2 ttl=64 time=7 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=3 ttl=64 time=66 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=4 ttl=64 time=8 ms
--- 192.168.0.1 ping statistics ---
4 packets transmitted, 4 received, +0 errors, 0% packet loss, time 4109ms
root@embox:(null)#ping -c 4 192.168.0.18
PING 192.168.0.18 (192.168.0.18) 64 bytes of data
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=1 ttl=128 time=4 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=2 ttl=128 time=6 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=3 ttl=128 time=5 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=4 ttl=128 time=5 ms
--- 192.168.0.18 ping statistics ---
4 packets transmitted, 4 received, +0 errors, 0% packet loss, time 4036ms
root@embox:(null)#ifconfig
eth0    Link encap:Ethernet  HWaddr 02:e4:a5:35:68:00
        inet addr:192.168.0.201  Bcast:192.168.0.255  Mask:255.255.255.0
        inet6 addr: ::/??  Scope:Host
        UP BROADCAST MULTICAST  MTU:1514  Metric:0
        RX packets:0 errors:0 dropped:0 overruns:0 frame:0
        TX packets:2 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:0 (0 MiB)  TX bytes:120 (0 MiB)
        Interrupt:0 Base address:0x0000000000000000

eth1    Link encap:Ethernet  HWaddr 02:e4:a5:35:68:01
        inet addr:192.168.0.200  Bcast:192.168.0.255  Mask:255.255.255.0
        inet6 addr: ::/??  Scope:Host
        UP BROADCAST MULTICAST  MTU:1514  Metric:0
        RX packets:0 errors:0 dropped:0 overruns:0 frame:0
        TX packets:21 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:0 (0 MiB)  TX bytes:2042 (0 MiB)
        Interrupt:0 Base address:0x0000000000000000

root@embox:(null)#
```