### PR TITLE
Add rk3568 wpa supplicant support and rtl8188eu can join ap

### DIFF
--- a/platform/rockchip/rk3568/mods.conf
+++ b/platform/rockchip/rk3568/mods.conf
@@ -132,6 +132,41 @@ configuration conf {
 	include embox.cmd.blockdev
 	include embox.cmd.fs.blkdump
 
+	/* net80211 wireless (third-party/net80211, cherryusb host on the
+	 * panel EHCI) and the wpa_supplicant port (third-party/wpa_supplicant). */
+	include third_party.net80211.cherryusb_host
+	include third_party.net80211.net80211_port_cherryusb
+	include third_party.net80211.net80211_wlan_cmd
+	include third_party.wpa_supplicant.wpa_supplicant_core
+	include third_party.wpa_supplicant.wpa_supplicant_net80211
+	include third_party.wpa_supplicant.wpa_supplicant_embox
+	include third_party.wpa_supplicant.wpa_cmd
+
+	/* Stock network stack over the wireless interface: L2 in net.core,
+	 * L3 for the data path (ping/dhcp once associated). */
+	@Runlevel(2) include embox.net.core
+	@Runlevel(2) include embox.net.skbuff(amount_skb=128)
+	@Runlevel(2) include embox.net.skbuff_data(amount_skb_data=128, data_size=1514, data_align=1, data_padto=1, ip_align=false)
+	@Runlevel(2) include embox.net.skbuff_extra(amount_skb_extra=128, extra_size=10, extra_align=1, extra_padto=1)
+	@Runlevel(2) include embox.net.socket
+	@Runlevel(2) include embox.net.dev
+	@Runlevel(2) include embox.net.net_entry
+	@Runlevel(2) include embox.net.af_inet
+	@Runlevel(2) include embox.net.ipv4
+	@Runlevel(2) include embox.net.arp
+	@Runlevel(2) include embox.net.rarp
+	@Runlevel(2) include embox.net.icmpv4
+	@Runlevel(2) include embox.net.udp
+	@Runlevel(2) include embox.net.udp_sock
+	@Runlevel(2) include embox.net.raw_sock
+	include embox.net.wifi.cfg80211
+
+	include embox.cmd.net.ping
+	include embox.cmd.net.ifconfig
+	include embox.cmd.net.route
+	include embox.cmd.net.arp
+	include embox.cmd.net.iwlist
+
 	include embox.compat.libc.all
 	include embox.compat.libc.stdio.asprintf
 	include embox.compat.libc.math_simple

--- a/src/include/kernel/spinlock.h
+++ b/src/include/kernel/spinlock.h
@@ -89,15 +89,20 @@ static inline int __spin_trylock_smp(spinlock_t *lock) {
 
 static inline int __spin_trylock(spinlock_t *lock) {
 	int ret;
+
+#if defined(SMP) || defined(SPIN_DEBUG)
 	unsigned int cpu_id = cpu_get_id();
 
 	assertf(lock->owner != cpu_id, "Recursive lock of a spin owned by this CPU");
+#endif
 
 	ret = __spin_trylock_smp(lock);
+#if defined(SMP) || defined(SPIN_DEBUG)
 	if (ret) {
 		assert(lock->owner == -1u);
 		lock->owner = cpu_id;
 	}
+#endif
 #ifdef SPIN_CONTENTION_LIMIT
 	if (ret)
 		lock->contention_count = SPIN_CONTENTION_LIMIT;
@@ -124,7 +129,6 @@ static inline void __spin_unlock(spinlock_t *lock) {
 	lock->l = __SPIN_UNLOCKED;
 	__barrier();
 #else /* !(SMP || SPIN_DEBUG) */
-	lock->owner = -1u;
 	__barrier();
 #endif /* SMP || SPIN_DEBUG */
 }

--- a/third-party/net80211/Makefile
+++ b/third-party/net80211/Makefile
@@ -6,8 +6,9 @@
 #   net80211/     NetBSD 802.11 stack (verbatim import)
 #   driver/urtwn/ RTL8188EU driver
 #   compat/netbsd/ shadow headers for the NetBSD kernel API
-#   port/         port interface + embox shims + cherryusb backend
+#   port/         the port interface with osal/, bus/ and net/
+#                 adapter categories; cmd/ holds the shell command
 
 PKG_NAME := net80211
-PKG_VER := a14682c4a0185ec3f7bbf5308e9f6a2aeffe1666
+PKG_VER := f202037238a086a4eecf1d6dcbee26276a4818d5
 PKG_SOURCES := https://github.com/KevinACoder/net_80211.git

--- a/third-party/net80211/Makefile
+++ b/third-party/net80211/Makefile
@@ -1,9 +1,6 @@
 # net80211 (NetBSD wireless stack + urtwn) fetched from its own repository.
 #
-# PKG_SOURCES is a git URL: extbld clones the repository's default branch
-# (main) and copies the checkout into each module build dir, where embox
-# compiles the sources directly. Bump by re-running make after the remote
-# main advances (or pin PKG_VER to a commit for a reproducible build).
+# extbld copies the pinned checkout into each module build directory.
 #
 # Checkout layout:
 #   net80211/     NetBSD 802.11 stack (verbatim import)
@@ -12,4 +9,5 @@
 #   port/         port interface + embox shims + cherryusb backend
 
 PKG_NAME := net80211
+PKG_VER := a14682c4a0185ec3f7bbf5308e9f6a2aeffe1666
 PKG_SOURCES := https://github.com/KevinACoder/net_80211.git

--- a/third-party/net80211/Mybuild
+++ b/third-party/net80211/Mybuild
@@ -22,18 +22,30 @@ package third_party.net80211
 module net80211_core {
 	@Cflags("-D_KERNEL")
 	@Cflags("-Wno-pointer-sign")
+	@Cflags("-Wno-unused-function")
+	@Cflags("-Wno-maybe-uninitialized")
 	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/port/port_config_bsd.h")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/compat/netbsd")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211")
-	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/net80211")
-	source "ieee80211.c",
-		"ieee80211_proto.c",
-		"ieee80211_node.c",
-		"ieee80211_output.c",
-		"ieee80211_input.c",
-		"ieee80211_netbsd.c",
-		"ieee80211_crypto.c",
-		"ieee80211_crypto_none.c"
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211")
+	source "net80211/ieee80211.c",
+		"net80211/ieee80211_proto.c",
+		"net80211/ieee80211_node.c",
+		"net80211/ieee80211_output.c",
+		"net80211/ieee80211_input.c",
+		"net80211/ieee80211_netbsd.c",
+		"net80211/ieee80211_crypto.c",
+		"net80211/ieee80211_crypto_none.c",
+		/* software AES-CCMP: the verbatim NetBSD crypto/aes import
+		 * plus the port shim binding <crypto/aes/aes.h> to
+		 * aes_bear_impl */
+		"crypto/aes/aes_bear.c",
+		"crypto/aes/aes_ct.c",
+		"crypto/aes/aes_ct_enc.c",
+		"crypto/aes/aes_ct_dec.c",
+		"crypto/aes/aes_ccm.c",
+		"crypto/aes/aes_ccm_mbuf.c",
+		"port/aes_impl_compat.c"
 }
 
 /*

--- a/third-party/net80211/Mybuild
+++ b/third-party/net80211/Mybuild
@@ -11,7 +11,8 @@
  *   net80211/       NetBSD 802.11 stack (verbatim import)
  *   driver/urtwn/   RTL8188EU driver (verbatim import + registration)
  *   compat/netbsd/  shadow headers for the NetBSD kernel API
- *   port/           portable port interface + embox/cherryusb ports
+ *   port/           the port interface with osal/, bus/ and net/
+ *                   adapter categories; cmd/ holds the shell command
  */
 package third_party.net80211
 
@@ -68,22 +69,43 @@ module net80211_urtwn {
 }
 
 /*
- * NetBSD kernel-API shims for embox (locks/threads, mbuf, ifnet,
- * firmware lookup). Any USB backend for embox builds on this module.
+ * The OS adaptation for embox: NetBSD kernel services (locks/threads,
+ * timers) and the embedded firmware lookup.
  */
 @Build(script = "$(EXTERNAL_MAKE)")
-module net80211_embox_osal {
+module net80211_osal_embox {
 	@Cflags("-D_KERNEL")
-	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211/port/port_config.h")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211/compat/netbsd")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_embox_osal/net_80211/port")
-	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/embox")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211/port/port_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/osal/embox")
 	source "osal_embox.c",
-		"bsd_mbuf.c",
-		"bsd_ifnet.c",
 		"firmware_embed.c"
 
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+	depends embox.kernel.timer.sys_timer
+	depends embox.kernel.timer.sleep
+	depends embox.compat.posix.util.gettimeofday
+}
+
+/*
+ * The presentation layer for the embox network stack: the BSD mbuf
+ * and ifnet shells the imported code runs on.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_net_embox {
+	@Cflags("-D_KERNEL")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_net_embox/net_80211/port/port_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_net_embox/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_net_embox/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_net_embox/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/net/embox")
+	source "bsd_mbuf.c",
+		"bsd_ifnet.c"
+
+	depends net80211_osal_embox
 	depends embox.kernel.thread.core
 	depends embox.kernel.thread.sync
 	depends embox.kernel.timer.sys_timer
@@ -101,12 +123,12 @@ module cherryusb_host {
 	/* the EHCI hardware link pointers are 32-bit: the truncation is
 	 * intentional, every pool sits below 4G on this platform */
 	@Cflags("-Wno-pointer-to-int-cast")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/core")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/common")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/class/hub")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/cherryusb/cherryusb/port/ehci")
