### PR TITLE
add rk3568 intel ac7260 pcie wifi (iwm) support with 5G band

### DIFF
--- a/platform/rockchip/rk3568/mods.conf
+++ b/platform/rockchip/rk3568/mods.conf
@@ -169,6 +169,9 @@ configuration conf {
 	 * panel EHCI) and the wpa_supplicant port (third-party/wpa_supplicant). */
 	include third_party.net80211.cherryusb_host
 	include third_party.net80211.net80211_port_cherryusb
+	/* Intel 7260 in the PCIe slot (pcie3x2 link trained by U-Boot). */
+	include third_party.net80211.net80211_pcie_bus_embox
+	include third_party.net80211.net80211_port_pcie_embox
 	include third_party.net80211.net80211_wlan_cmd
 	include third_party.wpa_supplicant.wpa_supplicant_core
 	include third_party.wpa_supplicant.wpa_supplicant_net80211

--- a/third-party/net80211/Makefile
+++ b/third-party/net80211/Makefile
@@ -10,5 +10,5 @@
 #                 adapter categories; cmd/ holds the shell command
 
 PKG_NAME := net80211
-PKG_VER := f202037238a086a4eecf1d6dcbee26276a4818d5
+PKG_VER := 1826e1d65fa728323554ca110fdc3b11bf0e1af8
 PKG_SOURCES := https://github.com/KevinACoder/net_80211.git

--- a/third-party/net80211/Makefile
+++ b/third-party/net80211/Makefile
@@ -10,5 +10,5 @@
 #                 adapter categories; cmd/ holds the shell command
 
 PKG_NAME := net80211
-PKG_VER := 1826e1d65fa728323554ca110fdc3b11bf0e1af8
+PKG_VER := f137141937db2d8f46414eba6c714865ffa8f993
 PKG_SOURCES := https://github.com/KevinACoder/net_80211.git

--- a/third-party/net80211/Mybuild
+++ b/third-party/net80211/Mybuild
@@ -34,6 +34,7 @@ module net80211_core {
 		"net80211/ieee80211_node.c",
 		"net80211/ieee80211_output.c",
 		"net80211/ieee80211_input.c",
+		"net80211/ieee80211_amrr.c",
 		"net80211/ieee80211_netbsd.c",
 		"net80211/ieee80211_crypto.c",
 		"net80211/ieee80211_crypto_none.c",
@@ -75,13 +76,16 @@ module net80211_urtwn {
 @Build(script = "$(EXTERNAL_MAKE)")
 module net80211_osal_embox {
 	@Cflags("-D_KERNEL")
+	@Cflags("-Wno-pointer-sign")
+	@Cflags("-Wno-unused-function")
 	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211/port/port_config.h")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211/compat/netbsd")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211")
 	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_osal_embox/net_80211/port")
 	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/osal/embox")
 	source "osal_embox.c",
-		"firmware_embed.c"
+		"firmware_embed.c",
+		"port_core.c"
 
 	depends embox.kernel.thread.core
 	depends embox.kernel.thread.sync
@@ -172,6 +176,68 @@ module net80211_port_cherryusb {
 	depends embox.kernel.thread.core
 	depends embox.kernel.thread.sync
 	depends embox.kernel.timer.sys_timer
+	depends embox.net.core
+	depends embox.net.wifi.cfg80211
+}
+
+/*
+ * The PCIe bus backend in the embox world: claim the device from the
+ * enumerated PCI tree, map its register window, allocate one MSI
+ * vector, run the interrupt worker, and implement the bus_dma /
+ * PCI-autoconf shims. Lives outside the BSD-world module so the
+ * embox and compat headers never meet in one translation unit.
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_pcie_bus_embox {
+	@Cflags("-Wno-unused-parameter")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_pcie_bus_embox/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_pcie_bus_embox/net_80211")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/port/bus/pcie/embox")
+	source "pcie_embox.c"
+
+	depends net80211_osal_embox
+	depends embox.driver.pci
+	/* the claim allocates an MSI vector: the ITS must be up first */
+	depends embox.driver.interrupt.gicv3_its
+	@NoRuntime depends embox.driver.pci_msi
+	@NoRuntime depends embox.arch.mem_barriers
+	depends embox.kernel.irq
+	depends embox.kernel.sched.sched
+	depends embox.kernel.thread.core
+	depends embox.kernel.thread.sync
+}
+
+/*
+ * The net80211 port over the embox PCI stack: the imported iwm driver
+ * with its bus adapter. The verbatim if_iwm.c is pulled in by the
+ * small registration translation unit (iwm_reg.c).
+ */
+@Build(script = "$(EXTERNAL_MAKE)")
+module net80211_port_pcie_embox {
+	@Cflags("-D_KERNEL")
+	@Cflags("-Wno-pointer-sign")
+	@Cflags("-Wno-unused-function")
+	@Cflags("-Wno-unused-parameter")
+	@Cflags("-Wno-unused-variable")
+	@Cflags("-Wno-unused-but-set-variable")
+	@Cflags("-Wno-sign-compare")
+	@Cflags("-Wno-missing-field-initializers")
+	@Cflags("-Wno-missing-prototypes")
+	@Cflags("-Wno-old-style-definition")
+	@Cflags("-Wno-unused-label")
+	@Cflags("-Wno-implicit-fallthrough")
+	@Cflags("-Wno-maybe-uninitialized")
+	@Cflags("-include$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_pcie_embox/net_80211/port/port_config_bsd.h")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_pcie_embox/net_80211/compat/netbsd")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_pcie_embox/net_80211")
+	@IncludePath("$(EXTERNAL_BUILD_DIR)/third_party/net80211/net80211_port_pcie_embox/net_80211/port")
+	@AddPrefix("^BUILD/extbld/^MOD_PATH/net_80211/driver/iwm")
+	source "iwm_reg.c"
+
+	depends net80211_core
+	depends net80211_osal_embox
+	depends net80211_net_embox
+	depends net80211_pcie_bus_embox
 	depends embox.net.core
 	depends embox.net.wifi.cfg80211
 }

