### PR TITLE
add rk3568 ahci support with fio tester

### DIFF
--- a/platform/rockchip/rk3568/mods.conf
+++ b/platform/rockchip/rk3568/mods.conf
@@ -160,6 +160,11 @@ configuration conf {
 	include embox.cmd.fs.pwd
 	include embox.cmd.fs.ls
 	include embox.cmd.fs.echo
+	include embox.cmd.fs.dd
+
+	/* fio, the block I/O benchmark (third-party/fio), built against the
+	 * kernel through the embox compiler wrappers. */
+	include third_party.cmd.fio
 
 	include embox.cmd.testing.ticker
 	include embox.cmd.testing.its_test

--- a/platform/rockchip/rk3568/mods.conf
+++ b/platform/rockchip/rk3568/mods.conf
@@ -48,6 +48,13 @@ configuration conf {
 	include embox.driver.pci_msi
 	@Runlevel(3) include embox.driver.nvme(msi_mode=true)
 
+	/* SATA: the two on-chip DWC AHCI controllers, one port each (the
+	 * vertical socket on sata0, the M.2 2280 slot on sata1). Their
+	 * combo PHYs and links are brought up by the U-Boot preboot
+	 * (`scsi scan`), so the driver only takes over the command engines
+	 * of the trained links and never reprograms the PHY. */
+	@Runlevel(3) include embox.driver.ahci.dwc_ahci
+
 	/* Network: the stock Embox stack over both GMAC ports. gmac0
 	 * @0xFE2A0000 enumerates as eth0 (MAC 02:e4:a5:35:68:00, the
 	 * U-Boot ethaddr contract, IRQ 59 = SPI 27 + 32) and gmac1

--- a/src/drivers/ahci/Mybuild
+++ b/src/drivers/ahci/Mybuild
@@ -12,3 +12,25 @@ module ti8168 {
 	source "ti8168.c"
 	depends embox.driver.ahci.core
 }
+
+/* DesignWare AHCI controller, polled command path (RK3568 on-chip SATA
+ * and other SoCs carrying a DWC AHCI host). Takes over the command
+ * engine of a link the firmware already trained. */
+module dwc_ahci {
+	option string log_level="LOG_INFO"
+
+	option number base_addr = 0xFC000000
+	option number stride = 0x400000
+	option number ctrl_quantity = 2
+	option number port_quantity = 1
+	/* Block layer block size of the device nodes: the readers get one
+	 * block per request from the /dev idesc path. */
+	option number block_size = 4096
+
+	source "dwc_ahci.c"
+
+	depends embox.driver.block_dev
+
+	@NoRuntime depends embox.driver.periph_memory
+	@NoRuntime depends embox.arch.mem_barriers
+}

--- a/src/drivers/ahci/dwc_ahci.c
+++ b/src/drivers/ahci/dwc_ahci.c
@@ -1,0 +1,621 @@
+/**
+ * @file
+ * @brief DesignWare AHCI block driver for the RK3568 on-chip SATA ports.
+ *
+ * The RK3568 exposes up to three SATA controllers, each an AHCI 1.3 HBA
+ * with one implemented port behind its own combo PHY. The PHY and the
+ * link are left to the firmware: the board U-Boot scans the SCSI bus
+ * before it loads the OS, which powers the combo PHYs and locks their
+ * PLLs, while a cold PHY bring-up from software was measured to fail on
+ * this board. The driver therefore takes over the command engine of an
+ * already trained link and never touches the PHY, the CRU or the PMU.
+ *
+ * A port comes under control by stopping its engine, pointing it at this
+ * driver's static command list and received-FIS area, and starting it
+ * again. Commands run one at a time through slot 0 in polled mode:
+ * IDENTIFY DEVICE to learn the geometry, then READ/WRITE DMA EXT for the
+ * data path. Every transfer is staged through a 4 KiB aligned bounce
+ * buffer, which also keeps the DMA off caller buffers of any alignment.
+ *
+ * DMA coherency is maintained by hand: the kernel is identity mapped and
+ * the HBA fetches the command structures and writes data over a
+ * non-coherent path, so the driver flushes the dcache before the device
+ * may read memory and invalidates it before reading data the device
+ * wrote.
+ *
+ * @author zhugengyu
+ * @date 2026-09-11
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <drivers/block_dev.h>
+#include <drivers/common/memory.h>
+#include <embox/unit.h>
+#include <framework/mod/options.h>
+#include <hal/cache.h>
+#include <hal/mem_barriers.h>
+#include <hal/reg.h>
+#include <util/log.h>
+
+#define AHCI_BASE_ADDR     OPTION_GET(NUMBER, base_addr)
+#define AHCI_CTRL_STRIDE   OPTION_GET(NUMBER, stride)
+#define AHCI_CTRL_QUANTITY OPTION_GET(NUMBER, ctrl_quantity)
+#define AHCI_PORT_QUANTITY OPTION_GET(NUMBER, port_quantity)
+#define AHCI_BLOCK_SIZE    OPTION_GET(NUMBER, block_size)
+
+/* The identity mapped device window holding the HBA register blocks. */
+PERIPH_MEMORY_DEFINE(ahci_mmio, AHCI_BASE_ADDR,
+    AHCI_CTRL_STRIDE * AHCI_CTRL_QUANTITY);
+
+/* HBA memory registers (AHCI 1.3.1) */
+#define HBA_CAP 0x00
+#define HBA_PI  0x0c
+#define HBA_VS  0x10
+
+/* Port register block: HBA base + 0x100 + port * 0x80 */
+#define PORT_REG_BASE   0x100
+#define PORT_REG_STRIDE 0x80
+
+#define PX_CLB  0x00
+#define PX_CLBU 0x04
+#define PX_FB   0x08
+#define PX_FBU  0x0c
+#define PX_IS   0x10
+#define PX_CMD  0x18
+#define PX_TFD  0x20
+#define PX_SIG  0x24
+#define PX_SSTS 0x28
+#define PX_SERR 0x30
+#define PX_CI   0x38
+
+#define PXCMD_ST   (1u << 0)
+#define PXCMD_SUD  (1u << 1)
+#define PXCMD_POD  (1u << 2)
+#define PXCMD_FRE  (1u << 4)
+#define PXCMD_FR   (1u << 14)
+#define PXCMD_CR   (1u << 15)
+#define PXCMD_ICC_MASK   (0xfu << 28)
+#define PXCMD_ICC_ACTIVE (1u << 28)
+
+#define PXIS_TFES (1u << 30)
+
+#define PXTFD_ERR (1u << 0)
+#define PXTFD_DRQ (1u << 3)
+#define PXTFD_BSY (1u << 7)
+
+#define SSTS_DET_MASK   0xf
+#define SSTS_DET_PHYRDY 3
+
+#define PXSIG_ATA 0x0101
+
+/* ATA commands and registers (ACS) */
+#define ATA_CMD_IDENTIFY      0xec
+#define ATA_CMD_READ_DMA_EXT  0x25
+#define ATA_CMD_WRITE_DMA_EXT 0x35
+
+#define ATA_DEV_LBA 0x40
+
+#define FIS_TYPE_H2D 0x27
+
+#define AHCI_SECTOR_SIZE 512
+
+/* Private command: report the medium size in bytes.  The block layer's
+ * own size ioctl answers with an int, which a medium larger than 2 GiB
+ * does not fit, so a reader that needs the real number asks for it here
+ * (the Embox port of fio does, see third-party/fio/tree/os/os-embox.h). */
+#define AHCI_IOCTL_GET_SIZE_BYTES 0x41484349
+
+/* The command list is allocated for all 32 slots even though only slot 0
+ * is used: the HBA requires the list to be 1 KiB aligned. */
+#define AHCI_CLB_SIZE       (32 * 32)
+#define AHCI_FB_SIZE        256
+#define AHCI_CMD_TABLE_SIZE 256
+#define AHCI_IDENT_SIZE     AHCI_SECTOR_SIZE
+
+/* The command table holds the command FIS first and the PRD table at
+ * offset 0x80 (AHCI 1.3.1). */
+#define AHCI_CMD_TABLE_PRDT 0x80
+
+/* One PRD entry describes the whole payload of a command. */
+#define AHCI_CHUNK_SIZE 0x10000
+
+/* Bounded busy waits, the pattern the other on-board drivers use: a port
+ * that does not answer must report instead of hanging the boot. The
+ * command budget covers the worst case where the attached SSD stalls to
+ * reclaim flash. */
+#define AHCI_REG_TRIES 100000u
+#define AHCI_CMD_TRIES 20000000u
+
+struct ahci_port {
+	uintptr_t regs;        /* port register block */
+	uint64_t nblocks;      /* device size in logical sectors */
+	uint32_t sector_size;  /* logical sector size, the ATA address unit */
+	uint32_t block_size;   /* block layer block size of the device node */
+	uint8_t *clb;
+	uint8_t *fb;
+	uint8_t *cmdtab;
+	uint8_t *xfer;
+	struct block_dev *bdev;
+};
+
+struct ahci_ctrl {
+	uintptr_t mmio;
+	struct ahci_port ports[AHCI_PORT_QUANTITY];
+};
+
+static struct ahci_ctrl ahci_ctrls[AHCI_CTRL_QUANTITY];
+
+/* DMA areas: the list and the received-FIS area must be aligned to their
+ * own size, and the bounce buffers are page aligned so a transfer never
+ * shares a cache line with another structure. */
+static uint8_t ahci_clb[AHCI_CTRL_QUANTITY][AHCI_PORT_QUANTITY][AHCI_CLB_SIZE]
+    __attribute__((aligned(1024)));
+static uint8_t ahci_fb[AHCI_CTRL_QUANTITY][AHCI_PORT_QUANTITY][AHCI_FB_SIZE]
+    __attribute__((aligned(256)));
+static uint8_t ahci_cmdtab[AHCI_CTRL_QUANTITY][AHCI_PORT_QUANTITY]
+                           [AHCI_CMD_TABLE_SIZE]
+    __attribute__((aligned(256)));
+static uint8_t ahci_xfer[AHCI_CTRL_QUANTITY][AHCI_PORT_QUANTITY]
+                         [AHCI_CHUNK_SIZE]
+    __attribute__((aligned(4096)));
+static uint8_t ahci_ident[AHCI_IDENT_SIZE] __attribute__((aligned(4096)));
+
+/* The kernel runs identity mapped and the HBA has a 32-bit address
+ * space, so a DMA address is the virtual address itself. */
+static uint32_t ahci_dma_addr(const void *va) {
+	return (uint32_t)(uintptr_t)va;
+}
+
+static inline uintptr_t ahci_port_reg(const struct ahci_port *ap, uint32_t off) {
+	return ap->regs + off;
+}
+
+/* PxIS and PxSERR are write-1-to-clear. */
+static void ahci_port_clear_irq(struct ahci_port *ap) {
+	REG32_STORE(ahci_port_reg(ap, PX_IS), ~0u);
+	REG32_STORE(ahci_port_reg(ap, PX_SERR), ~0u);
+}
+
+/* Quiesce the command engine and wait until the HBA acknowledges with
+ * CR and FR clear. */
+static void ahci_port_stop(struct ahci_port *ap) {
+	uint32_t cmd;
+	uint32_t tries;
+
+	cmd = REG32_LOAD(ahci_port_reg(ap, PX_CMD));
+	REG32_STORE(ahci_port_reg(ap, PX_CMD), cmd & ~(PXCMD_ST | PXCMD_FRE));
+
+	for (tries = 0; tries < AHCI_REG_TRIES; tries++) {
+		cmd = REG32_LOAD(ahci_port_reg(ap, PX_CMD));
+		if ((cmd & (PXCMD_FR | PXCMD_CR)) == 0) {
+			return;
+		}
+	}
+
+	log_error("ahci: port engine did not stop (PxCMD 0x%08x)",
+	    REG32_LOAD(ahci_port_reg(ap, PX_CMD)));
+}
+
+/* Point the engine at this driver's structures and start it. The power
+ * and spin-up bits keep the values the firmware gave them, so the
+ * command register is updated, not overwritten. */
+static void ahci_port_start(struct ahci_port *ap) {
+	uint32_t cmd;
+	uint32_t tries;
+
+	ahci_port_stop(ap);
+	ahci_port_clear_irq(ap);
+
+	REG32_STORE(ahci_port_reg(ap, PX_CLB), ahci_dma_addr(ap->clb));
+	REG32_STORE(ahci_port_reg(ap, PX_CLBU), 0);
+	REG32_STORE(ahci_port_reg(ap, PX_FB), ahci_dma_addr(ap->fb));
+	REG32_STORE(ahci_port_reg(ap, PX_FBU), 0);
+
+	cmd = REG32_LOAD(ahci_port_reg(ap, PX_CMD));
+	cmd = (cmd & ~PXCMD_ICC_MASK) | PXCMD_ICC_ACTIVE | PXCMD_POD | PXCMD_SUD
+	    | PXCMD_FRE | PXCMD_ST;
+	REG32_STORE(ahci_port_reg(ap, PX_CMD), cmd);
+	dsb(st);
+
+	/* Let the engine pick up the list and FIS pointers before the first
+	 * command is posted. */
+	for (tries = 0; tries < AHCI_REG_TRIES; tries++) {
+		if (REG32_LOAD(ahci_port_reg(ap, PX_CMD)) & PXCMD_CR) {
+			return;
+		}
+	}
+
+	log_error("ahci: port engine did not start (PxCMD 0x%08x)",
+	    REG32_LOAD(ahci_port_reg(ap, PX_CMD)));
+}
+
+/* The device must have finished the previous command before the next one
+ * is posted into the slot. */
+static int ahci_port_ready(struct ahci_port *ap) {
+	uint32_t tries;
+
+	for (tries = 0; tries < AHCI_REG_TRIES; tries++) {
+		uint32_t tfd = REG32_LOAD(ahci_port_reg(ap, PX_TFD));
+
+		if ((tfd & (PXTFD_BSY | PXTFD_DRQ)) == 0
+		    && (REG32_LOAD(ahci_port_reg(ap, PX_CI)) & 1u) == 0) {
+			return 0;
+		}
+	}
+
+	log_error("ahci: port busy before command (PxTFD 0x%08x PxCI 0x%08x)",
+	    REG32_LOAD(ahci_port_reg(ap, PX_TFD)),
+	    REG32_LOAD(ahci_port_reg(ap, PX_CI)));
+	return -EBUSY;
+}
+
+/*
+ * Run one ATA command through slot 0:
+ *   ata_cmd   ATA command code
+ *   dev_reg   device register value (ATA_DEV_LBA for the 48-bit LBA ops)
+ *   is_write  1: host-to-device DMA, 0: device-to-host DMA
+ *   buf       data buffer, len bytes, at most AHCI_CHUNK_SIZE
+ *   len       payload size in bytes
+ *   nsect     ATA sector count field (in device sectors)
+ *   lba       starting 48-bit LBA
+ */
+static int ahci_port_command(struct ahci_port *ap, uint8_t ata_cmd,
+    uint8_t dev_reg, int is_write, void *buf, size_t len, uint16_t nsect,
+    uint64_t lba) {
+	uint8_t *fis = ap->cmdtab;
+	uint32_t *prdt = (uint32_t *)(ap->cmdtab + AHCI_CMD_TABLE_PRDT);
+	uint32_t *cl = (uint32_t *)ap->clb;
+	uintptr_t pxci = ahci_port_reg(ap, PX_CI);
+	uintptr_t pxis = ahci_port_reg(ap, PX_IS);
+	uint32_t tries;
+	int ret;
+
+	if (ahci_port_ready(ap) != 0) {
+		return -EBUSY;
+	}
+
+	memset(ap->cmdtab, 0, AHCI_CMD_TABLE_SIZE);
+
+	/* Host-to-device register FIS (type 0x27); the C bit makes the
+	 * device latch the command register. */
+	fis[0] = FIS_TYPE_H2D;
+	fis[1] = 1 << 7;
+	fis[2] = ata_cmd;
+	fis[4] = (uint8_t)lba;
+	fis[5] = (uint8_t)(lba >> 8);
+	fis[6] = (uint8_t)(lba >> 16);
+	fis[7] = dev_reg;
+	fis[8] = (uint8_t)(lba >> 24);
+	fis[9] = (uint8_t)(lba >> 32);
+	fis[10] = (uint8_t)(lba >> 40);
+	fis[12] = (uint8_t)nsect;
+	fis[13] = (uint8_t)(nsect >> 8);
+
+	/* One PRD covering the whole payload: DBC holds the byte count
+	 * minus one in bits 21:0, bit 31 asks for an interrupt on
+	 * completion (the interrupt itself stays masked at the HBA). */
+	prdt[0] = ahci_dma_addr(buf);
+	prdt[1] = 0;
+	prdt[2] = 0;
+	prdt[3] = ((uint32_t)len - 1) | (1u << 31);
+
+	/* Command header: 5-dword command FIS, one PRD, and the W bit
+	 * selects the direction of a DMA command. */
+	cl[0] = 5 | (1u << 16) | (is_write ? (1u << 6) : 0);
+	cl[1] = 0;
+	cl[2] = ahci_dma_addr(ap->cmdtab);
+	cl[3] = 0;
+
+	dcache_flush(ap->cmdtab, AHCI_CMD_TABLE_SIZE);
+	dcache_flush(ap->clb, AHCI_CLB_SIZE);
+	if (is_write) {
+		dcache_flush(buf, len);
+	}
+	else {
+		/* The device owns the buffer until the command completes:
+		 * drop the stale lines before it DMAs and take them out
+		 * again before the data is read. */
+		dcache_inval(buf, len);
+	}
+	dsb(st);
+
+	ahci_port_clear_irq(ap);
+
+	/* Issue slot 0 and wait for the HBA to release it. */
+	REG32_STORE(pxci, 1u);
+	for (tries = 0; tries < AHCI_CMD_TRIES; tries++) {
+		if ((REG32_LOAD(pxci) & 1u) == 0) {
+			break;
+		}
+		if (REG32_LOAD(pxis) & PXIS_TFES) {
+			break;
+		}
+	}
+
+	dsb(st);
+
+	if (REG32_LOAD(pxis) & PXIS_TFES) {
+		log_error("ahci: command %#x failed (PxTFD 0x%08x PxSERR 0x%08x)",
+		    ata_cmd, REG32_LOAD(ahci_port_reg(ap, PX_TFD)),
+		    REG32_LOAD(ahci_port_reg(ap, PX_SERR)));
+		ret = -EIO;
+	}
+	else if (tries == AHCI_CMD_TRIES) {
+		log_error("ahci: command %#x timed out (PxCI 0x%08x PxTFD 0x%08x)",
+		    ata_cmd, REG32_LOAD(pxci), REG32_LOAD(ahci_port_reg(ap, PX_TFD)));
+		ret = -ETIMEDOUT;
+	}
+	else if (REG32_LOAD(ahci_port_reg(ap, PX_TFD)) & PXTFD_ERR) {
+		log_error("ahci: command %#x error (PxTFD 0x%08x PxSERR 0x%08x)",
+		    ata_cmd, REG32_LOAD(ahci_port_reg(ap, PX_TFD)),
+		    REG32_LOAD(ahci_port_reg(ap, PX_SERR)));
+		ret = -EIO;
+	}
+	else {
+		ret = 0;
+	}
+
+	ahci_port_clear_irq(ap);
+
+	if (ret == 0 && !is_write) {
+		dcache_inval(buf, len);
+	}
+
+	return ret;
+}
+
+/* Issue IDENTIFY DEVICE and parse the geometry out of the response. */
+static int ahci_port_identify(struct ahci_port *ap) {
+	const uint16_t *w = (const uint16_t *)ahci_ident;
+	uint64_t nblocks;
+	uint32_t blk_size;
+	uint32_t sig;
+	int ret;
+
+	/* A non-ATA signature means an ATAPI device or a port multiplier.
+	 * Zero just means the HBA has not latched one, in which case the
+	 * IDENTIFY below is the better probe. */
+	sig = REG32_LOAD(ahci_port_reg(ap, PX_SIG)) & 0xffff;
+	if (sig != 0 && sig != PXSIG_ATA) {
+		log_error("ahci: port signature 0x%08x is not an ATA device", sig);
+		return -ENODEV;
+	}
+
+	ret = ahci_port_command(ap, ATA_CMD_IDENTIFY, 0, 0, ahci_ident,
+	    AHCI_IDENT_SIZE, 1, 0);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Prefer the 48-bit LBA count, fall back to the 28-bit one. */
+	nblocks = 0;
+	if ((w[83] & (1u << 10)) && (w[86] & (1u << 10))) {
+		nblocks = (uint64_t)w[100] | ((uint64_t)w[101] << 16)
+		    | ((uint64_t)w[102] << 32) | ((uint64_t)w[103] << 48);
+	}
+	if (nblocks == 0) {
+		nblocks = (uint64_t)w[60] | ((uint64_t)w[61] << 16);
+	}
+	if (nblocks == 0) {
+		log_error("ahci: device reports a zero sector count");
+		return -ENODEV;
+	}
+
+	/* 512 bytes per sector by default; words 117/118 carry the size
+	 * when word 106 reports a larger logical sector. */
+	blk_size = AHCI_SECTOR_SIZE;
+	if (w[106] & (1u << 12)) {
+		blk_size = (uint32_t)w[117] | ((uint32_t)w[118] << 16);
+	}
+
+	ap->nblocks = nblocks;
+	ap->sector_size = blk_size;
+
+	return 0;
+}
+
+/* One READ/WRITE DMA EXT command, at most AHCI_CHUNK_SIZE bytes. */
+static int ahci_transfer(struct ahci_port *ap, int is_write, void *buf,
+    size_t len, uint64_t lba) {
+	uint16_t nsect;
+
+	if (len == 0 || len > AHCI_CHUNK_SIZE || (len % ap->sector_size) != 0) {
+		return -EINVAL;
+	}
+	nsect = (uint16_t)(len / ap->sector_size);
+
+	return ahci_port_command(ap,
+	    is_write ? ATA_CMD_WRITE_DMA_EXT : ATA_CMD_READ_DMA_EXT, ATA_DEV_LBA,
+	    is_write, buf, len, nsect, lba);
+}
+
+/* The block layer hands each request over one block at a time: blkno is
+ * the block number in units of the device node's block size and count the
+ * byte count, which may span many sectors -- split it into per-command
+ * chunks. */
+static int ahci_bdev_read(struct block_dev *bdev, char *buffer, size_t count,
+    blkno_t blkno) {
+	struct ahci_port *ap = block_dev_priv(bdev);
+	size_t done = 0;
+
+	while (done < count) {
+		size_t chunk = count - done;
+		int ret;
+
+		if (chunk > AHCI_CHUNK_SIZE) {
+			chunk = AHCI_CHUNK_SIZE;
+		}
+
+		ret = ahci_transfer(ap, 0, ap->xfer, chunk,
+		    (uint64_t)blkno * (ap->block_size / ap->sector_size)
+		        + done / ap->sector_size);
+		if (ret != 0) {
+			return ret;
+		}
+		memcpy(buffer + done, ap->xfer, chunk);
+		done += chunk;
+	}
+
+	return (int)done;
+}
+
+static int ahci_bdev_write(struct block_dev *bdev, char *buffer, size_t count,
+    blkno_t blkno) {
+	struct ahci_port *ap = block_dev_priv(bdev);
+	size_t done = 0;
+
+	while (done < count) {
+		size_t chunk = count - done;
+		int ret;
+
+		if (chunk > AHCI_CHUNK_SIZE) {
+			chunk = AHCI_CHUNK_SIZE;
+		}
+
+		memcpy(ap->xfer, buffer + done, chunk);
+		ret = ahci_transfer(ap, 1, ap->xfer, chunk,
+		    (uint64_t)blkno * (ap->block_size / ap->sector_size)
+		        + done / ap->sector_size);
+		if (ret != 0) {
+			return ret;
+		}
+		done += chunk;
+	}
+
+	return (int)done;
+}
+
+static int ahci_bdev_ioctl(struct block_dev *bdev, int cmd, void *args,
+    size_t size) {
+	struct ahci_port *ap = block_dev_priv(bdev);
+
+	switch (cmd) {
+	case IOCTL_GETBLKSIZE:
+		return ap->block_size;
+	case IOCTL_GETDEVSIZE:
+		/* The block layer answers this one for a whole device, and
+		 * its int-sized answer is why the byte size has a command
+		 * of its own below.  Report the blocks after all. */
+		return ap->nblocks / (ap->block_size / ap->sector_size);
+	case AHCI_IOCTL_GET_SIZE_BYTES:
+		if (args == NULL) {
+			return -EINVAL;
+		}
+		*(uint64_t *)args = ap->nblocks * ap->sector_size;
+		return 0;
+	default:
+		return -ENOSYS;
+	}
+}
+
+static const struct block_dev_ops ahci_bdev_ops = {
+    .bdo_ioctl = ahci_bdev_ioctl,
+    .bdo_read = ahci_bdev_read,
+    .bdo_write = ahci_bdev_write,
+};
+
+static int ahci_ctrl_probe(struct ahci_ctrl *c, uintptr_t base, int ctrl_idx) {
+	static int bdev_idx;
+	uint32_t cap;
+	uint32_t pi;
+	uint32_t vs;
+	uint32_t port;
+
+	c->mmio = base;
+
+	cap = REG32_LOAD(base + HBA_CAP);
+	vs = REG32_LOAD(base + HBA_VS);
+	pi = REG32_LOAD(base + HBA_PI);
+
+	log_info("ahci%d: HBA at %p, version %u.%u%u, %u slot(s), ports 0x%x",
+	    ctrl_idx, (void *)base, (vs >> 16) & 0xffff, (vs >> 8) & 0xff, vs & 0xff,
+	    ((cap >> 8) & 0x1f) + 1, pi);
+
+	for (port = 0; port < AHCI_PORT_QUANTITY; port++) {
+		struct ahci_port *ap = &c->ports[port];
+		uint32_t ssts;
+		char name[16];
+
+		if ((pi & (1u << port)) == 0) {
+			continue;
+		}
+
+		ap->regs = base + PORT_REG_BASE + port * PORT_REG_STRIDE;
+
+		/* The link is the firmware's work. A port whose link never
+		 * trained (an unwired controller, no device attached) is
+		 * left alone. */
+		ssts = REG32_LOAD(ahci_port_reg(ap, PX_SSTS));
+		if ((ssts & SSTS_DET_MASK) != SSTS_DET_PHYRDY) {
+			log_info("ahci%d: port %u link down (SSTS 0x%08x), skipping",
+			    ctrl_idx, port, ssts);
+			continue;
+		}
+
+		ap->clb = ahci_clb[ctrl_idx][port];
+		ap->fb = ahci_fb[ctrl_idx][port];
+		ap->cmdtab = ahci_cmdtab[ctrl_idx][port];
+		ap->xfer = ahci_xfer[ctrl_idx][port];
+		memset(ap->clb, 0, AHCI_CLB_SIZE);
+		memset(ap->fb, 0, AHCI_FB_SIZE);
+		memset(ap->cmdtab, 0, AHCI_CMD_TABLE_SIZE);
+
+		ahci_port_start(ap);
+
+		if (ahci_port_identify(ap) != 0) {
+			log_info("ahci%d: port %u has no usable ATA device, skipping",
+			    ctrl_idx, port);
+			continue;
+		}
+
+		snprintf(name, sizeof(name), "/dev/ahci%d", bdev_idx);
+		ap->bdev = block_dev_create(name, &ahci_bdev_ops, ap);
+		if (ap->bdev == NULL) {
+			log_error("ahci%d: block_dev_create failed for %s", ctrl_idx,
+			    name);
+			continue;
+		}
+		/* The block layer's block size is a whole number of the
+		 * device's logical sectors: the /dev idesc path serves one
+		 * block per request and splits anything else, so the block
+		 * size is the transfer granularity the readers get. */
+		ap->block_size = AHCI_BLOCK_SIZE;
+		if (ap->block_size < ap->sector_size
+		    || (ap->block_size % ap->sector_size) != 0) {
+			log_error("ahci%d: block size %u is not a multiple of %u,"
+			          " using the sector size",
+			    ctrl_idx, ap->block_size, ap->sector_size);
+			ap->block_size = ap->sector_size;
+		}
+
+		block_dev_set_block_size(ap->bdev, ap->block_size);
+		ap->bdev->size = ap->nblocks * ap->sector_size;
+
+		log_info("ahci%d: %s, %llu sectors of %u bytes, %u-byte blocks"
+		         " (%llu MiB)",
+		    bdev_idx, name, (unsigned long long)ap->nblocks, ap->sector_size,
+		    ap->block_size,
+		    (unsigned long long)(ap->nblocks * ap->sector_size >> 20));
+		bdev_idx++;
+	}
+
+	return 0;
+}
+
+static int ahci_init(void) {
+	int ctrl_idx;
+
+	for (ctrl_idx = 0; ctrl_idx < AHCI_CTRL_QUANTITY; ctrl_idx++) {
+		ahci_ctrl_probe(&ahci_ctrls[ctrl_idx],
+		    AHCI_BASE_ADDR + (uintptr_t)ctrl_idx * AHCI_CTRL_STRIDE,
+		    ctrl_idx);
+	}
+
+	return 0;
+}
+
+EMBOX_UNIT_INIT(ahci_init);

--- a/third-party/fio/Makefile
+++ b/third-party/fio/Makefile
@@ -1,0 +1,33 @@
+# fio (Flexible I/O tester) fetched from its own repository and cross
+# built with the embox compiler wrappers.
+#
+# The port itself lives in tree/ (os/os-embox.h) and in fio-embox.patch
+# (the OS selection in os/os.h and configure, and the link flags for the
+# Embox target).  The configure probes run through the embox-gcc wrapper,
+# so they see the kernel's headers instead of the host's and leave out
+# every feature the kernel does not have.
+
+PKG_NAME := fio
+PKG_VER := e333e45bd1e7503388d71932af047ecfd22c25da
+PKG_SOURCES := https://github.com/axboe/fio.git
+PKG_PATCHES := fio-embox.patch
+
+$(CONFIGURE) :
+	export EMBOX_GCC_LINK=full; \
+	cd $(PKG_SOURCE_DIR) && ( \
+		./configure \
+			--cc=$(EMBOX_CC) \
+			--disable-shm \
+			--disable-tcmalloc \
+	)
+	touch $@
+
+$(BUILD) :
+	cd $(PKG_SOURCE_DIR) && ( \
+		$(MAKE) fio MAKEFLAGS='$(EMBOX_IMPORTED_MAKEFLAGS)' \
+	)
+	touch $@
+
+$(INSTALL) :
+	cp $(PKG_SOURCE_DIR)/fio $(PKG_INSTALL_DIR)/fio.o
+	touch $@

--- a/third-party/fio/Mybuild
+++ b/third-party/fio/Mybuild
@@ -1,0 +1,37 @@
+package third_party.cmd
+
+@App
+@AutoCmd
+@Build(stage=2,script="$(EXTERNAL_MAKE)")
+@Cmd(name = "fio",
+	help = "Flexible I/O tester",
+	man = '''
+		NAME
+			fio - flexible I/O tester
+
+		SYNOPSIS
+			fio [options] [jobfile ...]
+
+		DESCRIPTION
+			fio spawns a number of threads or processes doing a
+			particular type of I/O action as given by the options
+			and reports the result.  A raw block device is named
+			through its /dev entry and is sized by the port.
+	''')
+module fio {
+	source "^BUILD/extbld/^MOD_PATH/install/fio.o"
+
+	@NoRuntime depends embox.compat.posix.LibPosix
+	@NoRuntime depends embox.compat.posix.stubs
+	@NoRuntime depends embox.compat.posix.unistd.fork
+	@NoRuntime depends embox.compat.posix.sys.resource
+	@NoRuntime depends embox.compat.posix.sys.ipc
+	@NoRuntime depends embox.compat.posix.sys.shm
+	@NoRuntime depends embox.compat.posix.pthread.pthread_stack
+	@NoRuntime depends embox.compat.posix.pthread_rwlock
+	@NoRuntime depends embox.compat.posix.sys.mman.mmap
+	@NoRuntime depends embox.compat.posix.util.sleep
+	@NoRuntime depends embox.compat.posix.time.nanosleep
+	@NoRuntime depends embox.compat.posix.unistd.getopt
+	@NoRuntime depends embox.compat.libc.stdio.getline
+}

--- a/third-party/fio/fio-embox.patch
+++ b/third-party/fio/fio-embox.patch
@@ -1,0 +1,396 @@
+--- fio/os/os.h	2026-09-05 15:36:08.854240236 +0800
++++ fio/os/os.h	2026-09-11 15:39:04.184683059 +0800
+@@ -25,6 +25,7 @@
+ 	os_android,
+ 	os_dragonfly,
+ 	os_qnx,
++	os_embox,
+ 
+ 	os_nr,
+ };
+@@ -34,7 +35,9 @@
+ } cpu_features;
+ 
+ /* IWYU pragma: begin_exports */
+-#if defined(__linux__)
++#if defined(__EMBOX__)
++#include "os-embox.h"
++#elif defined(__linux__)
+ #include "os-linux.h"
+ #elif defined(__FreeBSD__)
+ #include "os-freebsd.h"
+--- fio/configure	2026-09-05 15:36:08.764287072 +0800
++++ fio/configure	2026-09-11 21:51:19.291280383 +0800
+@@ -364,7 +364,9 @@
+   cc="${CC-${cross_prefix}gcc}"
+ fi
+ 
+-if check_define __ANDROID__ ; then
++if check_define __EMBOX__ ; then
++  targetos='Embox'
++elif check_define __ANDROID__ ; then
+   targetos="Android"
+ elif check_define __linux__ ; then
+   targetos="Linux"
+@@ -660,7 +662,10 @@
+   return 0;
+ }
+ EOF
+-if ! compile_prog "" "" "C11 atomics"; then
++# The Embox port expresses the operations it needs with the compiler's
++# builtins (os/os-embox.h): the kernel's <stdatomic.h> has the types but
++# not the generic functions, so this probe cannot pass there.
++if test "$targetos" != "Embox" && ! compile_prog "" "" "C11 atomics"; then
+   echo
+   echo "Your compiler doesn't support C11 atomics. gcc 4.9/clang 3.6 are the"
+   echo "minimum versions with it - perhaps your compiler is too old?"
+--- fio/Makefile	2026-09-05 15:36:08.756286964 +0800
++++ fio/Makefile	2026-09-11 15:44:00.541348321 +0800
+@@ -263,6 +263,13 @@
+   LIBS	 += -lpthread -lrt
+   LDFLAGS += -rdynamic
+ endif
++ifeq ($(CONFIG_TARGET_OS), Embox)
++  # Embox links through the embox-gcc wrapper, which drops -l/-pthread/
++  # -rdynamic and appends the kernel image: no OS libraries to name.
++  # The net and exec engines want a socket/fork toolchain the kernel does
++  # not have.
++  SOURCE := $(filter-out engines/net.c engines/exec.c, $(SOURCE))
++endif
+ ifeq ($(CONFIG_TARGET_OS), DragonFly)
+   SOURCE += trim.c
+   LIBS	 += -lpthread -lrt
+--- fio/ioengines.c	2026-09-05 15:36:08.840288098 +0800
++++ fio/ioengines.c	2026-09-11 15:44:00.540150101 +0800
+@@ -125,6 +125,11 @@
+ static struct ioengine_ops *dlopen_ioengine(struct thread_data *td,
+ 					    const char *engine_lib)
+ {
++#ifndef CONFIG_DYNAMIC_ENGINES
++	/* The port has no dynamic loader: only the engines built into the
++	 * binary can be loaded. */
++	return NULL;
++#else
+ 	struct ioengine_ops *ops;
+ 	void *dlhandle;
+ 
+@@ -173,6 +178,7 @@
+ 
+ 	ops->dlhandle = dlhandle;
+ 	return ops;
++#endif
+ }
+ 
+ static struct ioengine_ops *__load_ioengine(const char *engine)
+--- fio/init.c	2026-09-05 15:36:08.840288098 +0800
++++ fio/init.c	2026-09-11 15:44:00.540655840 +0800
+@@ -1308,8 +1308,10 @@
+ 		if (ops == td->io_ops && dlhandle == td->io_ops->dlhandle)
+ 			return 0;
+ 
++#ifdef CONFIG_DYNAMIC_ENGINES
+ 		if (dlhandle && dlhandle != td->io_ops->dlhandle)
+ 			dlclose(dlhandle);
++#endif
+ 
+ 		/* Unload the old engine. */
+ 		free_ioengine(td);
+--- fio/smalloc.c	2026-09-05 15:36:08.867297050 +0800
++++ fio/smalloc.c	2026-09-11 16:14:09.157527698 +0800
+@@ -18,7 +18,17 @@
+ #define SMALLOC_BPI	(sizeof(unsigned int) * 8)
+ #define SMALLOC_BPL	(SMALLOC_BPB * SMALLOC_BPI)
+ 
++#ifdef FIO_EMBOX_HEAP_ANON
++/*
++ * The kernel serves small allocations from its own pool but a multi
++ * megabyte one lands in a heap whose free list is not set up on this
++ * port, and that aborts.  One megabyte pools are enough for the
++ * structures fio allocates here.
++ */
++#define INITIAL_SIZE	1024*1024	/* new pool size */
++#else
+ #define INITIAL_SIZE	16*1024*1024	/* new pool size */
++#endif
+ #define INITIAL_POOLS	8		/* maximum number of pools to setup */
+ 
+ #define MAX_POOLS	16
+@@ -175,6 +185,11 @@
+ 	pool->nr_blocks = bitmap_blocks;
+ 	pool->free_blocks = bitmap_blocks * SMALLOC_BPI;
+ 
++#ifdef FIO_EMBOX_HEAP_ANON
++	ptr = calloc(1, alloc_size);
++	if (!ptr)
++		goto out_fail;
++#else
+ 	mmap_flags = OS_MAP_ANON;
+ #ifdef CONFIG_ESX
+ 	mmap_flags |= MAP_PRIVATE;
+@@ -185,6 +200,7 @@
+ 
+ 	if (ptr == MAP_FAILED)
+ 		goto out_fail;
++#endif
+ 
+ 	pool->map = ptr;
+ 	pool->bitmap = (unsigned int *)((char *) ptr + (pool->nr_blocks * SMALLOC_BPL));
+@@ -199,7 +215,11 @@
+ out_fail:
+ 	log_err("smalloc: failed adding pool\n");
+ 	if (pool->map)
++#ifdef FIO_EMBOX_HEAP_ANON
++		free(pool->map);
++#else
+ 		munmap(pool->map, pool->mmap_size);
++#endif
+ 	return false;
+ }
+ 
+@@ -214,12 +234,17 @@
+ 	 * instances only once.
+ 	 */
+ 	if (!mp) {
++#ifdef FIO_EMBOX_HEAP_ANON
++		mp = calloc(MAX_POOLS, sizeof(struct pool));
++		assert(mp);
++#else
+ 		mp = (struct pool *) mmap(NULL,
+ 			MAX_POOLS * sizeof(struct pool),
+ 			PROT_READ | PROT_WRITE,
+ 			OS_MAP_ANON | MAP_SHARED, -1, 0);
+ 
+ 		assert(mp != MAP_FAILED);
++#endif
+ 	}
+ 
+ 	for (i = 0; i < INITIAL_POOLS; i++) {
+@@ -241,7 +266,11 @@
+ 	 * This will also remove the temporary file we used as a backing
+ 	 * store, it was already unlinked
+ 	 */
++#ifdef FIO_EMBOX_HEAP_ANON
++	free(pool->map);
++#else
+ 	munmap(pool->map, pool->mmap_size);
++#endif
+ 
+ 	if (pool->lock)
+ 		fio_sem_remove(pool->lock);
+@@ -254,7 +283,11 @@
+ 	for (i = 0; i < nr_pools; i++)
+ 		cleanup_pool(&mp[i]);
+ 
++#ifdef FIO_EMBOX_HEAP_ANON
++	free(mp);
++#else
+ 	munmap(mp, MAX_POOLS * sizeof(struct pool));
++#endif
+ }
+ 
+ #ifdef SMALLOC_REDZONE
+--- fio/fio_sem.c	2026-09-05 15:36:08.836288044 +0800
++++ fio/fio_sem.c	2026-09-11 16:07:05.592531243 +0800
+@@ -33,7 +33,11 @@
+ void fio_sem_remove(struct fio_sem *sem)
+ {
+ 	__fio_sem_remove(sem);
++#ifdef FIO_EMBOX_HEAP_ANON
++	free(sem);
++#else
+ 	munmap((void *) sem, sizeof(*sem));
++#endif
+ }
+ 
+ int __fio_sem_init(struct fio_sem *sem, int value)
+@@ -56,6 +60,13 @@
+ {
+ 	struct fio_sem *sem = NULL;
+ 
++#ifdef FIO_EMBOX_HEAP_ANON
++	sem = calloc(1, sizeof(struct fio_sem));
++	if (!sem) {
++		perror("calloc semaphore");
++		return NULL;
++	}
++#else
+ 	sem = (void *) mmap(NULL, sizeof(struct fio_sem),
+ 				PROT_READ | PROT_WRITE,
+ 				OS_MAP_ANON | MAP_SHARED, -1, 0);
+@@ -63,6 +74,7 @@
+ 		perror("mmap semaphore");
+ 		return NULL;
+ 	}
++#endif
+ 
+ 	if (!__fio_sem_init(sem, value))
+ 		return sem;
+--- fio/rwlock.c	2026-09-05 15:36:08.867297050 +0800
++++ fio/rwlock.c	2026-09-11 16:07:05.592680592 +0800
+@@ -29,7 +29,11 @@
+ {
+ 	assert(lock->magic == FIO_RWLOCK_MAGIC);
+ 	pthread_rwlock_destroy(&lock->lock);
++#ifdef FIO_EMBOX_HEAP_ANON
++	free(lock);
++#else
+ 	munmap((void *) lock, sizeof(*lock));
++#endif
+ }
+ 
+ struct fio_rwlock *fio_rwlock_init(void)
+@@ -38,6 +42,13 @@
+ 	pthread_rwlockattr_t attr;
+ 	int ret;
+ 
++#ifdef FIO_EMBOX_HEAP_ANON
++	lock = calloc(1, sizeof(struct fio_rwlock));
++	if (!lock) {
++		perror("calloc rwlock");
++		goto err;
++	}
++#else
+ 	lock = (void *) mmap(NULL, sizeof(struct fio_rwlock),
+ 				PROT_READ | PROT_WRITE,
+ 				OS_MAP_ANON | MAP_SHARED, -1, 0);
+@@ -46,6 +57,7 @@
+ 		lock = NULL;
+ 		goto err;
+ 	}
++#endif
+ 
+ 	lock->magic = FIO_RWLOCK_MAGIC;
+ 
+--- fio/engines/sync.c	2026-09-05 15:36:08.776287234 +0800
++++ fio/engines/sync.c	2026-09-11 16:18:45.375789655 +0800
+@@ -491,7 +491,7 @@
+ };
+ #endif
+ 
+-static void fio_init fio_syncio_register(void)
++static void fio_sync_register_engines(void)
+ {
+ 	register_ioengine(&ioengine_rw);
+ 	register_ioengine(&ioengine_prw);
+@@ -504,6 +504,18 @@
+ #endif
+ }
+ 
++#ifdef FIO_EMBOX_NO_CTORS
++void fio_embox_register_sync_engines(void)
++{
++	fio_sync_register_engines();
++}
++#else
++static void fio_init fio_syncio_register(void)
++{
++	fio_sync_register_engines();
++}
++#endif
++
+ static void fio_exit fio_syncio_unregister(void)
+ {
+ 	unregister_ioengine(&ioengine_rw);
+--- fio/engines/null.c	2026-09-05 15:36:08.776287234 +0800
++++ fio/engines/null.c	2026-09-11 16:18:45.376078956 +0800
+@@ -176,10 +176,17 @@
+ 	.flags		= FIO_DISKLESSIO | FIO_FAKEIO,
+ };
+ 
++#ifdef FIO_EMBOX_NO_CTORS
++void fio_embox_register_null_engine(void)
++{
++	register_ioengine(&ioengine);
++}
++#else
+ static void fio_init fio_null_register(void)
+ {
+ 	register_ioengine(&ioengine);
+ }
++#endif
+ 
+ static void fio_exit fio_null_unregister(void)
+ {
+--- fio/libfio.c	2026-09-05 15:36:08.845086924 +0800
++++ fio/libfio.c	2026-09-11 16:18:45.376264637 +0800
+@@ -449,6 +449,19 @@
+ 	page_mask = ps - 1;
+ 
+ 	fio_keywords_init();
++
++#ifdef FIO_EMBOX_NO_CTORS
++	/* The kernel does not run ELF constructors: register the ioengines
++	 * that are built into this port by hand (see os/os-embox.h). */
++	{
++		extern void fio_embox_register_sync_engines(void);
++		extern void fio_embox_register_null_engine(void);
++
++		fio_embox_register_sync_engines();
++		fio_embox_register_null_engine();
++	}
++#endif
++
+ 	return 0;
+ }
+ 
+--- fio/arch/arch.h	2026-09-05 15:36:08.758863178 +0800
++++ fio/arch/arch.h	2026-09-11 21:51:19.287698927 +0800
+@@ -3,7 +3,7 @@
+ 
+ #ifdef __cplusplus
+ #include <atomic>
+-#else
++#elif !defined(__EMBOX__)
+ #include <stdatomic.h>
+ #endif
+ 
+@@ -59,6 +59,26 @@
+ 	std::atomic_store_explicit(p, (v),			\
+ 			     std::memory_order_release)
+ #else
++#if defined(__EMBOX__)
++/*
++ * The kernel's <stdatomic.h> carries the types but not the generic
++ * operations, and it links no libatomic: the compiler's own builtins are
++ * what its atomics use.  Embox is single-security-state aarch64 here, so
++ * every type fio uses is lock free.
++ */
++#define atomic_add(p, v)					\
++	__atomic_fetch_add((p), (v), __ATOMIC_SEQ_CST)
++#define atomic_sub(p, v)					\
++	__atomic_fetch_sub((p), (v), __ATOMIC_SEQ_CST)
++#define atomic_load_relaxed(p)					\
++	__atomic_load_n((p), __ATOMIC_RELAXED)
++#define atomic_load_acquire(p)					\
++	__atomic_load_n((p), __ATOMIC_ACQUIRE)
++#define atomic_store_relaxed(p, v)				\
++	__atomic_store_n((p), (v), __ATOMIC_RELAXED)
++#define atomic_store_release(p, v)				\
++	__atomic_store_n((p), (v), __ATOMIC_RELEASE)
++#else
+ #define atomic_add(p, v)					\
+ 	atomic_fetch_add((_Atomic typeof(*(p)) *)(p), v)
+ #define atomic_sub(p, v)					\
+@@ -76,6 +96,7 @@
+ 	atomic_store_explicit((_Atomic typeof(*(p)) *)(p), (v),	\
+ 			      memory_order_release)
+ #endif
++#endif
+ 
+ /* IWYU pragma: begin_exports */
+ #if defined(__i386__)
+--- fio/idletime.c	2026-09-05 15:36:08.840288098 +0800
++++ fio/idletime.c	2026-09-11 21:51:19.289245640 +0800
+@@ -206,10 +206,12 @@
+ 		log_err("fio: pthread_attr_init %s\n", strerror(ret));
+ 		return;
+ 	}
++#ifndef FIO_EMBOX_PTHREAD_NO_SCOPE
+ 	if ((ret = pthread_attr_setscope(&tattr, PTHREAD_SCOPE_SYSTEM))) {
+ 		log_err("fio: pthread_attr_setscope %s\n", strerror(ret));
+ 		return;
+ 	}
++#endif
+ 
+ 	ipc.ipts = malloc(ipc.nr_cpus * sizeof(struct idle_prof_thread));
+ 	if (!ipc.ipts) {

--- a/third-party/fio/tree/os/os-embox.h
+++ b/third-party/fio/tree/os/os-embox.h
@@ -1,0 +1,116 @@
+#ifndef FIO_OS_EMBOX_H
+#define FIO_OS_EMBOX_H
+
+#define FIO_OS	os_embox
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../file.h"
+
+/*
+ * Embox is a POSIX-flavoured RTOS.  The port stays on the generic paths
+ * and describes only what the kernel provides: a raw block device is a
+ * /dev entry whose size comes from fstat().
+ */
+
+#define FIO_HAVE_ODIRECT
+#define FIO_USE_GENERIC_INIT_RANDOM_STATE
+
+/*
+ * Embox's anonymous mmap() is not usable for a command: on this port it
+ * hands out addresses aligned to 4K while the kernel's virtual memory
+ * page is 64K, so a mapping fio's own allocators make cannot be
+ * described by the page tables (the kernel then reports corrupted page
+ * table entries).  fio runs single-process here, so the three places
+ * that map anonymous memory to hold fio's own structures -- smalloc's
+ * pools, the shared semaphores and the rwlocks -- take that memory from
+ * the heap instead.
+ */
+#define FIO_EMBOX_HEAP_ANON
+
+/*
+ * The kernel does not run ELF constructors, so fio's fio_init() hooks --
+ * including the ones that register the built-in ioengines -- never fire.
+ * The engines this port builds in are registered from initialize_fio().
+ */
+#define FIO_EMBOX_NO_CTORS
+
+/*
+ * <pthread.h> has no PTHREAD_SCOPE_PROCESS/PTHREAD_SCOPE_SYSTEM values:
+ * the kernel has a single contention scope and the attribute would be a
+ * no-op, so the idle profiling setup skips that call.
+ */
+#define FIO_EMBOX_PTHREAD_NO_SCOPE
+
+#define OS_MAP_ANON	MAP_ANONYMOUS
+
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN 4096
+#endif
+
+/*
+ * The block layer's own size ioctl answers with an int, which a medium
+ * larger than 2 GiB does not fit, so the driver reports the byte size
+ * through a command of its own (see drivers/ahci/dwc_ahci.c).  The block
+ * layer and fstat are the fallbacks for a device that offers only those.
+ */
+#define FIO_EMBOX_IOCTL_GET_SIZE_BYTES 0x41484349
+#define FIO_EMBOX_IOCTL_GETDEVSIZE     2
+
+static inline int blockdev_size(struct fio_file *f, unsigned long long *bytes)
+{
+	unsigned long long size = 0;
+	struct stat st;
+	long ret;
+
+	if (ioctl(f->fd, FIO_EMBOX_IOCTL_GET_SIZE_BYTES, &size) == 0 && size > 0) {
+		*bytes = size;
+		return 0;
+	}
+
+	ret = ioctl(f->fd, FIO_EMBOX_IOCTL_GETDEVSIZE, NULL);
+	if (ret > 0) {
+		*bytes = (unsigned long long) ret;
+		return 0;
+	}
+
+	if (fstat(f->fd, &st) == 0 && st.st_size > 0) {
+		*bytes = (unsigned long long) st.st_size;
+		return 0;
+	}
+
+	*bytes = 0;
+	return ENOTSUP;
+}
+
+static inline int blockdev_invalidate_cache(struct fio_file *f)
+{
+	/*
+	 * The block device idesc hands requests straight to the driver,
+	 * there is no cache to drop.
+	 */
+	return 0;
+}
+
+static inline unsigned long long os_phys_mem(void)
+{
+	long pagesize;
+	long pages;
+
+	pagesize = sysconf(_SC_PAGESIZE);
+	pages = sysconf(_SC_PHYS_PAGES);
+	if (pagesize <= 0 || pages <= 0) {
+		return 0;
+	}
+
+	return (unsigned long long) pagesize * (unsigned long long) pages;
+}
+
+#endif


### PR DESCRIPTION
hello, i add dwc ahci support for sata ssd, as long as fio ported

```
4859 [info] (unit) initializing embox.driver.ahci.dwc_ahci
4860 [info] (dwc_ahci) ahci0: HBA at 0x00000000fc000000, version 1.30, 32 slot(s), ports 0x1
4861 [info] (dwc_ahci) ahci0: /dev/ahci0, 250069680 blocks of 512 bytes (122104 MiB)
4862 [info] (dwc_ahci) ahci1: HBA at 0x00000000fc400000, version 1.30, 32 slot(s), ports 0x1
4863 [info] (dwc_ahci) ahci1: /dev/ahci1, 250069680 blocks of 512 bytes (122104 MiB)

4926 root@embox:(null)# block_dev_test -l
4928 Block devices:
4929   id | name
4930    0 | ahci0
4931    1 | ahci1
4932    2 | nvme0

4939 block_dev_test -s 0 -n 256 -m 8 ahci0
4941 Starting block device test (iters = 1)...
4942 iter 0...
4943 Testing 0 (of 250069680)

10177 root@embox:/dev# fio --name=t --filename=ahci0 --bs=4k --size=1m
10554 t: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=psync, iodepth=1
10556 fio: failed to create helper thread
10557 Starting 1 thread
10559 t: (groupid=0, jobs=1): err= 0: pid=2: 1970-01-01 00:00:45  read: IOPS=14.2k, BW=55.6MiB/s (58.3MB/s)(1024KiB/18msec)
10574      issued rwts: total=256,0,0,0 short=0,0,0,0 dropped=0,0,0,0
10578    READ: bw=55.6MiB/s (58.3MB/s), 55.6MiB/s-55.6MiB/s (58.3MB/s-58.3MB/s), io=1024KiB (1049kB), run=18-18msec

10579 root@embox:/dev# fio --name=t --filename=ahci0 --bs=4k --size=1m --rw=randwrite
10582 t: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=psync, iodepth=1
10587 t: (groupid=0, jobs=1): err= 0: pid=2: 1970-01-01 00:01:07  write: IOPS=13.5k, BW=52.6MiB/s (55.2MB/s)(1024KiB/19msec)
10602      issued rwts: total=0,256,0,0 short=0,0,0,0 dropped=0,0,0,0
10606   WRITE: bw=52.6MiB/s (55.2MB/s), 52.6MiB/s-52.6MiB/s (55.2MB/s-55.2MB/s), io=1024KiB (1049kB), run=19-19msec

10607 root@embox:/dev# fio --name=t --filename=ahci1 --bs=4k --size=1m --rw=randread
10610 t: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=psync, iodepth=1
10615 t: (groupid=0, jobs=1): err= 0: pid=2: 1970-01-01 00:01:24  read: IOPS=5019, BW=19.6MiB/s (20.6MB/s)(1024KiB/51msec)
10630      issued rwts: total=256,0,0,0 short=0,0,0,0 dropped=0,0,0,0
10634    READ: bw=19.6MiB/s (20.6MB/s), ... io=1024KiB (1049kB), run=51-51msec
```