-	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/cherryusb")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/bus/usb/cherryusb")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/bus/usb/cherryusb/cherryusb/core")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/bus/usb/cherryusb/cherryusb/common")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/bus/usb/cherryusb/cherryusb/class/hub")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/cherryusb_host/net_80211/port/bus/usb/cherryusb/cherryusb/port/ehci")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/bus/usb/cherryusb")
 	source "cherryusb/core/usbh_core.c",
 		"cherryusb/class/hub/usbh_hub.c",
 		"cherryusb/port/ehci/usb_hc_ehci.c",
@@ -124,8 +146,8 @@ module cherryusb_host {
 
 /*
  * The net80211 port over cherryusb: the usbd_* shim reroutes the
- * driver's transfers onto CherryUSB, plus the urtwn class hook, the
- * net bridge and the shell command.
+ * driver's transfers onto CherryUSB, plus the urtwn class hook and
+ * the net bridge.
  */
 @Build(script = "$(EXTERNAL_MAKE)")
 module net80211_port_cherryusb {
@@ -134,17 +156,18 @@ module net80211_port_cherryusb {
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/compat/netbsd")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb/cherryusb/core")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb/cherryusb/common")
-	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/cherryusb/cherryusb/class/hub")
-	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/cherryusb")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/bus/usb/cherryusb")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/bus/usb/cherryusb/cherryusb/core")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/bus/usb/cherryusb/cherryusb/common")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_cherryusb/net_80211/port/bus/usb/cherryusb/cherryusb/class/hub")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/bus/usb/cherryusb")
 	source "usbdi_compat.c",
 		"usbh_urtwn_class.c",
 		"net_bridge.c"
 
 	depends cherryusb_host
