### PR TITLE
Add rk3568 net80211 support with rtl8188eu test (scan ap only)

### DIFF
--- a/src/cmds/net/iwlist/iwlist.c
+++ b/src/cmds/net/iwlist/iwlist.c
@@ -24,9 +24,9 @@
 
 
 
-static inline void print_usage(void) {
+static inline void print_usage(const char *progname) {
 	printf("Usage:\n");
-	printf("  %s <interface> scanning\n");
+	printf("  %s <interface> scanning\n", progname);
 }
 
 int main(int argc, char *argv[]) {
@@ -36,12 +36,12 @@ int main(int argc, char *argv[]) {
 	iface = NULL;
 
 	if (!strcmp("-h", argv[1]) || !strcmp("--help", argv[1])) {
-		print_usage();
+		print_usage(argv[0]);
 		return 0;
 	}
 	
 	if (argc < 3) {
-		print_usage();
+		print_usage(argv[0]);
 		return 0;
 	}
 

--- a/third-party/net80211/Makefile
+++ b/third-party/net80211/Makefile
@@ -1,0 +1,15 @@
+# net80211 (NetBSD wireless stack + urtwn) fetched from its own repository.
+#
+# PKG_SOURCES is a git URL: extbld clones the repository's default branch
+# (main) and copies the checkout into each module build dir, where embox
+# compiles the sources directly. Bump by re-running make after the remote
+# main advances (or pin PKG_VER to a commit for a reproducible build).
+#
+# Checkout layout:
+#   net80211/     NetBSD 802.11 stack (verbatim import)
+#   driver/urtwn/ RTL8188EU driver
+#   compat/netbsd/ shadow headers for the NetBSD kernel API
+#   port/         port interface + embox shims + cherryusb backend
+
+PKG_NAME := net80211
+PKG_SOURCES := https://github.com/KevinACoder/net_80211.git

--- a/third-party/net80211/Mybuild
+++ b/third-party/net80211/Mybuild
@@ -1,0 +1,170 @@
+/*
+ * net80211 for embox.
+ *
+ * The sources are fetched from the net80211 repository by the extbld
+ * rules (see the Makefile in this directory) and compiled from the
+ * per-module build tree. All source/header paths below resolve into
+ *   $(EXTERNAL_BUILD_DIR)/third_party/net80211/<module>/net_80211/...
+ * which mirrors third-party/lib/sljit.
+ *
+ * The layout of the checkout:
+ *   net80211/       NetBSD 802.11 stack (verbatim import)
+ *   driver/urtwn/   RTL8188EU driver (verbatim import + registration)
+ *   compat/netbsd/  shadow headers for the NetBSD kernel API
+ *   port/           portable port interface + embox/cherryusb ports
+ */
+package third_party.net80211
+
+/*
+ * NetBSD 802.11 protocol stack. Pure C over the compat shadow headers.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_core {
+	@Cflags("-D_KERNEL")
+	@Cflags("-Wno-pointer-sign")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/port/port_config_bsd.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/net80211")
+	source "ieee80211.c",
+		"ieee80211_proto.c",
+		"ieee80211_node.c",
+		"ieee80211_output.c",
+		"ieee80211_input.c",
+		"ieee80211_netbsd.c",
+		"ieee80211_crypto.c",
+		"ieee80211_crypto_none.c"
+}
+
+/*
+ * RTL8188EU USB driver: the imported if_urtwn.c is pulled in by the
+ * small registration translation unit (urtwn_reg.c).
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_urtwn {
+	@Cflags("-D_KERNEL")
+	@Cflags("-Wno-pointer-sign")
+	@Cflags("-Wno-unused-function")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_urtwn/net_80211/port/port_config_bsd.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_urtwn/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_urtwn/net_80211")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/driver/urtwn")
+	source "urtwn_reg.c"
+
+	depends net80211_core
+}
+
+/*
+ * NetBSD kernel-API shims for embox (locks/threads, mbuf, ifnet,
+ * firmware lookup). Any USB backend for embox builds on this module.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_embox_osal {
+	@Cflags("-D_KERNEL")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211/port/port_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/embox")
+	source "osal_embox.c",
+		"bsd_mbuf.c",
+		"bsd_ifnet.c",
+		"firmware_embed.c"
+
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+	depends embox.kernel.timer.sys_timer
+	depends embox.kernel.timer.sleep
+	depends embox.compat.posix.util.gettimeofday
+}
+
+/*
+ * CherryUSB host stack (vendored inside the net80211 checkout) with an
+ * embox OSAL and the RK3568 EHCI glue.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module cherryusb_host {
+	@Cflags("-Wno-unused-parameter")
+	/* the EHCI hardware link pointers are 32-bit: the truncation is
+	 * intentional, every pool sits below 4G on this platform */
+	@Cflags("-Wno-pointer-to-int-cast")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/core")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/common")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/class/hub")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/port/ehci")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/cherryusb")
+	source "cherryusb/core/usbh_core.c",
+		"cherryusb/class/hub/usbh_hub.c",
+		"cherryusb/port/ehci/usb_hc_ehci.c",
+		"osal_usb_embox.c",
+		"usb_glue_rk3568.c"
+
+	depends embox.kernel.irq
+	depends embox.kernel.lthread.lthread
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+	depends embox.kernel.timer.sys_timer
+
+	@NoRuntime depends embox.driver.periph_memory
+}
+
+/*
+ * The net80211 port over cherryusb: the usbd_* shim reroutes the
+ * driver's transfers onto CherryUSB, plus the urtwn class hook, the
+ * net bridge and the shell command.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_port_cherryusb {
+	@Cflags("-D_KERNEL")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/port_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb/cherryusb/core")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb/cherryusb/common")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb/cherryusb/class/hub")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/cherryusb")
+	source "usbdi_compat.c",
+		"usbh_urtwn_class.c",
+		"net_bridge.c"
+
+	depends cherryusb_host
+	depends net80211_embox_osal
+	depends net80211_urtwn
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+	depends embox.kernel.timer.sys_timer
+	depends embox.net.core
+	depends embox.net.wifi.cfg80211
+}
+
+@AutoCmd
+@App
+@Cmd(name = "wlan",
+	help = "net80211 wireless devices",
+	man = '''
+NAME
+	wlan - scan for wireless networks
+
+SYNOPSIS
+	wlan scan [seconds]
+	wlan trace [0|1|2]
+
+DESCRIPTION
+	The scan subcommand brings the interface up, scans for
+	[seconds] and prints the networks found. The trace subcommand
+	selects the USB shim log verbosity: 0 (default) quiet, 1 async
+	events, 2 full control transfers.
+''')
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_wlan_cmd {
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_wlan_cmd/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_wlan_cmd/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_wlan_cmd/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/cherryusb")
+	source "wlan_cmd.c"
+
+	depends net80211_port_cherryusb
+}


### PR DESCRIPTION
hello, i port net80211 from netbsd-11 to embox，which i think is state-machine pattern and fit rtos/baremetal application (and easy to figure out how it works, haha), and tested with rl8188eu (as i known a well-drivered usb doggle in all kinds of bsd), i tried to use native embox usb stack in ehci, but failed with some issue, so i just pick cherryusb + embox net stack instead

<img width="428" height="263" alt="批注 2026-09-08 141743" src="https://github.com/user-attachments/assets/0f11cc5e-ffe2-4621-be63-1f138acc0cdc" />

```
U-Boot next-dev-g645c2149dd-250929-dirty #zhugy (Sep 05 2026 - 08:35:41 +0800)

Model: Indium Engine RK3568-E4AP5G1-ITX
MPIDR: 0x0
PreSerial: 2, raw, 0xfe660000
DRAM:  4 GiB
Sysmem: init
Relocation Offset: ef3a6000
Relocation fdt: ed9e6990 - ed9fece0
CR: M/C/I
usb dr_mode not found
I2c0 speed: 100000Hz
can't find shutdown-sequence prop
can't find vb-shutdown-sequence prop
PMIC:  RK8090 (on=0x40, off=0x00)
io-domain: OK
Failed to get scmi clk dev
No OTP device, ret=-19
dmc_fsp failed, ret=-19
Using default environment

NAND:  0 MiB
MMC:   dwmmc@fe2b0000: 0, dwmmc@fe2c0000: 2, sdhci@fe310000: 1
Model: Indium Engine RK3568-E4AP5G1-ITX
switch to partitions #0, OK
mmc1(part 0) is current device
switch to partitions #0, OK
mmc0 is current device
Bootdev(scan): mmc 0
MMC0: Legacy, 52Mhz
PartType: EFI
rockchip_set_serialno: could not find efuse/otp device
boot mode: None
CLK: (sync kernel. arm: enter 816000 KHz, init 816000 KHz, kernel 0N/A)
  apll 816000 KHz
  dpll 390000 KHz
  gpll 1188000 KHz
  cpll 1000000 KHz
  npll 1200000 KHz
  vpll 24000 KHz
  hpll 24000 KHz
  ppll 200000 KHz
  armclk 816000 KHz
  aclk_bus 150000 KHz
  pclk_bus 100000 KHz
  aclk_top_high 300000 KHz
  aclk_top_low 200000 KHz
  hclk_top 150000 KHz
  pclk_top 100000 KHz
  aclk_perimid 300000 KHz
  hclk_perimid 150000 KHz
  pclk_pmu 100000 KHz
Net:   eth1: ethernet@fe010000, eth0: ethernet@fe2a0000
scanning bus for devices...
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq stag pm led clo only pmp fbss pio slum part ccc apst 
  Device 0: (0:0) Vendor: ATA Prod.: SanDisk SD8SBAT1 Rev: Z232
            Type: Hard Disk
            Capacity: 122104.3 MB = 119.2 GB (250069680 x 512)
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq stag pm led clo only pmp fbss pio slum part ccc apst 
  Device 0: (0:0) Vendor: ATA Prod.: SanDisk SD8SBAT1 Rev: Z233
            Type: Hard Disk
            Capacity: 122104.3 MB = 119.2 GB (250069680 x 512)
cfg rdback: CON0=00001000 CON1=00004000 CON2=00000101 CON3=00000200 clksel9=00008088 gate2=00000000 con10=00000000 con34=00000000
cfg rdback mmio@00000000fe840000: 7c=10 74=c0 80=08 6c=4c 28=90 64=20 98=00000028 9c=00000000 a0=00000000
pcie@fe260000: PCIe Link up, LTSSM is 0x130011
pcie@fe260000: PCIE-0: Link up (Gen2-x1, Bus0)
pcie@fe280000: PCIe Linking... LTSSM is 0x1
pcie@fe280000: PCIe Link up, LTSSM is 0x30011
pcie@fe280000: PCIE-2: Link up (Gen1-x1, Bus2)
=> dhcp
ethernet@fe010000 Waiting for PHY auto negotiation to complete. done
BOOTP broadcast 1
BOOTP broadcast 2
BOOTP broadcast 3
*** Unhandled DHCP Option in OFFER/ACK: 213
DHCP client bound to address 192.168.0.200 (827 ms)
=> setenv serverip 192.168.0.18
=> tftp 0xa000000 embox-rk3568.bin
Using ethernet@fe010000 device
TFTP from server 192.168.0.18; our IP address is 192.168.0.200
Filename 'embox-rk3568.bin'.
Load address: 0xa000000
Loading: ######################################
         7.2 MiB/s
done
Bytes transferred = 554456 (875d8 hex)
=> go 0xa000000
## Starting application at 0x0A000000 ...

[info] (Kernel) Interrupt controller: gicv3
[info] (Kernel) Embox kernel start
[info] (unit) initializing embox.kernel.task.task_resource
[info] (unit) initializing embox.kernel.task.task_table
[info] (unit) initializing embox.kernel.task.kernel_task
[info] (unit) initializing embox.driver.periph_memory_mmap
[info] (unit) initializing embox.arch.aarch64.mmu
[info] (unit) initializing embox.driver.clock.armv8_phy_timer
[info] (unit) initializing embox.mem.phymem
[info] (phymem) start=0x000000000ea40000 end=0x000000001a000000 size=190578688
[info] (mod) runlevel is 0
[info] (unit) initializing embox.mem.static_heap
[info] (unit) initializing embox.kernel.sched.sched
[info] (mod) runlevel is 1
[info] (unit) initializing embox.device.char_dev
[info] (unit) initializing embox.fs.buffer_cache
[info] (unit) initializing embox.driver.pci_chip.pcie_dw
[info] (pcie_dw) pcie0: firmware link inherited (bus 0-1), link Gen2 x1 (max Gen2 x1)
[info] (pcie_dw) pcie1: firmware link inherited (bus 2-3), link Gen1 x1 (max Gen3 x2)
[info] (unit) initializing third_party.net80211.net80211_port_cherryusb
[info] (unit) initializing embox.driver.flash.flash_nofs
[info] (unit) initializing embox.driver.interrupt.gicv3_its
[info] (gicv3_its) its: base 0xfd440000 typer 000000130001ef31 pta 0 rd_target 0
[info] (gicv3_its) its: PROPBASER.IDbits 15
[info] (gicv3_its) its: BASER0 devices b9e000000a4b451f -> b9e700000a4b451f
[info] (gicv3_its) its: BASER1 collections bce000000a4b0400 -> bce100000a4b0400
[info] (gicv3_its) its: ready, irq window 208..255, doorbell 0xfd450040
[info] (unit) initializing embox.driver.pci
[info] (unit) initializing embox.driver.tty.serial
[info] (unit) initializing embox.fs.rootfs_oldfs
[info] (mod) runlevel is 2
[info] (unit) initializing embox.driver.nvme
[info] (gicv3_its) its: 01:00.0 got 2 message irq(s)
[info] (nvme) nvme: 2 message vector(s), completion irq 208
[info] (nvme) nvme0: 126f:2263 at 0x00000000f4300000, ns1: 500118192 blocks of 512 bytes (244198 MiB)
[info] (mod) runlevel is 3
[W/USB] Do not eDefault IO device[ttyS0]
>tish
root@embox:(null)#wlan: urtwn found at bus 0 addr 3 (hub 2 port 1)


urtwn0: Realtek RTL8188EU, addr 3
urtwn0: MAC/BB RTL8188EU, RF 6052 1T1R, address 20:f4:1b:52:8f:01
urtwn0: 1 rx pipe, 2 tx pipes
urtwn0: 11b rates: 1Mbps 2Mbps 5.5Mbps 11Mbps
urtwn0: 11g rates: 1Mbps 2Mbps 5.5Mbps 11Mbps 6Mbps 9Mbps 12Mbps 18Mbps 24Mbps 36Mbps 48Mbps 54Mbps
[E/usbh_core] Do not support Class:0x0e, Subclass:0x01, Protocl:0x00 on interface 0
[E/usbh_core] Do not support Class:0x0e, Subclass:0x02, Protocl:0x00 on interface 1
[E/usbh_core] Do not support Class:0x01, Subclass:0x01, Protocl:0x00 on interface 2
[E/usbh_core] Do not support Class:0x01, Subclass:0x02, Protocl:0x00 on interface 3
wlan scan 15
wlan: calling if_init 0x000000000a037e80 (fw load + power on, ~10s)...
wlan: if_init done, flags=8843
scanning for 15 s...
scan results:
urtwn state=SCAN opmode=1 ch=2422
  xxxx  ch=2442  rssi=20  ssid=Xiaomi_06EF
  xxxx  ch=2452  rssi=20  ssid=IoT_2.4G
.....
```