--- a/third-party/wpa_supplicant/Makefile
+++ b/third-party/wpa_supplicant/Makefile
@@ -6,5 +6,5 @@
 # directly. Keep the revision pinned for reproducible builds.
 
 PKG_NAME := wpa_supplicant
-PKG_VER := 7d69fde4a0f0f5af664efbd221acd420bd292cbc
+PKG_VER := 0248409847056512eafae878a0a2260f10437b3c
 PKG_SOURCES := https://github.com/KevinACoder/wpa_supplicant-rtos.git

--- a/third-party/wpa_supplicant/Mybuild
+++ b/third-party/wpa_supplicant/Mybuild
@@ -96,7 +96,9 @@ module wpa_supplicant_embox {
 
 	depends wpa_supplicant_core
 	depends wpa_supplicant_net80211
-	depends third_party.net80211.net80211_port_cherryusb
+	depends third_party.net80211.net80211_osal_embox
+	depends third_party.net80211.net80211_net_embox
+	depends third_party.net80211.net80211_core
 	depends embox.kernel.thread.core
 	depends embox.kernel.thread.sync
 	depends embox.net.core
@@ -127,7 +129,8 @@ module wpa_supplicant_net80211 {
 	@AddPrefix("^BUILD/extbld/^MOD_PATH/wpa_supplicant-rtos/port/embox")
 	source "driver_embox.c"
 
-	depends third_party.net80211.net80211_port_cherryusb
+	depends third_party.net80211.net80211_core
+	depends third_party.net80211.net80211_osal_embox
 	depends embox.kernel.thread.core
 	depends embox.kernel.thread.sync
 }


### PR DESCRIPTION

hello, i add ac7260 pcie wifi support with embox pci driver applied, data ok

<img width="546" height="291" alt="image" src="https://github.com/user-attachments/assets/4a10a4ab-d931-44fa-9514-98b32cde2c9e" />


```
=> dhcp
ethernet@fe010000 Waiting for PHY auto negotiation to complete. done
BOOTP broadcast 1
BOOTP broadcast 2
BOOTP broadcast 3
*** Unhandled DHCP Option in OFFER/ACK: 213
DHCP client bound to address 192.168.0.200 (823 ms)
=> setenv serverip 192.168.0.18
=> tftp 0xa000000 embox-rk3568.bin
Using ethernet@fe010000 device
TFTP from server 192.168.0.18; our IP address is 192.168.0.200
Filename 'embox-rk3568.bin'.
Load address: 0xa000000
Loading: #################################################################
         #################################################################
         ###############
         7 MiB/s
done
Bytes transferred = 2127528 (2076a8 hex)
=> crc32 0xa000000 2076a8
crc32 for 0a000000 ... 0a2076a7 ==> 96a37e0d
=> go 0xa000000
## Starting application at 0x0A000000 ...

[info] (Kernel) Interrupt controller: gicv3
[info] (Kernel) Embox kernel start
[info] (unit) initializing embox.kernel.task.task_resource
[info] (unit) initializing embox.kernel.task.task_table
[info] (unit) initializing embox.kernel.task.kernel_task
[info] (unit) initializing embox.driver.periph_memory_mmap
[info] (unit) initializing embox.arch.aarch64.mmu
[info] (unit) initializing embox.mem.phymem
[info] (phymem) start=0x000000000ec50000 end=0x000000001a000000 size=188416000
[info] (unit) initializing embox.driver.clock.armv8_phy_timer
[info] (mod) runlevel is 0
[info] (unit) initializing embox.mem.static_heap
[info] (unit) initializing embox.kernel.sched.sched
[info] (mod) runlevel is 1
[info] (unit) initializing embox.device.char_dev
[info] (unit) initializing embox.fs.buffer_cache
[info] (unit) initializing third_party.net80211.net80211_osal_embox
[info] (unit) initializing embox.driver.pci_chip.pcie_dw
[info] (pcie_dw) pcie0: firmware link inherited (bus 0-1), link Gen2 x1 (max Gen2 x1)
[info] (pcie_dw) pcie1: firmware link inherited (bus 2-3), link Gen1 x1 (max Gen3 x2)
[info] (unit) initializing embox.driver.pci
[info] (unit) initializing embox.driver.interrupt.gicv3_its
[info] (gicv3_its) its: base 0xfd440000 typer 000000130001ef31 pta 0 rd_target 0
[info] (gicv3_its) its: PROPBASER.IDbits 15
[info] (gicv3_its) its: BASER0 devices b9e000000a63451f -> b9e700000a63451f
[info] (gicv3_its) its: BASER1 collections bce000000a630400 -> bce100000a630400
[info] (gicv3_its) its: ready, irq window 208..255, doorbell 0xfd450040
[info] (unit) initializing third_party.net80211.net80211_port_cherryusb
[info] (unit) initializing third_party.net80211.net80211_pcie_bus_embox
[info] (unit) initializing embox.driver.flash.flash_nofs
[info] (unit) initializing embox.driver.net.loopback
[info] (unit) initializing embox.driver.tty.serial
[info] (unit) initializing embox.fs.rootfs_oldfs
[info] (unit) initializing embox.driver.net.rk3568_gmac
[info] (dwc_eqos) 02:e4:a5:35:68:00: mac version 0x3051
[info] (dwc_eqos) 02:e4:a5:35:68:00: mac version after soc init 0x3051
[info] (dwc_eqos) RTL8211F phy 0: id 0x1c:0xc916
[info] (dwc_eqos) RTL8211F phy 0: cleared strapped RGMII TX-delay (d08.0x11 0x109 -> 0x9)
[info] (dwc_eqos) RTL8211F phy 1: id 0x1c:0xc916
[info] (dwc_eqos) eth0 at 0xfe2a0000 irq 59 mac 02:e4:a5:35:68:00
[info] (dwc_eqos) 02:e4:a5:35:68:01: mac version 0x3051
[info] (gicv3_its) its: 03:00.0 got 1 message irq(s)
[info] (dwc_eqos) 02:e4:a5:35:68:01: mac version after soc init 0x3051
[info] (dwc_eqos) RTL8211F phy 0: id 0x1c:0xc916
[info] (dwc_eqos) RTL8211F phy 0: cleared strapped RGMII TX-delay (d08.0x11 0x109 -> 0x9)
[info] (dwc_eqos) RTL8211F phy 1: id 0x1c:0xc916
[info] (dwc_eqos) eth1 at 0xfe010000 irq 64 mac 02:e4:a5:35:68:01
[info] (mod) runlevel is 2
[info] (unit) initializing embox.driver.nvme
[info] (gicv3_its) its: 01:00.0 got 2 message irq(s)
[info] (nvme) nvme: 2 message vector(s), completion irq 209
[info] (nvme) nvme0: 126f:2263 at 0x00000000f4300000, ns1: 500118192 blocks of 512 bytes (244198 MiB)
[info] (mod) runlevel is 3
[W/USB] Do not eDefault IO device[ttyS0]
>tish
root@embox:(null)#iwm0: Ch. 1: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 2: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 3: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 4: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 5: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 6: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 7: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 8: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 9: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 10: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 11: valid +ibss active -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 12: valid -ibss passive -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 13: valid -ibss passive -radar -dfs +wide +40MHz -80MHz -160MHz
iwm0: Ch. 14: invalid -ibss passive -radar -dfs -wide -40MHz -80MHz -160MHz
iwm0: Ch. 36: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 40: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 44: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 48: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 52: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 56: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 60: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 64: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 100: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 104: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 108: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 112: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 116: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 120: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 124: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 128: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 132: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 136: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 140: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 144: valid -ibss passive +radar -dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 149: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 153: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 157: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 161: valid -ibss passive -radar +dfs +wide +40MHz +80MHz -160MHz
iwm0: Ch. 165: valid -ibss passive -radar +dfs +wide -40MHz -80MHz -160MHz
iwm0: hw rev 0x140, fw ver 17.352738.0, address 6c:29:95:12:f0:d9
iwm0: 11a rates: 6Mbps 9Mbps 12Mbps 18Mbps 24Mbps 36Mbps 48Mbps 54Mbps
iwm0: 11b rates: 1Mbps 2Mbps 5.5Mbps 11Mbps
iwm0: 11g rates: 1Mbps 2Mbps 5.5Mbps 11Mbps 6Mbps 9Mbps 12Mbps 18Mbps 24Mbps 36Mbps 48Mbps 54Mbps
wlan: urtwn found at bus 0 addr 3 (hub 2 port 1)


urtwn0: Realtek RTL8188EU, addr 3
urtwn0: MAC/BB RTL8188EU, RF 6052 1T1R, address 20:f4:1b:52:8f:01
urtwn0: 1 rx pipe, 2 tx pipes
urtwn0: 11b rates: 1Mbps 2Mbps 5.5Mbps 11Mbps
urtwn0: 11g rates: 1Mbps 2Mbps 5.5Mbps 11Mbps 6Mbps 9Mbps 12Mbps 18Mbps 24Mbps 36Mbps 48Mbps 54Mbps
[E/usbh_core] Do not support Class:0x08, Subclass:0x06, Protocl:0x50 on interface 0
wlan scan 8 iwm
wlan: calling if_init 0x000000000a047db0 (fw load + power on)...
wlan: if_init done, flags=8843
scanning for 8 s...
scan results:
  00:00:00:00:00:00  ch=5220  rssi=0  ssid=
  a0:99:21:9a:c9:42  ch=2412  rssi=77  ssid=midea_dc_1162
  e2:fd:e2:53:29:58  ch=2412  rssi=50  ssid=QiQiJia
  e2:fd:e2:53:29:5d  ch=2412  rssi=51  ssid=
  e2:fd:e2:53:29:66  ch=2412  rssi=52  ssid=QiQiJia_Wi-Fi5
  54:92:6a:db:4e:60  ch=2412  rssi=74  ssid=midea_dc_0231
  a2:32:48:eb:0c:b6  ch=2412  rssi=79  ssid=007
  f8:2a:53:1a:20:db  ch=2412  rssi=82  ssid=midea_db_0056
  14:a3:2f:18:07:31  ch=2417  rssi=21  ssid=
  14:a3:2f:18:07:2c  ch=2432  rssi=19  ssid=QiQiJia
  38:2f:b0:bd:d8:4e  ch=2412  rssi=79  ssid=midea_db_0058
  7c:7d:21:39:50:1e  ch=2427  rssi=78  ssid=mengmeng
  d4:27:87:56:41:66  ch=2437  rssi=82  ssid=HF-LPB170
  0a:67:61:58:5c:39  ch=2442  rssi=74  ssid=
  0e:67:61:58:5c:39  ch=2442  rssi=75  ssid=
  c4:92:d9:3a:9f:ff  ch=2447  rssi=82  ssid=Wang
  e2:9d:1e:3e:a1:6b  ch=2447  rssi=82  ssid=
  f4:fc:49:64:05:7e  ch=2447  rssi=84  ssid=1004
  2e:15:e1:25:1e:e3  ch=2452  rssi=79  ssid=IoT_2.4G
  e0:9d:1e:d0:cc:9d  ch=2452  rssi=79  ssid=701
  a4:ba:70:ae:de:81  ch=2462  rssi=76  ssid=1102
  f2:a9:51:5b:a4:c8  ch=2462  rssi=78  ssid=802
  c2:1d:76:ee:30:af  ch=2462  rssi=82  ssid=HUAWEI-66
  14:a3:2f:18:07:32  ch=5300  rssi=26  ssid=
  14:a3:2f:f8:07:30  ch=5300  rssi=26  ssid=
  e2:fd:e2:53:29:5c  ch=5220  rssi=69  ssid=QiQiJia
  e2:fd:e2:53:29:5e  ch=5220  rssi=69  ssid=
  e2:fd:e2:53:29:67  ch=5220  rssi=69  ssid=QiQiJia_Wi-Fi5
root@embox:(null)#wpa connect QiQiJia ****** e2:fd:e2:53:29:5c
embox: unsupported key alg 0
embox: unsupported key alg 0
wpa_embox: supplicant running
wlan0: CTRL-EVENT-DSCP-POLICY clear_all
wpa_embox: connecting to "QiQiJia"
wpa: connecting to "QiQiJia"
root@embox:(null)#wlan0: Trying to associate with e2:fd:e2:53:29:5c (SSID='QiQiJia' freq=5220 MHz)
wlan0: Associated with e2:fd:e2:53:29:5c
wlan0: WPA: Key negotiation completed with e2:fd:e2:53:29:5c [PTK=CCMP GTK=CCMP]
wlan0: CTRL-EVENT-CONNECTED - Connection to e2:fd:e2:53:29:5c completed [id=0 id_str=]
bootpc -d wlan0
DHCP OFFER 192.168.0.11
DHCP ACK 192.168.0.11 lease=86400 seconds
root@embox:(null)#ifconfig -a
lo      Link encap:Local Loopback
        inet addr:0.0.0.0  Mask:0.0.0.0
        inet6 addr: ::/??  Scope:Host
        LOOPBACK RUNNING  MTU:16436  Metric:0
        RX packets:0 errors:0 dropped:0 overruns:0 frame:0
        TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:0 (0 MiB)  TX bytes:0 (0 MiB)

eth0    Link encap:Ethernet  HWaddr 02:e4:a5:35:68:00
        inet addr:0.0.0.0  Bcast:0.0.0.0  Mask:0.0.0.0
        inet6 addr: ::/??  Scope:Host
        BROADCAST MULTICAST  MTU:1514  Metric:0
        RX packets:0 errors:0 dropped:0 overruns:0 frame:0
        TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:0 (0 MiB)  TX bytes:0 (0 MiB)
        Interrupt:0 Base address:0x0000000000000000

eth1    Link encap:Ethernet  HWaddr 02:e4:a5:35:68:01
        inet addr:0.0.0.0  Bcast:0.0.0.0  Mask:0.0.0.0
        inet6 addr: ::/??  Scope:Host
        BROADCAST MULTICAST  MTU:1514  Metric:0
        RX packets:0 errors:0 dropped:0 overruns:0 frame:0
        TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:0 (0 MiB)  TX bytes:0 (0 MiB)
        Interrupt:0 Base address:0x0000000000000000

wlan0   Link encap:Ethernet  HWaddr 6c:29:95:12:f0:d9
        inet addr:192.168.0.11  Bcast:192.168.0.255  Mask:255.255.255.0
        inet6 addr: ::/??  Scope:Host
        UP BROADCAST RUNNING  MTU:1500  Metric:0
        RX packets:226 errors:0 dropped:0 overruns:0 frame:0
        TX packets:2 errors:0 dropped:0 overruns:0 carrier:0
        collisions:0
        RX bytes:89521 (0 MiB)  TX bytes:684 (0 MiB)
        Interrupt:0 Base address:0x0000000000000000

root@embox:(null)#route
Destination     Gateway         Genmask         Flags  Iface
192.168.0.0     *               255.255.255.0   U      wlan0
default         192.168.0.1     0.0.0.0         UG     wlan0
root@embox:(null)#ping -c 20 192.168.0.18
PING 192.168.0.18 (192.168.0.18) 64 bytes of data
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=1 ttl=128 time=12 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=2 ttl=128 time=8 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=3 ttl=128 time=12 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=4 ttl=128 time=12 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=5 ttl=128 time=15 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=6 ttl=128 time=15 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=7 ttl=128 time=14 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=9 ttl=128 time=15 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=10 ttl=128 time=14 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=11 ttl=128 time=17 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=12 ttl=128 time=15 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=13 ttl=128 time=14 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=15 ttl=128 time=13 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=17 ttl=128 time=12 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=18 ttl=128 time=14 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=19 ttl=128 time=14 ms
84 bytes from 192.168.0.18 (192.168.0.18): icmp_seq=20 ttl=128 time=11 ms
--- 192.168.0.18 ping statistics ---
20 packets transmitted, 17 received, +0 errors, 15% packet loss, time 20715ms
ping: Command returned with code 3: Unknown error code
```