-	depends net80211_embox_osal
+	depends net80211_osal_embox
+	depends net80211_net_embox
 	depends net80211_urtwn
 	depends embox.kernel.thread.core
 	depends embox.kernel.thread.sync
@@ -180,7 +203,7 @@ module net80211_wlan_cmd {
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_wlan_cmd/net_80211/compat/netbsd")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_wlan_cmd/net_80211")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_wlan_cmd/net_80211/port")
-	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/cherryusb")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/cmd")
 	source "wlan_cmd.c"
 
 	depends net80211_port_cherryusb

--- a/third-party/net80211/Mybuild
+++ b/third-party/net80211/Mybuild
@@ -36,6 +36,7 @@ module net80211_core {
 		"net80211/ieee80211_netbsd.c",
 		"net80211/ieee80211_crypto.c",
 		"net80211/ieee80211_crypto_none.c",
+		"net80211/ieee80211_crypto_ccmp.c",
 		/* software AES-CCMP: the verbatim NetBSD crypto/aes import
 		 * plus the port shim binding <crypto/aes/aes.h> to
 		 * aes_bear_impl */
@@ -162,11 +163,15 @@ NAME
 
 SYNOPSIS
 	wlan scan [seconds]
+	wlan status
+	wlan ccmtest
 	wlan trace [0|1|2]
 
 DESCRIPTION
 	The scan subcommand brings the interface up, scans for
-	[seconds] and prints the networks found. The trace subcommand
+	[seconds] and prints the networks found. status prints interface,
+	association, crypto counters and receiver registers without keys.
+	ccmtest runs the RFC 3610 AES-CCM self-tests. The trace subcommand
 	selects the USB shim log verbosity: 0 (default) quiet, 1 async
 	events, 2 full control transfers.
 ''')

--- a/third-party/wpa_supplicant/Makefile
+++ b/third-party/wpa_supplicant/Makefile
@@ -3,7 +3,8 @@
 #
 # PKG_SOURCES is a git URL: extbld clones the repository and copies the
 # checkout into each module build dir, where embox compiles the sources
-# directly. Pin PKG_VER to a commit for a reproducible build.
+# directly. Keep the revision pinned for reproducible builds.
 
 PKG_NAME := wpa_supplicant
+PKG_VER := 7d69fde4a0f0f5af664efbd221acd420bd292cbc
 PKG_SOURCES := https://github.com/KevinACoder/wpa_supplicant-rtos.git

--- a/third-party/wpa_supplicant/Makefile
+++ b/third-party/wpa_supplicant/Makefile
@@ -1,0 +1,9 @@
+# wpa_supplicant (hostap 2.11 base, NXP wpa_supplicant-rtos fork) fetched
+# from its own repository, ported to embox in port/embox.
+#
+# PKG_SOURCES is a git URL: extbld clones the repository and copies the
+# checkout into each module build dir, where embox compiles the sources
+# directly. Pin PKG_VER to a commit for a reproducible build.
+
+PKG_NAME := wpa_supplicant
+PKG_SOURCES := https://github.com/KevinACoder/wpa_supplicant-rtos.git

--- a/third-party/wpa_supplicant/Mybuild
+++ b/third-party/wpa_supplicant/Mybuild
@@ -1,0 +1,165 @@
+/*
+ * wpa_supplicant for embox.
+ *
+ * The hostap 2.11 based sources are fetched from the wpa_supplicant-rtos
+ * repository by the extbld rules and compiled from the per-module build
+ * tree, mirroring third-party/net80211:
+ *
+ *   src/            hostap tree (vanilla, two small OS-ifdef patches)
+ *   port/embox/     the embox port: os/eloop/l2/driver, supplicant
+ *                   thread, event queue and the wpa command
+ *
+ * The core module compiles the PSK-only file set (no EAP/WPS/P2P/
+ * ctrl-iface/SME); the config header port/embox/wpa_embox_config.h is
+ * force-included everywhere. Warnings are off for the vanilla tree.
+ */
+package third_party.wpa_supplicant
+
+@Build(script = "$(EXTERNAL_MAKE)")
+module wpa_supplicant_core {
+	@Cflags("-w")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_core/wpa_supplicant-rtos/port/embox/wpa_embox_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_core/wpa_supplicant-rtos/src")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_core/wpa_supplicant-rtos/src/utils")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/wpa_supplicant-rtos")
+	source "src/common/wpa_common.c",
+		"src/common/ieee802_11_common.c",
+		"src/common/hw_features_common.c",
+		"src/drivers/driver_common.c",
+		"src/drivers/drivers.c",
+		"src/rsn_supp/wpa.c",
+		"src/rsn_supp/wpa_ie.c",
+		"src/rsn_supp/pmksa_cache.c",
+		"src/rsn_supp/preauth.c",
+		"src/utils/common.c",
+		"src/utils/wpabuf.c",
+		"src/utils/base64.c",
+		"src/utils/bitfield.c",
+		"src/utils/wpa_debug.c",
+		"src/crypto/crypto_internal.c",
+		"src/crypto/aes-internal.c",
+		"src/crypto/aes-internal-dec.c",
+		"src/crypto/aes-internal-enc.c",
+		"src/crypto/aes-wrap.c",
+		"src/crypto/aes-unwrap.c",
+		"src/crypto/aes-omac1.c",
+		"src/crypto/sha1.c",
+		"src/crypto/sha1-internal.c",
+		"src/crypto/sha1-prf.c",
+		"src/crypto/sha1-pbkdf2.c",
+		"src/crypto/md5.c",
+		"src/crypto/md5-internal.c",
+		"src/crypto/rc4.c",
+		"src/crypto/sha256.c",
+		"src/crypto/sha256-internal.c",
+		"src/crypto/sha256-prf.c",
+		"src/crypto/tls_none.c",
+		"wpa_supplicant/wpa_supplicant.c",
+		"wpa_supplicant/events.c",
+		"wpa_supplicant/scan.c",
+		"wpa_supplicant/bss.c",
+		"wpa_supplicant/config.c",
+		"wpa_supplicant/config_none.c",
+		"wpa_supplicant/notify.c",
+		"wpa_supplicant/wpas_glue.c",
+		"wpa_supplicant/bssid_ignore.c",
+		"wpa_supplicant/eap_register.c",
+		"wpa_supplicant/op_classes.c",
+		"wpa_supplicant/rrm.c",
+		"wpa_supplicant/robust_av.c"
+}
+
+/*
+ * The embox side of the port: supplicant thread and event queue, the
+ * net80211 driver wrapper and the embox netdev bridge.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module wpa_supplicant_embox {
+	@Cflags("-Wno-undef")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/port/embox/wpa_embox_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/src")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/src/utils")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/src/l2_packet")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/src/drivers")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/wpa_supplicant")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos/port/embox")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_embox/wpa_supplicant-rtos")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/wpa_supplicant-rtos/port/embox")
+	source "os_embox.c",
+		"eloop_embox.c",
+		"supp_main_embox.c",
+		"l2_packet_embox.c",
+		"netdev_bridge.c"
+
+	depends wpa_supplicant_core
+	depends wpa_supplicant_net80211
+	depends third_party.net80211.net80211_port_cherryusb
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+	depends embox.net.core
+	depends embox.net.dev
+	depends embox.net.l2.ethernet
+	depends embox.net.skbuff
+	depends embox.compat.posix.util.gettimeofday
+}
+
+/*
+ * The one translation unit that lives in both worlds: the driver
+ * wrapper calls net80211 directly, so it compiles with the BSD port
+ * config (which owns the shadow types) plus the hostap headers.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module wpa_supplicant_net80211 {
+	@Cflags("-Wno-undef")
+	@Cflags("-D_KERNEL")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_net80211/wpa_supplicant-rtos/port/embox/wpa_embox_config.h")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/port/port_config_bsd.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_net80211/wpa_supplicant-rtos/src")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_net80211/wpa_supplicant-rtos/src/utils")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_net80211/wpa_supplicant-rtos/src/drivers")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_supplicant_net80211/wpa_supplicant-rtos/port/embox")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_core/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/wpa_supplicant-rtos/port/embox")
+	source "driver_embox.c"
+
+	depends third_party.net80211.net80211_port_cherryusb
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+}
+
+@AutoCmd
+@App
+@Cmd(name = "wpa",
+	help = "control the wpa_supplicant port",
+	man = '''
+NAME
+	wpa - connect to a WPA2-PSK network with the supplicant
+
+SYNOPSIS
+	wpa start
+	wpa connect <ssid> <psk>
+	wpa status
+	wpa disconnect
+
+DESCRIPTION
+	start brings up the supplicant thread. connect selects the
+	network (the association, the 4-way handshake and the key
+	installation then run in the supplicant). status prints the
+	current state, disconnect clears the selection.
+''')
+@Build(script = "$(EXTERNAL_MAKE)")
+module wpa_cmd {
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_cmd/wpa_supplicant-rtos/port/embox/wpa_embox_config.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_cmd/wpa_supplicant-rtos/src")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_cmd/wpa_supplicant-rtos/src/utils")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/wpa_supplicant/wpa_cmd/wpa_supplicant-rtos/port/embox")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/wpa_supplicant-rtos/port/embox")
+	source "wpa_cmd.c"
+
+	depends wpa_supplicant_embox
+}


### PR DESCRIPTION

hello, i port wap supplicant and now rtl8188eu can join ap, although with some issue and the connection not that stable

<img width="618" height="511" alt="image" src="https://github.com/user-attachments/assets/9ea0bdc3-fd87-42cd-a977-13ac67be7f72" />


```
urtwn0: Realtek RTL8188EU, addr 3
urtwn0: MAC/BB RTL8188EU, RF 6052 1T1R, address 20:f4:1b:52:8f:01
urtwn0: 1 rx pipe, 2 tx pipes
urtwn0: 11b rates: 1Mbps 2Mbps 5.5Mbps 11Mbps
urtwn0: 11g rates: 1Mbps 2Mbps 5.5Mbps 11Mbps 6Mbps 9Mbps 12Mbps 18Mbps 24Mbps 36Mbps 48Mbps 54Mbps
[E/usbh_core] Do not support Class:0x0e, Subclass:0x01, Protocl:0x00 on interface 0
[E/usbh_core] Do not support Class:0x0e, Subclass:0x02, Protocl:0x00 on interface 1
[E/usbh_core] Do not support Class:0x01, Subclass:0x01, Protocl:0x00 on interface 2
[E/usbh_core] Do not support Class:0x01, Subclass:0x02, Protocl:0x00 on interface 3
wlan ccmtest
AES-CCM RFC3610: PASS
root@embox:(null)#wpa connect QiQiJia xxxxxx
wlan: calling if_init 0x000000000a0803e0 (fw load + power on, ~10s)...
wlan: if_init done, flags=8843
embox: unsupported key alg 0
embox: unsupported key alg 0
wpa_embox: supplicant running
wlan0: CTRL-EVENT-DSCP-POLICY clear_all
wpa_embox: connecting to "QiQiJia"
wpa: connecting to "QiQiJia"
root@embox:(null)#[drv] scan requested ssid_len=0
[drv] scan complete flags=40000
wlan0: Trying to associate with 14:a3:2f:18:07:2c (SSID='QiQiJia' freq=2412 MHz)
[drv] association complete
wlan0: Associated with 14:a3:2f:18:07:2c
wlan0: WPA: Key negotiation completed with 14:a3:2f:18:07:2c [PTK=CCMP GTK=CCMP]
wlan0: CTRL-EVENT-CONNECTED - Connection to 14:a3:2f:18:07:2c completed [id=0 id_str=]
wlan0: CTRL-EVENT-DISCONNECTED bssid=14:a3:2f:18:07:2c reason=0
BSSID 14:a3:2f:18:07:2c ignore list count incremented to 2, ignoring for 10 seconds
[drv] scan requested ssid_len=7
[drv] scan complete flags=3041010
wlan0: Trying to associate with e2:fd:e2:53:29:58 (SSID='QiQiJia' freq=2412 MHz)
[drv] association complete
wlan0: Associated with e2:fd:e2:53:29:58
wlan0: WPA: Key negotiation completed with e2:fd:e2:53:29:58 [PTK=CCMP GTK=CCMP]
wlan0: CTRL-EVENT-CONNECTED - Connection to e2:fd:e2:53:29:58 completed [id=0 id_str=]
wpa status
wpa: state=COMPLETED ssid="QiQiJia" bssid=e2:fd:e2:53:29:58 freq=2412
root@embox:(null)#ifconfig wlan0 192.168.0.201 netmask 255.255.255.0 up
root@embox:(null)#route add 192.168.0.0 netmask 255.255.255.0 wlan0
root@embox:(null)#wpa status
wpa: state=COMPLETED ssid="QiQiJia" bssid=e2:fd:e2:53:29:58 freq=2412
root@embox:(null)#wlan status
wlan mac=20:f4:1b:52:8f:01 flags=8843 mtu=0
wlan bssid=e2:fd:e2:53:29:58 ni_flags=1 caps=581c500
unicast cipher=AES-CCM flags=13 index=0 txpn=0 rxpn=0
group[0] key cipher=NONE flags=3 index=65535 txpn=0 rxpn=0
group[1] key cipher=AES-CCM flags=17 index=1 txpn=0 rxpn=23777324
group[2] key cipher=NONE flags=3 index=65535 txpn=0 rxpn=0
group[3] key cipher=NONE flags=3 index=65535 txpn=0 rxpn=0
wlan stats tx=36 txerr=0 rx=94 rxerr=0 auth=1 key=13
wlan crypto no-key=0 wepfail=0 ccmpmic=0 ccmpreplay=0 unauth=0
wlan ccmpformat=0
urtwn RCR=700060cf RXFLTMAP=ffff/0000/ffff SECCFG=00
urtwn BSSID registers=53e2fde2/5829
urtwn state=RUN opmode=1 ch=2412
root@embox:(null)#ifconfig
wlan0   Link encap:Ethernet  HWaddr 20:f4:1b:52:8f:01
        inet addr:192.168.0.201  Bcast:192.168.0.255  Mask:255.255.255.0
        inet6 addr: ::/??  Scope:Host
        UP BROADCAST RUNNING  MTU:1500  Metric:0
        RX packets:100 errors:0 dropped:0 overruns:0 frame:0
        TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:48488 (0 MiB)  TX bytes:0 (0 MiB)
        Interrupt:0 Base address:0x0000000000000000

root@embox:(null)#route
Destination     Gateway         Genmask         Flags  Iface
192.168.0.0     *               255.255.255.0   U      wlan0
root@embox:(null)#arp
Address         HWtype  HWaddress         Flags Iface
192.168.3.1     ether   14:a3:2f:18:07:24 C     wlan0
192.168.0.1     ether   40:dc:a5:56:29:53 C     wlan0
root@embox:(null)#ping -c 20 -i 0.2 192.168.0.1
PING 192.168.0.1 (192.168.0.1) 64 bytes of data
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=1 ttl=64 time=21 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=2 ttl=64 time=11 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=3 ttl=64 time=13 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=4 ttl=64 time=10 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=5 ttl=64 time=9 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=6 ttl=64 time=12 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=7 ttl=64 time=11 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=8 ttl=64 time=8 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=9 ttl=64 time=9 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=10 ttl=64 time=9 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=12 ttl=64 time=54 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=13 ttl=64 time=9 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=14 ttl=64 time=10 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=15 ttl=64 time=13 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=16 ttl=64 time=12 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=17 ttl=64 time=55 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=18 ttl=64 time=10 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=19 ttl=64 time=9 ms
84 bytes from 192.168.0.1 (192.168.0.1): icmp_seq=20 ttl=64 time=14 ms
--- 192.168.0.1 ping statistics ---
20 packets transmitted, 19 received, +0 errors, 5% packet loss, time 4344ms
```